### PR TITLE
Soho 7901 / Soho-7932 typeahead delay re-implementation / filtering improvements

### DIFF
--- a/app/views/components/dropdown/example-no-search-filtering.html
+++ b/app/views/components/dropdown/example-no-search-filtering.html
@@ -1,0 +1,126 @@
+<div class="row">
+  <div class="six columns">
+    <h2>Dropdown Test: No Searching/Filtering Numbers</h2>
+    <p>Related JIRA: <a class="hyperlink" href="https://jira.infor.com/browse/SOHO-7901" target="_blank">SOHO-7901</a></p>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+    <div class="field">
+      <label for="nosearch-dropdown">No-Search Dropdown</label>
+      <select id="nosearch-dropdown" class="dropdown" data-options="{noSearch: true}">
+        <option value="">&nbsp;</option>
+        <option value="01">01</option>
+        <option value="02">02</option>
+        <option value="03">03</option>
+        <option value="04">04</option>
+        <option value="05">05</option>
+        <option value="06">06</option>
+        <option value="07">07</option>
+        <option value="08">08</option>
+        <option value="09">09</option>
+        <option value="10">10</option>
+        <option value="11">11</option>
+        <option value="12">12</option>
+        <option value="13">13</option>
+        <option value="14">14</option>
+        <option value="15">15</option>
+        <option value="16">16</option>
+        <option value="17">17</option>
+        <option value="18">18</option>
+        <option value="19">19</option>
+        <option value="20">20</option>
+        <option value="21">21</option>
+        <option value="22">22</option>
+        <option value="23">23</option>
+        <option value="24">24</option>
+        <option value="25">25</option>
+        <option value="26">26</option>
+        <option value="27">27</option>
+        <option value="28">28</option>
+        <option value="29">29</option>
+        <option value="30">30</option>
+        <option value="31">31</option>
+        <option value="32">32</option>
+        <option value="33">33</option>
+        <option value="34">34</option>
+        <option value="35">35</option>
+        <option value="36">36</option>
+        <option value="37">37</option>
+        <option value="38">38</option>
+        <option value="39">39</option>
+        <option value="40">40</option>
+        <option value="41">41</option>
+        <option value="42">42</option>
+        <option value="43">43</option>
+        <option value="44">44</option>
+        <option value="45">45</option>
+        <option value="46">46</option>
+        <option value="47">47</option>
+        <option value="48">48</option>
+        <option value="49">49</option>
+        <option value="50">50</option>
+
+        <option value="51">51</option>
+        <option value="52">52</option>
+        <option value="53">53</option>
+        <option value="54">54</option>
+        <option value="55">55</option>
+        <option value="56">56</option>
+        <option value="57">57</option>
+        <option value="58">58</option>
+        <option value="59">59</option>
+        <option value="60">60</option>
+        <option value="61">61</option>
+        <option value="62">62</option>
+        <option value="63">63</option>
+        <option value="64">64</option>
+        <option value="65">65</option>
+        <option value="66">66</option>
+        <option value="67">67</option>
+        <option value="68">68</option>
+        <option value="69">69</option>
+        <option value="70">70</option>
+        <option value="71">71</option>
+        <option value="72">72</option>
+        <option value="73">73</option>
+        <option value="74">74</option>
+        <option value="75">75</option>
+        <option value="76">76</option>
+        <option value="77">77</option>
+        <option value="78">78</option>
+        <option value="79">79</option>
+        <option value="80">80</option>
+        <option value="81">81</option>
+        <option value="82">82</option>
+        <option value="83">83</option>
+        <option value="84">84</option>
+        <option value="85">85</option>
+        <option value="86">86</option>
+        <option value="87">87</option>
+        <option value="88">88</option>
+        <option value="89">89</option>
+        <option value="90">90</option>
+        <option value="91">91</option>
+        <option value="92">92</option>
+        <option value="93">93</option>
+        <option value="94">94</option>
+        <option value="95">95</option>
+        <option value="96">96</option>
+        <option value="97">97</option>
+        <option value="98">98</option>
+        <option value="99">99</option>
+        <option value="100">100</option>
+        <option value="101">101</option>
+        <option value="102">102</option>
+      </select>
+    </div>
+  </div>
+</div>
+
+<script>
+  $('#nosearch-dropdown').on('change', function () {
+    console.log($(this).val());
+  });
+</script>

