### PR TITLE
Wait for aria, and class selected attributes to be added to DOM

### DIFF
--- a/test/components/listview/listview.e2e-spec.js
+++ b/test/components/listview/listview.e2e-spec.js
@@ -26,7 +26,7 @@ describe('Listview example-singleselect tests', () => {
     const listviewItemEl = await element(by.css('li[aria-posinset="1"]'));
     listviewItemEl.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.className('is-selected'))), config.waitsFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-selected="true"]')).isPresent()).toBeTruthy();
     await browser.driver
@@ -39,7 +39,7 @@ describe('Listview example-singleselect tests', () => {
     const listviewItemEl = await element(by.css('li[aria-posinset="1"]'));
     listviewItemEl.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.className('is-selected'))), config.waitsFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-selected="true"]')).isPresent()).toBeTruthy();
     expect(await element(by.className('selection-count')).getText()).toContain('1 Selected');
@@ -57,15 +57,15 @@ describe('Listview example-singleselect tests', () => {
     const listviewItemElTwo = await element(by.css('li[aria-posinset="2"]'));
     await listviewEl.sendKeys(protractor.Key.TAB);
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.className('is-selected'))), config.waitsFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-posinset="1"][aria-selected="true"]')).isPresent()).toBeTruthy();
     await listviewItemElOne.sendKeys(protractor.Key.ARROW_DOWN);
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.className('is-selected'))), config.waitsFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitsFor);
     await listviewItemElTwo.sendKeys(protractor.Key.ARROW_DOWN);
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.className('is-selected'))), config.waitsFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-posinset="3"].is-selected')).isPresent()).toBeTruthy();
     expect(await element(by.className('selection-count')).getText()).toContain('1 Selected');
@@ -92,7 +92,7 @@ describe('Listview example-multiselect tests', () => {
     const listviewItemEl = await element(by.css('li[aria-posinset="1"]'));
     listviewItemEl.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.className('is-selected'))), config.waitsFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-selected="true"]'))).toBeTruthy();
     await browser.driver
@@ -105,7 +105,7 @@ describe('Listview example-multiselect tests', () => {
     const listviewItemEl = await element(by.css('li[aria-posinset="1"]'));
     listviewItemEl.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.className('is-selected'))), config.waitsFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-selected="true"]'))).toBeTruthy();
     expect(await element(by.className('selection-count')).getText()).toContain('1 Selected');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes random failing test possible due to a timing issue. This fix ensures that we wait for aria-selected, and class to be present in DOM before testing
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related github/jira issue (required)**:
Relates to https://jira.infor.com/browse/SOHO-8061

<!-- Provide a link to the related issue to this Pull Request.-->

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
Focus, isolate the tests on listview.e2e.*, or just run `npm run e2e:ci` as a whole a couple of times