### PR TITLE
SOHO-8078 - Added functional and e2e tests for Colorpicker

### DIFF
--- a/app/views/components/colorpicker/example-custom-labels.html
+++ b/app/views/components/colorpicker/example-custom-labels.html
@@ -1,15 +1,26 @@
 <div class="row">
   <div class="twelve columns">
+    <p>Pick from first three color swatch</p><br>
+  </div>
+</div>
 
+<div class="row">
+  <div class="twelve columns">
     <div class="field">
-      <label for="background-color">Color Picker</label>
-      <input class="colorpicker" id="background-color" type="text" value="#488421"
-        data-options="{'uppercase': false, 'colors': [
+      <label for="custom-color">Color Picker (custom color)</label>
+      <input class="colorpicker" id="custom-color" type="text" data-options="{'uppercase': false, 'colors': [
           {label: 'Grape', value: '2578a9', number: '10'},
           {label: 'Blueberry', value: '368ac0', number: '08'},
           {label: 'Banana', value: 'efa836', number: '09'}
         ]}" />
     </div>
-
+    <div class="field">
+      <label for="custom-label">Color Picker (custom label)</label>
+      <input class="colorpicker" id="custom-label" type="text" data-options="{'uppercase': false, 'showLabel': true, 'colors': [
+          {label: 'Grape', value: '2578a9', number: '10'},
+          {label: 'Blueberry', value: '368ac0', number: '08'},
+          {label: 'Banana', value: 'efa836', number: '09'}
+        ]}" />
+    </div>
   </div>
 </div>

--- a/src/components/colorpicker/colorpicker.js
+++ b/src/components/colorpicker/colorpicker.js
@@ -463,7 +463,12 @@ ColorPicker.prototype = {
    * @returns {string} the translated text color
    */
   translateColorLabel(colorText) {
-    return Locale.translate(colorText, true);
+    if (!colorText) {
+      return '';
+    }
+    const translatedText = Locale.translate(colorText, true);
+    return typeof translatedText === 'string' ?
+      Locale.translate(colorText, true) : colorText;
   },
 
   /**
@@ -600,9 +605,7 @@ ColorPicker.prototype = {
     }
 
     /* eslint-disable no-bitwise */
-    return `rgb(${n & 0xFF},
-      ${(n & 0xFF00) >> 8},
-      ${(n & 0xFF0000) >> 16})`;
+    return `rgb(${n & 0xFF}, ${(n & 0xFF00) >> 8}, ${(n & 0xFF0000) >> 16})`;
     /* eslint-disable no-console */
   },
 

