### PR TITLE
SOHO-7856 added spaces for the focus to be display properly

### DIFF
--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -70,9 +70,22 @@
         width: 400px;
       }
     }
+
+    &:first-child .audible ~ input:not(.spinbox):not(.colorpicker),
+    &:first-child .audible ~ .searchfield-wrapper {
+      margin-top: 4px;
+    }
+
+    &:first-child .checkbox-label {
+      margin-top: 2px;
+    }
+
+    &:last-child .checkbox-label {
+      margin-bottom: 1px;
+    }
   }
 
-  .field:last-child input:not(.spinbox):not(.colorpicker),
+  .field:last-child input:not(.spinbox):not(.colorpicker):not(.searchfield),
   .field:last-child .dropdown,
   .field:last-child textarea,
   .field:last-child .spinbox-wrapper,


### PR DESCRIPTION
Provide a margin only to first-child input elements like input field and checkbox preceded by a label with a class name audio. This will directly solved the focus cut-off issue.

**Related issue (required)**:
This will also solved the focus issue of the search field inside the modal component.
http://localhost:4000/components/modal/test-required-fields


**Steps necessary to review your pull request (required)**:
Open this test page once fixed have been merge.
http://localhost:4000/components/modal/test-focus-box-shadow-cut

