### PR TITLE
SOHO-7991 - Fixed rightclick was returning wrong index TreeDatagrid

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4192,7 +4192,7 @@ Datagrid.prototype = {
     const self = this;
     const cell = $(e.target).closest('td').index();
     const rowElem = $(e.target).closest('tr');
-    let row = self.dataRowIndex(rowElem);
+    let row = this.settings.treeGrid ? this.actualRowIndex(rowElem) : this.dataRowIndex(rowElem);
     let isTrigger = true;
 
     if ($(e.target).is('a')) {


### PR DESCRIPTION
http://localhost:4000/components/datagrid/test-tree-contextmenu.html
QA Notes:
- Open above link
- Open developer tools
- Right click on any row
- See console log for row number