--- a/test/components/colorpicker/colorpicker-api.func-spec.js
+++ b/test/components/colorpicker/colorpicker-api.func-spec.js
@@ -1,0 +1,75 @@
+import { ColorPicker } from '../../../src/components/colorpicker/colorpicker';
+
+const colorpickerHTML = require('../../../app/views/components/colorpicker/example-index.html');
+const svg = require('../../../src/components/icons/svg.html');
+
+let colorpickerEl;
+let svgEl;
+let colorpickerObj;
+
+describe('ColorPicker API', () => {
+  beforeEach(() => {
+    colorpickerEl = null;
+    svgEl = null;
+    colorpickerObj = null;
+    document.body.insertAdjacentHTML('afterbegin', svg);
+    document.body.insertAdjacentHTML('afterbegin', colorpickerHTML);
+    colorpickerEl = document.getElementById('background-color');
+    svgEl = document.body.querySelector('.svg-icons');
+    colorpickerEl.classList.add('no-init');
+    colorpickerObj = new ColorPicker(colorpickerEl);
+  });
+
+  afterEach(() => {
+    colorpickerObj.destroy();
+    colorpickerEl.parentNode.removeChild(colorpickerEl);
+    svgEl.parentNode.removeChild(svgEl);
+  });
+
+  it('Should be defined on jQuery object', () => {
+    expect(colorpickerObj).toEqual(jasmine.any(Object));
+  });
+
+  it('Should open colorpicker', (done) => {
+    colorpickerObj.toggleList();
+
+    setTimeout(() => {
+      expect(colorpickerObj.isPickerOpen).toBeTruthy();
+      expect(document.body.querySelector('.colorpicker.is-open')).toBeTruthy();
+      done();
+    }, 300);
+  });
+
+  it('Should destroy colorpicker', () => {
+    colorpickerObj.destroy();
+
+    expect(colorpickerEl.parentNode.classList.contains('colorpicker-container')).toBeFalsy();
+  });
+
+  it('Should disable colorpicker', () => {
+    colorpickerObj.disable();
+
+    expect(colorpickerEl.parentNode.classList.contains('is-disabled')).toBeTruthy();
+    expect(colorpickerObj.isDisabled()).toBeTruthy();
+  });
+
+  it('Should enable colorpicker', () => {
+    colorpickerObj.disable();
+
+    expect(colorpickerEl.parentNode.classList.contains('is-disabled')).toBeTruthy();
+    expect(colorpickerObj.isDisabled()).toBeTruthy();
+
+    colorpickerObj.enable();
+
+    expect(colorpickerEl.parentNode.classList.contains('is-disabled')).toBeFalsy();
+    expect(colorpickerObj.isDisabled()).toBeFalsy();
+  });
+
+  it('Should render colorpicker readonly', () => {
+    colorpickerObj.readonly();
+
+    expect(document.body.querySelector('.colorpicker[readonly]')).toBeTruthy();
+    expect(colorpickerEl.parentNode.classList.contains('is-readonly')).toBeTruthy();
+    expect(colorpickerObj.isDisabled()).toBeFalsy();
+  });
+});

--- a/test/components/colorpicker/colorpicker-aria.func-spec.js
+++ b/test/components/colorpicker/colorpicker-aria.func-spec.js
@@ -1,0 +1,49 @@
+import { ColorPicker } from '../../../src/components/colorpicker/colorpicker';
+
+const colorpickerHTML = require('../../../app/views/components/colorpicker/example-index.html');
+const svg = require('../../../src/components/icons/svg.html');
+
+let colorpickerEl;
+let svgEl;
+let colorpickerObj;
+
+describe('ColorPicker ARIA', () => {
+  beforeEach(() => {
+    colorpickerEl = null;
+    svgEl = null;
+    colorpickerObj = null;
+    document.body.insertAdjacentHTML('afterbegin', svg);
+    document.body.insertAdjacentHTML('afterbegin', colorpickerHTML);
+    colorpickerEl = document.getElementById('background-color');
+    svgEl = document.body.querySelector('.svg-icons');
+    colorpickerEl.classList.add('no-init');
+    colorpickerObj = new ColorPicker(colorpickerEl);
+  });
+
+  afterEach(() => {
+    colorpickerObj.destroy();
+    colorpickerEl.parentNode.removeChild(colorpickerEl);
+    svgEl.parentNode.removeChild(svgEl);
+  });
+
+  it('Should set ARIA labels', () => {
+    const parent = colorpickerEl.parentNode;
+
+    expect(parent.querySelector('.colorpicker[aria-autocomplete="list"]')).toBeTruthy();
+    expect(parent.querySelector('.colorpicker[role="combobox"]')).toBeTruthy();
+    expect(parent.querySelector('.icon[aria-hidden="true"]')).toBeTruthy();
+    expect(parent.querySelector('.icon[role="presentation"]')).toBeTruthy();
+  });
+
+  it('Should update ARIA labels with popup open', (done) => {
+    colorpickerObj.toggleList();
+
+    setTimeout(() => {
+      const parent = colorpickerEl.parentNode;
+
+      expect(parent.querySelector('.colorpicker[aria-haspopup="true"]')).toBeTruthy();
+      expect(parent.querySelector('.colorpicker[aria-controls="colorpicker-menu"]')).toBeTruthy();
+      done();
+    }, 300);
+  });
+});

