### PR TITLE
SOHO-7682 - Added api options focusAfterSort with Datagrid

### DIFF
--- a/app/views/components/datagrid/test-focus-after-sort.html
+++ b/app/views/components/datagrid/test-focus-after-sort.html
@@ -1,0 +1,92 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <p>
+      Related JIRA: <a class="hyperlink" href="https://jira.infor.com/browse/SOHO-7682" target="_blank">SOHO-7682</a><br>
+      When sorting on any column, if there is any selected cell in the grid and not currently visible (e.g. because there are many columns which doesn't fit to entire page, sort was on first and selected cell was from the last column), the view is shifted to that selected cell.
+    </p>
+    <p>
+      This api option `focusAfterSort` can use to fix this issue.<br>
+      - Make your browser window short as much, so you have some hidden columns<br>
+      - Click to change the setting for "focusAfterSort" by clicking on button top of grid<br>
+      - If the button state as "Set Focus After Sort To: False"<br>
+      - This means currently option is set as "True"<br>
+      - Click on any cell in last column<br>
+      - Go to first column and click in header to do sort<br>
+      - See it should scroll to last column for focused cell<br><br>
+      - Now change the setting by clicking on button “focusAfterSort” top of grid<br>
+      - This time button should state as "Set Focus After Sort To: True"<br>
+      - This time option should set as "False"<br>
+      - Click on any cell in last column<br>
+      - Go to first column and click in header to do sort<br>
+      - See this time it should NOT scroll to last column for focused cell<br>
+    </p>
+    <br>
+    <button class="btn-secondary" type="button" id="btn-focusaftersort">Set Focus After Sort To: <span class="focus-text" style="color: #000000;">True</span></button>
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid"></div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+
+    var data = [];
+    var columns = [];
+    var elem = $('#datagrid');
+    var focusAfterSortBtn = $('#btn-focusaftersort');
+    var focusAfterSortText = focusAfterSortBtn.find('.focus-text');
+
+    // Some Sample Data
+    data.push({ id: 1, productId: 'T100', productName: 'Compressor', phone: '191/2004', activity:  'Assemble Paint', quantity: 1, price: '800.9905673502324', percent: 0.10, status: 'OK', orderDate: '00000000', action: 'Action'});
+    data.push({ id: 2, productId: '200', productName: 'Different Compressor', phone: '(888) 888-8888', activity:  'Inspect and Repair', quantity: '2', percent: 0.10, price: null, status: '', orderDate: '2015-01-01T06:00:00.000Z', action: 'On Hold'});
+    data.push({ id: 3, productId: '300', productName: 'Compressor', phone: '(888) 888-8888', activity:  'Inspect and Repair', quantity: 1, price: '120.99', percent: 0.10, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+    data.push({ id: 4, productId: 'Z400', productName: 'Another Compressor', phone: '(888) 888-8888', activity:  'Assemble Paint', quantity: 3, price: '2345', percent: 0.10, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+    data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: '2345', percent: 0.10, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+    data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: '210.99', percent: 0.10, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+    data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: '120.99', percent: 0.10, status: 'OK', orderDate:new Date(2017, 5, 5), action: 'On Hold'});
+    data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '123.99', percent: 0.10, status: 'OK', orderDate: null, action: 'On Hold'});
+
+    //Define Columns for the Grid.
+    columns.push({ id: 'productId', name: 'Id', field: 'productId', reorderable: true, formatter: Formatters.Text, width: 100});
+    columns.push({ id: 'productName', name: 'Product Name', field: 'productName', reorderable: true, formatter: Formatters.Hyperlink, width: 300});
+    columns.push({ id: 'activity', name: 'Activity', field: 'activity', reorderable: true});
+    columns.push({ id: 'hidden', hidden: true, name: 'Hidden', field: 'hidden'});
+    columns.push({ id: 'price', align: 'right', name: 'Actual Price', field: 'price', reorderable: true, formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'currency', currencySign: '$'}});
+    columns.push({ id: 'percent', align: 'right', name: 'Actual %', field: 'percent', reorderable: true, formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'percent'}});
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', reorderable: true, formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+    columns.push({ id: 'phone', name: 'Phone', field: 'phone', reorderable: true, formatter: Formatters.Text});
+
+    // Default settings
+    var settings = {
+      focusAfterSort: false,
+      columns: columns,
+      dataset: data,
+      saveColumns: false,
+      toolbar: {title: 'Compressors', results: true, actions: true, rowHeight: true, personalize: true}
+    };
+
+
+    // Init the grid
+    elem.datagrid(settings);
+
+    // Toggles the `setting.focusAfterSort` and set button text
+    // Bind the button to toggles
+    focusAfterSortBtn.on('click.test', function () {
+      focusAfterSortText.html(settings.focusAfterSort ? 'True' : 'False');
+      settings.focusAfterSort = !settings.focusAfterSort;
+
+      var grid = elem.data('datagrid');
+      if (grid) {
+        grid.updated(settings);
+      } else {
+        elem.datagrid(settings)
+      }
+    });
+
+ });
+</script>

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -46,6 +46,7 @@ const COMPONENT_NAME = 'datagrid';
  * @param {object}   [settings.saveUserSettings.pageSize=true]
  * @param {object}   [settings.saveUserSettings.activePage=true]
  * @param {object}   [settings.saveUserSettings.filter=true]
+ * @param {boolean}  [settings.focusAfterSort=false] If true will focus the active cell after sorting.
  * @param {boolean}  [settings.editable=false] Enable editing in the grid, requires column editors.
  * @param {boolean}  [settings.isList=false] Makes the grid have readonly "list" styling
  * @param {string}   [settings.menuId=null]  ID of the menu to use for a row level right click context menu
@@ -114,6 +115,7 @@ const DATAGRID_DEFAULTS = {
   columnReorder: false, // Allow Column reorder
   saveColumns: false, // Save Column Reorder and resize
   saveUserSettings: {},
+  focusAfterSort: false, // If true will focus the active cell after sorting.
   editable: false,
   isList: false, // Makes a readonly "list"
   menuId: null, // Id to the right click context menu
@@ -7476,6 +7478,10 @@ Datagrid.prototype = {
     // Do Sort on Data Set
     this.setSortIndicator(id, ascending);
     this.sortDataset();
+
+    if (!this.settings.focusAfterSort && this.activeCell && this.activeCell.isFocused) {
+      this.activeCell.isFocused = false;
+    }
 
     const wasFocused = this.activeCell.isFocused;
     this.setTreeDepth();


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

When sorting on any column, if there is any selected cell in the grid and not currently visible (e.g. because there are many columns which doesn't fit to entire page, sort was on first and selected cell was from the last column), the view was shifted to that selected cell.

> **Related issue (required)**:

https://jira.infor.com/browse/SOHO-7682

> **Steps necessary to review your pull request (required)**:

http://localhost:4000/components/datagrid/test-focus-after-sort
- Open above link
- Make your browser window short as much, so you have some hidden columns
- Click to change the setting for “focusAfterSort” by clicking on button top of grid
- If the button state as “Set Focus After Sort To: False”
- This means currently option is set as “True”
- Click on any cell in last column
- Go to first column and click in header to do sort
- See it should scroll to last column for focused cell
- Now change the setting by clicking on button “focusAfterSort” top of grid
- This time button should state as "Set Focus After Sort To: True"
- This time option should set as “False”
- Click on any cell in last column
- Go to first column and click in header to do sort
- See this time it should NOT scroll to last column for focused cell