### PR TITLE
Fixed a bug hiding/showing columns with expandableRow

### DIFF
--- a/app/views/components/datagrid/example-expandable-row.html
+++ b/app/views/components/datagrid/example-expandable-row.html
@@ -47,10 +47,9 @@
         idProperty:'officeId',
         dataset: data,
         filterable: true,
-        isList: true,
         rowTemplate: rowTemplate,
         toolbar: {title: 'Data Grid Header Title', collapsibleFilter: true,
-          results: true, keywordFilter: true, actions: true, exportToExcel: true, rowHeight: true}
+          results: true, keywordFilter: true, actions: true, exportToExcel: true, rowHeight: true, personalize: true}
       });
 
       grid.on('expandrow', function (e, args) {

--- a/app/views/components/datagrid/example-expandable-row.html
+++ b/app/views/components/datagrid/example-expandable-row.html
@@ -25,15 +25,10 @@
 
       //Define Columns for the Grid.
 
-      columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Expander, filterType: 'text', textOverflow: 'ellipsis', width: 300});
-      //columns.push({ id: 'drilldown', name: '', field: '', formatter: Formatters.Drilldown, sortable: false, resizable: false, click: function(a, b) {console.log(b[0].item, b[0].row);}, align: 'center'});
+      columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Expander, filterType: 'text', textOverflow: 'ellipsis', width: 300, hideable: false});
       columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', filterType: 'text', formatter: Formatters.Hyperlink});
       columns.push({ id: 'activity', name: 'Activity', field: 'activity', filterType: 'text'});
       columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity'});
-      //columns.push({ id: 'price', name: 'Price', field: 'price', formatter: Formatters.Decimal, width: 80});
-      //columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', width: 100, formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
-      //columns.push({ id: 'status', name: 'Status', field: 'status', width: 200, formatter: Formatters.Text});
-      //columns.push({ id: 'action', name: 'Action Item', field: 'action', width: 200});
 
       var rowTemplate = '<div class="datagrid-cell-layout"><div class="img-placeholder"><svg class="icon" focusable="false" aria-hidden="true" role="presentation"><use xlink:href="#icon-camera"></use></svg></div></div>'+
                         '<div class="datagrid-cell-layout"><p class="datagrid-row-heading">Expandable Content Area</p>' +

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3822,9 +3822,23 @@ Datagrid.prototype = {
       }
     }
 
+    // Handle expandable rows
+    if (this.settings.rowTemplate || this.settings.expandableRow) {
+      this.syncExpandableRowColspan();
+    }
+
     this.element.trigger('columnchange', [{ type: 'hidecolumn', index: idx, columns: this.settings.columns }]);
     this.saveColumns();
     this.saveUserSettings();
+  },
+
+  /**
+  * Sync the colspan on the expandable row. (When column count changes)
+  * @private
+  */
+  syncExpandableRowColspan() {
+    const visibleColumnCount = this.visibleColumns().length;
+    this.tableBody.find('.datagrid-expandable-row td').attr('colspan', visibleColumnCount);
   },
 
   /**
@@ -3861,6 +3875,11 @@ Datagrid.prototype = {
           this.tableBody.find(`td:nth-child(${idx + 1})`).removeClass('is-hidden');
         }
       }
+    }
+
+    // Handle expandable rows
+    if (this.settings.rowTemplate || this.settings.expandableRow) {
+      this.syncExpandableRowColspan();
     }
 
     this.element.trigger('columnchange', [{ type: 'showcolumn', index: idx, columns: this.settings.columns }]);

--- a/test/components/autocomplete/autocomplete-select.func-spec.js
+++ b/test/components/autocomplete/autocomplete-select.func-spec.js
@@ -52,7 +52,7 @@ describe('Autocomplete API (select)', () => {
     autocompleteInputEl.parentNode.removeChild(autocompleteInputEl);
   });
 
-  it('returns an object with metadata about an item that was programmatically selected', () => {
+  it('returns an object with index, label and value about an item that was programmatically selected', () => {
     autocompleteAPI.openList('new', statesData);
     const autocompleteListEl = document.querySelector('#autocomplete-list');
     const resultItems = autocompleteListEl.querySelectorAll('li');
@@ -64,7 +64,7 @@ describe('Autocomplete API (select)', () => {
     expect(selectedItem.value).toEqual('NJ'); // Should be retrieved from `data-value`
   });
 
-  it('returns an object with metadata about an item that was programmatically selected', () => {
+  it('returns an object with index, value and addedValue about an item that was programmatically selected', () => {
     autocompleteAPI.openList('new', statesExtraData);
     const autocompleteListEl = document.querySelector('#autocomplete-list');
     const resultItems = autocompleteListEl.querySelectorAll('li');

--- a/test/components/autocomplete/autocomplete-select.func-spec.js
+++ b/test/components/autocomplete/autocomplete-select.func-spec.js
@@ -52,7 +52,7 @@ describe('Autocomplete API (select)', () => {
     autocompleteInputEl.parentNode.removeChild(autocompleteInputEl);
   });
 
-  it('returns an object with index, label and value about an item that was programmatically selected', () => {
+  it('returns an object with metadata about an item that was programmatically selected', () => {
     autocompleteAPI.openList('new', statesData);
     const autocompleteListEl = document.querySelector('#autocomplete-list');
     const resultItems = autocompleteListEl.querySelectorAll('li');
@@ -64,7 +64,7 @@ describe('Autocomplete API (select)', () => {
     expect(selectedItem.value).toEqual('NJ'); // Should be retrieved from `data-value`
   });
 
-  it('returns an object with index, value and addedValue about an item that was programmatically selected', () => {
+  it('returns an object with metadata about an item that was programmatically selected', () => {
     autocompleteAPI.openList('new', statesExtraData);
     const autocompleteListEl = document.querySelector('#autocomplete-list');
     const resultItems = autocompleteListEl.querySelectorAll('li');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When hiding and showing columns , if you have expandable row. The columns get messed up.

**Related github/jira issue (required)**:

soho-8103

**Steps necessary to review your pull request (required)**:

http://localhost:4000/components/datagrid/example-expandable-row.html
- expand any row
- under the ... menu personalize columns
- hide a few / show a few

Note: Hiding the expandable row is disabled..
