### PR TITLE
SOHO-7839 - [All Browsers] Datagrid Editable Control: Price Column giving "Nan" error

### DIFF
--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -158,7 +158,7 @@ const formatters = {
         formatted !== null && formatted !== undefined && formatted !== '') {
       formatted = Locale.formatNumber(value, col.numberFormat);
     }
-    return ((formatted === null || formatted === undefined) ? '' : formatted);
+    return ((formatted === null || formatted === undefined || formatted === 'NaN') ? '' : formatted);
   },
 
   Integer(row, cell, value, col) {
@@ -167,7 +167,7 @@ const formatters = {
         formatted !== null && formatted !== undefined && formatted !== '') {
       formatted = Locale.formatNumber(value, col.numberFormat || { style: 'integer' });
     }
-    return (formatted === null || formatted === undefined) ? '' : formatted;
+    return (formatted === null || formatted === undefined || formatted === 'NaN') ? '' : formatted;
   },
 
   Hyperlink(row, cell, value, col, item, api) {


### PR DESCRIPTION
http://localhost:4000/components/datagrid/example-editable.html

Click on any cell in the Price column
Remove the text from the field box
Click out of the cell. You will get "Required" icon
Click back into the same cell and start type anything and click out of the cell
The "NaN" error does NOT  appears in the field box

The change means that any invalid entry eg. 'd' is cleared.