### PR TITLE
SOHO-8078 - Fixed colorpicker tests

### DIFF
--- a/test/components/colorpicker/colorpicker.func-spec.js
+++ b/test/components/colorpicker/colorpicker.func-spec.js
@@ -43,33 +43,17 @@ describe('ColorPicker Methods', () => {
     expect(colorpickerEl.parentNode.style.width).toEqual('400px');
   });
 
-  it('Should get the current hex value', (done) => {
-    colorpickerObj.toggleList();
+  it('Should get the current hex value', () => {
+    colorpickerObj.setColor('#1a1a1a');
 
-    setTimeout(() => {
-      expect(colorpickerObj.isPickerOpen).toBeTruthy();
-      expect(document.body.querySelector('.colorpicker.is-open')).toBeTruthy();
-      const anchor = document.body.querySelector('#colorpicker-menu li a');
-      anchor.click();
-
-      expect(colorpickerObj.getHexValue()).toEqual('#1A1A1A');
-      done();
-    }, 300);
+    expect(colorpickerObj.getHexValue()).toEqual('#1A1A1A');
   });
 
-  it('Should get the current label value', (done) => {
+  it('Should get the current label value', () => {
     colorpickerObj.settings.showLabel = true;
-    colorpickerObj.toggleList();
+    colorpickerObj.setColor('#1a1a1a');
 
-    setTimeout(() => {
-      expect(colorpickerObj.isPickerOpen).toBeTruthy();
-      expect(document.body.querySelector('.colorpicker.is-open')).toBeTruthy();
-      const anchor = document.body.querySelector('#colorpicker-menu li a');
-      anchor.click();
-
-      expect(colorpickerObj.getLabelValue()).toEqual('Slate10');
-      done();
-    }, 300);
+    expect(colorpickerObj.getLabelValue()).toEqual('Slate10');
   });
 
   it('Should set the color/label on the field', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Removed setTimeout from colorpicker tests to prevent occasional race conditions.  The two tests that were replaced are now testing API methods instead of depending on clicks.

**Related github/jira issue (required)**:

https://jira.infor.com/browse/SOHO-8078

**Steps necessary to review your pull request (required)**:

Pull this branch and run the Colorpicker functional tests.

SOHO-8078

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->