### PR TITLE
SOHO-8061 - Add unique ID for BrowserStack builds

### DIFF
--- a/test/protractor.ci.bs.conf.js
+++ b/test/protractor.ci.bs.conf.js
@@ -12,6 +12,12 @@ const getSpecs = (listSpec) => {
 };
 
 const theme = process.env.ENTERPRISE_THEME || 'light'
+let browserstackBuildID = `${theme} theme: ci:bs e2e ${Date.now()}`;
+
+if (process.env.TRAVIS_BUILD_NUMBER) {
+  browserstackBuildID = process.env.TRAVIS_BUILD_NUMBER;
+  browserstackBuildID = `${theme} theme: ci:bs e2e ${process.env.TRAVIS_BUILD_NUMBER}`;
+}
 
 exports.config = {
   params: {
@@ -35,7 +41,7 @@ exports.config = {
     'browserstack.video' : true,
     'browserstack.local': false,
     'browserstack.networkLogs' : false,
-    build: `${theme} theme: ci:bs e2e`,
+    build: browserstackBuildID,
     name: `${theme} theme ci:bs e2e tests`,
     project: 'ids-enterprise-e2e-ci'
   },
@@ -45,7 +51,8 @@ exports.config = {
       browser_version: '66.0',
       resolution: '1280x800',
       os_version: '10',
-      os: 'Windows'
+      os: 'Windows',
+      'browserstack.selenium_version': '3.11.0',
     }
   ],
   onPrepare: () => {

--- a/test/protractor.local.bs.conf.js
+++ b/test/protractor.local.bs.conf.js
@@ -13,6 +13,12 @@ const getSpecs = (listSpec) => {
 };
 
 const theme = process.env.ENTERPRISE_THEME || 'light'
+let browserstackBuildID = `${theme} theme: ci:bs e2e ${Date.now()}`;
+
+if (process.env.TRAVIS_BUILD_NUMBER) {
+  browserstackBuildID = process.env.TRAVIS_BUILD_NUMBER;
+  browserstackBuildID = `${theme} theme: ci:bs e2e ${process.env.TRAVIS_BUILD_NUMBER}`;
+}
 
 exports.config = {
   params: {
@@ -37,7 +43,7 @@ exports.config = {
     'browserstack.debug': true,
     'browserstack.local': true,
     'browserstack.networkLogs' : true,
-    build: `${theme} theme: local tunnel e2e`,
+    build: browserstackBuildID,
     name: `${theme} theme local tunnel e2e tests`
   },
   multiCapabilities: [


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Add unique ID to build to ensure badge reflects the correct build status. Links failing BrowserStack build to failing travis build 

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related github/jira issue (required)**:
Relates to SOHO-8061, SOHO-7331
<!-- Provide a link to the related issue to this Pull Request.-->

**Steps necessary to review your pull request (required)**:
Run locally, check BrowserStack dashboard... If possible, verify that TRAVIS_BUILD_NUMBER works
