### PR TITLE
SOHO-4815 provide a param to control the default behavior of up/down arrow

### DIFF
--- a/app/views/components/dropdown/test-allow-custom-keystroke.html
+++ b/app/views/components/dropdown/test-allow-custom-keystroke.html
@@ -30,7 +30,12 @@
   $('body').one('initialized', function () {
 
     $('#dropdown').dropdown({
-      onKeyDown: true
+      onKeyDown: function(e) {
+        if (e.which === 40) {
+          alert('You customized the down key (:');
+          return false;
+        }
+      }
     })
 
   })

--- a/app/views/components/dropdown/test-allow-custom-keystroke.html
+++ b/app/views/components/dropdown/test-allow-custom-keystroke.html
@@ -1,0 +1,37 @@
+<div class="row">
+  <div class="six columns">
+    <h2>Dropdown Test: Allows custom keystoke</h2>
+    <p>
+      Related JIRA: <a class="hyperlink" href="https://jira.infor.com/browse/SOHO-4815" target="_blank">SOHO-4815</a>
+      This is a demo where a user will not be able to used the up/down arrows on selecting a value in the dropdown.
+      This will allow the developers to customized the event for the up/down arrows.
+    </p>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="six columns">
+
+    <div class="field">
+      <label for="dropdown" class="label">Dropdown allows custom keystroke</label>
+      <select id="dropdown" name="dropdown" class="dropdown">
+        <option value="FE1">Fire Level E1</option>
+        <option value="FE2">Fire Level E2</option>
+        <option value="FE3">Fire Level E3</option>
+        <option value="FE4">Fire Level E4</option>
+        <option value="FE5">Fire Level E5</option>
+      </select>
+    </div>
+
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+
+    $('#dropdown').dropdown({
+      onKeyDown: true
+    })
+
+  })
+</script>

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -38,6 +38,7 @@ const moveSelectedOpts = ['none', 'all', 'group'];
 * @param {number} [settings.maxWidth = null] If set the width of the dropdown is limited to this pixel width.
 * Fx 300 for the 300 px size fields. Default is size of the largest data.
 * @param {object} [settings.placementOpts = null]  Gets passed to this control's Place behavior
