### PR TITLE
SOHO-7723 fix button alignment issue

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -642,7 +642,14 @@ a.btn-menu {
         }
       }
     }
- 	}
+  }
+  button {
+    margin-bottom: 5px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
 }
 
 // Short field buttons


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added CSS fix for the button alignment issue
 
**Related github/jira issue (required)**:
SOHO-7723

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/tabs/example-beforeactivate-callback
- open the link above then resize the window
- Expected result: Buttons should have a 5px space/gap vertically when in stacked