### PR TITLE
SOHO-7939 make checkbox default align left

### DIFF
--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -22,7 +22,7 @@
   }
 
   .field-checkbox {
-    text-align: center;
+    text-align: left;
   }
 
   .lookup-wrapper {
@@ -44,10 +44,5 @@
     .field .checkbox > label {
       margin-top: -10px;
     }
-
-    .field-checkbox {
-      text-align: left;
-    }
-
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
change the css property of the class name field-checkbox to left to make it the default alignment of the checkbox inside the field.

**Related github/jira issue (required)**:
SOHO-7939

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/form/example-inputs.html
- open the link above. try to resize the window.
- Expected result: Checkbox should be left align in any window sizes.