### PR TITLE
SOHO-7939 checkbox centered in large breakpoint

### DIFF
--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -38,7 +38,7 @@
 
 }
 
-@include respond-to(tabletdown) {
+@include respond-to(phone) {
   .form-responsive {
     .field .checkbox-label,
     .field .checkbox > label {


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

Adjust the breakpoint to phone for the checkbox align center when screen lower than 1280

> **Related issue (required)**:

https://jira.infor.com/browse/SOHO-7939

> **Steps necessary to review your pull request (required)**:

- open http://localhost:4000/components/form/example-inputs.html
- Test this page by resizing the browser. Checkbox is aligned left on small screen. Aligned center both for tablet and desktop.
