### PR TITLE
SOHO-7935 Add findRowsByValue to datagrid control

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5806,7 +5806,10 @@ Datagrid.prototype = {
   },
 
   /**
-   * Returns an array of row numbers for the rows containing the value for the field name.
+   * Returns an array of row numbers for the rows containing the value for the specified field.
+   * @param  {string} fieldName The field name to search.
+   * @param  {any} value The value to use in search.
+   * @returns {array} an array of row numbers.
    */
   findRowsByValue(fieldName, value) {
     const s = this.settings;

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5805,6 +5805,33 @@ Datagrid.prototype = {
     return selectedRows;
   },
 
+  /**
+   * Returns an array of row numbers for the rows containing the value for the field name.
+   */
+  findRowsByValue(fieldName, value) {
+    const s = this.settings;
+    const dataset = s.treeGrid ? s.treeDepth : s.dataset;
+    let idx = -1;
+    const matchedRows = [];
+    for (let i = 0, data; i < dataset.length; i++) {
+      if (s.groupable) {
+        for (let k = 0; k < dataset[i].values.length; k++) {
+          idx++;
+          data = dataset[i].values[k];
+          if (data[fieldName] === value) {
+            matchedRows.push(idx); 
+          }
+        }
+      } else {
+        data = s.treeGrid ? dataset[i].node : dataset[i];
+        if (data[fieldName] === value) {
+          matchedRows.push(i); 
+        }
+      }
+    }
+    return matchedRows;
+  },
+
   // Set the row status
   rowStatus(idx, status, tooltip) {
     if (!status) {


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?
current datagrid control does not provide a function for find rows by field value.  this delivery add such function to  datagrid control.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
sometimes, we need find rows numbers based on a row's field name, for example, we need find a row based on a row's unique id, sometimes, such id is internal, so we could not find it by going through all cells, also, performance is another consideration.

> **Related issue (required)**:
SOHO-7935 Add findRowsByValue to datagrid control

<!-- Provide a link to the related issue to this Pull Request. ***Please do not open a PR without a related issue.*** -->

> **Steps necessary to review your pull request (required)**:
the logic is similar to the existing function selectedRows(), which selectedRows checks row's selection status, this function checks value of the field of data for rows.

<!-- What does someone need to do to confirm that this PR is ready to merge? Please include the exact commands you ran and their output, screenshots / videos if the pull request changes UI. You can skip this if you're fixing a typo or the change is very obvious in the diff. -->

> Other Details:
n/a
<!-- Please add `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if exists). -->

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
