### PR TITLE
SOHO-7942 - Better handling of "empty" popupmenu items.

### DIFF
--- a/app/views/components/popupmenu/test-empty-items.html
+++ b/app/views/components/popupmenu/test-empty-items.html
@@ -1,0 +1,46 @@
+<div class="row">
+  <div class="six columns">
+    <h2>Popupmenu Test: Empty Items</h2>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="six columns">
+
+    <div class="field">
+      <button type="button" id="single-check" class="btn-primary btn-menu">
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use xlink:href="#icon-settings"></use>
+        </svg>
+        <span>This Has Empty Items</span>
+      </button>
+      <ul class="popupmenu is-selectable">
+        <li class="is-checked">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-delete"></use>
+          </svg>
+          <a href="#"></a>
+        </li>
+        <li>
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-settings"></use>
+          </svg>
+          <a href="#"></a>
+        </li>
+        <li>
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-mail"></use>
+          </svg>
+          <a href="#"></a>
+        </li>
+        <li>
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-print"></use>
+          </svg>
+          <a href="#"></a>
+        </li>
+      </ul>
+    </div>
+
+  </div>
+</div>

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -414,8 +414,6 @@ a.btn-menu {
 
 .btn-tertiary,
 .btn-menu {
-  padding: 0 10px;
-
   // Dark Ui on Light UI
   &.inverse {
     color: $tertiary-btn-dark-color;
@@ -436,6 +434,18 @@ a.btn-menu {
   }
 }
 
+.btn-tertiary {
+  padding: 0 10px;
+}
+
+.btn-menu {
+  padding: 0 10px;
+
+  &.btn-primary,
+  &.btn-secondary {
+    padding-right: 20px;
+  }
+}
 
 // Icon Buttons
 // Also see ./_icons.scss
@@ -711,6 +721,14 @@ html[dir='rtl'] {
           margin-right: 0;
         }
       }
+    }
+  }
+
+  .btn-menu {
+    &.btn-primary,
+    &.btn-secondary {
+      padding-left: 20px;
+      padding-right: 10px;
     }
   }
 }

--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -258,6 +258,7 @@
     color: $popupmenu-color;
     display: block;
     line-height: 32px;
+    min-height: 34px;
     padding: 0 30px 0 10px;
     position: relative;
     text-decoration: none;


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

In some cases where popupmenu items are rendered without a visible text label, the menu item would not have a computed height, causing any icons included in that item to appear to "stack" on top of other items.  This change allows "empty" items to render with a minimum height.

> **Related issue (required)**:

https://jira.infor.com/browse/SOHO-7942

> **Steps necessary to review your pull request (required)**:

Run the demoapp and navigate to http://localhost:4000/components/popupmenu/test-empty-items.html.
- Open the popupmenu
- Confirm that all items present are empty (except for the icons), but stacking properly.

> Other Details:

Closes SOHO-7942

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