--- a/test/components/colorpicker/colorpicker-events.func-spec.js
+++ b/test/components/colorpicker/colorpicker-events.func-spec.js
@@ -1,0 +1,44 @@
+import { ColorPicker } from '../../../src/components/colorpicker/colorpicker';
+
+const colorpickerHTML = require('../../../app/views/components/colorpicker/test-events.html');
+const svg = require('../../../src/components/icons/svg.html');
+
+let colorpickerEl;
+let svgEl;
+let colorpickerObj;
+
+describe('ColorPicker Events', () => {
+  beforeEach(() => {
+    colorpickerEl = null;
+    svgEl = null;
+    colorpickerObj = null;
+
+    document.body.insertAdjacentHTML('afterbegin', svg);
+    document.body.insertAdjacentHTML('afterbegin', colorpickerHTML);
+    colorpickerEl = document.body.querySelector('.colorpicker');
+    svgEl = document.body.querySelector('.svg-icons');
+    colorpickerEl.classList.add('no-init');
+    colorpickerObj = new ColorPicker(colorpickerEl);
+  });
+
+  afterEach(() => {
+    colorpickerObj.destroy();
+    colorpickerEl.parentNode.removeChild(colorpickerEl);
+    svgEl.parentNode.removeChild(svgEl);
+  });
+
+  it('Should trigger "change" event', (done) => {
+    const spyEvent = spyOnEvent('#cp-event-change', 'change');
+    colorpickerObj.toggleList();
+
+    setTimeout(() => {
+      expect(colorpickerObj.isPickerOpen).toBeTruthy();
+      expect(document.body.querySelector('.colorpicker.is-open')).toBeTruthy();
+      const anchor = document.body.querySelector('#colorpicker-menu li a');
+      anchor.click();
+
+      expect(spyEvent).toHaveBeenTriggered();
+      done();
+    }, 300);
+  });
+});

