### PR TITLE
SOHO-7922 - Example Showing Dynamic Disabled Dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Note: There may be a cost involved to using this with Infor's amazon s3 account 
 From within the project folder:
 
 * Run `npx grunt` to compile initial assets
-* Run `node server` to start the web server
+* Run `npm run server` or `node app/server.js` to start the web server
 * Make a new terminal window and from within your project folder run `npx grunt watch` to watch for any file changes and rebuild
 * Open up [`localhost:4000`](http://localhost:4000) in a browser to see the local app
 
@@ -143,4 +143,3 @@ Please use the internal Infor [Jira issue tracker](http://jira.infor.com/browse/
 For release updates see our upcoming and past version in our [releases road map](http://jira.infor.com/projects/SOHO?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page).
 
 If you're an Infor employee, you can join our [MS Teams Group](https://teams.microsoft.com/l/team/19%3a2b0c9ce520b0481a9ce115f0ca4a326f%40thread.skype/conversations?groupId=4f50ef7d-e88d-4ccb-98ca-65f26e57fe35&tenantId=457d5685-0467-4d05-b23b-8f817adda47c) for updates.
-

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Note: There may be a cost involved to using this with Infor's amazon s3 account 
 From within the project folder:
 
 * Run `npx grunt` to compile initial assets
-* Run `npm run server` or `node app/server.js` to start the web server
+* Run `npm start` to start the web server
 * Make a new terminal window and from within your project folder run `npx grunt watch` to watch for any file changes and rebuild
 * Open up [`localhost:4000`](http://localhost:4000) in a browser to see the local app
 

--- a/app/views/components/datagrid/test-datepicker-dynamic-disabled-dates.html
+++ b/app/views/components/datagrid/test-datepicker-dynamic-disabled-dates.html
@@ -1,0 +1,70 @@
+
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="contextual-toolbar toolbar is-hidden">
+      <div class="title selection-count">1 Selected</div>
+      <div class="buttonset">
+        <button class="btn" type="button">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-delete"></use>
+          </svg>
+          <span>Remove</span>
+        </button>
+      </div>
+    </div>
+
+    <div id="datagrid">
+
+    </div>
+  </div>
+</div>
+
+<script>
+  var gridApi = null;
+
+  $('body').one('initialized', function () {
+
+    Locale.set('en-US').done(function () {
+        var grid,
+          data = [],
+          columns = [];
+
+        // Some Sample Data
+        data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  '<svg/onload=alert(1)>', quantity: 1, price: 210.99, status: 'OK', state:'California', orderDate:  new Date(2018, 4, 15, 12, 30, 36), portable: false, action: 'ac', description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning'});
+        data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, status: '', state:'Oklahoma', orderDate: new Date(2018, 4, 15, 0, 30, 36), portable: false, action: 'oh', description: 'The kit has an air blow gun that can be used for cleaning'});
+        data.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity:  'Inspect and Repair', portable: true, quantity: 1, price: 120.992, status: null, state:'Wisconsin', orderDate: new Date(2018, 4, 3), action: 'ac'});
+        data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', portable: true, quantity: 3, price: null, status: 'OK', state:'Michigan', orderDate: new Date(2018, 4, 3), action: 'ac', description: 'Compressor comes with with air tool kit'});
+        data.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, status: 'OK', state:'Northern Mariana Island Teritory', orderDate: new Date(2018, 4, 5), action: 'oh'});
+        data.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', portable: false, quantity: 41, price: 120.99, status: 'OK', state:'New York', orderDate: new Date(2018, 4, 9), action: 'oh'});
+        data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', state:'Idaho', orderDate: new Date(2018, 4, 9), action: 'oh'});
+
+        //Define Columns for the Grid.
+        columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center', width: 65});
+        columns.push({ id: 'productId', name: 'ProductId Id ', field: 'productId'});
+        columns.push({ id: 'orderDate', name: 'Order Date Disabled', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date, filterType: 'date', width: 200, editorOptions: {disable: {'dates': ['5/9/2018', '5/10/2018'], 'dayOfWeek': [0,6]}} });
+        columns.push({ id: 'productName', name: 'Product Name', field: 'productName', filterType: 'text'});
+
+        //Init and get the api for the grid
+        var datagrid = $('#datagrid').datagrid({
+          columns: columns,
+          dataset: data,
+          editable: true,
+          filterable: true,
+          clickToSelect: false,
+          selectable: 'multiple',
+          toolbar: {title: 'Compressors', results: true, actions: true, rowHeight: true}
+        }).on('activecellchange', function (e, args) {
+          // Look at other cell values : data[args.row] rather than use random
+          var random = Math.floor(Math.random() * 12) + 1
+          datagrid.settings.columns[2].editorOptions.disable = {'minDate':  '5/'+random.toString()+'/2018', 'maxDate': '5/31/2018'};
+        }).on('cellchange', function (e, args) {
+          console.log(args , 'was changed');
+        }).on('beforeentereditmode', function (e, args) {
+          console.log(args , 'new event on 4.7');
+        }).data('datagrid');
+
+    });
+  });
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,7 @@ http://usalvlhlpool1.infor.com/4.6.0/components/
 - Treemap Component Added
 - Launch of new docs site https://design.infor.com/code/ids-enterprise/latest
 - Now passes CSP - Content Security Policy Compliance for info see docs/SECURITY.md
