### PR TITLE
Set master branch version back to 4.7.0-dev

### DIFF
--- a/publish/package.json
+++ b/publish/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ids-enterprise",
   "slug": "ids-enterprise",
-  "version": "4.7.0-dev.20180511",
+  "version": "4.7.0-dev",
   "description": "Infor Design System (IDS) Enterprise Components for the web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The master branch version should reflect what we are working on. In this case we are working on `4.7.0-dev`.

When we do special or nightly npm releases, those will get tagged/versioned outside of source control and published as snapshots in time with the date appended:
i.e. `4.7.0-dev.YYYYMMDD`.