### PR TITLE
Fixed expand row was not expanding with Datagrid

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7395,6 +7395,7 @@ Datagrid.prototype = {
     if (self.settings.allowOneExpandedRow && self.settings.groupable === null) {
       // collapse any other expandable rows
       const prevExpandRow = self.tableBody.find('tr.is-expanded');
+      const prevExpandButton = prevExpandRow.prev().find('.datagrid-expand-btn');
       const parentRow = prevExpandRow.prev();
       const parentRowIdx = self.actualRowNode(parentRow);
       const parentdataRowIdx = self.dataRowIndex(parentRow);
@@ -7402,11 +7403,11 @@ Datagrid.prototype = {
       if (prevExpandRow.length && expandRow.index() !== prevExpandRow.index()) {
         const prevDetail = prevExpandRow.find('.datagrid-row-detail');
 
-        prevExpandRow.removeClass('is-expanded');
+        prevExpandRow.add(prevExpandButton).removeClass('is-expanded');
         parentRow.removeClass('is-rowactivated');
         parentRow.find('.plus-minus').removeClass('active');
         prevDetail.animateClosed().on('animateclosedcomplete', () => {
-          prevExpandRow.css('display', 'none').removeClass('is-expanded');
+          prevExpandRow.removeClass('is-expanded');
           self.element.triggerHandler('collapserow', [{ grid: self, row: parentRowIdx, detail: prevDetail, item: self.settings.dataset[parentdataRowIdx] }]);
         });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Expandable row was not expanding after another row expanded

**Related github/jira issue (required)**:

https://jira.infor.com/browse/SOHO-8154

**Steps necessary to review your pull request (required)**:

http://localhost:4000/components/datagrid/example-expandable-row
- Open above link
- Click on the "+" for product id "2142201" to expand (it will expand)
- Click on the "+" for product id "2241202" to expand (it will expand and close "2142201")
- Click on the "+" for product id "2142201" to expand (it will expand and close "2241202")
- Click on the "+" for product id "2142201" to close (it will close all)
- Click on the "+" for product id "2142201" to expand (it should expand)
