### PR TITLE
SOHO-8059 - Fixed pressing enter key twice was closing Modal with Editor

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -555,7 +555,7 @@ Modal.prototype = {
     $(this.element).on('keypress.modal', (e) => {
       const target = $(e.target);
 
-      if (target.is('.searchfield') || target.is('textarea') || target.is(':button') || target.is('.dropdown') || target.closest('.tab-list').length) {
+      if (target.is('.dropdown, .editor, .searchfield, textarea, :button') || target.closest('.tab-list').length) {
         return;
       }
 


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

Editor Modal was closing soon “Enter” key get pressed twice

> **Related issue (required)**:

https://jira.infor.com/browse/SOHO-8059

> **Steps necessary to review your pull request (required)**:

http://localhost:4000/components/editor/test-modal
- Open above link
- Click on button “Show Modal” to open modal
- Press “Enter” key twice
- Modal should not close