### PR TITLE
Adds task to run e2e if cron task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
 script:
   - npm run build
   - npm run functional:ci
+  - if [ $TRAVIS_EVENT_TYPE = cron ]; then npm run e2e:ci; fi
 deploy:
     # DEPLOY BUILD TO DEMO SERVER
     # this runs conditionally `on`


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

Runs e2e tests (`npm run e2e:ci`) if build job is kicked off from cron (which is our nightly builds). Authentication is handled with saved environment variables in Travis and sourced in the e2e config file.