### PR TITLE
QA - Soho 8036 - Autocomplete `select()` from string

### DIFF
--- a/src/components/autocomplete/autocomplete.js
+++ b/src/components/autocomplete/autocomplete.js
@@ -631,7 +631,7 @@ Autocomplete.prototype = {
   select(anchorOrEvent, items) {
     let a;
     let li;
-    let ret;
+    let ret = {};
     let isEvent = false;
 
     // Initial Values
@@ -648,7 +648,7 @@ Autocomplete.prototype = {
     }
 
     li = a.parent('li');
-    ret = a.text().trim();
+    ret.value = a.text().trim();
     const dataIndex = li.attr('data-index');
     const dataValue = li.attr('data-value');
 
@@ -662,9 +662,14 @@ Autocomplete.prototype = {
       } else if (dataValue) {
         // Otherwise use data-value to get the item (a custom template may not supply data-index)
         for (let i = 0, value; i < items.length; i++) {
-          value = items[i].value.toString();
+          if (typeof items[i] === 'object' && items[i].value !== undefined) {
+            value = items[i].value.toString();
+          } else {
+            value = items[i].toString();
+          }
+
           if (value === dataValue) {
-            ret = items[i];
+            ret.value = value;
           }
         }
       }


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

In some cases, Autocomplete components were failing because internal value checking on the `select()` method wasn't properly picking up a string from an object with extra metadata.  This PR fixes this problem to use the object as a source of truth.

> **Related issue (required)**:

https://jira.infor.com/browse/SOHO-8036

> **Steps necessary to review your pull request (required)**:

- Open http://localhost:4000/components/autocomplete/example-searchfield.html
- focus the Autocomplete field
- type "CA"
- press down to highlight "California" and press enter
- Check that "California" is now the value of the Autocomplete, and that there are no JS console errors.

Also, run the Autocomplete functional tests to ensure there are no errors.

> Other Details:

Closes SOHO-8036

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