--- a/app/views/components/dropdown/example-no-search-lsf.html
+++ b/app/views/components/dropdown/example-no-search-lsf.html
@@ -18,6 +18,7 @@
     <div class="field">
       <label for="nosearch-dropdown">No-Search Dropdown</label>
       <select id="nosearch-dropdown" class="dropdown" data-options="{noSearch: true}">
+        <option value="">&nbsp;</option>
         <option value="1">1</option>
         <option value="2">2</option>
         <option value="3">3</option>

--- a/app/views/components/dropdown/example-no-search.html
+++ b/app/views/components/dropdown/example-no-search.html
@@ -18,6 +18,7 @@
     <div class="field">
       <label for="nosearch-dropdown">No-Search Dropdown</label>
       <select id="nosearch-dropdown" class="dropdown" data-options="{noSearch: true}">
+        <option value="">&nbsp;</option>
         <option value="1">One</option>
         <option value="2">Two</option>
         <option value="3">Three</option>

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1198,12 +1198,12 @@ Dropdown.prototype = {
     self.initialFilter = true;
     self.filterTerm += e.key;
 
-    if (self.settings.noSearch) {
-      self.selectStartsWith(self.filterTerm);
-      return;
-    }
-
     this.timer = setTimeout(() => {
+      if (self.settings.noSearch) {
+        self.selectStartsWith(self.filterTerm);
+        return;
+      }
+
       if (!self.isOpen()) {
         self.searchInput.val(self.filterTerm);
         self.toggleList();

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -988,7 +988,8 @@ Dropdown.prototype = {
 
     if (blank.length > 0) {
       blank[0].selected = true;
-      this.element.triggerHandler('updated').triggerHandler('change');
+      this.element.triggerHandler('updated');
+      this.element.triggerHandler('change');
     }
   },
 

--- a/test/components/dropdown/dropdown-light-theme.e2e-spec.js
+++ b/test/components/dropdown/dropdown-light-theme.e2e-spec.js
@@ -7,6 +7,8 @@ const config = requireHelper('e2e-config');
 requireHelper('rejection');
 const axeOptions = { rules };
 
+const NONBREAKING_SPACE = '\u00A0';
+
 jasmine.getEnv().addReporter(browserStackErrorReporter);
 
 const clickOnDropdown = async () => {
@@ -213,6 +215,28 @@ describe('Dropdown No-Search Mode Tests', () => {
     await browser.driver.sleep(config.sleep);
 
     expect(dropdownPseudoEl.getText()).toEqual('56');
+
+    dropdownPseudoEl = null;
+  });
+
+  it('should clear a previous dropdown selection when pressing DELETE', async () => {
+    await browser.waitForAngularEnabled(false);
+    await browser.driver.get('http://localhost:4000/components/dropdown/example-no-search-filtering');
+
+    let dropdownPseudoEl = await element(by.css('div[aria-controls="dropdown-list"]'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
+
+    await dropdownPseudoEl.click();
+    await dropdownPseudoEl.sendKeys('15');
+    await browser.driver.sleep(config.sleep);
+
+    expect(dropdownPseudoEl.getText()).toEqual('15');
+
+    await dropdownPseudoEl.sendKeys(protractor.Key.DELETE);
+    await browser.driver.sleep(config.sleep);
+
+    expect(dropdownPseudoEl.getText()).toEqual(NONBREAKING_SPACE);
 
     dropdownPseudoEl = null;
   });

--- a/test/components/dropdown/dropdown-light-theme.e2e-spec.js
+++ b/test/components/dropdown/dropdown-light-theme.e2e-spec.js
@@ -131,19 +131,89 @@ describe('Dropdown example-ajax tests', () => {
 });
 
 describe('Dropdown No-Search Mode Tests', () => {
-  beforeEach(async () => {
+  it('should select a Dropdown item when keying on a closed Dropdown component', async () => {
     await browser.waitForAngularEnabled(false);
     await browser.driver.get('http://localhost:4000/components/dropdown/example-no-search-lsf');
-  });
 
-  it('should select a Dropdown item when keying on a closed Dropdown component', async () => {
-    const dropdownPseudoEl = await element(by.css('div[aria-controls="dropdown-list"]'));
+    let dropdownPseudoEl = await element(by.css('div[aria-controls="dropdown-list"]'));
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
     await dropdownPseudoEl.click();
     await dropdownPseudoEl.sendKeys('r');
+    await browser.driver.sleep(config.sleep);
 
     expect(dropdownPseudoEl.getText()).toEqual('R - Rocket Raccoon');
+
+    dropdownPseudoEl = null;
+  });
+
+  it('should cycle through dropdown options that begin with the same character', async () => {
+    await browser.waitForAngularEnabled(false);
+    await browser.driver.get('http://localhost:4000/components/dropdown/example-no-search-lsf');
+
+    let dropdownPseudoEl = await element(by.css('div[aria-controls="dropdown-list"]'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
+
+    await dropdownPseudoEl.click();
+    await dropdownPseudoEl.sendKeys('t');
+    await browser.driver.sleep(config.sleep);
+
+    expect(dropdownPseudoEl.getText()).toEqual('T - Thor');
+
+    await dropdownPseudoEl.sendKeys('t');
+    await browser.driver.sleep(config.sleep);
+
+    expect(dropdownPseudoEl.getText()).toEqual('T2 - Thanos');
+
+    await dropdownPseudoEl.sendKeys('t');
+    await browser.driver.sleep(config.sleep);
+
+    expect(dropdownPseudoEl.getText()).toEqual('T3 - That other one that won\'t get selected');
+
+    await dropdownPseudoEl.sendKeys('t');
+    await browser.driver.sleep(config.sleep);
+
+    expect(dropdownPseudoEl.getText()).toEqual('T - Thor');
+
+    dropdownPseudoEl = null;
+  });
+
+  it('should properly filter when multiple characters are typed ahead', async () => {
+    await browser.waitForAngularEnabled(false);
+    await browser.driver.get('http://localhost:4000/components/dropdown/example-no-search-filtering');
+
+    let dropdownPseudoEl = await element(by.css('div[aria-controls="dropdown-list"]'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
+
+    await dropdownPseudoEl.click();
+    await dropdownPseudoEl.sendKeys('15');
+    await browser.driver.sleep(config.sleep);
+
+    expect(dropdownPseudoEl.getText()).toEqual('15');
+
+    await dropdownPseudoEl.sendKeys('1');
+    await browser.driver.sleep(config.sleep);
+
+    expect(dropdownPseudoEl.getText()).toEqual('10');
+
+    await dropdownPseudoEl.sendKeys('1');
+    await browser.driver.sleep(config.sleep);
+
+    expect(dropdownPseudoEl.getText()).toEqual('11');
+
+    await dropdownPseudoEl.sendKeys('101');
+    await browser.driver.sleep(config.sleep);
+
+    expect(dropdownPseudoEl.getText()).toEqual('101');
+
+    await dropdownPseudoEl.sendKeys('56');
+    await browser.driver.sleep(config.sleep);
+
+    expect(dropdownPseudoEl.getText()).toEqual('56');
+
+    dropdownPseudoEl = null;
   });
 });

--- a/test/components/dropdown/dropdown-light-theme.e2e-spec.js
+++ b/test/components/dropdown/dropdown-light-theme.e2e-spec.js
@@ -17,6 +17,7 @@ const clickOnDropdown = async () => {
   await dropdownEl.click();
 };
 
+/*
 describe('Dropdown example-index tests', () => {
   beforeEach(async () => {
     await browser.waitForAngularEnabled(false);
@@ -131,13 +132,14 @@ describe('Dropdown example-ajax tests', () => {
     });
   }
 });
+*/
 
 describe('Dropdown No-Search Mode Tests', () => {
   it('should select a Dropdown item when keying on a closed Dropdown component', async () => {
     await browser.waitForAngularEnabled(false);
     await browser.driver.get('http://localhost:4000/components/dropdown/example-no-search-lsf');
 
-    let dropdownPseudoEl = await element(by.css('div[aria-controls="dropdown-list"]'));
+    let dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
@@ -145,99 +147,128 @@ describe('Dropdown No-Search Mode Tests', () => {
     await dropdownPseudoEl.sendKeys('r');
     await browser.driver.sleep(config.sleep);
 
-    expect(dropdownPseudoEl.getText()).toEqual('R - Rocket Raccoon');
+    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
-    dropdownPseudoEl = null;
+    expect(dropdownPseudoEl.getText()).toEqual('R - Rocket Raccoon');
   });
 
   it('should cycle through dropdown options that begin with the same character', async () => {
     await browser.waitForAngularEnabled(false);
     await browser.driver.get('http://localhost:4000/components/dropdown/example-no-search-lsf');
 
-    let dropdownPseudoEl = await element(by.css('div[aria-controls="dropdown-list"]'));
+    let dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
     await dropdownPseudoEl.click();
     await dropdownPseudoEl.sendKeys('t');
     await browser.driver.sleep(config.sleep);
+    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
     expect(dropdownPseudoEl.getText()).toEqual('T - Thor');
 
     await dropdownPseudoEl.sendKeys('t');
     await browser.driver.sleep(config.sleep);
+    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
     expect(dropdownPseudoEl.getText()).toEqual('T2 - Thanos');
 
     await dropdownPseudoEl.sendKeys('t');
     await browser.driver.sleep(config.sleep);
+    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
     expect(dropdownPseudoEl.getText()).toEqual('T3 - That other one that won\'t get selected');
 
     await dropdownPseudoEl.sendKeys('t');
     await browser.driver.sleep(config.sleep);
+    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
     expect(dropdownPseudoEl.getText()).toEqual('T - Thor');
-
-    dropdownPseudoEl = null;
   });
 
   it('should properly filter when multiple characters are typed ahead', async () => {
     await browser.waitForAngularEnabled(false);
     await browser.driver.get('http://localhost:4000/components/dropdown/example-no-search-filtering');
 
-    let dropdownPseudoEl = await element(by.css('div[aria-controls="dropdown-list"]'));
+    let dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
     await dropdownPseudoEl.click();
     await dropdownPseudoEl.sendKeys('15');
     await browser.driver.sleep(config.sleep);
+    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
     expect(dropdownPseudoEl.getText()).toEqual('15');
 
     await dropdownPseudoEl.sendKeys('1');
     await browser.driver.sleep(config.sleep);
+    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
     expect(dropdownPseudoEl.getText()).toEqual('10');
 
     await dropdownPseudoEl.sendKeys('1');
     await browser.driver.sleep(config.sleep);
+    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
     expect(dropdownPseudoEl.getText()).toEqual('11');
 
     await dropdownPseudoEl.sendKeys('101');
     await browser.driver.sleep(config.sleep);
+    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
     expect(dropdownPseudoEl.getText()).toEqual('101');
 
     await dropdownPseudoEl.sendKeys('56');
     await browser.driver.sleep(config.sleep);
+    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
     expect(dropdownPseudoEl.getText()).toEqual('56');
-
-    dropdownPseudoEl = null;
   });
 
   it('should clear a previous dropdown selection when pressing DELETE', async () => {
     await browser.waitForAngularEnabled(false);
     await browser.driver.get('http://localhost:4000/components/dropdown/example-no-search-filtering');
 
-    let dropdownPseudoEl = await element(by.css('div[aria-controls="dropdown-list"]'));
+    let dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
     await dropdownPseudoEl.click();
     await dropdownPseudoEl.sendKeys('15');
     await browser.driver.sleep(config.sleep);
+    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
     expect(dropdownPseudoEl.getText()).toEqual('15');
 
     await dropdownPseudoEl.sendKeys(protractor.Key.DELETE);
     await browser.driver.sleep(config.sleep);
+    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
     expect(dropdownPseudoEl.getText()).toEqual(NONBREAKING_SPACE);
-
-    dropdownPseudoEl = null;
   });
 });

--- a/test/components/dropdown/dropdown-light-theme.e2e-spec.js
+++ b/test/components/dropdown/dropdown-light-theme.e2e-spec.js
@@ -7,8 +7,6 @@ const config = requireHelper('e2e-config');
 requireHelper('rejection');
 const axeOptions = { rules };
 
-const NONBREAKING_SPACE = '\u00A0';
-
 jasmine.getEnv().addReporter(browserStackErrorReporter);
 
 const clickOnDropdown = async () => {
@@ -17,7 +15,6 @@ const clickOnDropdown = async () => {
   await dropdownEl.click();
 };
 
-/*
 describe('Dropdown example-index tests', () => {
   beforeEach(async () => {
     await browser.waitForAngularEnabled(false);
@@ -132,14 +129,13 @@ describe('Dropdown example-ajax tests', () => {
     });
   }
 });
-*/
 
 describe('Dropdown No-Search Mode Tests', () => {
   it('should select a Dropdown item when keying on a closed Dropdown component', async () => {
     await browser.waitForAngularEnabled(false);
     await browser.driver.get('http://localhost:4000/components/dropdown/example-no-search-lsf');
 
-    let dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
+    const dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
@@ -147,128 +143,91 @@ describe('Dropdown No-Search Mode Tests', () => {
     await dropdownPseudoEl.sendKeys('r');
     await browser.driver.sleep(config.sleep);
 
-    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
-    await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
-
-    expect(dropdownPseudoEl.getText()).toEqual('R - Rocket Raccoon');
+    expect(await element.all(by.css('div[aria-controls="dropdown-list"]')).first().getText()).toEqual('R - Rocket Raccoon');
   });
 
   it('should cycle through dropdown options that begin with the same character', async () => {
     await browser.waitForAngularEnabled(false);
     await browser.driver.get('http://localhost:4000/components/dropdown/example-no-search-lsf');
 
-    let dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
+    const dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
     await dropdownPseudoEl.click();
     await dropdownPseudoEl.sendKeys('t');
     await browser.driver.sleep(config.sleep);
-    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
-    await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
-    expect(dropdownPseudoEl.getText()).toEqual('T - Thor');
+    expect(await element.all(by.css('div[aria-controls="dropdown-list"]')).first().getText()).toEqual('T - Thor');
 
     await dropdownPseudoEl.sendKeys('t');
     await browser.driver.sleep(config.sleep);
-    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
-    await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
-    expect(dropdownPseudoEl.getText()).toEqual('T2 - Thanos');
+    expect(await element.all(by.css('div[aria-controls="dropdown-list"]')).first().getText()).toEqual('T2 - Thanos');
 
     await dropdownPseudoEl.sendKeys('t');
     await browser.driver.sleep(config.sleep);
-    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
-    await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
-    expect(dropdownPseudoEl.getText()).toEqual('T3 - That other one that won\'t get selected');
+    expect(await element.all(by.css('div[aria-controls="dropdown-list"]')).first().getText()).toEqual('T3 - That other one that won\'t get selected');
 
     await dropdownPseudoEl.sendKeys('t');
     await browser.driver.sleep(config.sleep);
-    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
-    await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
-    expect(dropdownPseudoEl.getText()).toEqual('T - Thor');
+    expect(await element.all(by.css('div[aria-controls="dropdown-list"]')).first().getText()).toEqual('T - Thor');
   });
 
   it('should properly filter when multiple characters are typed ahead', async () => {
     await browser.waitForAngularEnabled(false);
     await browser.driver.get('http://localhost:4000/components/dropdown/example-no-search-filtering');
 
-    let dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
+    const dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
     await dropdownPseudoEl.click();
     await dropdownPseudoEl.sendKeys('15');
     await browser.driver.sleep(config.sleep);
-    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
-    await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
-    expect(dropdownPseudoEl.getText()).toEqual('15');
+    expect(await element.all(by.css('div[aria-controls="dropdown-list"]')).first().getText()).toEqual('15');
 
     await dropdownPseudoEl.sendKeys('1');
     await browser.driver.sleep(config.sleep);
-    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
-    await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
-    expect(dropdownPseudoEl.getText()).toEqual('10');
+    expect(await element.all(by.css('div[aria-controls="dropdown-list"]')).first().getText()).toEqual('10');
 
     await dropdownPseudoEl.sendKeys('1');
     await browser.driver.sleep(config.sleep);
-    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
-    await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
-    expect(dropdownPseudoEl.getText()).toEqual('11');
+    expect(await element.all(by.css('div[aria-controls="dropdown-list"]')).first().getText()).toEqual('11');
 
     await dropdownPseudoEl.sendKeys('101');
     await browser.driver.sleep(config.sleep);
-    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
-    await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
-    expect(dropdownPseudoEl.getText()).toEqual('101');
+    expect(await element.all(by.css('div[aria-controls="dropdown-list"]')).first().getText()).toEqual('101');
 
     await dropdownPseudoEl.sendKeys('56');
     await browser.driver.sleep(config.sleep);
-    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
-    await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
-    expect(dropdownPseudoEl.getText()).toEqual('56');
+    expect(await element.all(by.css('div[aria-controls="dropdown-list"]')).first().getText()).toEqual('56');
   });
 
   it('should clear a previous dropdown selection when pressing DELETE', async () => {
     await browser.waitForAngularEnabled(false);
     await browser.driver.get('http://localhost:4000/components/dropdown/example-no-search-filtering');
 
-    let dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
+    const dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
     await dropdownPseudoEl.click();
     await dropdownPseudoEl.sendKeys('15');
     await browser.driver.sleep(config.sleep);
-    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
-    await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
-    expect(dropdownPseudoEl.getText()).toEqual('15');
+    expect(await element.all(by.css('div[aria-controls="dropdown-list"]')).first().getText()).toEqual('15');
 
     await dropdownPseudoEl.sendKeys(protractor.Key.DELETE);
     await browser.driver.sleep(config.sleep);
-    dropdownPseudoEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).first();
-    await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(dropdownPseudoEl), config.waitsFor);
 
-    expect(dropdownPseudoEl.getText()).toEqual(NONBREAKING_SPACE);
+    expect(await element.all(by.css('div[aria-controls="dropdown-list"]')).first().getText()).toEqual(' ');
   });
 });


### PR DESCRIPTION
Explain the **details** for making this change. What existing problem does the pull request solve?

Previous changes related to SOHO-7901 caused some filtering functionality on un-opened Dropdown components to disappear.  This PR re-enables them while keeping the changes related to cycling through results that share a common first character.  See the comments from Duncan on https://jira.infor.com/browse/SOHO-7901?focusedCommentId=4476991&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4476991

Also, it was discovered by the LSF team that at some point in 4.6.0, another dropdown change is causing SOHO-7932, where pressing the "DELETE" (not Mac's equivalent of Backspace) would throw JS errors, when it should simply be clearing the selected Dropdown option and resetting to blank.
 
**Related issue (required)**:

https://jira.infor.com/browse/SOHO-7901
https://jira.infor.com/browse/SOHO-7932

**Steps necessary to review your pull request (required)**:

Run the demoapp and see:
- http://localhost:4000/components/dropdown/example-no-search
- http://localhost:4000/components/dropdown/example-no-search-lsf
- http://localhost:4000/components/dropdown/example-no-search-filtering

Also, new Dropdown e2e tests are included that test the original issue, and the fix.

**Other Details**:
- closes SOHO-7901
- closes SOHO-7932