### PR TITLE
Patch app.js for demo server

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,7 @@ let express = require('express'),
   http = require('http'),
   BASE_PATH = process.env.BASEPATH || '/',
   fullBasePath = function (req) {
-    const fullPath = (`${req.protocol}://${req.headers.host.replace('/', '')}${BASE_PATH}`);
+    const fullPath = (`//${req.headers.host.replace('/', '')}${BASE_PATH}`);
     return fullPath;
   },
   getJSONFile = require(path.resolve(__dirname, 'demoapp', 'js', 'getJSONFile')),


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

This change is necessary to run HTTPS and proxy on the `latest` demo server. This will essentially deploy `4.6.1` plus the app server patch.

It's not necessary at this time to bump a patch version of `4.6.x`. I think this fix is fine sitting on the tip of that branch and could go out if there's ever a need for `4.6.2`.