### PR TITLE
Kick off Jenkins deploy on merge to master

### DIFF
--- a/scripts/jenkins-deploy.sh
+++ b/scripts/jenkins-deploy.sh
@@ -1,5 +1,82 @@
 #!/bin/bash
 
-BRANCH=$1
+JENKINS_USER="jeeves"
+JENKINS_DOMAIN="hl-jenkins-dev.us-east-1.elasticbeanstalk.com"
+JENKINS_JOB="soho4-swarm-deploy"
+JENKINS_URL="http://$JENKINS_USER:$JENKINS_SECRET@$JENKINS_DOMAIN"
 
-echo "TEST DEPLOY SCRIPT FROM $BRANCH"
+if [ -z "$1" ]; then
+    BRANCH="master"
+else
+    BRANCH=$1
+fi
+
+if [[ -z $JENKINS_SECRET ]]; then echo "JENKINS_SECRET must be defined"; exit 1; fi
+if [[ -z $JENKINS_JOB_TOKEN ]]; then echo "JENKINS_JOB_TOKEN must be defined"; exit 1; fi
+if [[ -z $JENKINS_CRUMB_TOKEN ]]; then echo "JENKINS_CRUMB_TOKEN must be defined"; exit 1; fi
+
+check_status () {
+    job_status=$(curl -s $JENKINS_URL/job/$JENKINS_JOB/lastBuild/api/json | \
+        python -c "import sys, json; print json.load(sys.stdin)['result']")
+    echo $job_status
+}
+
+get_build_number () {
+    build_number=$(curl -s $JENKINS_URL/job/$JENKINS_JOB/lastBuild/api/json | \
+        python -c "import sys, json; print json.load(sys.stdin)['number']")
+    echo $build_number
+}
+
+CURRENT_JOB_STATUS=`check_status`
+
+if [[ "$CURRENT_JOB_STATUS" == "None" ]]; then
+    CURRENT_BUILD_NUMBER=`get_build_number`
+    echo "Job #$CURRENT_BUILD_NUMBER is already running. Aborting that job now..."
+    RESP=$(curl --write-out "%{http_code}\n" --silent --output /dev/null -X POST "$JENKINS_URL/job/$JENKINS_JOB/$CURRENT_BUILD_NUMBER/stop")
+    if [[ "$RESP" == "302" ]]; then
+        echo "Successfully aborted job #$CURRENT_BUILD_NUMBER"
+    else
+        exit 1
+        echo "ERROR: Request to Jenkins returned $RESP"
+    fi
+else
+    echo "Adding Jenkins build of $BRANCH branch to queue..."
+fi
+
+CRUMB=$(curl -s -X GET "$JENKINS_URL/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,%22:%22,//crumb)")
+RESP=$(curl --write-out "%{http_code}\n" --silent --output /dev/null -X POST -H "Jenkins-Crumb:$JENKINS_CRUMB_TOKEN" "$JENKINS_URL/job/$JENKINS_JOB/buildWithParameters?CONTAINER=enterprise&GIT_BRANCH=$BRANCH&GIT_TAG=4.6.0&GIT_TAG_OR_BRANCH=branch&token=$JENKINS_JOB_TOKEN")
+
+if [[ "$RESP" == "201" ]]; then
+    echo "SUCCESS: Jenkins sucessfully queued job"
+else
+    exit 1
+    echo "ERROR: Request to Jenkins returned $RESP"
+fi
+
+INITIAL_STATUS=`check_status`
+if [ -n "initial_status" ]
+then
+    BUILD_STATUS=`check_status`
+    CURRENT_BUILD_NUMBER=`get_build_number`
+    echo -n "Watching build #$CURRENT_BUILD_NUMBER to report on status..."
+    while [[ "$BUILD_STATUS" == "None" ]]; do
+        sleep 10
+        echo -n "."
+        BUILD_STATUS=`check_status`
+    done
+    if [[ "$BUILD_STATUS" == "SUCCESS" ]]; then
+        echo "" # new line
+        echo "DEPLOY to http://$BRANCH-enterprise.demo.design.infor.com SUCCESSFUL."
+        exit
+    elif [[ "$BUILD_STATUS" == "ABORTED" ]]; then
+        echo "" # new line
+        echo "Build was $BUILD_STATUS. Exiting with 0 since this was likely intentional."
+        exit 0
+    else
+        echo "Build was ended with status: $BUILD_STATUS!"
+        exit 1
+    fi
+else
+  echo "BUILD FAILURE: Other build is unsuccessful or status could not be obtained."
+  exit 1
+fi


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

Travis kicks off this script here: https://github.com/infor-design/enterprise/blob/master/.travis.yml#L19-L21

1. Checks if a branch name is passed in, if not sets it to `master`
2. Checks that all necessary environment variables are set
    * If not, exits with code `1`
3. Checks to see if a build is already running.
    * If there is one, it kills that build. There's an edge case where this could unintentionally kill a desired build but this is built in because in many cases, where you're merging in subsequent PRs into master, the build that's in progress is outdated by the new merge so cancelling it and replacing it with the latest build is desirable
4. Initiates the build with Jenkins
    * Reports the status of the request and exits if it's not the expected `201` HTTP response
5. Initiates a loop to check the status of the build every 10s
    * If `SUCCESS`, you get the URL that you just deployed to and the script exits `0`
    * If `ABORTED`, the script will exit `0`, which will indicate to Travis NOT to break the build, since it was likely that this was aborted intentionally, like mentioned above where another build has a higher importance.
    * If any other status, the script will return the status and exit `1`, which will break the Travis build.

> **Steps necessary to review your pull request (required)**:

Message me directly if you'd like to test locally since private environment variables need to be stored to authenticate with the system.

> Other Details:

On a successful build, the logs look like this:

```
Adding Jenkins build of master branch to queue...
SUCCESS: Jenkins sucessfully queued job
Watching build #35 to report on status........................
DEPLOY to http://master-enterprise.demo.design.infor.com SUCCESSFUL.
```

On abort:

```
Adding Jenkins build of master branch to queue...
SUCCESS: Jenkins sucessfully queued job
Watching build #38 to report on status....
Build was ABORTED. Exiting with 0 since this was likely intentional.
```

When it kills a previous build:

```
Job #33 is already running. Aborting that job now...
Successfully aborted job #33
Adding Jenkins build of master branch to queue...
SUCCESS: Jenkins sucessfully queued job
Watching build #34 to report on status........................
DEPLOY to http://master-enterprise.demo.design.infor.com SUCCESSFUL.
```

