### PR TITLE
SOHO-7850 - Autocomplete/Searchfield tests for related Searchfield refactoring

### DIFF
--- a/app/data/autocomplete-users.json
+++ b/app/data/autocomplete-users.json
@@ -1,0 +1,27 @@
+[
+  {
+    "label": "John Smith",
+    "email": "John.Smith@example.com",
+    "value": "0"
+  },
+  {
+    "label": "Alex Mills",
+    "email": "Alex.Mills@example.com",
+    "value": "1"
+  },
+  {
+    "label": "Steve Mills",
+    "email": "Steve.Mills@example.com",
+    "value": "2"
+  },
+  {
+    "label": "Quincy Adams",
+    "email": "Quincy.Adams@example.com",
+    "value": "3"
+  },
+  {
+    "label": "Paul Thompson",
+    "email": "Paul.Thompson@example.com",
+    "value": "4"
+  }
+]

--- a/app/data/autocomplete-xss.json
+++ b/app/data/autocomplete-xss.json
@@ -1,0 +1,8 @@
+[
+  "1. Raw html i onmouseover <i onmouseover='alert()'>THIS</i>",
+  "2. Escaped html i onmouseover &lt;i onmouseover='alert()'&gt;THIS&lt;/i&gt;",
+  "3. Raw html span onmouseover <span onmouseover='alert()'>THIS</span>",
+  "4. Escaped html span onmouseover &lt;span onmouseover='alert()'&gt;THIS&lt;/span&gt;",
+  "5. Raw html svg onload <svg onload='alert()' />",
+  "6. Escaped html svg onload &lt;svg onload='alert()' /&gt;"
+]

--- a/app/views/components/autocomplete/example-contains.html
+++ b/app/views/components/autocomplete/example-contains.html
@@ -1,19 +1,14 @@
-
 <div class="row">
   <div class="twelve columns">
-
     <div class="field">
       <label for="autocomplete-default">States</label>
       <input type="text" autocomplete="off" class='autocomplete' data-options='{source: "{{basepath}}api/states?term=", filterMode: "contains"}' placeholder="Type to Search" id="autocomplete-default">
     </div>
-
   </div>
-
-  <script>
-    $('#autocomplete-default').on('selected', function (e, args) {
-      console.log(args.parent().attr('data-value'));
-    });
-  </script>
-
 </div>
 
+<script id="test-scripts">
+  $('#autocomplete-default').on('selected', function (e, args) {
+    console.log(args.parent().attr('data-value'));
+  });
+</script>

--- a/app/views/components/autocomplete/example-templates.html
+++ b/app/views/components/autocomplete/example-templates.html
@@ -1,18 +1,15 @@
+<div class="row">
+  <div class="twelve columns">
+    <h2 class="fieldset-title">Autocomplete Example: Alternate Templates</h2>
+  </div>
+</div>
 
 <div class="row">
   <div class="twelve columns">
-    <h2 class="fieldset-title">Autocomplete - for search and textbox</h2>
-
     <div class="field">
-      <label for="auto-default">#auto-default (autocomplete with stock settings)</label>
-      <input data-autocomplete="{{basepath}}api/states?term=" id="auto-default" class="autocomplete" placeholder="Type to Search" type="text" />
+      <label for="auto-template">Users</label>
+      <input class="autocomplete" data-autocomplete="source" data-init="false" data-tmpl="#autocomplete-template-email" id="auto-template" placeholder="Type to Search" type="text">
     </div>
-
-    <div class="field">
-      <label for="auto-template">#auto-template (uses an alternate source and external template)</label>
-      <input data-autocomplete="source" data-init="false" dataclass="autocomplete" data-tmpl="#autocomplete-template-email" id="auto-template" placeholder="Type to Search" type="text">
-    </div>
-
   </div>
 </div>
 
@@ -30,7 +27,7 @@
 </script>
 <%={{ }}=%>
 