--- a/test/components/colorpicker/colorpicker.e2e-spec.js
+++ b/test/components/colorpicker/colorpicker.e2e-spec.js
@@ -1,0 +1,206 @@
+const { browserStackErrorReporter } = requireHelper('browserstack-error-reporter');
+const config = requireHelper('e2e-config');
+const utils = requireHelper('e2e-utils');
+requireHelper('rejection');
+
+jasmine.getEnv().addReporter(browserStackErrorReporter);
+
+describe('Colorpicker example-index tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/colorpicker/example-index');
+  });
+
+  it('Should open popup on icon click', async () => {
+    await element(by.css('#background-color + .trigger .icon')).click();
+
+    expect(await element(by.css('#background-color.is-open')).isDisplayed()).toBe(true);
+  });
+
+  it('Should pick color from picker', async () => {
+    await element(by.css('#background-color + .trigger .icon')).click();
+    await element(by.css('#colorpicker-menu li:first-child a:first-child')).click();
+
+    expect(await element(by.id('background-color')).getAttribute('value')).toEqual('#1A1A1A');
+  });
+
+  it('Should pick clear color from picker', async () => {
+    await element(by.css('#background-color + .trigger .icon')).click();
+    await element(by.css('#colorpicker-menu li:last-child a:first-child')).click();
+
+    expect(await element(by.id('background-color')).getAttribute('value')).toEqual('');
+    expect(await element(by.css('.swatch.is-invalid')).isDisplayed()).toBe(true);
+  });
+
+  it('Should open popup on keypress(arrow-down)', async () => {
+    await element(by.id('background-color')).sendKeys(protractor.Key.ARROW_DOWN);
+
+    expect(await element(by.css('#background-color.is-open')).isDisplayed()).toBe(true);
+  });
+
+  it('Should pick color from picker with keypress', async () => {
+    await element(by.id('background-color')).sendKeys(protractor.Key.ARROW_DOWN);
+
+    expect(await element(by.css('#background-color.is-open')).isDisplayed()).toBe(true);
+
+    await element(by.css('#colorpicker-menu li:first-child a:first-child')).sendKeys(protractor.Key.SPACE);
+
+    expect(await element(by.id('background-color')).getAttribute('value')).toEqual('#1A1A1A');
+  });
+
+  it('Should pick clear color from picker with keypress', async () => {
+    await element(by.id('background-color')).sendKeys(protractor.Key.ARROW_DOWN);
+
+    expect(await element(by.css('#background-color.is-open')).isDisplayed()).toBe(true);
+
+    await element(by.css('#colorpicker-menu li:last-child a:first-child')).sendKeys(protractor.Key.SPACE);
+
+    expect(await element(by.id('background-color')).getAttribute('value')).toEqual('');
+    expect(await element(by.css('.swatch.is-invalid')).isDisplayed()).toBe(true);
+  });
+
+  it('Should set clear swatch', async () => {
+    await element(by.id('background-color')).sendKeys(protractor.Key.BACK_SPACE);
+    await element(by.css('body')).click();
+
+    expect(await element(by.id('background-color')).getAttribute('value')).toEqual('#B94E4');
+    expect(await element(by.css('.swatch.is-invalid')).isDisplayed()).toBe(true);
+  });
+});
+
+describe('Colorpicker show label tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/colorpicker/example-show-label');
+  });
+
+  it('Should pick color from picker and set label', async () => {
+    await element(by.css('#show-label + .trigger .icon')).click();
+    await element(by.css('#colorpicker-menu li:first-child a:first-child')).click();
+
+    expect(await element(by.id('show-label')).getAttribute('value')).toEqual('Slate10');
+  });
+
+  it('Should pick clear color from picker and set label', async () => {
+    await element(by.css('#show-label + .trigger .icon')).click();
+    await element(by.css('#colorpicker-menu li:last-child a:first-child')).click();
+
+    expect(await element(by.id('show-label')).getAttribute('value')).toEqual('None');
+  });
+});
+
+describe('Colorpicker custom label tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/colorpicker/example-custom-labels');
+  });
+
+  it('Should pick color from picker as custom color and label', async () => {
+    await element(by.css('#custom-color + .trigger .icon')).click();
+    await element(by.css('#colorpicker-menu li:first-child a:first-child')).click();
+
+    expect(await element(by.id('custom-color')).getAttribute('value')).toEqual('#2578a9');
+
+    await element(by.css('#custom-label + .trigger .icon')).click();
+    await element(by.css('#colorpicker-menu li:first-child a:first-child')).click();
+
+    expect(await element(by.id('custom-label')).getAttribute('value')).toEqual('Grape10');
+  });
+});
+
+describe('Colorpicker case types tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/colorpicker/test-case-types');
+  });
+
+  it('Should pick color from picker and use upper case', async () => {
+    await element(by.css('#colorpicker-uc + .trigger .icon')).click();
+    await element(by.css('#colorpicker-menu li:first-child a:first-child')).click();
+
+    expect(await element(by.id('colorpicker-uc')).getAttribute('value')).toEqual('#1A1A1A');
+  });
+
+  it('Should pick color from picker and use lower case', async () => {
+    await element(by.css('#colorpicker-lc + .trigger .icon')).click();
+    await element(by.css('#colorpicker-menu li:first-child a:first-child')).click();
+
+    expect(await element(by.id('colorpicker-lc')).getAttribute('value')).toEqual('#1a1a1a');
+  });
+});
+
+describe('Colorpicker clearable tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/colorpicker/test-clearable');
+  });
+
+  it('Should show clearable option', async () => {
+    await element(by.css('#cp-clearable-true + .trigger .icon')).click();
+
+    expect(await element(by.css('#colorpicker-menu li:last-child .swatch')).getAttribute('class')).toContain('is-empty');
+  });
+
+  it('Should not show clearable option', async () => {
+    await element(by.css('#cp-clearable-false + .trigger .icon')).click();
+
+    expect(await element(by.css('#colorpicker-menu li:last-child .swatch')).getAttribute('class')).not.toContain('is-empty');
+  });
+});
+
+describe('Colorpicker states tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/colorpicker/test-states');
+  });
+
+  it('Should check for state Non-Editable', async () => {
+    await element(by.css('#non-editable + .trigger .icon')).click();
+    await element(by.css('#colorpicker-menu li:first-child a:first-child')).click();
+
+    expect(await element(by.id('non-editable')).getAttribute('value')).toEqual('#1A1A1A');
+
+    await element(by.id('non-editable')).sendKeys(protractor.Key.BACK_SPACE);
+    await element(by.css('body')).click();
+
+    expect(await element(by.id('non-editable')).getAttribute('value')).toEqual('#1A1A1A');
+  });
+
+  it('Should check for state Disabled', async () => {
+    await element(by.css('#foreground-color + .trigger .icon')).click();
+
+    expect(await element(by.css('#foreground-color.is-open')).isPresent()).toBe(false);
+    expect(await element(by.css('#foreground-color')).isEnabled()).toBeFalsy();
+  });
+
+  it('Should check for state Readonly', async () => {
+    await element(by.css('#readonly-color + .trigger .icon')).click();
+
+    expect(await element(by.css('#readonly-color.is-open')).isPresent()).toBe(false);
+    expect(await element(by.css('#readonly-color[readonly]')).isDisplayed()).toBe(true);
+  });
+
+  it('Should check for Dirty Tracking', async () => {
+    await element(by.css('#dirty-color + .trigger .icon')).click();
+    await element(by.css('#colorpicker-menu li:first-child a:first-child')).click();
+
+    expect(await element(by.css('.icon-dirty')).isPresent()).toBe(true);
+
+    await element(by.css('#dirty-color + .trigger .icon')).click();
+    await element(by.css('#colorpicker-menu li:last-child a:first-child')).click();
+
+    expect(await element(by.css('.icon-dirty')).isPresent()).toBe(false);
+  });
+
+  it('Should check for Validation required rule', async () => {
+    const colorpickerEl = await element(by.id('required-color'));
+    await colorpickerEl.clear();
+
+    expect(await colorpickerEl.getAttribute('value')).toEqual('');
+
+    await colorpickerEl.sendKeys(protractor.Key.TAB);
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('.message-text')).getText()).toBe('Required');
+    expect(await element(by.css('.icon-error')).isPresent()).toBe(true);
+    expect(await colorpickerEl.getAttribute('class')).toContain('error');
+  });
+
+  it('Should check for api option Just Color', async () => {
+    expect(await element(by.id('color-only')).getCssValue('width')).toBe('10px');
+  });
+});

