### PR TITLE
Fixed sort indicator was not showing with Datagrid

### DIFF
--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -349,12 +349,6 @@ $datagrid-short-row-height: 23px;
         }
       }
 
-      &.l-center-text.sort-indicator-can-fit {
-        .datagrid-header-text {
-          margin-top: 5px;
-        }
-      }
-
       .datagrid-checkbox {
         top: -13px;
       }
@@ -1950,28 +1944,6 @@ $datagrid-short-row-height: 23px;
       }
     }
 
-    // Centering Text
-    .datagrid-column-wrapper.l-center-text {
-      width: 100%;
-
-      .sort-indicator {
-        display: none;
-      }
-
-      &.sort-indicator-can-fit {
-        width: calc(100% + 20px);
-
-        .sort-indicator {
-          display: inline-block;
-        }
-
-        .datagrid-header-text {
-          display: inline-block;
-          margin-top: 10px;
-        }
-      }
-    }
-
     &.is-active {
       background-color: $datagrid-header-active-color;
     }
@@ -2317,6 +2289,15 @@ $datagrid-short-row-height: 23px;
     display: block;
     height: 10px;
     margin-left: 5px;
+  }
+}
+
+// Centered Columns
+.datagrid-column-wrapper.l-center-text {
+  width: 100%;
+
+  .sort-indicator {
+    margin: -6px -23px 0px 3px;
   }
 }
 

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -2002,7 +2002,7 @@ $datagrid-short-row-height: 23px;
       float: right;
 
       .sort-indicator {
-        margin: 2px 5px 0;
+        margin: 2px 2px 0;
       }
     }
   }
@@ -2297,7 +2297,7 @@ $datagrid-short-row-height: 23px;
   width: 100%;
 
   .sort-indicator {
-    margin: -6px -23px 0px 3px;
+    margin: -6px -22px 0 0;
   }
 }
 

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -349,6 +349,12 @@ $datagrid-short-row-height: 23px;
         }
       }
 
+      &.l-center-text.sort-indicator-can-fit {
+        .datagrid-header-text {
+          margin-top: 5px;
+        }
+      }
+
       .datagrid-checkbox {
         top: -13px;
       }
