### PR TITLE
SOHO-7998 - Dropdown Focus/Premature closing issues

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1264,15 +1264,6 @@ Dropdown.prototype = {
 
     selectText();
 
-    /*
-    function setFocus() {
-      if (document.activeElement === input[0] || !$(document.activeElement).is('body')) {
-        return;
-      }
-      input[0].focus();
-    }
-    */
-
     // Set focus back to the element
     if (self.isIe10 || self.isIe11) {
       setTimeout(() => {

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1264,20 +1264,22 @@ Dropdown.prototype = {
 
     selectText();
 
+    /*
     function setFocus() {
       if (document.activeElement === input[0] || !$(document.activeElement).is('body')) {
         return;
       }
       input[0].focus();
     }
+    */
 
     // Set focus back to the element
     if (self.isIe10 || self.isIe11) {
       setTimeout(() => {
-        setFocus();
+        input[0].focus();
       }, 0);
     } else {
-      setFocus();
+      input[0].focus();
     }
   },
 


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

There was a bug in the dropdown component that originated from some previous patches (SOHO-7901 and related issues), which was causing filtering not to occur properly on Dropdown components that were NOT configured with searching disabled.

> **Related issue (required)**:

https://jira.infor.com/browse/SOHO-7998

> **Steps necessary to review your pull request (required)**:

SOHO-7998:
- Open http://localhost:4000/components/dropdown/example-index
- focus the dropdown
- type "al"
- the list should properly open and display search results containing "al"

SOHO-8020: 
- Open http://localhost:4000/components/dropdown/example-clearable.html
- focus the last dropdown on the page labeled "Not Clearable"
- open the list, try to enter junk data and press enter/return
- the previous selection, "New York", should remain selected (previously this series of steps was causing the dropdown to become blank, which is incorrect for this configuration)

> Other Details:

Closes SOHO-8020 (Regression test from @CindyMercadoReyes)
Closes SOHO-7998

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
