### PR TITLE
SOHO-8061 - Drop failing bs e2e builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ before_script:
 script:
   - npm run build
   - npm run functional:ci
-  - if [ $TRAVIS_EVENT_TYPE = cron ]; then npm run e2e:ci; fi
 deploy:
     # DEPLOY BUILD TO DEMO SERVER
     # this runs conditionally `on`


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

Stop builds from failing. We are receiving false negatives from BrowserStack. Tests will pass locally on Chrome OSX, but fail in the Chrome OSX VM. We have a local replacement in other branch, that will upgrade Chrome, and tests e2e tests on each branch, on every commit

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> **Related issue (required)**:

https://jira.infor.com/browse/SOHO-8061
<!-- Provide a link to the related issue to this Pull Request. ***Please do not open a PR without a related issue.*** -->

> **Steps necessary to review your pull request (required)**:

Review this build on travis