### PR TITLE
SOHO-8061 - Correct BrowserStack REST API error reporting for any *bs.conf*

### DIFF
--- a/test/helpers/browserstack-error-reporter.js
+++ b/test/helpers/browserstack-error-reporter.js
@@ -1,25 +1,23 @@
 const r2 = require('r2');
 
 const browserStackErrorHTTPReporter = async (error) => {
-  if (process.argv.filter(item => !item.includes('bs.conf')).length > 0) {
-    return;
-  }
+  if (process.argv.filter(item => item.includes('bs.conf')).length > 0) {
+    const username = process.env.BROWSER_STACK_USERNAME;
+    const accessKey = process.env.BROWSER_STACK_ACCESS_KEY;
+    const session = await browser.driver.getSession();
+    const sessionId = session.getId();
+    const url = `https://${username}:${accessKey}@api.browserstack.com/automate/sessions/${sessionId}.json`;
+    const obj = {
+      status: 'error',
+      reason: error.description
+    };
 
-  const username = process.env.BROWSER_STACK_USERNAME;
-  const accessKey = process.env.BROWSER_STACK_ACCESS_KEY;
-  const session = await browser.driver.getSession();
-  const sessionId = session.getId();
-  const url = `https://${username}:${accessKey}@api.browserstack.com/automate/sessions/${sessionId}.json`;
-  const obj = {
-    status: 'error',
-    reason: error.description
-  };
-
-  try {
-    await r2.put(url, { json: obj }).json;
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.log(err);
+    try {
+      await r2.put(url, { json: obj }).json;
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.log(err);
+    }
   }
 };
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Corrects error reporting in BrowserStack reporting console via REST API
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related github/jira issue (required)**:
https://jira.infor.com/browse/SOHO-8061

<!-- Provide a link to the related issue to this Pull Request.-->

**Steps necessary to review your pull request (required)**:
Run BrowserStack locally, and look for errors to be reported, `npm run e2e:local:bs`
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

<img width="1023" alt="screen shot 2018-06-11 at 2 29 32 pm" src="https://user-images.githubusercontent.com/1667967/41250073-e6dc95bc-6d83-11e8-8dbb-5cd34c8fae67.png">


**Closing issues**
<!-- Please add `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