@@ -1946,11 +1952,23 @@ $datagrid-short-row-height: 23px;
 
     // Centering Text
     .datagrid-column-wrapper.l-center-text {
-      width: calc(100% + 20px);
+      width: 100%;
 
-      .datagrid-header-text {
-        display: inline-block;
-        margin-top: 10px;
+      .sort-indicator {
+        display: none;
+      }
+
+      &.sort-indicator-can-fit {
+        width: calc(100% + 20px);
+
+        .sort-indicator {
+          display: inline-block;
+        }
+
+        .datagrid-header-text {
+          display: inline-block;
+          margin-top: 10px;
+        }
       }
     }
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4053,7 +4053,6 @@ Datagrid.prototype = {
     this.saveColumns();
     this.saveUserSettings();
     this.headerWidths[idx].width = width;
-    this.setHeaderCenterTextAndSortIndicator();
   },
 
   /**

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -991,6 +991,28 @@ Datagrid.prototype = {
       this.restoreFilter = false;
       this.savedFilter = null;
     }
+    this.setHeaderCenterTextAndSortIndicator();
+  },
+
+  /**
+  * Set header center-text sort-indicator.
+  * @private
+  * @returns {void}
+  */
+  setHeaderCenterTextAndSortIndicator() {
+    const centerTextWrappers = this.headerRow.find('.datagrid-column-wrapper.l-center-text');
+    centerTextWrappers.each(function () {
+      this.style.width = 'auto';
+      const textWidth = this.getElementsByClassName('datagrid-header-text')[0].clientWidth;
+      const thWidth = this.parentNode.clientWidth;
+      this.style.width = '';
+
+      if ((thWidth - 35) > textWidth) {
+        this.classList.add('sort-indicator-can-fit');
+      } else {
+        this.classList.remove('sort-indicator-can-fit');
+      }
+    });
   },
 
   /**
@@ -4048,6 +4070,7 @@ Datagrid.prototype = {
     this.saveColumns();
     this.saveUserSettings();
     this.headerWidths[idx].width = width;
+    this.setHeaderCenterTextAndSortIndicator();
   },
 
   /**

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -928,7 +928,14 @@ Datagrid.prototype = {
       }${column.reorderable === false ? ' data-reorder="false"' : ''
       }${colGroups ? ` headers="${self.getColumnGroup(j)}"` : ''}${isExportable ? 'data-exportable="yes"' : 'data-exportable="no"'}>`;
 
-      headerRow += `<div class="${isSelection ? 'datagrid-checkbox-wrapper ' : 'datagrid-column-wrapper'}${column.align === undefined ? '' : ` l-${column.align}-text`}"><span class="datagrid-header-text${column.required ? ' required' : ''}">${self.headerText(this.settings.columns[j])}</span>`;
+      let sortIndicator = '';
+      if (isSortable) {
+        sortIndicator = `${'<div class="sort-indicator">' +
+          '<span class="sort-asc">'}${$.createIcon({ icon: 'dropdown' })}</span>` +
+          `<span class="sort-desc">${$.createIcon({ icon: 'dropdown' })}</div>`;
+      }
+
+      headerRow += `<div class="${isSelection ? 'datagrid-checkbox-wrapper ' : 'datagrid-column-wrapper'}${column.align === undefined ? '' : ` l-${column.align}-text`}"><span class="datagrid-header-text${column.required ? ' required' : ''}">${self.headerText(this.settings.columns[j])}${column.align === 'center' ? sortIndicator : ''}</span>`;
       cols += `<col${this.columnWidth(column, j)}${column.hidden ? ' class="is-hidden"' : ''}>`;
 
       if (isSelection) {
@@ -939,10 +946,8 @@ Datagrid.prototype = {
         }
       }
 
-      if (isSortable) {
-        headerRow += `${'<div class="sort-indicator">' +
-          '<span class="sort-asc">'}${$.createIcon({ icon: 'dropdown' })}</span>` +
-          `<span class="sort-desc">${$.createIcon({ icon: 'dropdown' })}</div>`;
+      if (isSortable && column.align !== 'center') {
+        headerRow += sortIndicator;
       }
 
       headerRow += `</div>${self.filterRowHtml(column, j)}</th>`;
@@ -991,28 +996,6 @@ Datagrid.prototype = {
       this.restoreFilter = false;
       this.savedFilter = null;
     }
-    this.setHeaderCenterTextAndSortIndicator();
-  },
-
-  /**
-  * Set header center-text sort-indicator.
-  * @private
-  * @returns {void}
-  */
-  setHeaderCenterTextAndSortIndicator() {
-    const centerTextWrappers = this.headerRow.find('.datagrid-column-wrapper.l-center-text');
-    centerTextWrappers.each(function () {
-      this.style.width = 'auto';
-      const textWidth = this.getElementsByClassName('datagrid-header-text')[0].clientWidth;
-      const thWidth = this.parentNode.clientWidth;
-      this.style.width = '';
-
-      if ((thWidth - 35) > textWidth) {
-        this.classList.add('sort-indicator-can-fit');
-      } else {
-        this.classList.remove('sort-indicator-can-fit');
-      }
-    });
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Column that is specified to be sortable, sort indicators was not showing when the column alignment is set to center.

**Related github/jira issue (required)**:

https://jira.infor.com/browse/SOHO-7444
https://jira.infor.com/browse/SOHO-7918

**Steps necessary to review your pull request (required)**:

http://localhost:4000/components/datagrid/example-filter
Open above link
Hover to column header “Status”
See sort indicator should be visible

http://localhost:4000/components/datagrid/test-rowdata-issue.html
Open above link
In "Datagrid B"
Hover to star column header “Default”
See sort indicator should not be visible, and row-height not breaking
Resize and make this column wider by dragging in header
See sort indicator should be visible
Hover to column header “Status”
See sort indicator should be visible
