### PR TITLE
SOHO-7331 - Add more e2e tests for listview, fix data routes, typos

### DIFF
--- a/app/data.js
+++ b/app/data.js
@@ -880,14 +880,9 @@ module.exports = function(router){
 
   function sendJSONFile(filename, req, res, next) {
     const data = getJSONFile(path.resolve('app', 'data', `${filename}.json`));
-    res.setHeader('Content-Type', 'application/json');
-    res.end(JSON.stringify(data));
+    res.json(data);
     next();
   }
-
-  router.get('/api/:fileName', (req, res, next) => {
-    sendJSONFile(req.params.fileName, req, res, next);
-  });
 
   router.get('/api/my-projects', (req, res, next) => {
     sendJSONFile('projects', req, res, next);
@@ -903,13 +898,28 @@ module.exports = function(router){
   });
 
   router.get('/api/dummy-dropdown-data', (req, res, next) => {
-    const data = require(path.resolve('app', 'src', 'js', 'getJunkDropdownData'));
-    res.setHeader('Content-Type', 'application/json');
-    res.end(JSON.stringify(data));
+    const data = require(path.resolve('app', 'src', 'js', 'get-junk-dropdown-data'));
+    res.json(data);
     next();
   });
 
   router.get('/api/org-chart', (req, res, next) => {
     sendJSONFile('org-chart', req, res, next);
+  });
+
+  router.get('/api/:fileName', (req, res, next) => {
+    if (
+      [
+        'periods',
+        'product',
+        'states',
+        'colleagues',
+        'dummy-dropdown-data',
+        'my-projects',
+        'fruits',
+        'nav-items'
+      ].includes(req.params.fileName)
+    ) { return; }
+    sendJSONFile(req.params.fileName, req, res, next);
   });
 }

--- a/app/views/components/listview/remove-clear.html
+++ b/app/views/components/listview/remove-clear.html
@@ -81,7 +81,7 @@
     // On selection ============================================================
     listApi.element.on('selected', function (e, args) {
       clearDisplay();
-      showStatus(args.length);
+      showStatus(args.selectedItems.length);
     });
 
     // Remove selected items from list ========================================

--- a/src/components/listview/readme.md
+++ b/src/components/listview/readme.md
@@ -97,7 +97,7 @@ Creating a Multiselect Listview also uses the listview component. API guidelines
 -   The attribute aria-posinset should point to the position index for each item starting at 1
 -   The attribute aria-setsize - should be the list count
 -   The attribute aria-disabled should be added to any disabled items
--   The aria-selcted tag should be added to any selected entries
+-   The aria-selected tag should be added to any selected entries
 -   For multiselect note that aria-selected = "true" will set on the selected elements.
 
 ## Responsive Guidelines

--- a/test/components/listview/listview-light-theme.e2e-spec.js
+++ b/test/components/listview/listview-light-theme.e2e-spec.js
@@ -1,0 +1,463 @@
+const AxeBuilder = require('axe-webdriverjs');
+
+const { browserStackErrorReporter } = requireHelper('browserstack-error-reporter');
+const utils = requireHelper('e2e-utils');
+const rules = requireHelper('default-axe-options');
+const config = requireHelper('e2e-config');
+requireHelper('rejection');
+const axeOptions = { rules };
+
+jasmine.getEnv().addReporter(browserStackErrorReporter);
+
+describe('Listview example-singleselect light theme tests', () => {
+  beforeEach(async () => {
+    await browser.waitForAngularEnabled(false);
+    await browser.driver.get('http://localhost:4000/components/listview/example-singleselect');
+    const listviewEl = await element(by.id('period-end'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(listviewEl), config.waitsFor);
+  });
+
+  if (!utils.isIE()) {
+    xit('Should be accessible on init with no WCAG 2AA violations on example-singleselect', async () => {
+      await browser.driver.sleep(config.sleep);
+      const res = await AxeBuilder(browser.driver)
+        .configure(axeOptions)
+        .exclude('header')
+        .analyze();
+
+      expect(res.violations.length).toEqual(0);
+    });
+  }
+
+  it('Should select one item on click', async () => {
+    const listviewItemEl = await element(by.css('li[aria-posinset="1"]'));
+    listviewItemEl.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.className('is-selected')).isPresent()).toBeTruthy();
+    expect(await element(by.css('li[aria-selected="true"]')).isPresent()).toBeTruthy();
+    expect(await element(by.className('selection-count')).getText()).toEqual('1 Selected');
+  });
+
+  it('Should deselect one item on click', async () => {
+    const listviewItemEl = await element(by.css('li[aria-posinset="1"]'));
+    listviewItemEl.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.className('is-selected')).isPresent()).toBeTruthy();
+    expect(await element(by.css('li[aria-selected="true"]')).isPresent()).toBeTruthy();
+    expect(await element(by.className('selection-count')).getText()).toEqual('1 Selected');
+
+    listviewItemEl.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('li[aria-selected="false"]')).isPresent()).toBeTruthy();
+  });
+
+  it('Should tab into, and select, arrow key down over disabled item, and select item on space key, ', async () => {
+    const listviewEl = await element(by.id('period-end'));
+    const listviewItemElOne = await element(by.css('li[aria-posinset="1"]'));
+    const listviewItemElTwo = await element(by.css('li[aria-posinset="2"]'));
+    await listviewEl.sendKeys(protractor.Key.TAB);
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('li[aria-posinset="1"].is-selected')).isPresent()).toBeTruthy();
+    expect(await element(by.css('li[aria-posinset="1"][aria-selected="true"]')).isPresent()).toBeTruthy();
+    await listviewItemElOne.sendKeys(protractor.Key.ARROW_DOWN);
+    await browser.driver.sleep(config.sleep);
+    await listviewItemElTwo.sendKeys(protractor.Key.ARROW_DOWN);
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('li[aria-posinset="3"].is-selected')).isPresent()).toBeTruthy();
+    expect(await element(by.className('selection-count')).getText()).toEqual('1 Selected');
+  });
+});
+
+describe('Listview example-multiselect light theme tests', () => {
+  beforeEach(async () => {
+    await browser.waitForAngularEnabled(false);
+    await browser.driver.get('http://localhost:4000/components/listview/example-multiselect');
+    const listviewEl = await element(by.id('multiselect-listview'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(listviewEl), config.waitsFor);
+  });
+
+  if (!utils.isIE()) {
+    xit('Should be accessible on init with no WCAG 2AA violations on example-multiselect page', async () => {
+      await browser.driver.sleep(config.sleep);
+      const res = await AxeBuilder(browser.driver)
+        .configure(axeOptions)
+        .exclude('header')
+        .analyze();
+
+      expect(res.violations.length).toEqual(0);
+    });
+  }
+
+  it('Should select item on click', async () => {
+    const listviewItemEl = await element(by.css('li[aria-posinset="1"]'));
+    listviewItemEl.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.className('is-selected')).isPresent()).toBeTruthy();
+    expect(await element(by.css('li[aria-selected="true"]'))).toBeTruthy();
+    expect(await element(by.className('selection-count')).getText()).toEqual('1 Selected');
+  });
+
+  it('Should deselect item on click', async () => {
+    const listviewItemEl = await element(by.css('li[aria-posinset="1"]'));
+    listviewItemEl.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.className('is-selected'))).toBeTruthy();
+    expect(await element(by.css('li[aria-selected="true"]'))).toBeTruthy();
+    expect(await element(by.className('selection-count')).getText()).toEqual('1 Selected');
+
+    listviewItemEl.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('li[aria-selected="false"]'))).toBeTruthy();
+  });
+
+  if (utils.isChrome()) {
+    it('Should mouseover 1st, and change background-color', async () => {
+      const listviewItemElOne = await element(by.css('li[aria-posinset="1"]'));
+      await browser.driver
+        .wait(protractor.ExpectedConditions.presenceOf(listviewItemElOne), config.waitsFor);
+      await browser.driver.actions().mouseMove(listviewItemElOne).perform();
+      await browser.driver.sleep(config.sleep);
+      // Value returned will be as the browser interprets it, tricky to form a proper assertion
+      expect(await listviewItemElOne.getCssValue('background-color')).toBe('rgba(216, 216, 216, 1)');
+    });
+  }
+
+  it('Should select two items on click', async () => {
+    const listviewItemElOne = await element(by.css('li[aria-posinset="1"]'));
+    const listviewItemElThree = await element(by.css('li[aria-posinset="3"]'));
+    listviewItemElOne.click();
+    await browser.driver.sleep(config.sleep);
+    listviewItemElThree.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('li[aria-posinset="1"].is-selected')).isPresent()).toBeTruthy();
+    expect(await element(by.css('li[aria-posinset="1"][aria-selected="true"]'))).toBeTruthy();
+    expect(await element(by.css('li[aria-posinset="3"].is-selected')).isPresent()).toBeTruthy();
+    expect(await element(by.css('li[aria-posinset="3"][aria-selected="true"]')).isPresent()).toBeTruthy();
+    expect(await element(by.className('selection-count')).getText()).toEqual('2 Selected');
+  });
+
+  it('Should tab into, arrow key down over disabled item, and select each item on space key, ', async () => {
+    const listviewEl = await element(by.id('multiselect-listview'));
+    await listviewEl.sendKeys(protractor.Key.TAB);
+    const listviewItemElOne = await element(by.css('li[aria-posinset="1"]'));
+    await listviewItemElOne.sendKeys(protractor.Key.SPACE);
+    await browser.driver.sleep(config.sleep);
+    await listviewItemElOne.sendKeys(protractor.Key.ARROW_DOWN);
+
+    expect(await element(by.css('li[aria-posinset="1"][tabindex="0"]'))).toBeTruthy();
+    await listviewEl.sendKeys(protractor.Key.SPACE);
+    const listviewItemElThree = await element(by.css('li[aria-posinset="3"]'));
+    await listviewItemElThree.sendKeys(protractor.Key.SPACE);
+
+    expect(await element(by.css('li[aria-posinset="1"].is-selected')).isPresent()).toBeTruthy();
+    expect(await element(by.css('li[aria-posinset="1"][aria-selected="true"]')).isPresent()).toBeTruthy();
+    expect(await element(by.css('li[aria-posinset="3"].is-selected')).isPresent()).toBeTruthy();
+    expect(await element(by.className('selection-count')).getText()).toEqual('2 Selected');
+  });
+});
+
+describe('Listview example-mixed selection light theme tests', () => {
+  beforeEach(async () => {
+    await browser.waitForAngularEnabled(false);
+    await browser.driver.get('http://localhost:4000/components/listview/example-mixed-selection');
+    const listviewEl = await element(by.id('task-listview'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(listviewEl), config.waitsFor);
+  });
+
+  if (!utils.isIE()) {
+    xit('Should be accessible on init with no WCAG 2AA violations on example-mixed selection page', async () => {
+      await browser.driver.sleep(config.sleep);
+      const res = await AxeBuilder(browser.driver)
+        .configure(axeOptions)
+        .exclude('header')
+        .analyze();
+
+      expect(res.violations.length).toEqual(0);
+    });
+  }
+
+  it('Should select item on click on checkbox', async () => {
+    const listviewItemInputEl = await element(by.css('li[aria-posinset="1"] .label-text'));
+    listviewItemInputEl.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.className('is-selected')).isPresent()).toBeTruthy();
+    expect(await element(by.css('li[aria-selected="true"]'))).toBeTruthy();
+  });
+
+  it('Should deselect item on click on checkbox', async () => {
+    const listviewItemInputEl = await element(by.css('li[aria-posinset="1"] .label-text'));
+    listviewItemInputEl.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.className('is-selected'))).toBeTruthy();
+    expect(await element(by.css('li[aria-selected="true"]'))).toBeTruthy();
+
+    listviewItemInputEl.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('li[aria-selected="false"]'))).toBeTruthy();
+  });
+
+  it('Should two items on click', async () => {
+    const listviewItemElOne = await element(by.css('li[aria-posinset="1"] .label-text'));
+    const listviewItemElThree = await element(by.css('li[aria-posinset="3"] .label-text'));
+    await listviewItemElOne.click();
+    await browser.driver.sleep(config.sleep);
+    await listviewItemElThree.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('li[aria-posinset="1"].is-selected')).isPresent()).toBeTruthy();
+    expect(await element(by.css('li[aria-posinset="1"][aria-selected="true"]'))).toBeTruthy();
+    expect(await element(by.css('li[aria-posinset="3"].is-selected')).isPresent()).toBeTruthy();
+    expect(await element(by.css('li[aria-posinset="3"][aria-selected="true"]')).isPresent()).toBeTruthy();
+  });
+
+  it('Should activate element on click outside of checkbox', async () => {
+    const listviewItemElOne = await element(by.css('li[aria-posinset="1"]'));
+    await listviewItemElOne.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('li[aria-posinset="1"].is-activated')).isPresent()).toBeTruthy();
+    expect(await element(by.css('li[aria-posinset="1"][aria-selected="false"]'))).toBeTruthy();
+  });
+});
+
+describe('Listview example-search light theme tests', () => {
+  beforeEach(async () => {
+    await browser.waitForAngularEnabled(false);
+    await browser.driver.get('http://localhost:4000/components/listview/example-search');
+    const listviewEl = await element(by.id('search-listview'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(listviewEl), config.waitsFor);
+  });
+
+  if (!utils.isIE()) {
+    it('Should be accessible on init with no WCAG 2AA violations on example-search page', async () => {
+      await browser.driver.sleep(config.sleep);
+      const res = await AxeBuilder(browser.driver)
+        .configure(axeOptions)
+        .exclude('header')
+        .analyze();
+
+      expect(res.violations.length).toEqual(0);
+    });
+  }
+
+  xit('Should highlight search terms', async () => {
+    const searchListviewEl = await element(by.id('gridfilter'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(searchListviewEl), config.waitsFor);
+    await searchListviewEl.click();
+    await browser.driver.switchTo().activeElement().clear();
+    await browser.driver.switchTo().activeElement().sendKeys('co');
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('li[aria-posinset="1"] .highlight')).getText()).toEqual('co');
+    expect(await element(by.css('li[aria-posinset="1"] .highlight')).isPresent()).toBeTruthy();
+    expect(await element(by.css('li[aria-posinset="1"]')).isPresent()).toBeTruthy();
+  });
+});
+
+describe('Listview example-paging light theme tests', () => {
+  beforeEach(async () => {
+    await browser.waitForAngularEnabled(false);
+    await browser.driver.get('http://localhost:4000/components/listview/example-paging');
+    const listviewPagerEl = await element(by.css('.pager-toolbar.is-listview'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(listviewPagerEl), config.waitsFor);
+  });
+
+  if (!utils.isIE()) {
+    xit('Should be accessible on init with no WCAG 2AA violations on example-paging page', async () => {
+      await browser.driver.sleep(config.sleep);
+      const res = await AxeBuilder(browser.driver)
+        .configure(axeOptions)
+        .exclude('header')
+        .analyze();
+
+      expect(res.violations.length).toEqual(0);
+    });
+  }
+
+  it('Should click page "2" in pager bar, and display new listings', async () => {
+    const listviewPagerEl = await element.all(by.css('.pager-toolbar li')).get(2);
+    await listviewPagerEl.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('li[aria-posinset="4"] .listview-heading')).isDisplayed()).toBeTruthy();
+    expect(await element(by.css('li[aria-posinset="4"] .listview-heading')).getText()).toEqual('Maplewood St. Resurfacing');
+  });
+
+  it('Should click page next icon in pager bar, and display correct listings', async () => {
+    const listviewPagerNextEl = await element(by.css('.pager-next'));
+    await listviewPagerNextEl.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('li[aria-posinset="4"] .listview-heading')).isDisplayed()).toBeTruthy();
+    expect(await element(by.css('li[aria-posinset="4"] .listview-heading')).getText()).toEqual('Maplewood St. Resurfacing');
+  });
+
+  it('Should click page next two times, then prev once, and display correct listings', async () => {
+    const listviewPagerPrevEl = await element(by.css('.pager-prev'));
+    const listviewPagerNextEl = await element(by.css('.pager-next'));
+    await listviewPagerNextEl.click();
+    await listviewPagerNextEl.click();
+    await listviewPagerNextEl.click();
+    await listviewPagerPrevEl.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('li[aria-posinset="7"] .listview-heading')).isDisplayed()).toBeTruthy();
+    expect(await element(by.css('li[aria-posinset="7"] .listview-heading')).getText()).toEqual('Beechtree Dr. Resurfacing');
+  });
+});
+
+describe('Listview example-index light theme tests', () => {
+  beforeEach(async () => {
+    await browser.waitForAngularEnabled(false);
+    await browser.driver.get('http://localhost:4000/components/listview/example-index');
+    const listviewEl = await element(by.id('task-listview'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(listviewEl), config.waitsFor);
+  });
+
+  it('Should do nothing on a disabled item', async () => {
+    const listviewDisabledEl = await element(by.css('.is-disabled'));
+    await listviewDisabledEl.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.className('is-disabled')).getAttribute('disabled').isPresent()).toBeTruthy();
+  });
+});
+
+describe('Listview example-paging-clientside light theme tests', () => {
+  beforeEach(async () => {
+    await browser.waitForAngularEnabled(false);
+    await browser.driver.get('http://localhost:4000/components/listview/example-paging-clientside');
+    const listviewPagerEl = await element(by.css('.pager-toolbar.is-listview'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(listviewPagerEl), config.waitsFor);
+  });
+
+  if (!utils.isIE()) {
+    it('Should be accessible on init with no WCAG 2AA violations on example-paging-clientside page', async () => {
+      await browser.driver.sleep(config.sleep);
+      const res = await AxeBuilder(browser.driver)
+        .configure(axeOptions)
+        .exclude('header')
+        .analyze();
+
+      expect(res.violations.length).toEqual(0);
+    });
+  }
+
+  it('Should click page "2" in pager-clientside bar, and display new listings', async () => {
+    const listviewPagerEl = await element.all(by.css('.pager-toolbar li')).get(2);
+    listviewPagerEl.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('li[aria-posinset="12"] .listview-heading')).isDisplayed()).toBeTruthy();
+    expect(await element(by.css('li[aria-posinset="12"] .listview-heading')).getText()).toEqual('Maplewood St. Resurfacing');
+  });
+
+  it('Should click page next icon in pager-clientside bar, and display correct listings', async () => {
+    const listviewPagerNextEl = await element(by.css('.pager-next'));
+    listviewPagerNextEl.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('li[aria-posinset="12"] .listview-heading')).isDisplayed()).toBeTruthy();
+    expect(await element(by.css('li[aria-posinset="12"] .listview-heading')).getText()).toEqual('Maplewood St. Resurfacing');
+  });
+
+  it('Should click page next two times, then prev once, and display correct listingsi, clientside', async () => {
+    const listviewPagerPrevEl = await element(by.css('.pager-prev'));
+    const listviewPagerNextEl = await element(by.css('.pager-next'));
+    await listviewPagerNextEl.click();
+    await listviewPagerNextEl.click();
+    await listviewPagerPrevEl.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('li[aria-posinset="11"] .listview-heading')).isDisplayed()).toBeTruthy();
+    expect(await element(by.css('li[aria-posinset="11"] .listview-heading')).getText()).toEqual('Fort Woods Swimming Pool');
+  });
+});
+
+describe('Listview remove-clear light theme tests', () => {
+  beforeEach(async () => {
+    await browser.waitForAngularEnabled(false);
+    await browser.driver.get('http://localhost:4000/components/listview/remove-clear');
+    const listviewMultiSelectEl = await element(by.id('multiselect-listview'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(listviewMultiSelectEl), config.waitsFor);
+  });
+
+  if (!utils.isIE()) {
+    xit('Should be accessible on init with no WCAG 2AA violations on remove-clear page', async () => {
+      await browser.driver.sleep(config.sleep);
+      const res = await AxeBuilder(browser.driver)
+        .configure(axeOptions)
+        .exclude('header')
+        .analyze();
+
+      expect(res.violations.length).toEqual(0);
+    });
+  }
+
+  it('Should remove selected items, and update status pane', async () => {
+    const listviewItemElOne = await element(by.css('li[aria-posinset="1"]'));
+    const listviewItemElThree = await element(by.css('li[aria-posinset="3"]'));
+    const listviewItemElFour = await element(by.css('li[aria-posinset="4"]'));
+    const listviewRemove = await element(by.id('remove'));
+    await listviewItemElOne.click();
+    await listviewItemElThree.click();
+    await listviewItemElFour.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.className('status')).getText()).toEqual('3 of 12 items selected');
+    await listviewRemove.click();
+
+    expect(await element(by.className('msg')).getText()).toEqual('3 selected items removed');
+  });
+});
+
+describe('Listview example-header-totals` light theme tests', () => {
+  beforeEach(async () => {
+    await browser.waitForAngularEnabled(false);
+    await browser.driver.get('http://localhost:4000/components/listview/example-header-totals');
+    const listviewButtonToggleEl = await element(by.css('.listview-header button'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(listviewButtonToggleEl), config.waitsFor);
+  });
+
+  if (!utils.isIE()) {
+    it('Should be accessible on init with no WCAG 2AA violations on example-header-total', async () => {
+      await browser.driver.sleep(config.sleep);
+      const res = await AxeBuilder(browser.driver)
+        .configure(axeOptions)
+        .exclude('header')
+        .analyze();
+
+      expect(res.violations.length).toEqual(0);
+    });
+  }
+
+  it('Should toggle listview on listviewer-header button click', async () => {
+    const listviewButtonToggleEl = await element(by.css('.listview-header button'));
+    listviewButtonToggleEl.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.className('listview')).getCssValue('height')).toEqual('0px');
+  });
+});


### PR DESCRIPTION
Explain the **details** for making this change. What existing problem does the pull request solve?
Adds additional listview e2e light-theme tests, fixes some routes for data

**Related issue (required)**:
https://jira.infor.com/browse/SOHO-7901

**Steps necessary to review your pull request (required)**:
Pleas run:
```sh
env PROTRACTOR_SPECS='components/listview/listview-light-theme.e2e-spec.js' npx -n=--inspect-brk protractor test/protractor.conf.js
```

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Please run the above command, no errors at this time are expected. Failing tests have been skipped temporarily.

<!-- Make sure tests pass on Travis. -->

Other Details:

<!-- Please add `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if exists). -->
