### PR TITLE
Bugfix: Dropdown `HTMLElement.selectedOptions` usage

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1415,8 +1415,20 @@ Dropdown.prototype = {
     if (!this.settings.multiple && this.initialFilter) {
       setTimeout(() => {
         if (self.settings.noSearch) {
-          const selectedOptions = self.element[0].selectedOptions;
-          self.searchInput.val(selectedOptions.length > 0 ? selectedOptions[0].innerText : '');
+          let selectedOpt;
+          let selectedOptText = '';
+
+          // Set the text of the SearchInput.
+          // Use fallback for `HTMLSelectElement.selectedOptions` in IE
+          if (this.isIe10 || this.isIe11) {
+            selectedOpt = self.element[0].options[self.element[0].selectedIndex];
+            selectedOptText = selectedOpt ? selectedOpt.innerText : '';
+          } else {
+            selectedOpt = self.element[0].selectedOptions;
+            selectedOptText = selectedOpt.length > 0 ? selectedOpt[0].innerText : '';
+          }
+
+          self.searchInput.val(selectedOptText);
           return;
         }
 

--- a/test/components/dropdown/dropdown-light-theme.e2e-spec.js
+++ b/test/components/dropdown/dropdown-light-theme.e2e-spec.js
@@ -129,3 +129,21 @@ describe('Dropdown example-ajax tests', () => {
     });
   }
 });
+
+describe('Dropdown No-Search Mode Tests', () => {
+  beforeEach(async () => {
+    await browser.waitForAngularEnabled(false);
+    await browser.driver.get('http://localhost:4000/components/dropdown/example-no-search-lsf');
+  });
+
+  it('should select a Dropdown item when keying on a closed Dropdown component', async () => {
+    const dropdownPseudoEl = await element(by.css('div[aria-controls="dropdown-list"]'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
+
+    await dropdownPseudoEl.click();
+    await dropdownPseudoEl.sendKeys('r');
+
+    expect(dropdownPseudoEl.getText()).toEqual('R - Rocket Raccoon');
+  });
+});

--- a/test/components/dropdown/dropdown-updates-events.func-spec.js
+++ b/test/components/dropdown/dropdown-updates-events.func-spec.js
@@ -118,4 +118,12 @@ describe('Dropdown updates, events', () => {
 
     expect(spyEvent).toHaveBeenTriggered();
   });
+
+  it('should display the text of the first selected option when the list opens', (done) => {
+    dropdownObj.open();
+    const searchInput = dropdownObj.searchInput;
+
+    expect(searchInput[0].value).toBe('New Jersey');
+    done();
+  });
 });


### PR DESCRIPTION
Explain the **details** for making this change. What existing problem does the pull request solve?

When opening the Dropdown component on Internet Explorer 11, Javascript errors were previously thrown due to the usage of `HTMLSelectElement.selectedOptions` for checking on the selected item.

**Related issue (required)**:  https://jira.infor.com/browse/SOHO-7901

**Steps necessary to review your pull request (required)**:

Run the application server and open http://localhost:4000/components/dropdown/example-no-search-lsf in a browser, or run the Dropdown E2E tests.

**Test plan (required)**

Check that the first Dropdown on http://localhost:4000/components/dropdown/example-no-search-lsf correctly displays a result with a first character that matches an alphanumeric keypress (ex: pressing "R" while the dropdown has focus should change its selection to "R - Rocket Raccoon")

**Other Details:**

Closes SOHO-7901
