### PR TITLE
Added sample and test for soho-5168

### DIFF
--- a/app/views/components/datagrid/test-number-rounding.html
+++ b/app/views/components/datagrid/test-number-rounding.html
@@ -1,0 +1,61 @@
+
+<div class="row">
+    <div class="twelve columns">
+      <div role="toolbar" class="toolbar">
+        <div class="title">
+          Data Grid Header Title
+          <span class="datagrid-result-count">(N Results)</span>
+        </div>
+
+        <div class="buttonset">
+        </div>
+      </div>
+
+      <div id="datagrid">
+      </div>
+    </div>
+</div>
+
+  <script>
+    var gridApi = null;
+
+    $('body').one('initialized', function () {
+        var grid,
+        columns = [],
+        data = [];
+
+        // Some Sample Data
+        data.push({ id: 1, productId: 2142201, revenue: 800.9905673502324, col2: 20, col3: 30, col4: 40, col5: 60, col6: 70, col6: new Date(2018, 0, 1)});
+        data.push({ id: 2, productId: 2142202, revenue: 800.9905673502324, col2: 20, col3: 30, col4: 40, col5: 60, col6: 70, col6: new Date(2018, 0, 2)});
+        data.push({ id: 3, productId: 2142202, revenue: 800.9905673502324, col2: 20, col3: 30, col4: 40, col5: 60, col6: 70, col6: new Date(2018, 0, 3)});
+        data.push({ id: 4, productId: 2142202, revenue: 800.9905673502324, col2: 20, col3: 30, col4: 40, col5: 60, col6: 70, col6: new Date(2018, 0, 4)});
+        data.push({ id: 5, productId: 2142202, revenue: 800.9905673502324, col2: 20, col3: 30, col4: 40, col5: 60, col6: 70, col6: new Date(2018, 0, 5)});
+        data.push({ id: 7, productId: 2142202, revenue: 800.9905673502324, col2: 20, col3: 30, col4: 40, col5: 60, col6: 70, col6: new Date(2018, 0, 6)});
+        data.push({ id: 8, productId: 2142202, revenue: 800.9905673502324, col2: 20, col3: 30, col4: 40, col5: 60, col6: 70, col6: new Date(2018, 0, 7)});
+
+        // Define Columns for the Grid.
+        columns.push({ id: 'id', name: 'Row Id', field: 'id', formatter: Formatters.Readonly, editor: Editors.Input});
+        columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Hyperlink, editor: Editors.Input});
+        columns.push({ id: 'revenue', name: 'Revenue', field: 'revenue', formatter: Formatters.Decimal, align: 'right', numberFormat: {round: true, minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'currency', currencySign: '$'}});
+        columns.push({ id: 'col2', name: 'Column One', field: 'col2', filterType: 'decimal', editor: Editors.Input});
+        columns.push({ id: 'col3', name: 'Column One', field: 'col3', filterType: 'decimal', editor: Editors.Input});
+        columns.push({ id: 'col4', name: 'Column One', field: 'col4', filterType: 'decimal', editor: Editors.Input});
+        columns.push({ id: 'col5', name: 'Column One', field: 'col5', filterType: 'decimal', editor: Editors.Input});
+        columns.push({ id: 'col6', name: 'Column One', field: 'col6', formatter: Formatters.Date, editor: Editors.Date, validate: 'required date'});
+
+        // Init and get the api for the grid
+        grid = $('#datagrid').datagrid({
+          columns: columns,
+          dataset: data,
+          editable: true,
+          clickToSelect: false,
+          selectable: 'multiple',
+          toolbar: {title: 'Data Grid Header Title', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: true,  collapsibleFilter: true},
+          paging: true,
+          pagesize: 20,
+          pagesizes: [2, 4, 6]
+        });
+
+});
+
+</script>

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -716,6 +716,7 @@ describe('Locale API', () => {
     Locale.set('en-US');
 
     expect(Locale.formatNumber('3.01999', { maximumFractionDigits: 2, round: true })).toEqual('3.02');
+    expect(Locale.formatNumber('800.9905673502324', { round: true, minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'currency', currencySign: '$' })).toEqual('$801');
     expect(Locale.formatNumber('4.1', { minimumFractionDigits: 0, maximumFractionDigits: 2 })).toEqual('4.1');
     expect(Locale.formatNumber('5.1', { minimumFractionDigits: 2, maximumFractionDigits: 2 })).toEqual('5.10');
     expect(Locale.formatNumber('12.341', { minimumFractionDigits: 0, maximumFractionDigits: 2, round: true })).toEqual('12.34');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Reviwed soho-5168 and noted it was already possible. So added an example and unit test for the exact case

**Related github/jira issue (required)**:

soho-5168
**Steps necessary to review your pull request (required)**:

http://localhost:4000/components/datagrid/test-number-rounding.html
- column should show 810
- run functional tests specifically this one:
https://github.com/infor-design/enterprise/blob/soho-5168-rounding/test/components/locale/locale.func-spec.js#L719
