### PR TITLE
SOHO-8076 - autocomplete `select()` return value bugfix

### DIFF
--- a/src/components/autocomplete/autocomplete.js
+++ b/src/components/autocomplete/autocomplete.js
@@ -681,11 +681,16 @@ Autocomplete.prototype = {
       for (let i = 0, value; i < items.length; i++) {
         if (typeof items[i] === 'object' && items[i].value !== undefined) {
           value = items[i].value.toString();
-          ret = items[i];
         } else {
           value = items[i].toString();
         }
-        ret.value = value;
+
+        if (value === dataValue) {
+          if (typeof items[i] === 'object') {
+            ret = items[i];
+          }
+          ret.value = value;
+        }
       }
     }
 

--- a/test/components/autocomplete/autocomplete-select.func-spec.js
+++ b/test/components/autocomplete/autocomplete-select.func-spec.js
@@ -15,12 +15,21 @@ const statesExtraData = (function (data) {
   return modified;
 }(statesData));
 
+// Modified template that doesn't contain a `data-index`
+const modifiedTemplateHTML = `<script id="autocomplete-template-modified" type="text/html">
+<li id="{{listItemId}}" {{#hasValue}}data-value="{{value}}"{{/hasValue}} role="listitem">
+ <a href="#" tabindex="-1">
+   <span>{{{label}}}</span>
+ </a>
+</li>
+</script>`;
+
 let autocompleteInputEl;
 let autocompleteLabelEl;
 let autocompleteAPI;
 let svgEl;
 
-describe('Autocomplete API (select)', () => {
+fdescribe('Autocomplete API (select)', () => {
   beforeEach(() => {
     autocompleteInputEl = null;
     autocompleteAPI = null;
@@ -64,7 +73,25 @@ describe('Autocomplete API (select)', () => {
     expect(selectedItem.value).toEqual('NJ'); // Should be retrieved from `data-value`
   });
 
-  it('returns an object with metadata about an item that was programmatically selected', () => {
+  it('retains extra information from the original data source inside its return object', () => {
+    autocompleteAPI.openList('new', statesExtraData);
+    const autocompleteListEl = document.querySelector('#autocomplete-list');
+    const resultItems = autocompleteListEl.querySelectorAll('li');
+    const selectedItem = autocompleteAPI.select($(resultItems[1]));
+
+    expect(selectedItem).toBeDefined();
+    expect(selectedItem.index).toEqual(1);
+    expect(selectedItem.value).toEqual('NJ');
+    expect(selectedItem.addedValue).toEqual('sandwich');
+  });
+
+  it('returns the correct item when selecting with a `data-value`', () => {
+    document.body.insertAdjacentHTML('afterbegin', modifiedTemplateHTML);
+
+    autocompleteAPI.updated({
+      template: '#autocomplete-template-modified'
+    });
+
     autocompleteAPI.openList('new', statesExtraData);
     const autocompleteListEl = document.querySelector('#autocomplete-list');
     const resultItems = autocompleteListEl.querySelectorAll('li');

--- a/test/components/autocomplete/autocomplete-select.func-spec.js
+++ b/test/components/autocomplete/autocomplete-select.func-spec.js
@@ -29,7 +29,7 @@ let autocompleteLabelEl;
 let autocompleteAPI;
 let svgEl;
 
-fdescribe('Autocomplete API (select)', () => {
+describe('Autocomplete API (select)', () => {
   beforeEach(() => {
     autocompleteInputEl = null;
     autocompleteAPI = null;


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

a previous fix for SOHO-8076 was causing incorrect values to be returned as `selected` when a `data-index` attribute wasn't used in templates.  This has been fixed and a tests was added to demonstrate.

> **Related issue (required)**:

https://jira.infor.com/browse/SOHO-8076?focusedCommentId=4543384&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4543384

> **Steps necessary to review your pull request (required)**:

- Pull the branch and run the functional tests for Autocomplete.  All should pass.

> Other Details:

Closes SOHO-8076

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
