### PR TITLE
SOHO-8121: 4.0 Validation getting multiple events firing for one occu…

### DIFF
--- a/app/views/components/validation/test-message-types.html
+++ b/app/views/components/validation/test-message-types.html
@@ -24,6 +24,9 @@
       <div class="field">
         <input type="checkbox" class="checkbox" id="is-alert">
         <label for="is-alert" class="checkbox-label">Is Alert</label>
+
+        <input type="checkbox" class="checkbox" id="trigger-events" checked>
+        <label for="trigger-events" class="checkbox-label">Trigger Events</label>
       </div>
 
       <div class="field">
@@ -62,21 +65,23 @@
 </form>
 
 <script>
-  var currentValidationType = 'error';
-  var message = 'Message';
-  var fields = $('#text-field, #date-field');
-  var fieldsOutput = $('#output-text-field, #output-date-field');
+  let currentValidationType = 'error';
+  const message = 'Message';
+  const fields = $('#text-field, #date-field');
+  const fieldsOutput = $('#output-text-field, #output-date-field');
 
   function addMessage() {
-    var isAlert = $('#is-alert').prop('checked');
-    var alertText = (isAlert) ? ' is alert,' : '';
-    var options = {
-      message    : message + alertText + ' type is ' + currentValidationType,
-      type       : currentValidationType,
-      showTooltip: false,
-      inline     : true,
-      isAlert    : isAlert
-    }
+    const triggerEvents = $('#trigger-events').prop('checked');
+    const isAlert = $('#is-alert').prop('checked');
+    const alertText = (isAlert) ? ' is alert,' : '';
+    const options = {
+      message      : message + alertText + ' type is ' + currentValidationType,
+      type         : currentValidationType,
+      showTooltip  : false,
+      inline       : true,
+      triggerEvents: triggerEvents,
+      isAlert      : isAlert
+    };
 
     if (currentValidationType === 'icon') {
       options.icon = 'mail';
@@ -86,17 +91,33 @@
   }
 
   function removeMessage() {
+    const triggerEvents = $('#trigger-events').prop('checked');
     fields.removeMessage({
-      message: '',
-      type   : currentValidationType
+      message      : '',
+      type         : currentValidationType,
+      triggerEvents: triggerEvents
     });
   }
 
   function getMessage() {
-    var dataAttr = currentValidationType + 'message';
+    const types = ['error', 'alert', 'confirm', 'info', 'icon'];
+    let outputText = '';
+    let outputDate = '';
 
-    $('#output-text-field').val($('#text-field').data(dataAttr));
-    $('#output-date-field').val($('#date-field').data(dataAttr));
+    types.forEach( (type) => {
+      let value = $('#text-field').getMessage( {type: type} );
+      if (value) {
+        outputText += value + '; ';
+      }
+
+      value = $('#date-field').getMessage( {type: type} );
+      if (value) {
+        outputDate += value + '; ';
+      }
+    });
+
+    $('#output-text-field').val(outputText);
+    $('#output-date-field').val(outputDate);
   }
 
   function clearAllMessages() {
@@ -132,9 +153,7 @@
 
   $('form').on('valid', function (e, args) {
     console.log('valid', e, args);
-  });
-
-  $('form').on('error', function (e, args) {
+  }).on('error', function (e, args) {
     console.log('error', e, args);
   });
 

--- a/app/views/components/validation/test-message-types.html
+++ b/app/views/components/validation/test-message-types.html
@@ -65,16 +65,16 @@
 </form>
 
 <script>
-  let currentValidationType = 'error';
-  const message = 'Message';
-  const fields = $('#text-field, #date-field');
-  const fieldsOutput = $('#output-text-field, #output-date-field');
+  var currentValidationType = 'error';
+  var message = 'Message';
+  var fields = $('#text-field, #date-field');
+  var fieldsOutput = $('#output-text-field, #output-date-field');
 
   function addMessage() {
-    const triggerEvents = $('#trigger-events').prop('checked');
-    const isAlert = $('#is-alert').prop('checked');
-    const alertText = (isAlert) ? ' is alert,' : '';
-    const options = {
+    var triggerEvents = $('#trigger-events').prop('checked');
+    var isAlert = $('#is-alert').prop('checked');
+    var alertText = (isAlert) ? ' is alert,' : '';
+    var options = {
       message      : message + alertText + ' type is ' + currentValidationType,
       type         : currentValidationType,
       showTooltip  : false,
@@ -91,7 +91,7 @@
   }
 
   function removeMessage() {
-    const triggerEvents = $('#trigger-events').prop('checked');
+    var triggerEvents = $('#trigger-events').prop('checked');
     fields.removeMessage({
       message      : '',
       type         : currentValidationType,
@@ -100,12 +100,12 @@
   }
 
   function getMessage() {
-    const types = ['error', 'alert', 'confirm', 'info', 'icon'];
-    let outputText = '';
-    let outputDate = '';
+    var types = ['error', 'alert', 'confirm', 'info', 'icon'];
+    var outputText = '';
+    var outputDate = '';
 
     types.forEach( (type) => {
-      let value = $('#text-field').getMessage( {type: type} );
+      var value = $('#text-field').getMessage( {type: type} );
       if (value) {
         outputText += value + '; ';
       }

--- a/src/components/validation/validation.jquery.js
+++ b/src/components/validation/validation.jquery.js
@@ -20,18 +20,16 @@ $.fn.validation = Validation;
 /**
  * Returns the specific type message data object for a Field
  * @param {object} [settings] incoming settings
- * @returns {object} error message data
+ * @returns {object} message data for the specific type
  */
 $.fn.getMessage = function (settings) {
   const dataAttr = `${settings.type}message`;
 
-  return this.each(function () {
-    let instance = $.data(this, VALIDATOR_COMPONENT_NAME);
-    if (!instance) {
-      instance = $.data(this, VALIDATOR_COMPONENT_NAME, new Validator(this, settings));
-    }
-    return instance.getField($(this)).data(dataAttr);
-  });
+  let instance = $.data(this, VALIDATOR_COMPONENT_NAME);
+  if (!instance) {
+    instance = $.data(this, VALIDATOR_COMPONENT_NAME, new Validator(this, settings));
+  }
+  return instance.getField($(this)).data(dataAttr);
 };
 
 /**
@@ -67,7 +65,7 @@ $.fn.scrollIntoView = function (alignToTop, settings) {
 /**
  * Add a Message to a Field
  * @param {object} [settings] incoming settings
- * @returns {jQuery[]} elements receiving errors
+ * @returns {jQuery[]} elements receiving messages
  */
 $.fn.addMessage = function (settings) {
   return this.each(function () {
@@ -83,6 +81,7 @@ $.fn.addMessage = function (settings) {
       settings.inline,
       settings.showTooltip,
       settings.isAlert,
+      settings.triggerEvents,
       settings.icon
     );
   });
@@ -114,7 +113,7 @@ $.fn.removeMessage = function (settings) {
     }
 
     const field = $(this);
-    instance.removeMessage(field, settings.type);
+    instance.removeMessage(field, settings.type, settings.triggerEvents);
     instance.setIconOnParent(field, settings.type);
 
     $.removeData(this, VALIDATOR_COMPONENT_NAME);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Changed $.fn.getMessage() to return the message data for the specific type for an individual field instead of a collection of jQuery objects which caused the soho-alert.directive in enterprise-ng to break.

- Changed $.fn.addMessage() and $.fn.removeMessage() to accept a new triggerEvents parameter that will indicate whether to trigger events. This will alleviate possible infinite loops when callers using soho-alert.directive are also executing these methods.

**Related github/jira issue (required)**:
[SOHO-8112: 4.0 Validation getMessage() does not return message text as expected](https://jira.infor.com/browse/SOHO-8112)
[SOHO-8121: 4.0 Validation getting multiple events firing for one occurrence](https://jira.infor.com/browse/SOHO-8121)

**Steps necessary to review your pull request (required)**:
Use test-message-types.html to test
- Click on Error radio button and then click Add Inline Message button
- Error messages should display below the Text Field and Date Field
- Browser console should display two 'error' log messages
- Click on Remove Message button
- Error messages should no longer display below the Text Field and Date Field
- Browser console should display two 'valid' log messages
- Uncheck the Trigger Events checkbox
- Clear the browser console
- Click Add Inline Message button
- Error messages should display below the Text Field and Date Field
- Browser console should remain clear
- Click on Remove Message button
- Error messages should no longer display below the Text Field and Date Field
- Browser console should remain clear

![soho-8121](https://user-images.githubusercontent.com/20212079/41369454-7f730c34-6f0a-11e8-9fc2-b6d78402f35d.gif)

**Closing issues**
closes SOHO-8112
closes SOHO-8121