--- a/test/components/colorpicker/colorpicker.func-spec.js
+++ b/test/components/colorpicker/colorpicker.func-spec.js
@@ -1,0 +1,123 @@
+import { ColorPicker } from '../../../src/components/colorpicker/colorpicker';
+
+const colorpickerHTML = require('../../../app/views/components/colorpicker/example-index.html');
+const svg = require('../../../src/components/icons/svg.html');
+
+let colorpickerEl;
+let svgEl;
+let colorpickerObj;
+
+describe('ColorPicker Methods', () => {
+  beforeEach(() => {
+    colorpickerEl = null;
+    svgEl = null;
+    colorpickerObj = null;
+
+    document.body.insertAdjacentHTML('afterbegin', svg);
+    document.body.insertAdjacentHTML('afterbegin', colorpickerHTML);
+    colorpickerEl = document.getElementById('background-color');
+    svgEl = document.body.querySelector('.svg-icons');
+    colorpickerEl.classList.add('no-init');
+    colorpickerObj = new ColorPicker(colorpickerEl);
+  });
+
+  afterEach(() => {
+    colorpickerObj.destroy();
+    colorpickerEl.parentNode.removeChild(colorpickerEl);
+    svgEl.parentNode.removeChild(svgEl);
+  });
+
+  it('Should get the hex value based on a label', () => {
+    expect(colorpickerObj.getHexFromLabel('Turquoise10')).toEqual('#0E5B52');
+  });
+
+  it('Should get the label value based on a hex', () => {
+    expect(colorpickerObj.getLabelFromHex('#0E5B52')).toEqual('Turquoise10');
+  });
+
+  it('Should set custom width', () => {
+    colorpickerEl.style.width = '400px';
+    colorpickerObj.setCustomWidth();
+
+    expect(colorpickerEl.style.width).toEqual('368px');
+    expect(colorpickerEl.parentNode.style.width).toEqual('400px');
+  });
+
+  it('Should get the current hex value', (done) => {
+    colorpickerObj.toggleList();
+
+    setTimeout(() => {
+      expect(colorpickerObj.isPickerOpen).toBeTruthy();
+      expect(document.body.querySelector('.colorpicker.is-open')).toBeTruthy();
+      const anchor = document.body.querySelector('#colorpicker-menu li a');
+      anchor.click();
+
+      expect(colorpickerObj.getHexValue()).toEqual('#1A1A1A');
+      done();
+    }, 300);
+  });
+
+  it('Should get the current label value', (done) => {
+    colorpickerObj.settings.showLabel = true;
+    colorpickerObj.toggleList();
+
+    setTimeout(() => {
+      expect(colorpickerObj.isPickerOpen).toBeTruthy();
+      expect(document.body.querySelector('.colorpicker.is-open')).toBeTruthy();
+      const anchor = document.body.querySelector('#colorpicker-menu li a');
+      anchor.click();
+
+      expect(colorpickerObj.getLabelValue()).toEqual('Slate10');
+      done();
+    }, 300);
+  });
+
+  it('Should set the color/label on the field', () => {
+    colorpickerObj.setColor('#0E5B52');
+
+    expect(colorpickerEl.value).toEqual('#0E5B52');
+
+    colorpickerObj.settings.showLabel = true;
+    colorpickerObj.setColor('#0E5B52', 'Turquoise10');
+
+    expect(colorpickerEl.value).toEqual('Turquoise10');
+  });
+
+  it('Should set the value on the field', () => {
+    const parent = colorpickerEl.parentNode;
+    colorpickerObj.setValueOnField({ isEmpty: true });
+
+    expect(parent.querySelector('.swatch.is-empty')).toBeTruthy();
+
+    colorpickerObj.setValueOnField({ hex: '#88550', invalid: true });
+
+    expect(parent.querySelector('.swatch.is-invalid')).toBeTruthy();
+
+    colorpickerObj.setValueOnField({ hex: '#0E5B52', label: 'Turquoise10' });
+
+    expect(parent.querySelector('.swatch.is-empty')).toBeFalsy();
+    expect(parent.querySelector('.swatch.is-invalid')).toBeFalsy();
+    expect(colorpickerEl.value).toEqual('#0E5B52');
+
+    colorpickerObj.settings.showLabel = true;
+    colorpickerObj.setValueOnField({ hex: '#0E5B52', label: 'Turquoise10' });
+
+    expect(parent.querySelector('.swatch.is-empty')).toBeFalsy();
+    expect(parent.querySelector('.swatch.is-invalid')).toBeFalsy();
+    expect(colorpickerEl.value).toEqual('Turquoise10');
+  });
+
+  it('Should translate color label', () => {
+    expect(colorpickerObj.translateColorLabel()).toEqual('');
+    expect(colorpickerObj.translateColorLabel('Invalid label')).toEqual('Invalid label');
+    expect(colorpickerObj.translateColorLabel('Turquoise10')).toEqual('Turquoise10');
+  });
+
+  it('Should gets the decimal as a rgb value', () => {
+    expect(colorpickerObj.decimal2rgb(5397262)).toEqual('rgb(14, 91, 82)');
+  });
+
+  it('Should gets the rgb to hex value', () => {
+    expect(colorpickerObj.rgb2hex('rgb(14, 91, 82)').toUpperCase()).toEqual('#0E5B52');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Added functional and e2e tests for Colorpicker

**Related github/jira issue (required)**:

https://jira.infor.com/browse/SOHO-8078

**Steps necessary to review your pull request (required)**:

E2E
`env PROTRACTOR_SPECS='components/colorpicker/colorpicker.e2e-spec.js' npm run e2e:local:debug`
`env npm run e2e:local:debug`

FUNCTIONAL
`npm run functional:local`
