### PR TITLE
Use bold for PR template headings instead of quote indent

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,21 @@
-> Explain the **details** for making this change. What existing problem does the pull request solve?
+**Explain the _details_ for making this change. What existing problem does the pull request solve?**
 
 <!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
 
-> **Related issue (required)**:
+**Related github/jira issue (required)**:
 
-<!-- Provide a link to the related issue to this Pull Request. ***Please do not open a PR without a related issue.*** -->
+<!-- Provide a link to the related issue to this Pull Request.-->
 
-> **Steps necessary to review your pull request (required)**:
+**Steps necessary to review your pull request (required)**:
+<!--
+Include:
+- commands you ran and their output
+- screenshots / videos
+- test scenarios
+-->
 
-<!-- What does someone need to do to confirm that this PR is ready to merge? Please include the exact commands you ran and their output, screenshots / videos if the pull request changes UI. You can skip this if you're fixing a typo or the change is very obvious in the diff. -->
 
-> Other Details:
-
-<!-- Please add `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if exists). -->
+**Closing issues**
+<!-- Please add `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
 
 <!-- After submitting your PR, please check back to make sure tests pass on Travis. -->


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

I originally liked the grayed out quoted titles in the PR template, but I've slowly grown to dislike them.  
I want to know what you guys think...

**Steps necessary to review your pull request (required)**:

Which do you like better, old:

<img width="400" alt="old" src="https://user-images.githubusercontent.com/742319/41128430-249d167a-6a7c-11e8-97b0-41b89af1e3c5.png">

or new (aka this PR):

<img width="400" alt="new" src="https://user-images.githubusercontent.com/742319/41128436-285b9750-6a7c-11e8-8b35-33f3c083acd9.png">

