### PR TITLE
Fixed incorrect event handlers in tabs

### DIFF
--- a/app/views/components/validation/test-error-on-tab.html
+++ b/app/views/components/validation/test-error-on-tab.html
@@ -17,9 +17,11 @@
       <div id="tabs-normal-opportunities" class="tab-panel">
         <div class="row">
           <div class="twelve columns">
-
+            <div class="field">
+             <label class="required" for="email-address-ok">Email Address <span class="audible">Required</span></label>
+             <input type="text" id="email-address-ok" name="email-address-ok" data-validate="required" value="someone@someplace.com"/>
+            </div>
           </div>
-
         </div>
       </div>
       <div id="tabs-normal-attachments" class="tab-panel">
@@ -34,10 +36,4 @@
     </div>
 
   </div>
-</div>
-
-
-<div class="field">
- <label class="required" for="email-address-ok">Email Address <span class="audible">Required</span></label>
- <input type="text" id="email-address-ok" name="email-address-ok" data-validate="required" value="someone@someplace.com"/>
 </div>

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -725,8 +725,9 @@ Tabs.prototype = {
     });
     self.handleResize(true);
 
-    $('input').on('isvalid', () => {
-      const currentLi = $('li.is-selected');
+    // Resize the tab to show the error
+    $('.tab-panel input').on('isvalid.tabs', () => {
+      const currentLi = $('.tab.is-selected');
       self.focusBar(currentLi);
     });
 
@@ -3935,6 +3936,7 @@ Tabs.prototype = {
       this.animatedBar.remove();
       this.animatedBar = undefined;
     }
+    $('.tab-panel input').off('isvalid.tabs');
 
     return this;
   },


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

Tabs had some un-qualified / unneeded events and a memory leak. This is fixed.

> **Related issue (required)**:

SOHO-7948

> **Steps necessary to review your pull request (required)**:

- place an input out of the tabset and tab out of it. should not fire focusBar
