### PR TITLE
SOHO-7444 - Fixed sort indicator was not showing with Datagrid

### DIFF
--- a/app/views/components/datagrid/example-filter.html
+++ b/app/views/components/datagrid/example-filter.html
@@ -47,7 +47,7 @@
       columns.push({ id: 'quantity', name: 'Qty', field: 'quantity', align: 'right', filterType: 'integer'});
       columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'MM/dd/yyyy', filterType: 'date', width: 250});
       columns.push({ id: 'inStock', name: 'In Stock', field: 'inStock', formatter: Formatters.Checkbox, align: 'center', filterType: 'checkbox'});
-      columns.push({ id: 'status', name: 'Status', field: 'status', formatter: Formatters.Alert, filterType: 'select', editorOptions: {source: testSource1}, options: statuses, ranges: [{'value':'Confirmed', 'classes': 'confirm', text: 'Confirmed'}, {'value':'Error', 'classes': 'error', text: 'Error'}]});
+      columns.push({ id: 'status', name: 'Status', align: 'center', field: 'status', formatter: Formatters.Alert, filterType: 'select', editorOptions: {source: testSource1}, options: statuses, ranges: [{'value':'Confirmed', 'classes': 'confirm', text: 'Confirmed'}, {'value':'Error', 'classes': 'error', text: 'Error'}]});
       columns.push({ id: 'price',  name: 'Price', field: 'price', formatter: Formatters.Decimal, filterType: 'decimal', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###,####.000'});
 
       //Supported Filter Types: text, integer, date, select, decimal, checkbox, contents (FUTURE: lookup, percent)

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1946,10 +1946,11 @@ $datagrid-short-row-height: 23px;
 
     // Centering Text
     .datagrid-column-wrapper.l-center-text {
-      width: 100%;
+      width: calc(100% + 20px);
 
-      .sort-indicator {
-        display: none;
+      .datagrid-header-text {
+        display: inline-block;
+        margin-top: 10px;
       }
     }
 


### PR DESCRIPTION
Column that is specified to be sortable, sort indicators was not showing when the column alignment is set to center.
SOHO-7444
http://localhost:4000/components/datagrid/example-filter
QA Notes:
- Open above link
- Hover to column header “Status”
- See sort indicator should be visible