### PR TITLE
Q/A - SOHO-8076 - Missing properties in Autocomplete return object

### DIFF
--- a/src/components/autocomplete/autocomplete.js
+++ b/src/components/autocomplete/autocomplete.js
@@ -251,6 +251,8 @@ Autocomplete.prototype = {
       });
     }
 
+    this.currentDataSet = modifiedFilterResults;
+
     // If a "resultsCallback" method is defined, pipe the filtered items to that method and skip
     // building a popupmenu.
     if (typeof this.settings.displayResultsCallback === 'function') {
@@ -328,7 +330,7 @@ Autocomplete.prototype = {
     // Overrides the 'click' listener attached by the Popupmenu plugin
     self.list.off('click touchend')
       .on('touchend.autocomplete click.autocomplete', 'a', (e) => {
-        self.select(e, filterResult);
+        self.select(e);
       })
       .off('focusout.autocomplete').on('focusout.autocomplete', () => {
         self.checkActiveElement();
@@ -374,6 +376,7 @@ Autocomplete.prototype = {
       popup.close();
     }
 
+    this.currentDataSet = null;
     this.element.trigger('listclose');
     $('#autocomplete-list').parent('.popupmenu-wrapper').remove();
     $('#autocomplete-list').remove();
@@ -443,7 +446,7 @@ Autocomplete.prototype = {
         e.stopPropagation();
         e.preventDefault();
         self.noSelect = true;
-        self.select(highlighted, this.currentDataSet);
+        self.select(highlighted);
       } else {
         self.closeList();
       }
@@ -612,6 +615,12 @@ Autocomplete.prototype = {
     }, 10);
   },
 
+  /**
+   * Highlights (and focuses) an Autocomplete list option
+   * @param {jQuery} anchor the anchor to be highlighted
+   * @param {jQuery[]} [allAnchors=null] optional list of anchors to deselect when the new one becomes selected.
+   * @returns {void}
+   */
   highlight(anchor, allAnchors) {
     let text = anchor.text().trim();
 
@@ -628,6 +637,12 @@ Autocomplete.prototype = {
     this.element.val(text).focus();
   },
 
+  /**
+   * Selects an Autocomplete result.
+   * @param {jQuery|jQuery.Event} anchorOrEvent either a reference to a jQuery-wrapped HTMLElement, or a jQuery Event object with a target.
+   * @param {object[]} [items=this.currentDataSet] an array of objects representing autocomplete options.
+   * @returns {object} contains information about the selected item.
+   */
   select(anchorOrEvent, items) {
     let a;
     let li;
@@ -648,31 +663,35 @@ Autocomplete.prototype = {
     }
 
     li = a.parent('li');
-    ret.value = a.text().trim();
     const dataIndex = li.attr('data-index');
     const dataValue = li.attr('data-value');
 
     this.element.attr('aria-activedescendant', li.attr('id'));
 
-    if (items && items.length) {
-      // If the data-index attr is supplied, use it to get the item
-      // (since two items could have same value)
-      if (dataIndex) {
-        ret = items[parseInt(dataIndex, 10)];
-      } else if (dataValue) {
-        // Otherwise use data-value to get the item (a custom template may not supply data-index)
-        for (let i = 0, value; i < items.length; i++) {
-          if (typeof items[i] === 'object' && items[i].value !== undefined) {
-            value = items[i].value.toString();
-          } else {
-            value = items[i].toString();
-          }
+    if (!items || !items.length) {
+      items = this.currentDataSet;
+    }
 
-          if (value === dataValue) {
-            ret.value = value;
-          }
+    // If the data-index attr is supplied, use it to get the item
+    // (since two items could have same value)
+    if (dataIndex) {
+      ret = items[parseInt(dataIndex, 10)];
+    } else if (dataValue) {
+      // Otherwise use data-value to get the item (a custom template may not supply data-index)
+      for (let i = 0, value; i < items.length; i++) {
+        if (typeof items[i] === 'object' && items[i].value !== undefined) {
+          value = items[i].value.toString();
+          ret = items[i];
+        } else {
+          value = items[i].toString();
         }
+        ret.value = value;
       }
+    }
+
+    // Use the label as the value, if we're not working from a true dataset
+    if (!ret.value || !ret.value.length === 0) {
+      ret.value = a.text().trim();
     }
 
     this.closeList();
@@ -699,7 +718,7 @@ Autocomplete.prototype = {
       anchorOrEvent.preventDefault();
     }
 
-    return false;
+    return ret;
   },
 
   /*

--- a/test/components/autocomplete/autocomplete-select.func-spec.js
+++ b/test/components/autocomplete/autocomplete-select.func-spec.js
@@ -1,0 +1,78 @@
+import { Autocomplete } from '../../../src/components/autocomplete/autocomplete';
+
+const svgHTML = require('../../../src/components/icons/svg.html');
+
+// For basic API
+const exampleHTML = require('../../../app/views/components/autocomplete/example-index.html');
+const statesData = require('../../../app/data/states-all.json');
+
+// Modified states data (for augmented results test)
+const statesExtraData = (function(data) {
+  const modified = [].concat(data);
+  modified.forEach((item) => {
+    item.addedValue = 'sandwich';
+  });
+  return modified;
+})(statesData);
+
+let autocompleteInputEl;
+let autocompleteLabelEl;
+let autocompleteAPI;
+let svgEl;
+
+fdescribe('Autocomplete API (select)', () => {
+  beforeEach(() => {
+    autocompleteInputEl = null;
+    autocompleteAPI = null;
+    svgEl = null;
+
+    document.body.insertAdjacentHTML('afterbegin', svgHTML);
+    document.body.insertAdjacentHTML('afterbegin', exampleHTML);
+
+    svgEl = document.body.querySelector('.svg-icons');
+    autocompleteLabelEl = document.body.querySelector('label[for="autocomplete-default"]');
+    autocompleteInputEl = document.body.querySelector('.autocomplete');
+    autocompleteInputEl.removeAttribute('data-options');
+    autocompleteInputEl.classList.add('no-init');
+
+    autocompleteAPI = new Autocomplete(autocompleteInputEl, {
+      source: statesData
+    });
+  });
+
+  afterEach(() => {
+    autocompleteAPI.destroy();
+    svgEl.parentNode.removeChild(svgEl);
+
+    const autocompleteListEl = document.querySelector('#autocomplete-list');
+    if (autocompleteListEl) {
+      autocompleteListEl.parentNode.removeChild(autocompleteListEl);
+    }
+    autocompleteLabelEl.parentNode.removeChild(autocompleteLabelEl);
+    autocompleteInputEl.parentNode.removeChild(autocompleteInputEl);
+  });
+
+  it('returns an object with metadata about an item that was programmatically selected', () => {
+    autocompleteAPI.openList('new', statesData);
+    const autocompleteListEl = document.querySelector('#autocomplete-list');
+    const resultItems = autocompleteListEl.querySelectorAll('li');
+    const selectedItem = autocompleteAPI.select($(resultItems[1]));
+
+    expect(selectedItem).toBeDefined();
+    expect(selectedItem.index).toEqual(1);
+    expect(selectedItem.label).toEqual('New Jersey');
+    expect(selectedItem.value).toEqual('NJ'); // Should be retrieved from `data-value`
+  });
+
+  it('returns an object with metadata about an item that was programmatically selected', () => {
+    autocompleteAPI.openList('new', statesExtraData);
+    const autocompleteListEl = document.querySelector('#autocomplete-list');
+    const resultItems = autocompleteListEl.querySelectorAll('li');
+    const selectedItem = autocompleteAPI.select($(resultItems[1]));
+
+    expect(selectedItem).toBeDefined();
+    expect(selectedItem.index).toEqual(1);
+    expect(selectedItem.value).toEqual('NJ');
+    expect(selectedItem.addedValue).toEqual('sandwich');
+  });
+});

--- a/test/components/autocomplete/autocomplete-select.func-spec.js
+++ b/test/components/autocomplete/autocomplete-select.func-spec.js
@@ -7,20 +7,20 @@ const exampleHTML = require('../../../app/views/components/autocomplete/example-
 const statesData = require('../../../app/data/states-all.json');
 
 // Modified states data (for augmented results test)
-const statesExtraData = (function(data) {
+const statesExtraData = (function (data) {
   const modified = [].concat(data);
   modified.forEach((item) => {
     item.addedValue = 'sandwich';
   });
   return modified;
-})(statesData);
+}(statesData));
 
 let autocompleteInputEl;
 let autocompleteLabelEl;
 let autocompleteAPI;
 let svgEl;
 
-fdescribe('Autocomplete API (select)', () => {
+describe('Autocomplete API (select)', () => {
   beforeEach(() => {
     autocompleteInputEl = null;
     autocompleteAPI = null;


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

A change I made in SOHO-8036 to the Autocomplete's return object was causing some integrity problems when running the `selected` method.  If the original piece of data had properties added by app developers, it should be possible to pass those properties through the return value, as well as any event listeners attached to the `selected` event.  This PR fixes those problems and adds tests for both a clean data and modified data scenario.

> **Related issue (required)**:

https://jira.infor.com/browse/SOHO-8076

> **Steps necessary to review your pull request (required)**:

Pull this branch and run the new "Autocomplete API (selected)" functional tests.  Both should pass.

> Other Details:

Fixes SOHO-8036
Closes SOHO-8076

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
