### PR TITLE
SOHO-8006 fixed the extra padding in popupmenu

### DIFF
--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -557,7 +557,7 @@ PopupMenu.prototype = {
       const a = $(li).children('a')[0]; // TODO: do this better when we have the infrastructure
       let span = $(a).children('span')[0];
       let submenu = $(li).children('ul')[0];
-      const icon = $(li).children('.icon:not(.close):not(.icon-dropdown)');
+      const icon = $(li).find('svg.icon:not(.close):not(.icon-dropdown)').length;
       const submenuWrapper = $(li).children('.wrapper')[0];
 
       li.setAttribute('role', 'presentation');
@@ -623,7 +623,7 @@ PopupMenu.prototype = {
         }
       }
 
-      if (icon) {
+      if (icon !== 0) {
         hasIcons = true;
       }
     });


### PR DESCRIPTION
Get the descendants of li element specifically an svg with class selector icon not close and dropdown. This will served as checker if a ul should have a class 'has-icon' or not. The aim of this fix is to removed the extra padding in the item list when a list doesn't contained an svg icon.

No padding
http://localhost:4000/components/popupmenu/example-index.html
http://localhost:4000/components/popupmenu/example-menubutton.html

with padding
http://localhost:4000/components/popupmenu/example-icons.html

