### PR TITLE
SOHO-6271 Fixed issue regarding slider step

### DIFF
--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -427,10 +427,11 @@ Slider.prototype = {
 
     self.checkHandleDifference(targetHandle, targetOldVal, rangeVal);
 
+    const moveBy = self.settings.step ? self.settings.step : 0;
     if (rangeVal < targetOldVal) {
-      self.decreaseValue(e, targetHandle, rangeVal, 0);
+      self.decreaseValue(e, targetHandle, rangeVal, moveBy);
     } else {
-      self.increaseValue(e, targetHandle, rangeVal, 0);
+      self.increaseValue(e, targetHandle, rangeVal, moveBy);
     }
 
     // Tooltip repositioner will focus the handle after positioning occurs, but if


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?
- Updated handleRangeClick function to move to nearest step when clicking on range
- http://localhost:4000/components/slider/example-stepping.html

> **Steps necessary to review your pull request (required)**:
- Click on range bar near the dot (left or right side)
- Dot should now move to nearest step