### PR TITLE
SOHO-7998 (Q/A patch) - Non-clearable Dropdown Reset

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1083,7 +1083,10 @@ Dropdown.prototype = {
 
           e.preventDefault();
 
-          self.selectOption($(options[selectedIndex])); // store the current selection
+          if (options.length && selectedIndex > -1) {
+            self.selectOption($(options[selectedIndex])); // store the current selection
+          }
+
           if (self.settings.closeOnSelect) {
             self.closeList('select'); // Close the option list
             self.activate();
@@ -1984,7 +1987,7 @@ Dropdown.prototype = {
    * fire on the list item.
    */
   selectOption(option, noTrigger) {
-    if (!option) {
+    if (!option || !option.length) {
       return;
     }
     let li;


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

Fixed a bug where Dropdowns with no clearable options were appearing to be empty when using the Enter key to close a dropdown with no filtered items -- soho-7998

> **Related issue (required)**:

https://jira.infor.com/browse/SOHO-7998

> **Steps necessary to review your pull request (required)**:

- Open http://localhost:4000/components/dropdown/example-clearable.html
- focus the last dropdown on the page labeled "Not Clearable"
- open the list with the keyboard by pressing Down Arrow 
- try to enter junk data that has no matches, and press Enter/Return
- the previous selection, "New York", should remain selected (previously this series of steps was causing the dropdown to become blank, which is incorrect for this configuration)

> Other Details:

Closes SOHO-7998

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
