### PR TITLE
Repurpose "test" as it was a duplicate cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "eslint:error-only": "npx eslint -c .eslintrc.js --quiet src test",
     "functional:local": "npx karma start test/karma.conf.js",
     "functional:ci": "npx karma start test/karma.conf.js --single-run",
-    "all-checks": "npm run mdlint && npm run eslint && npm run functional:ci && npm run e2e:ci",
     "e2e:ci": "npm run webdriver:update && npx protractor test/protractor.ci.conf.js",
     "e2e:ci:bs": "npx protractor test/protractor.ci.bs.conf.js",
     "e2e:local:bs": "npm run webdriver:update && npx protractor test/protractor.local.bs.conf.js",
@@ -51,7 +50,7 @@
     "release:rc": "release-it minor --preRelease=rc",
     "release:final": "release-it minor",
     "prepublishOnly": "npm run build",
-    "test": "npx karma start test/karma.conf.js --single-run"
+    "test": "npm run mdlint && npm run eslint && npm run functional:ci && npm run e2e:ci"
   },
   "dependencies": {
     "d3": "^4.13.0",


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

- `npm test` is a duplicate cmd, we can move the `all-checks` script content to it and avoid having to have another cmd in the list

**Related github/jira issue (required)**:
- n/a

**Steps necessary to review your pull request (required)**:

- make sure `npm run test` isn't used other places where the server might be required, yet unavailable
