### PR TITLE
SOHO-8118 - Fixed quick entry on editable datagrids after page 1 when…

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -6185,7 +6185,7 @@ Datagrid.prototype = {
       // or click to activate using a mouse.
       if (self.settings.editable && key === 32) {
         if (!self.editor) {
-          self.makeCellEditable(row, cell, e);
+          self.makeCellEditable(self.activeCell.rowIndex, cell, e);
         }
       }
 
@@ -6207,7 +6207,7 @@ Datagrid.prototype = {
           self.commitCellEdit(self.editor.input);
           self.setNextActiveCell(e);
         } else {
-          self.makeCellEditable(row, cell, e);
+          self.makeCellEditable(self.activeCell.rowIndex, cell, e);
           if (self.isContainTextfield(node) && self.notContainTextfield(node)) {
             self.quickEditMode = true;
           }
@@ -6219,7 +6219,7 @@ Datagrid.prototype = {
       if ([9, 13, 32, 35, 36, 37, 38, 39, 40, 113].indexOf(key) === -1 &&
         !e.altKey && !e.shiftKey && !e.ctrlKey && !e.metaKey && self.settings.editable) {
         if (!self.editor) {
-          self.makeCellEditable(row, cell, e);
+          self.makeCellEditable(self.activeCell.rowIndex, cell, e);
         }
       }
 


### PR DESCRIPTION
The SX.e team found an issue where quick keyboard entry on editable datagrids only works on page 1 when cells are conditionally editable. I have a fix I will contribute for this issue.

Reproduce:

1. Use this example /components/datagrid/example-editable.html
2. Using the keyboard navigate over to an editable Quantity cell
3. Type "5" without clicking on the cell (the edit works properly)
4. Go to page 2
5. Using the keyboard navigate over to an editable Quantity cell
6. Type "5" without clicking on the cell (the edit does not happen)