### PR TITLE
Prevent BrowserStack cron from failing entire build, and therefore nightly builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "functional:ci": "npx karma start test/karma.conf.js --single-run",
     "all-checks": "npm run mdlint && npm run eslint && npm run functional:ci && npm run e2e:ci",
     "e2e:ci": "npm run webdriver:update && npx protractor test/protractor.ci.conf.js",
-    "e2e:ci:bs": "npx protractor test/protractor.ci.bs.conf.js",
+    "e2e:ci:bs": "npx protractor test/protractor.ci.bs.conf.js || true",
     "e2e:local:bs": "npm run webdriver:update && npx protractor test/protractor.local.bs.conf.js",
     "e2e:local:debug": "npm run webdriver:update && npx protractor test/protractor.local.debug.conf.js",
     "webdriver:update": "npx webdriver-manager update --standalone false --quiet",


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Continue to run BrowserStack tests without failing entire build as we need to deploy nightlies every night. e2e smoke testing will continue to be executed on branch commit, and on PR.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related github/jira issue (required)**:
https://jira.infor.com/browse/SOHO-8061
<!-- Provide a link to the related issue to this Pull Request.-->

**Steps necessary to review your pull request (required)**:
Fail a test, place a command after this script  (grouping and using `&&` or just write your own .sh (shell script) ), that script should execute as we are returning `exit 0` not matter what.
