### PR TITLE
QA - SOHO-8034 - Remove vertical scrolling from horizontal tab lists

### DIFF
--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -310,6 +310,7 @@
   .tab-list-container {
     display: inline-block;
     overflow-x: auto; // facilitates scrolling of the tabset
+    overflow-y: hidden; // prevents vertical scrolling
     position: relative;
     width: calc(100% - 51px);
   }


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

In Firefox, there used to be no overflow limit on vertical scrolling on Horizontal Tab lists, which was causing scrollbars to appear.  This PR removes vertical scrolling from inside of these tabs lists.

> **Related issue (required)**:

https://jira.infor.com/browse/SOHO-8034

> **Steps necessary to review your pull request (required)**:

- Pull down this branch and run the demoapp
- Open http://localhost:4000/components/tabs/example-index in Firefox on Mac.
- Ensure that it's no longer possible to scroll vertically inside the tab list (horizontal scrolling is allowed).

> Other Details:

Closes SOHO-8034

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