-<script>
+<script id="test-scripts">
   $('body').on('initialized', function() {
 
   // Setup an alternate source for the templated Autocomplete.

--- a/app/views/components/autocomplete/test-xss-security.html
+++ b/app/views/components/autocomplete/test-xss-security.html
@@ -1,4 +1,3 @@
-
 <div class="row">
   <div class="twelve columns">
      <h2>Autocomplete Test: Script Injection Attacks</h2>

--- a/src/components/autocomplete/autocomplete.js
+++ b/src/components/autocomplete/autocomplete.js
@@ -161,12 +161,15 @@ Autocomplete.prototype = {
       this.settings.source = data;
     }
 
+    const listFilterSettings = {
+      filterMode: this.settings.filterMode,
+      highlightMatchedText: this.settings.highlightMatchedText,
+      searchableTextCallback: this.settings.searchableTextCallback
+    };
     if (!this.listFilter) {
-      this.listFilter = new ListFilter({
-        filterMode: this.settings.filterMode,
-        highlightMatchedText: this.settings.highlightMatchedText,
-        searchableTextCallback: this.settings.searchableTextCallback
-      });
+      this.listFilter = new ListFilter(listFilterSettings);
+    } else {
+      this.listFilter.updated(listFilterSettings);
     }
 
     this.addMarkup();

--- a/test/components/autocomplete/autocomplete-api.func-spec.js
+++ b/test/components/autocomplete/autocomplete-api.func-spec.js
@@ -1,0 +1,124 @@
+import { Autocomplete } from '../../../src/components/autocomplete/autocomplete';
+
+const svgHTML = require('../../../src/components/icons/svg.html');
+
+// For basic API
+const exampleHTML = require('../../../app/views/components/autocomplete/example-index.html');
+const statesData = require('../../../app/data/states-all.json');
+
+let autocompleteInputEl;
+let autocompleteLabelEl;
+let autocompleteAPI;
+let svgEl;
+
+describe('Autocomplete API', () => {
+  beforeEach(() => {
+    autocompleteInputEl = null;
+    autocompleteAPI = null;
+    svgEl = null;
+
+    document.body.insertAdjacentHTML('afterbegin', svgHTML);
+    document.body.insertAdjacentHTML('afterbegin', exampleHTML);
+
+    svgEl = document.body.querySelector('.svg-icons');
+    autocompleteLabelEl = document.body.querySelector('label[for="autocomplete-default"]');
+    autocompleteInputEl = document.body.querySelector('.autocomplete');
+    autocompleteInputEl.removeAttribute('data-options');
+    autocompleteInputEl.classList.add('no-init');
+
+    autocompleteAPI = new Autocomplete(autocompleteInputEl, {
+      source: statesData
+    });
+  });
+
+  afterEach(() => {
+    autocompleteAPI.destroy();
+    svgEl.parentNode.removeChild(svgEl);
+
+    const autocompleteListEl = document.querySelector('#autocomplete-list');
+    if (autocompleteListEl) {
+      autocompleteListEl.parentNode.removeChild(autocompleteListEl);
+    }
+    autocompleteLabelEl.parentNode.removeChild(autocompleteLabelEl);
+    autocompleteInputEl.parentNode.removeChild(autocompleteInputEl);
+  });
+
+  it('can be invoked', () => {
+    expect(autocompleteAPI).toEqual(jasmine.any(Object));
+  });
+
+  it('can be enabled/disabled', () => {
+    autocompleteAPI.disable();
+
+    expect(autocompleteInputEl.disabled).toBeTruthy();
+
+    autocompleteAPI.enable();
+
+    expect(autocompleteInputEl.disabled).toBeFalsy();
+  });
+
+  it('renders with proper ARIA attributes', () => {
+    expect(autocompleteInputEl.getAttribute('autocomplete')).toBe('off');
+    expect(autocompleteInputEl.getAttribute('role')).toBe('combobox');
+  });
+
+  it('can be updated with new settings', () => {
+    const newSettings = {
+      filterMode: 'contains',
+      delay: 500
+    };
+    autocompleteAPI.updated(newSettings);
+
+    expect(autocompleteAPI.settings.filterMode).toEqual(newSettings.filterMode);
+  });
+
+  it('can render a search result list', () => {
+    autocompleteAPI.openList('new', statesData);
+    const autocompleteListEl = document.querySelector('#autocomplete-list');
+
+    expect(autocompleteListEl).toBeDefined();
+
+    const resultItems = autocompleteListEl.querySelectorAll('li');
+
+    expect(resultItems).toBeDefined();
+    expect(resultItems.length).toEqual(4);
+  });
+
+  it('can change the search terms and re-render its list with new results', () => {
+    autocompleteAPI.openList('new', statesData);
+    const autocompleteListEl = document.querySelector('#autocomplete-list');
+
+    expect(autocompleteListEl).toBeDefined();
+
+    let resultItems = autocompleteListEl.querySelectorAll('li');
+
+    expect(resultItems).toBeDefined();
+    expect(resultItems.length).toEqual(4);
+    expect(resultItems[1].innerText.trim()).toEqual('New Jersey');
+
+    autocompleteAPI.openList('co', statesData);
+    resultItems = autocompleteListEl.querySelectorAll('li');
+
+    expect(resultItems.length).toEqual(3);
+    expect(resultItems[2].innerText.trim()).toEqual('District Of Columbia');
+  });
+
+  it('can programmatically highlight an available search result item', () => {
+    autocompleteAPI.openList('new', statesData);
+    const autocompleteListEl = document.querySelector('#autocomplete-list');
+    const resultItems = autocompleteListEl.querySelectorAll('li');
+    autocompleteAPI.highlight($(resultItems[2].querySelector('a')));
+
+    expect(resultItems[2].classList.contains('is-selected')).toBeTruthy();
+  });
+
+  it('can explain whether or not its list is open', () => {
+    autocompleteAPI.openList('new', statesData);
+
+    expect(autocompleteAPI.listIsOpen()).toBeTruthy();
+
+    autocompleteAPI.closeList();
+
+    expect(autocompleteAPI.listIsOpen()).toBeFalsy();
+  });
+});

--- a/test/components/autocomplete/autocomplete-events.func-spec.js
+++ b/test/components/autocomplete/autocomplete-events.func-spec.js
@@ -1,0 +1,72 @@
+import { Autocomplete } from '../../../src/components/autocomplete/autocomplete';
+
+const exampleHTML = require('../../../app/views/components/autocomplete/example-index.html');
+const svgHTML = require('../../../src/components/icons/svg.html');
+const data = require('../../../app/data/states-all.json');
+
+let autocompleteInputEl;
+let autocompleteLabelEl;
+let autocompleteAPI;
+let svgEl;
+
+describe('Autocomplete API', () => {
+  beforeEach(() => {
+    autocompleteInputEl = null;
+    autocompleteAPI = null;
+    svgEl = null;
+
+    document.body.insertAdjacentHTML('afterbegin', svgHTML);
+    document.body.insertAdjacentHTML('afterbegin', exampleHTML);
+
+    svgEl = document.body.querySelector('.svg-icons');
+    autocompleteLabelEl = document.body.querySelector('label[for="autocomplete-default"]');
+    autocompleteInputEl = document.body.querySelector('.autocomplete');
+    autocompleteInputEl.removeAttribute('data-options');
+    autocompleteInputEl.classList.add('no-init');
+
+    autocompleteAPI = new Autocomplete(autocompleteInputEl, {
+      source: data
+    });
+  });
+
+  afterEach(() => {
+    autocompleteAPI.destroy();
+    svgEl.parentNode.removeChild(svgEl);
+
+    const autocompleteListEl = document.querySelector('#autocomplete-list');
+    if (autocompleteListEl) {
+      autocompleteListEl.parentNode.removeChild(autocompleteListEl);
+    }
+    autocompleteLabelEl.parentNode.removeChild(autocompleteLabelEl);
+    autocompleteInputEl.parentNode.removeChild(autocompleteInputEl);
+  });
+
+  it('triggers a `listopen` event when the results list is opened', (done) => {
+    const spyListopenEvent = spyOnEvent($(autocompleteInputEl), 'listopen');
+    autocompleteAPI.openList('new', data);
+
+    expect(spyListopenEvent).toHaveBeenTriggered();
+    done();
+  });
+
+  it('triggers a `listclose` event when the results list is closed', (done) => {
+    const spyListcloseEvent = spyOnEvent($(autocompleteInputEl), 'listclose');
+    autocompleteAPI.openList('new', data);
+    autocompleteAPI.closeList();
+
+    expect(spyListcloseEvent).toHaveBeenTriggered();
+    done();
+  });
+
+  it('triggers a `selected` event when a list item is clicked', (done) => {
+    const spySelectedEvent = spyOnEvent($(autocompleteInputEl), 'selected');
+    autocompleteAPI.openList('new', data);
+    const autocompleteListEl = document.querySelector('#autocomplete-list');
+    const resultItems = autocompleteListEl.querySelectorAll('li');
+
+    autocompleteAPI.select($(resultItems[0].querySelector('a')), data);
+
+    expect(spySelectedEvent).toHaveBeenTriggered();
+    done();
+  });
+});

--- a/test/components/autocomplete/autocomplete-filtermode.func-spec.js
+++ b/test/components/autocomplete/autocomplete-filtermode.func-spec.js
@@ -1,0 +1,50 @@
+import { Autocomplete } from '../../../src/components/autocomplete/autocomplete';
+
+const svgHTML = require('../../../src/components/icons/svg.html');
+
+// For FilterMode "contains" tests
+const newTemplateHTML = require('../../../app/views/components/autocomplete/example-contains.html');
+const statesData = require('../../../app/data/states-all.json');
+
+let autocompleteInputEl;
+let autocompleteAPI;
+
+describe('Autocomplete API', () => {
+  it('can provide search results with a "contains" filter', () => {
+    document.body.insertAdjacentHTML('afterbegin', svgHTML);
+    document.body.insertAdjacentHTML('afterbegin', newTemplateHTML);
+
+    // remove unncessary stuff
+    const inlineScripts = document.body.querySelector('#test-scripts');
+    inlineScripts.parentNode.removeChild(inlineScripts);
+
+    autocompleteInputEl = document.body.querySelector('#autocomplete-default');
+    autocompleteInputEl.classList.add('no-init');
+    autocompleteInputEl.removeAttribute('data-options');
+
+    autocompleteAPI = new Autocomplete(autocompleteInputEl, {
+      source: statesData
+    });
+
+    // Try opening the list with text content that will not match a "startsWith" filter
+    autocompleteAPI.openList('ia', statesData);
+    let autocompleteListEl = document.querySelector('#autocomplete-list');
+    let resultItems = autocompleteListEl.querySelectorAll('li');
+
+    expect(resultItems).toBeDefined();
+    expect(resultItems.length).toEqual(0);
+
+    // Update the component with a "contains" filterMode
+    autocompleteAPI.updated({
+      filterMode: 'contains'
+    });
+    autocompleteAPI.openList('ia', statesData);
+    autocompleteListEl = document.querySelector('#autocomplete-list');
+    resultItems = autocompleteListEl.querySelectorAll('li');
+
+    // Results should be present
+    expect(resultItems).toBeDefined();
+    expect(resultItems.length).toEqual(10);
+    expect(resultItems[7].innerText.trim()).toBe('Pennsylvania');
+  });
+});

--- a/test/components/autocomplete/autocomplete-template.func-spec.js
+++ b/test/components/autocomplete/autocomplete-template.func-spec.js
@@ -1,0 +1,67 @@
+import { Autocomplete } from '../../../src/components/autocomplete/autocomplete';
+
+const svgHTML = require('../../../src/components/icons/svg.html');
+
+// For Non-standard Template
+const newTemplateHTML = require('../../../app/views/components/autocomplete/example-templates.html');
+const emailData = require('../../../app/data/autocomplete-users.json');
+
+let autocompleteInputEl;
+let autocompleteLabelEl;
+let autocompleteAPI;
+let svgEl;
+let alternateTemplateEl;
+
+describe('Autocomplete API', () => {
+  beforeEach(() => {
+    alternateTemplateEl = null;
+    autocompleteInputEl = null;
+    autocompleteAPI = null;
+    svgEl = null;
+
+    document.body.insertAdjacentHTML('afterbegin', svgHTML);
+    document.body.insertAdjacentHTML('afterbegin', newTemplateHTML);
+
+    // remove unncessary stuff
+    const inlineScripts = document.body.querySelector('#test-scripts');
+    inlineScripts.parentNode.removeChild(inlineScripts);
+
+    svgEl = document.body.querySelector('.svg-icons');
+    autocompleteLabelEl = document.body.querySelector('label[for="auto-template"]');
+    autocompleteInputEl = document.body.querySelector('#auto-template');
+    autocompleteInputEl.classList.add('no-init');
+    autocompleteInputEl.removeAttribute('data-autocomplete');
+    autocompleteInputEl.removeAttribute('data-tmpl');
+    alternateTemplateEl = document.body.querySelector('#autocomplete-template-email');
+
+    autocompleteAPI = new Autocomplete(autocompleteInputEl, {
+      template: alternateTemplateEl,
+      source: emailData
+    });
+  });
+
+  afterEach(() => {
+    autocompleteAPI.destroy();
+    svgEl.parentNode.removeChild(svgEl);
+
+    const autocompleteListEl = document.querySelector('#autocomplete-list');
+    if (autocompleteListEl) {
+      autocompleteListEl.parentNode.removeChild(autocompleteListEl);
+    }
+    autocompleteLabelEl.parentNode.removeChild(autocompleteLabelEl);
+    autocompleteInputEl.parentNode.removeChild(autocompleteInputEl);
+  });
+
+  it('should render a user-provided, alternate template for its results', () => {
+    autocompleteAPI.openList('q', emailData);
+    const autocompleteListEl = document.querySelector('#autocomplete-list');
+    const resultItems = autocompleteListEl.querySelectorAll('li');
+
+    expect(resultItems).toBeDefined();
+    expect(resultItems.length).toEqual(1);
+    expect(resultItems[0].querySelector('span').innerText.trim()).toEqual('Quincy Adams');
+
+    // Look for an extra element not provided by the standard template
+    expect(resultItems[0].querySelector('small')).toBeDefined();
+  });
+});

--- a/test/components/autocomplete/autocomplete.e2e-spec.js
+++ b/test/components/autocomplete/autocomplete.e2e-spec.js
@@ -1,0 +1,84 @@
+/* eslint-disable max-len */
+const { browserStackErrorReporter } = requireHelper('browserstack-error-reporter');
+const config = requireHelper('e2e-config');
+requireHelper('rejection');
+
+jasmine.getEnv().addReporter(browserStackErrorReporter);
+
+const clickOnAutocomplete = async () => {
+  const autocompleteEl = await element(by.css('#autocomplete-default'));
+  await browser.driver.wait(protractor.ExpectedConditions.presenceOf(autocompleteEl), config.waitsFor);
+  await autocompleteEl.click();
+};
+
+describe('Autocomplete example-index tests', () => {
+  beforeEach(async () => {
+    await browser.waitForAngularEnabled(false);
+    await browser.driver.get(`${browser.baseUrl}/components/autocomplete/example-index?theme=${browser.params.theme}`);
+  });
+
+  it('Should open a filtered results list after focusing and keying text', async () => {
+    await clickOnAutocomplete();
+    const autocompleteEl = await element(by.css('#autocomplete-default'));
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(autocompleteEl), config.waitFor);
+    await autocompleteEl.sendKeys('new');
+
+    const autocompleteListEl = await element(by.css('#autocomplete-list'));
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(autocompleteListEl), config.waitFor);
+
+    expect(await element(by.css('#autocomplete-list')).isDisplayed()).toBe(true);
+  });
+
+  it('Should fill the input field with the correct text contents when an item is clicked', async () => {
+    await clickOnAutocomplete();
+    const autocompleteEl = await element(by.css('#autocomplete-default'));
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(autocompleteEl), config.waitFor);
+    await autocompleteEl.sendKeys('new');
+
+    const autocompleteListEl = await element(by.css('#autocomplete-list'));
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(autocompleteListEl), config.waitFor);
+
+    const njOption = await element(by.css('li[data-value="NJ"]'));
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(njOption), config.waitFor);
+    await njOption.click();
+    await browser.driver.sleep(config.sleep);
+
+    const autocompleteText = await browser.executeScript('return document.querySelector("#autocomplete-default").value');
+
+    expect(autocompleteText).toEqual('New Jersey');
+  });
+
+  it('Should fill the input field with the correct text contents when an item is chosen with the keyboard', async () => {
+    await clickOnAutocomplete();
+    const autocompleteEl = await element(by.css('#autocomplete-default'));
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(autocompleteEl), config.waitFor);
+    await autocompleteEl.sendKeys('new');
+
+    const autocompleteListEl = await element(by.css('#autocomplete-list'));
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(autocompleteListEl), config.waitFor);
+    await autocompleteEl.sendKeys(protractor.Key.ARROW_DOWN);
+    await autocompleteEl.sendKeys(protractor.Key.ARROW_DOWN);
+    await autocompleteEl.sendKeys(protractor.Key.ENTER);
+    await browser.driver.sleep(config.sleep);
+
+    const autocompleteText = await browser.executeScript('return document.querySelector("#autocomplete-default").value');
+
+    expect(autocompleteText).toEqual('New Jersey');
+  });
+
+  it('should clear a dirty autocomplete field with `alt + backspace/del`', async () => {
+    await clickOnAutocomplete();
+    const autocompleteEl = await element(by.css('#autocomplete-default'));
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(autocompleteEl), config.waitFor);
+    await autocompleteEl.sendKeys('new');
+
+    const autocompleteListEl = await element(by.css('#autocomplete-list'));
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(autocompleteListEl), config.waitFor);
+    await autocompleteEl.sendKeys(protractor.Key.chord(protractor.Key.ALT, protractor.Key.BACK_SPACE));
+    await browser.driver.sleep(config.sleep);
+
+    const autocompleteText = await browser.executeScript('return document.querySelector("#autocomplete-default").value');
+
+    expect(autocompleteText).toEqual('');
+  });
+});

