### PR TITLE
SOHO-8029 - Cannot select individual options with different values but same labels

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -2017,7 +2017,7 @@ Dropdown.prototype = {
 
     const code = option.val();
     let val = this.element.val();
-    const oldText = this.pseudoElem.text();
+    const oldCode = this.element.find('option:selected').val();
     let text = '';
     let trimmed = '';
     let clearSelection = false;
@@ -2073,9 +2073,10 @@ Dropdown.prototype = {
         }
       });
     }
+
     // If we're working with a single select and the value hasn't changed, just return without
     // firing a change event
-    if (text === oldText) {
+    if (code === oldCode) {
       return;
     }
 


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

The scenario involves a `single-select` dropdown that contains options that will always have a unique value, but may (under some circumstances) have matching text labels. If we select an option from the list, and then select a second option with a different value, but a matching text label, the dropdown component does not (as far as we can tell) detect that the selected value has been changed, and thus does not perform logic that would normally be executed when a change occurs (updating the model or triggering associated events).

This is specifically an issue for the Angular controls, where the 'change' event is required to update the Form model.  In the above scenario, the `changed` event is not fired is the text label is the same even though the value is different.

> **Related issue (required)**:

N/A

> **Steps necessary to review your pull request (required)**:

Run the attached example, which shows the 'change' event not being fired.

> Other Details:

Closes [SOHO-8029](https://jira.infor.com/browse/SOHO-8029)

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
