### PR TITLE
QA - SOHO 8043 - Module tabs' app-menu trigger instantly closes the app-menu after it's opened

### DIFF
--- a/src/components/applicationmenu/applicationmenu.js
+++ b/src/components/applicationmenu/applicationmenu.js
@@ -678,7 +678,7 @@ ApplicationMenu.prototype = {
     });
 
     $(document).on('open-applicationmenu', () => {
-      self.openMenu();
+      self.openMenu(undefined, true);
     }).on('close-applicationmenu', () => {
       self.closeMenu();
     });


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

In Module Tabs components, Application Menu triggers are optional, and use events to open/close the Application Menu.  The event handler inside the Application Menu that handles the opening of the menu wasn't properly being identified as "User Opened", which was causing the menu to instantly close as soon as it's opened from the Module Tabs trigger.  This problem is fixed in this PR.

> **Related issue (required)**:

https://jira.infor.com/browse/SOHO-8043

> **Steps necessary to review your pull request (required)**:

- Pull the branch and open http://localhost:4000/components/tabs-module/example-app-menu-button.html
- Resize the screen to below 767px to enable the responsive Application Menu mode.
- Click the App Menu trigger in the top left.
- Ensure that once the menu opens, it doesn't immediately close again.

> Other Details:

Closes SOHO-8043

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
