### PR TITLE
Display Jenkins log in Travis upon failure

### DIFF
--- a/scripts/jenkins-deploy.sh
+++ b/scripts/jenkins-deploy.sh
@@ -45,6 +45,11 @@ get_build_number () {
     echo $build_number
 }
 
+get_build_log () {
+    build_log=$(curl -s $JENKINS_URL/job/$JENKINS_JOB/lastBuild/consoleText)
+    echo "$build_log"
+}
+
 stop_jenkins_build () {
     response=$(curl --write-out "%{http_code}\n" --silent --output /dev/null -X POST \
                 "$JENKINS_URL/job/$JENKINS_JOB/$CURRENT_BUILD_NUMBER/stop"
@@ -109,6 +114,11 @@ if [ $WATCH_FOR_BUILD_STATUS = true ]; then
             exit 0
         else
             echo "" # new line
+            echo "$BUILD_STATUS! See log for details:"
+            echo "" # new line
+            while IFS='\n' read -r line; do
+                printf "\t%s\n" "$line"
+            done <<< "$(get_build_log)"
             echo "Build was ended with status: $BUILD_STATUS!"
             exit 1
         fi


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

If the Jenkins build that Travis kicks off returns a status other than `SUCCESS` or `ABORTED`, Travis will now retrieve the Jenkins log and display it.

> Other Details:

It'll look something like this:

```
Building master as master-enterprise...
- adding Jenkins build to queue...
SUCCESS: Jenkins sucessfully queued job
Watching build #118 to report on status.....
FAILED! See log for details:

        Started by remote host 198.179.75.179
        Building in workspace /var/jenkins_home/jobs/soho4-swarm-deploy/workspace
        [workspace] $ /bin/bash /tmp/jenkins8957704905126335100.sh
        WARNING! This will remove:
                - all stopped containers
                - all networks not used by at least one container
                - all dangling images
                - all build cache
        Are you sure you want to continue? [y/N] Total reclaimed space: 0B
        Cloning into 'enterprise'...
        Fetching origin
        Already on 'master'
        Your branch is up-to-date with 'origin/master'.
        Build was aborted
        Aborted by jeeves
        Finished: FAILED

Build was ended with status: FAILED
```