--- a/test/components/searchfield/searchfield.func-spec.js
+++ b/test/components/searchfield/searchfield.func-spec.js
@@ -1,0 +1,43 @@
+import { SearchField } from '../../../src/components/searchfield/searchfield';
+
+const exampleHTML = require('../../../app/views/components/searchfield/example-index.html');
+const svgHTML = require('../../../src/components/icons/svg.html');
+const data = require('../../../app/data/states-all.json');
+
+let searchfieldInputEl;
+let searchfieldAPI;
+let svgEl;
+
+describe('Searchfield API', () => {
+  beforeEach(() => {
+    searchfieldInputEl = null;
+    searchfieldAPI = null;
+    svgEl = null;
+
+    document.body.insertAdjacentHTML('afterbegin', svgHTML);
+    document.body.insertAdjacentHTML('afterbegin', exampleHTML);
+
+    svgEl = document.body.querySelector('.svg-icons');
+    searchfieldInputEl = document.body.querySelector('.searchfield');
+    searchfieldInputEl.removeAttribute('data-options');
+    searchfieldInputEl.classList.add('no-init');
+
+    searchfieldAPI = new SearchField(searchfieldInputEl, {
+      source: data
+    });
+  });
+
+  afterEach(() => {
+    searchfieldAPI.destroy();
+    svgEl.parentNode.removeChild(svgEl);
+    searchfieldInputEl.parentNode.removeChild(searchfieldInputEl);
+  });
+
+  it('can be invoked', () => {
+    expect(searchfieldAPI).toEqual(jasmine.any(Object));
+  });
+
+  it('renders attributes', () => {
+    expect(searchfieldInputEl.getAttribute('autocomplete')).toBe('off');
+  });
+});


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

Adding basic functional/e2e tests for the Autocomplete component (and a couple for Searchfield).

Also, the new Autocomplete tests revealed a lifecycle bug where the component's internal ListFilter component wasn't updated on an Autocomplete `updated()` call.  This is now fixed.

> **Related issue (required)**:

https://jira.infor.com/browse/SOHO-7850

> **Steps necessary to review your pull request (required)**:

Run the new Autocomplete/Searchfield functional and e2e test suites.  All of these new tests should pass.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