+* @param {object} [settings.onKeyDown = false]  If set to true, will prevent the default behavior of the up/down arrow
 */
 
 const DROPDOWN_DEFAULTS = {
@@ -57,7 +58,8 @@ const DROPDOWN_DEFAULTS = {
   empty: false,
   delay: 300,
   maxWidth: null,
-  placementOpts: null
+  placementOpts: null,
+  onKeyDown: false
 };
 
 function Dropdown(element, settings) {
@@ -1098,6 +1100,12 @@ Dropdown.prototype = {
         }
         this.searchKeyMode = false;
 
+        if (self.settings.onKeyDown === true) {
+          e.stopPropagation();
+          e.preventDefault();
+          return false; //eslint-disable-line
+        }
+
         if (selectedIndex > 0) {
           next = $(options[selectedIndex - 1]);
           this.highlightOption(next);
@@ -1118,6 +1126,12 @@ Dropdown.prototype = {
           return;
         }
         this.searchKeyMode = false;
+
+        if (self.settings.onKeyDown === true) {
+          e.stopPropagation();
+          e.preventDefault();
+          return false; //eslint-disable-line
+        }
 
         if (selectedIndex < options.length - 1) {
           next = $(options[selectedIndex + 1]);

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -38,9 +38,8 @@ const moveSelectedOpts = ['none', 'all', 'group'];
 * @param {number} [settings.maxWidth = null] If set the width of the dropdown is limited to this pixel width.
 * Fx 300 for the 300 px size fields. Default is size of the largest data.
 * @param {object} [settings.placementOpts = null]  Gets passed to this control's Place behavior
-* @param {object} [settings.onKeyDown = false]  If set to true, will prevent the default behavior of the up/down arrow
+* @param {object} [settings.onKeyDown = false]  If set to true, will provide a hook into to keydown behavior which can be cancelled.
 */
-
 const DROPDOWN_DEFAULTS = {
   closeOnSelect: true,
   cssClass: null,
@@ -59,7 +58,7 @@ const DROPDOWN_DEFAULTS = {
   delay: 300,
   maxWidth: null,
   placementOpts: null,
-  onKeyDown: false
+  onKeyDown: null
 };
 
 function Dropdown(element, settings) {
@@ -1016,6 +1015,15 @@ Dropdown.prototype = {
       return;
     }
 
+    if (self.settings.onKeyDown) {
+      const ret = self.settings.onKeyDown(e);
+      if (ret === false) {
+        e.stopPropagation();
+        e.preventDefault();
+        return false; //eslint-disable-line
+      }
+    }
+
     // Down arrow, Up arrow, or Spacebar to open
     if (!self.isOpen() && (key === 38 || key === 40 || key === 32)) {
       self.toggleList();
@@ -1100,12 +1108,6 @@ Dropdown.prototype = {
         }
         this.searchKeyMode = false;
 
-        if (self.settings.onKeyDown === true) {
-          e.stopPropagation();
-          e.preventDefault();
-          return false; //eslint-disable-line
-        }
-
         if (selectedIndex > 0) {
           next = $(options[selectedIndex - 1]);
           this.highlightOption(next);
@@ -1126,12 +1128,6 @@ Dropdown.prototype = {
           return;
         }
         this.searchKeyMode = false;
-
-        if (self.settings.onKeyDown === true) {
-          e.stopPropagation();
-          e.preventDefault();
-          return false; //eslint-disable-line
-        }
 
         if (selectedIndex < options.length - 1) {
           next = $(options[selectedIndex + 1]);

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -38,7 +38,7 @@ const moveSelectedOpts = ['none', 'all', 'group'];
 * @param {number} [settings.maxWidth = null] If set the width of the dropdown is limited to this pixel width.
 * Fx 300 for the 300 px size fields. Default is size of the largest data.
 * @param {object} [settings.placementOpts = null]  Gets passed to this control's Place behavior
-* @param {object} [settings.onKeyDown = false]  If set to true, will provide a hook into to keydown behavior which can be cancelled.
+* @param {function} [settings.onKeyDown = null]  Allows you to hook into the onKeyDown. If you do you can access the keydown event data. And optionally return false to cancel the keyDown action.
 */
 const DROPDOWN_DEFAULTS = {
   closeOnSelect: true,

--- a/test/components/dropdown/dropdown-updates-events.func-spec.js
+++ b/test/components/dropdown/dropdown-updates-events.func-spec.js
@@ -42,7 +42,8 @@ describe('Dropdown updates, events', () => {
       reloadSourceOnOpen: false,
       showEmptyGroupHeaders: false,
       showSelectAll: false,
-      sourceArguments: {}
+      sourceArguments: {},
+      onKeyDown: false
     };
 
     expect(dropdownObj.settings).toEqual(settings);
@@ -63,7 +64,8 @@ describe('Dropdown updates, events', () => {
       reloadSourceOnOpen: false,
       showEmptyGroupHeaders: false,
       showSelectAll: false,
-      sourceArguments: {}
+      sourceArguments: {},
+      onKeyDown: false
     };
 
     dropdownObj.updated();
@@ -88,7 +90,8 @@ describe('Dropdown updates, events', () => {
       reloadSourceOnOpen: false,
       showEmptyGroupHeaders: false,
       showSelectAll: false,
-      sourceArguments: {}
+      sourceArguments: {},
+      onKeyDown: false
     };
     dropdownObj.updated(settings);
 
@@ -110,7 +113,8 @@ describe('Dropdown updates, events', () => {
       reloadSourceOnOpen: false,
       showEmptyGroupHeaders: false,
       showSelectAll: false,
-      sourceArguments: {}
+      sourceArguments: {},
+      onKeyDown: false
     };
 
     const spyEvent = spyOnEvent('.dropdown', 'has-updated');

--- a/test/components/dropdown/dropdown-updates-events.func-spec.js
+++ b/test/components/dropdown/dropdown-updates-events.func-spec.js
@@ -43,7 +43,7 @@ describe('Dropdown updates, events', () => {
       showEmptyGroupHeaders: false,
       showSelectAll: false,
       sourceArguments: {},
-      onKeyDown: false
+      onKeyDown: null
     };
 
     expect(dropdownObj.settings).toEqual(settings);
@@ -65,7 +65,7 @@ describe('Dropdown updates, events', () => {
       showEmptyGroupHeaders: false,
       showSelectAll: false,
       sourceArguments: {},
-      onKeyDown: false
+      onKeyDown: null
     };
 
     dropdownObj.updated();
@@ -91,7 +91,7 @@ describe('Dropdown updates, events', () => {
       showEmptyGroupHeaders: false,
       showSelectAll: false,
       sourceArguments: {},
-      onKeyDown: false
+      onKeyDown: null
     };
     dropdownObj.updated(settings);
 
@@ -114,7 +114,7 @@ describe('Dropdown updates, events', () => {
       showEmptyGroupHeaders: false,
       showSelectAll: false,
       sourceArguments: {},
-      onKeyDown: false
+      onKeyDown: null
     };
 
     const spyEvent = spyOnEvent('.dropdown', 'has-updated');


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?
Added onKeyDown param that will allow us to manipulate the default behavior of the up/down arrow

> **Related issue (required)**:
SOHO-4815

> **Steps necessary to review your pull request (required)**:
http://localhost:4000/components/dropdown/test-allow-custom-keystroke.html

- Open the dropdown
- Try to select a value on the dropdown list using the up/down arrow
- The expected behavior, You won't be able to select any value using the up/down arrow.