-- New Flex Toolbar - We added an updated toolbar to eventually replace the current one. This toolbar is much faster as it uses mainly css http://usalvlhlpool1.infor.com/4.6.0/components/toolbar-flex this can be used now but note we will eventually replace so expect a future breaking change from flex-toolbar to toolbar when all features are implemented. As of now collapsible search is not supported yet.
+- New Flex Toolbar - We added an updated toolbar to eventually replace the current one. This toolbar is much faster as it uses mainly css http://usalvlhlpool1.infor.com/4.6.0/components/toolbar-flex/list this can be used now but note we will eventually replace so expect a future breaking change from flex-toolbar to toolbar when all features are implemented. As of now collapsible search is not supported yet.
 
 ### <a name="version-4.6.0-behavior-changes">Behavior Changes</a>
 - App Menu - Now automatically closes when items are clicked on mobile devices
@@ -78,14 +78,14 @@ If you have a delimiter syntax to embed html such as `{{& name}}` please change 
 - Multiselect - Fixed bug with select all not working correctly
 - Multiselect - Fixed bug with required validation rule.
 - Spinbox - Fixed issue on short field versions
-- Textarea - Fixed issue with counter whenin angular and on a modal
+- Textarea - Fixed issue with counter when in angular and on a modal
 - Toast - Fixed XSS vulnerability
 - Tree - Fixed checkbox click issue
 - Lookup - Fixed issue in the example when running on Edge
 - Validation - Fixed broken form submit validation
 - Vertical Tabs - Fix cut off header
 
-(X Jira Issues Solved this release, Backlog Dev X, Design X, Unresolved X, Test Coverage X% )
+(98 Jira Issues Solved this release, Backlog Dev 388, Design 105, Unresolved 595, Test Coverage 6.66%)
 
 ## <a name="version-4.5.0">4.5.0</a>
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -6306,6 +6306,22 @@ Datagrid.prototype = {
       cellParent.addClass('is-editing-inline');
     }
 
+    /**
+    * Fires before a cell goes into edit mode. Giving you a chance to adjust column settings.
+    * @event entereditmode
+    * @memberof Datagrid
+    * @property {object} event The jquery event object
+    * @property {object} args Additional arguments
+    * @property {number} args.row An array of selected rows.
+    * @property {number} args.cell An array of selected rows.
+    * @property {object} args.item The current sort column.
+    * @property {HTMLElement} args.target The cell html element that was entered.
+    * @property {any} args.value The cell value.
+    * @property {object} args.column The column object
+    * @property {object} args.editor The editor object.
+    */
+    this.element.triggerHandler('beforeentereditmode', [{ row: idx, cell, item: rowData, target: cellNode, value: cellValue, column: col, editor: this.editor }]);
+
     this.editor =  new col.editor(idx, cell, cellValue, cellNode, col, event, this, rowData); // eslint-disable-line
 
     if (this.settings.onEditCell) {


### PR DESCRIPTION
- Added an example (compatible with 4.5.0) that shows changing dates dynamically
- Update README command
- Added new pre-edit mode event
- Added new docs for new event

Related Issue: 
https://jira.infor.com/browse/SOHO-7922

Test Plan:
- Make a test for example http://localhost:4000/components/datagrid/test-datepicker-dynamic-disabled-dates when i start on that soon.
- Make test for the new event when i start on that soon.

Steps:
- http://localhost:4000/components/datagrid/test-datepicker-dynamic-disabled-dates
- click each column to edit the date
- the disabled dates will be randomly different for each column
- new event will show in the console