### PR TITLE
SOHO-8120 Adjusted alignment of dismiss icon

### DIFF
--- a/src/components/badges/_badges.scss
+++ b/src/components/badges/_badges.scss
@@ -232,4 +232,15 @@ html[dir='rtl'] {
     margin-left: inherit;
     margin-right: 10px;
   }
+
+  .tag,
+  .badge {
+    &.is-dismissible {
+      .dismissible-btn {
+        .icon {
+          left: -7px;
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Adjusted alignment of dismiss icon
- http://localhost:4000/components/tag/example-dismissible-and-clickable.html?locale=ar-SA#

**Steps necessary to review your pull request (required)**:
- Upon opening the test page, dismiss icon should no longer be misaligned to the right