### PR TITLE
Soho 7993 - Fix Documentation Examples

### DIFF
--- a/app/src/js/custom-route-options.js
+++ b/app/src/js/custom-route-options.js
@@ -47,6 +47,11 @@ module.exports = function customRouteOptions(req, res) {
     customOpts.layout = 'components/place/scrolling/layout-nested';
   }
 
+  // Searchfield in Headers (needs to load the Header layout)
+  if (url.match(/searchfield\/example-header/)) {
+    customOpts.layout = 'components/header/layout';
+  }
+
   // Sign-in Dialog
   if (url.match(/tests\/signin/)) {
     customOpts.layout = 'tests/layout-noheader';

--- a/app/views/components/input/example-textarea.html
+++ b/app/views/components/input/example-textarea.html
@@ -1,0 +1,1 @@
+{{> components/textarea/example-index}}

--- a/app/views/components/pager/example-circlepager.html
+++ b/app/views/components/pager/example-circlepager.html
@@ -1,0 +1,1 @@
+{{> components/circlepager/example-index}}

--- a/app/views/components/pager/example-datagrid.html
+++ b/app/views/components/pager/example-datagrid.html
@@ -1,0 +1,1 @@
+{{> components/datagrid/example-paging}}

--- a/app/views/components/pager/example-listview.html
+++ b/app/views/components/pager/example-listview.html
@@ -1,0 +1,1 @@
+{{> components/listview/example-paging}}

--- a/app/views/components/pie/example-donut.html
+++ b/app/views/components/pie/example-donut.html
@@ -1,0 +1,1 @@
+{{> components/donut/example-index}}

--- a/app/views/components/searchfield/example-header-compact.html
+++ b/app/views/components/searchfield/example-header-compact.html
@@ -1,0 +1,1 @@
+{{> components/header/example-searchfield-full}}

--- a/app/views/components/searchfield/example-header-large.html
+++ b/app/views/components/searchfield/example-header-large.html
@@ -1,0 +1,1 @@
+{{> components/header/example-searchfield-large}}

--- a/app/views/components/targeted-achievement/example-datagrid.html
+++ b/app/views/components/targeted-achievement/example-datagrid.html
@@ -1,0 +1,1 @@
+{{> components/datagrid/test-targeted-achievement}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6774,12 +6774,12 @@
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "js-yaml": {
@@ -6788,8 +6788,8 @@
           "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
           "dev": true,
           "requires": {
-            "argparse": "1.0.10",
-            "esprima": "2.7.3"
+            "argparse": "^1.0.2",
+            "esprima": "^2.6.0"
           }
         }
       }
@@ -16251,8 +16251,8 @@
           "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
           "dev": true,
           "requires": {
-            "ajv": "6.5.1",
-            "ajv-keywords": "3.2.0"
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
           }
         }
       }

--- a/src/components/area/readme.md
+++ b/src/components/area/readme.md
@@ -1,16 +1,21 @@
 ---
 title: Area
 description: This page describes Area.
+demo:
+  pages:
+  - name: Main Example
+    slug: example-index
+  - name: Make the Tooltip Formatted (Currency)
+    slug: example-formatter
+  - name: Set animation speed
+    slug: example-animation
+  - name: Make a slice selected by default
+    slug: example-selected
+  - name: Example showing Get Selected value
+    slug: example-get-selected
+  - name: Example showing Set Selected value
+    slug: example-set-selected
 ---
-
-## Configuration Options
-
-1. Area Chart Example [View Example]( ../components/area/example-index)
-2. Make the Tooltip Formatted (Currency) [View Example]( ../components/area/example-formatter)
-3. Set animation speed [View Example]( ../components/area/example-animation)
-4. Make a slice selected by default [View Example]( ../components/area/example-selected)
-5. Example showing Get Selected value [View Example]( ../components/area/example-get-selected)
-6. Example showing Set Selected value [View Example]( ../components/area/example-set-selected)
 
 The area chart is a line chart with the isArea set that adds the fills. See the [line chart api]( ../components/line) for more details.
 

--- a/src/components/arrange/readme.md
+++ b/src/components/arrange/readme.md
@@ -1,11 +1,11 @@
 ---
 title: Arrange
 description: This page describes Arrange.
+demo:
+  pages:
+  - name: Main Example
+    slug: example-index
 ---
-
-## Configuration Options
-
-1. Default Arrange Example [View Example]( ../components/arrange/example-index)
 
 ## Code Example
 

--- a/src/components/bar-grouped/readme.md
+++ b/src/components/bar-grouped/readme.md
@@ -1,17 +1,23 @@
 ---
 title: Bar Chart (Grouped)
 description: This page describes Bar Chart (Grouped).
+demo:
+  pages:
+  - name: Standard Grouped Bar Chart
+    slug: example-index
+  - name: Example showing defaulting a selected value
+    slug: example-selected
+  - name: Example showing with negative values
+    slug: example-negative
+  - name: Adapts to handle a large number of groups
+    slug: test-many-groups
+  - name: Set animation speed
+    slug: example-animation
+  - name: Example showing Get Selected value
+    slug: example-get-selected
+  - name: Example showing Set Selected value
+    slug: example-set-selected
 ---
-
-## Configuration Options
-
-1. Grouped bar chart example [View Example]( ../components/bar-grouped/example-index)
-1. Default a selected Group [View Example]( ../components/bar-grouped/example-selected)
-1. Handle Negative Values [View Example]( ../components/bar-grouped/example-negative)
-1. Adapts to handle a large number of groups [View Example]( ../components/bar-grouped/test-many-groups)
-1. Set animation speed [View Example]( ../components/bar-grouped/example-animation)
-1. Example showing Get Selected value [View Example]( ../components/bar-grouped/example-get-selected)
-1. Example showing Set Selected value [View Example]( ../components/bar-grouped/example-set-selected)
 
 ## Code Example
 

--- a/src/components/bar-stacked/readme.md
+++ b/src/components/bar-stacked/readme.md
@@ -1,19 +1,27 @@
 ---
 title: Bar Chart (Stacked)
 description: This page describes Bar Chart (Stacked).
+demo:
+  pages:
+  - name: Standard Stacked Bar Chart
+    slug: example-index
+  - name: 100% Stacked Bar Chart
+    slug: example-stacked-100
+  - name: Colors
+    slug: example-stacked-colors
+  - name: Patterns
+    slug: example-stacked-patterns
+  - name: Formatting Tooltip Data
+    slug: example-stacked-formatter-string
+  - name: Set animation speed
+    slug: example-animation
+  - name: Example showing defaulting a selected value
+    slug: example-stacked-selected
+  - name: Example showing Get Selected value
+    slug: example-get-selected
+  - name: Example showing Set Selected value
+    slug: example-set-selected
 ---
-
-## Configuration Options
-
-1. Stacked bar chart example [View Example]( ../components/bar-stacked/example-index)
-2. 100% Stacked Bar Chart [View Example]( ../components/bar-stacked/example-stacked-100)
-3. Changing Bar Colors [View Example]( ../components/bar-stacked/example-stacked-colors)
-4. Formatting Tooltip Data [View Example]( ../components/bar-stacked/example-stacked-formatter-string)
-5. Patterns [View Example]( ../components/bar-stacked/example-stacked-patterns)
-6. Set animation speed [View Example]( ../components/bar-stacked/example-animation)
-7. Defaulting Selected [View Example]( ../components/bar-stacked/example-stacked-selected)
-8. Example showing Get Selected value [View Example]( ../components/bar-stacked/example-get-selected)
-9. Example showing Set Selected value [View Example]( ../components/bar-stacked/example-set-selected)
 
 ## Code Example
 

--- a/src/components/bar/readme.md
+++ b/src/components/bar/readme.md
@@ -1,23 +1,35 @@
 ---
 title: Bar Chart
 description: This page describes Bar Chart.
+demo:
+  pages:
+  - name: Standard Bar Chart
+    slug: example-index
+  - name: Example with More Elements and Longer Text
+    slug: example-alignment
+  - name: Example showing how to set Colors
+    slug: example-colors
+  - name: Example showing the formatter
+    slug: example-formatter
+  - name: Example showing the option to hide the formatter
+    slug: example-hide-legend
+  - name: Example showing an edge case of longer text
+    slug: example-long-text
+  - name: Example showing with negative values
+    slug: example-negative-value
+  - name: Set animation speed
+    slug: example-animation
+  - name: Example showing color patterns
+    slug: example-patterns
+  - name: Example showing defaulting a selected value
+    slug: example-selected
+  - name: Example showing Get Selected value
+    slug: example-get-selected
+  - name: Example showing Set Selected value
+    slug: example-set-selected
+  - name: Example showing empty data set
+    slug: test-empty
 ---
-
-## Configuration Options
-
-1. Bar Chart Main Example [View Example]( ../components/bar/example-index)
-2. Another Example with More Elements and Longer Text [View Example]( ../components/bar/example-alignment)
-3. Example showing how to set Colors [View Example]( ../components/bar/example-colors)
-4. Example showing the formatter [View Example]( ../components/bar/example-formatter)
-5. Example showing the option to hide the formatter [View Example]( ../components/bar/example-hide-legend)
-6. Example showing an edge case of longer text [View Example]( ../components/bar/example-long-text)
-7. Example showing with negative values [View Example]( ../components/bar/example-negative-value)
-8. Set animation speed [View Example]( ../components/bar/example-animation)
-9. Example showing color patterns [View Example]( ../components/bar/example-patterns)
-10. Example showing defaulting a selected value  [View Example]( ../components/bar/example-selected)
-11. Example showing Get Selected value [View Example]( ../components/bar/example-get-selected)
-12. Example showing Set Selected value [View Example]( ../components/bar/example-set-selected)
-13. Example showing empty data set [View Example]( ../components/bar/test-empty)
 
 ## Code Example
 

--- a/src/components/breakpoints/readme.md
+++ b/src/components/breakpoints/readme.md
@@ -1,11 +1,11 @@
 ---
 title: Favorites
 description: This page describes Favorites.
+demo:
+  pages:
+  - name: Breakpoint Event Change Detection
+    slug: example-change-detection
 ---
-
-## Configuration Options
-
-1. Breakpoint Event Change Detection [View Example](../components/breakpoints/example-change-detection)
 
 ## Code Example
 

--- a/src/components/bubble/readme.md
+++ b/src/components/bubble/readme.md
@@ -1,6 +1,18 @@
 ---
 title: Bubble Chart
 description: This page describes Bubble Chart.
+demo:
+  pages:
+  - name: Standard Bubble Chart
+    slug: example-index
+  - name: Defaulting a selected bubble
+    slug: example-selected
+  - name: Set animation speed
+    slug: example-animation
+  - name: Example showing Get Selected value
+    slug: example-get-selected
+  - name: Example showing Set Selected value
+    slug: example-set-selected
 ---
 
 ## Configuration Options

--- a/src/components/bullet/readme.md
+++ b/src/components/bullet/readme.md
@@ -1,15 +1,19 @@
 ---
 title: Bullet Chart
 description: This page describes Bullet Chart.
+demo:
+  pages:
+  - name: Standard Bullet Chart
+    slug: example-index
+  - name: Shows Grouping a Series of Related Bullet Charts
+    slug: example-data-group
+  - name: Shows a Bullet Chart with Positive and Negative Values
+    slug: example-selected
+  - name: Shows a bullet with a negative value
+    slug: example-negative-value
+  - name: Set animation speed
+    slug: example-animation
 ---
-
-## Configuration Options
-
-1. Standard Bullet Chart [View Example]( ../components/bullet/example-index)
-2. Shows Grouping a Series of Related Bullet Charts [View Example]( ../components/bullet/example-data-group)
-3. Shows a Bullet Chart with Positive and Negative Values [View Example]( ../components/bullet/example-negative-positive-value)
-4. Shows a bullet with a negative value [View Example]( ../components/bullet/example-negative-value)
-5. Set animation speed [View Example]( ../components/bullet/example-animation)
 
 ## Code Example
 

--- a/src/components/charts/readme.md
+++ b/src/components/charts/readme.md
@@ -1,33 +1,35 @@
 ---
 title: Charts
-description: This page describes Charts .
+description: This page describes Charts.
+demo:
+  pages:
+  - name: Using Patterns on Chart Colors
+    slug: example-chart-patterns
+  - name: How to Hide / Show a Chart
+    slug: example-hide-show
+  - name: How to Change Chart Type
+    slug: example-change-type
 ---
 
 All of the charts are documented separately by type. See the respective pages for each chart in addition to this shared API info page. The following charts are currently supported
 
 ## Chart Types
 
-1. Area [View Example]( ./area)
-1. Bar [View Example]( ./bar)
-1. Bar Grouped [View Example]( ./bar-grouped)
-1. Bar Stacked [View Example]( ./bar-stacked)
-1. Bubble [View Example]( ./bubble)
-1. Column [View Example]( ./column)
-1. Column Grouped [View Example]( ./column-grouped)
-1. Completion Chart [View Example]( ./completion-chart)
-1. Donut [View Example]( ./donut)
-1. Line [View Example]( ./line)
-1. Positive Negative [View Example]( ./positive-negative)
-1. Sparkline [View Example]( ./sparkline)
-1. Step Chart [View Example]( ./step-chart)
-1. Targeted Achievement [View Example]( ./targeted-achievement)
-1. Timeline [View Example]( ./timeline)
-
-## Other Chart Use Cases
-
-1. Using Patterns on Chart Colors [View Example]( ../components/charts/example-chart-patterns.html)
-1. How to Hide / Show a Chart [View Example]( ../components/charts/example-hide-show.html)
-1. How to Change Chart Type [View Example]( ../components/charts/example-change-type.html)
+1. Area [View Example]( ../area)
+1. Bar [View Example]( ../bar)
+1. Bar Grouped [View Example]( ../bar-grouped)
+1. Bar Stacked [View Example]( ../bar-stacked)
+1. Bubble [View Example]( ../bubble)
+1. Column [View Example]( ../column)
+1. Column Grouped [View Example]( ../column-grouped)
+1. Completion Chart [View Example]( ../completion-chart)
+1. Donut [View Example]( ../donut)
+1. Line [View Example]( ../line)
+1. Positive Negative [View Example]( ../positive-negative)
+1. Sparkline [View Example]( ../sparkline)
+1. Step Chart [View Example]( ../step-chart)
+1. Targeted Achievement [View Example]( ../targeted-achievement)
+1. Timeline [View Example]( ../timeline)
 
 ## Code Example
 

--- a/src/components/charts/readme.md
+++ b/src/components/charts/readme.md
@@ -7,21 +7,21 @@ All of the charts are documented separately by type. See the respective pages fo
 
 ## Chart Types
 
-1. Area [View Example]( ../components/area)
-1. Bar [View Example]( ../components/bar)
-1. Bar Grouped [View Example]( ../components/bar-grouped)
-1. Bar Stacked [View Example]( ../components/bar-stacked)
-1. Bubble [View Example]( ../components/bubble)
-1. Column [View Example]( ../components/column)
-1. Column Grouped [View Example]( ../components/column-grouped)
-1. Completion Chart [View Example]( ../components/completion-chart)
-1. Donut [View Example]( ../components/donut)
-1. Line [View Example]( ../components/line)
-1. Positive Negative [View Example]( ../components/positive-negative)
-1. Sparkline [View Example]( ../components/sparkline)
-1. Step Chart [View Example]( ../components/step-chart)
-1. Targeted Achievement [View Example]( ../components/targeted-achievement)
-1. Timeline [View Example]( ../components/timeline)
+1. Area [View Example]( ./area)
+1. Bar [View Example]( ./bar)
+1. Bar Grouped [View Example]( ./bar-grouped)
+1. Bar Stacked [View Example]( ./bar-stacked)
+1. Bubble [View Example]( ./bubble)
+1. Column [View Example]( ./column)
+1. Column Grouped [View Example]( ./column-grouped)
+1. Completion Chart [View Example]( ./completion-chart)
+1. Donut [View Example]( ./donut)
+1. Line [View Example]( ./line)
+1. Positive Negative [View Example]( ./positive-negative)
+1. Sparkline [View Example]( ./sparkline)
+1. Step Chart [View Example]( ./step-chart)
+1. Targeted Achievement [View Example]( ./targeted-achievement)
+1. Timeline [View Example]( ./timeline)
 
 ## Other Chart Use Cases
 

--- a/src/components/column-grouped/readme.md
+++ b/src/components/column-grouped/readme.md
@@ -1,6 +1,20 @@
 ---
 title: Column Chart (Grouped)
 description: This page describes Column Chart (Grouped).
+demo:
+  pages:
+  - name: Standard Grouped Column Chart
+    slug: example-index
+  - name: Default a Selected Group
+    slug: example-selected
+  - name: Handle negative values
+    slug: example-negative
+  - name: Set animation speed
+    slug: example-animation
+  - name: Example showing Get Selected value
+    slug: example-get-selected
+  - name: Example showing Set Selected value
+    slug: example-set-selected
 ---
 
 ## Configuration Options

--- a/src/components/column-stacked/readme.md
+++ b/src/components/column-stacked/readme.md
@@ -1,18 +1,25 @@
 ---
 title: Column Chart (Stacked)
 description: This page describes Column Chart (Stacked).
+demo:
+  pages:
+  - name: Standard Stacked Column Chart
+    slug: example-index
+  - name: Defaulting Selected Stacks
+    slug: example-selected
+  - name: Single Column Chart
+    slug: example-singular
+  - name: Set animation speed
+    slug: example-animation
+  - name: Example showing Get Selected value
+    slug: example-get-selected
+  - name: Example showing Singular Get Selected value
+    slug: example-singular-get-selected
+  - name: Example showing Set Selected value
+    slug: example-set-selected
+  - name: Example showing Singular Set Selected value
+    slug: example-singular-set-selected
 ---
-
-## Configuration Options
-
-1. Stacked Column Chart Example [View Example]( ../components/column-stacked/example-index)
-1. Defaulting Selected Stacks [View Example]( ../components/column-stacked/example-selected)
-1. Single Column Chart [View Example]( ../components/column-stacked/example-singular)
-1. Set animation speed [View Example]( ../components/column-stacked/example-animation)
-1. Example showing Get Selected value [View Example]( ../components/column-stacked/example-get-selected)
-1. Example showing Singular Get Selected value [View Example]( ../components/column-stacked/example-singular-get-selected)
-1. Example showing Set Selected value [View Example]( ../components/column-stacked/example-set-selected)
-1. Example showing Singular Set Selected value [View Example]( ../components/column-stacked/example-singular-set-selected)
 
 ### Dataset Settings
 

--- a/src/components/column/readme.md
+++ b/src/components/column/readme.md
@@ -1,23 +1,35 @@
 ---
 title: Column Chart
 description: This page describes Column Chart.
+demo:
+  pages:
+  - name: Standard Column Chart
+    slug: example-index
+  - name: Column Chart with Legend
+    slug: example-legend
+  - name: Balance Widget
+    slug: example-balance
+  - name: Changing Colors
+    slug: example-colors
+  - name: Changing the Y Domain
+    slug: example-domain-change
+  - name: Formatting the Values (Tooltip)
+    slug: example-formatter
+  - name: Negative Values
+    slug: example-negative-value
+  - name: Testing Date Values
+    slug: test-by-date
+  - name: Pattern Colors
+    slug: example-patterns
+  - name: Selecting a Section Colors
+    slug: example-selected
+  - name: Set animation speed
+    slug: example-animation
+  - name: Example showing Get Selected value
+    slug: example-get-selected
+  - name: Example showing Set Selected value
+    slug: example-set-selected
 ---
-
-## Configuration Options
-
-1. Column Chart Main Example [View Example]( ../components/column/example-index)
-1. Column Chart with Legend [View Example]( ../components/column/example-legend)
-1. Balance Widget [View Example]( ../components/column/example-balance)
-1. Changing Colors [View Example]( ../components/column/example-colors)
-1. Changing the Y Domain [View Example]( ../components/column/example-domain-change)
-1. Formatting the Values (Tooltip) [View Example]( ../components/column/example-formatter)
-1. Negative Values [View Example]( ../components/column/example-negative-value)
-1. Pattern Colors [View Example]( ../components/column/example-patterns)
-1. Selecting a Section Colors [View Example]( ../components/column/example-selected)
-1. Set animation speed [View Example]( ../components/column/example-animation)
-1. Testing Date Values [View Test]( ../components/column/test-by-date)
-1. Example showing Get Selected value [View Test]( ../components/column/example-get-selected)
-1. Example showing Set Selected value [View Test]( ../components/column/example-set-selected)
 
 ## Dataset Settings
 

--- a/src/components/completion-chart/readme.md
+++ b/src/components/completion-chart/readme.md
@@ -1,13 +1,17 @@
 ---
 title: Completion Chart
 description: This page describes Completion Chart.
+demo:
+  pages:
+  - name: Standard Completion Chart Example
+    slug: example-index
+  - name: All Completion Chart Examples
+    slug: example-variations
+  - name: Range of Colors for Completion Chart
+    slug: example-colors
 ---
 
 ## Configuration Options
-
-1. Simple Completion Chart Example [View Example]( ../components/completion-chart/example-index)
-2. All Completion Chart Examples [View Example]( ../components/completion-chart/example-variations)
-3. Range of Colors for Completion Chart [View Example]( ../components/completion-chart/example-colors)
 
 Format used the [D3 formatter (v3)](https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3_format)
 

--- a/src/components/donut/readme.md
+++ b/src/components/donut/readme.md
@@ -1,17 +1,23 @@
 ---
 title: Donut Chart
 description: This page describes Donut Chart.
+demo:
+  pages:
+  - name: Standard Donut Chart
+    slug: example-index
+  - name: Showing Slices as Alerts
+    slug: example-alerts
+  - name: With a Right Click Menu
+    slug: example-rightclick
+  - name: Longer and Zero Labels
+    slug: example-values
+  - name: Set animation speed
+    slug: example-animation
+  - name: Example showing Get Selected value
+    slug: example-get-selected
+  - name: Example showing Set Selected value
+    slug: example-set-selected
 ---
-
-## Configuration Options
-
-1. Donut Chart Main Example [View Example]( ../components/donut/example-index)
-2. Showing Slices as Alerts [View Example]( ../components/donut/example-alerts)
-3. With a Right Click Menu [View Example]( ../components/donut/example-rightclick)
-4. Longer and Zero Labels [View Example]( ../components/donut/example-values)
-5. Set animation speed [View Example]( ../components/donut/example-animation)
-6. Example showing Get Selected value [View Example]( ../components/donut/example-get-selected)
-7. Example showing Set Selected value [View Example]( ../components/donut/example-set-selected)
 
 ## Settings
 

--- a/src/components/drag/readme.md
+++ b/src/components/drag/readme.md
@@ -1,11 +1,11 @@
 ---
 title: Drag Behavior
 description: This page describes Drag Behavior.
+demo:
+  pages:
+  - name: Basic Drag Examples
+    slug: example-index
 ---
-
-## Configuration Options
-
-Drag Examples [View Example]( ../components/drag/example-index)
 
 ## Code Example
 

--- a/src/components/dropdown/readme.md
+++ b/src/components/dropdown/readme.md
@@ -6,25 +6,25 @@ demo:
   - name: Default Dropdown Example
     slug: example-index
   - name: Clearable Dropdown
-    slug: example-clearable.html
+    slug: example-clearable
   - name: Updating the Contents
-    slug: example-updating.html
+    slug: example-updating
   - name: Ajax Contents on Open
-    slug: example-ajax.html
+    slug: example-ajax
   - name: Section / Groups
-    slug: example-groups.html
+    slug: example-groups
   - name: Disable Search
-    slug: example-no-search.html
+    slug: example-no-search
   - name: States
-    slug: example-states.htm
+    slug: example-states
   - name: Validation
-    slug: example-validation.html
+    slug: example-validation
   - name: Widths
-    slug: example-widths.html
+    slug: example-widths
   - name: Data Attributes
-    slug: example-with-data-attribute.html
+    slug: example-with-data-attribute
   - name: Icons
-    slug: example-icons.html
+    slug: example-icons
 ---
 
 To distinguish between single and multi-select situations, use checkboxes in multi-select lists. See the live example for how multiple selections are handled in the field display and the list display. The field height is not dynamic so the height of the field should not be expanded to display multiple selections.

--- a/src/components/hierarchy/readme.md
+++ b/src/components/hierarchy/readme.md
@@ -6,7 +6,7 @@ demo:
   - name: Org Chart Example
     slug: example-index
   - name: Lazy Loading Example
-    slug: example-lazy-loading
+    slug: example-lazy-load
   - name: Example Paging
     slug: example-paging
   - name: Example Single Manager/Subordinate

--- a/src/components/input/readme.md
+++ b/src/components/input/readme.md
@@ -14,7 +14,7 @@ demo:
   - name: Input Widths (Sm, Md, Lg)
     slug: example-sizes
   - name: Text Area
-    slug: textarea
+    slug: example-textarea
   - name: Clearable Input (With an X)
     slug: example-clearable
   - name: Input with Right Click Context Menu

--- a/src/components/line/readme.md
+++ b/src/components/line/readme.md
@@ -1,20 +1,29 @@
 ---
 title: Line
 description: This page describes Line.
+demo:
+  pages:
+  - name: Standard Line Chart
+    slug: example-index
+  - name: Labels on Axis
+    slug: example-axis-labels
+  - name: Ticks Adjustment (Less ticks than data points)
+    slug: example-axis-ticks
+  - name: Customize Tooltip
+    slug: example-custom-tooltip
+  - name: Customize Dot Size
+    slug: example-custom-dots
+  - name: Rotate Bottom Labels
+    slug: test-rotate
+  - name: Example showing two line x axis
+    slug: example-two-lines
+  - name: Set animation speed
+    slug: example-animation
+  - name: Example showing Get Selected value
+    slug: example-get-selected
+  - name: Example showing Set Selected value
+    slug: example-set-selected
 ---
-
-## Configuration Options
-
-1. Line Chart Example [View Example]( ../components/line/example-index)
-2. Labels on Axis [View Example]( ../components/line/example-axis-labels)
-3. Ticks Adjustment (Less ticks than data points) [View Example]( ../components/line/example-axis-ticks)
-4. Customize Tooltip [View Example]( ../components/line/example-custom-tooltip)
-5. Customize Dot Size [View Example]( ../components/line/example-custom-dots)
-6. Set animation speed [View Example]( ../components/line/example-animation)
-7. Rotate Bottom Labels [View Example]( ../components/line/test-rotate)
-8. Example showing Get Selected value [View Example]( ../components/line/example-get-selected)
-9. Example showing Set Selected value [View Example]( ../components/line/example-set-selected)
-10. Example showing two line x axis [View Example]( ../components/line/example-two-lines)
 
 ## Code Example
 

--- a/src/components/listfilter/readme.md
+++ b/src/components/listfilter/readme.md
@@ -1,10 +1,6 @@
 ---
 title: List Filter
 description: This page describes List Filter.
-demo:
-  pages:
-  - name: Multiselect Filter Types
-    slug: test-filter-types
 ---
 
 ## Code Example

--- a/src/components/mask/readme.md
+++ b/src/components/mask/readme.md
@@ -1,14 +1,17 @@
 ---
 title: Mask
 description: This page describes Mask.
+demo:
+  pages:
+  - name: Main Example
+    slug: example-index
+  - name: Common Mask Patterns
+    slug: example-common-patterns
+  - name: Fields with Symbols
+    slug: example-fields-with-symbols
+  - name: The Number Mask Gauntlet
+    slug: test-number-mask-gauntlet
 ---
-
-## Configuration Options
-
-1. Inputs with Masks [View Example]( ../components/mask/example-index)
-2. Common Mask Patterns [View Example]( ../components/mask/example-common-patterns)
-3. Fields with Symbols [View Example]( ../components/mask/example-fields-with-symbols)
-4. Number Mask Gauntlet [View Example]( ../components/mask/test-number-mask-gauntlet)
 
 ## Behavior Guidelines
 

--- a/src/components/personalize/readme.md
+++ b/src/components/personalize/readme.md
@@ -1,14 +1,13 @@
 ---
 title: Personalize
 description: This page describes Personalize.
+demo:
+  pages:
+  - name: Themes Example
+    slug: example-index?colors=800000
+  - name: Property Page
+    slug: example-settings-page
 ---
-
-## Configuration Options
-
-1. Themes Example [View Example]( ../components/personalize/example-index?colors=800000)
-2. Module Tabs [View Example]( ../patterns/module-tabs?colors=800000)
-3. Sub Headers/Header [View Example](../patterns/builder?colors=800000)
-4. Property Page  [View Example]( ../components/personalize/example-settings-page)
 
 ## Code Example
 

--- a/src/components/pie/readme.md
+++ b/src/components/pie/readme.md
@@ -1,17 +1,23 @@
 ---
 title: Pie Chart
 description: This page describes Pie Chart.
+demo:
+  pages:
+  - name: Standard Pie Chart
+    slug: example-index
+  - name: HCM Example
+    slug: example-hcm
+  - name: Tooltips
+    slug: example-tooltip
+  - name: Donut Chart
+    slug: example-donut
+  - name: Set animation speed
+    slug: example-animation
+  - name: Example showing Get Selected value
+    slug: example-get-selected
+  - name: Example showing Set Selected value
+    slug: example-set-selected
 ---
-
-## Configuration Options
-
-1. Pie Chart Main Example [View Example]( ../components/pie/example-index)
-2. Hcm Example [View Example]( ../components/pie/example-hcm)
-3. Tooltips [View Example]( ../components/pie/example-tooltip)
-4. Donut Chart [View Example]( ../components/donut/example-index)
-5. Set animation speed [View Example]( ../components/pie/example-animation)
-6. Example showing Get Selected value [View Example]( ../components/pie/example-get-selected)
-7. Example showing Set Selected value [View Example]( ../components/pie/example-set-selected)
 
 ## Code Example
 

--- a/src/components/place/readme.md
+++ b/src/components/place/readme.md
@@ -1,11 +1,17 @@
 ---
 title: Place
 description: This page describes Place.
+demo:
+  pages:
+  - name: Place by Coordinate
+    slug: test-coordinates
+  - name: Place by Relative Parent
+    slug: test-relative-to-parent
+  - name: Place in a Nested Container
+    slug: test-container-is-nested
+  - name: Place in the document body
+    slug: test-container-is-body
 ---
-
-## Configuration Options
-
-1. Test List [View Example]( ../components/place/list)
 
 ## Description
 

--- a/src/components/positive-negative/readme.md
+++ b/src/components/positive-negative/readme.md
@@ -1,6 +1,18 @@
 ---
 title: Positive-Negative Chart
 description: This page describes Positive-Negative Chart.
+demo:
+  pages:
+  - name: Standard Positive/Negative Chart
+    slug: example-index
+  - name: Example showing color patterns
+    slug: example-patterns
+  - name: Set animation speed
+    slug: example-animation
+  - name: Example showing Get Selected value
+    slug: example-get-selected
+  - name: Example showing Set Selected value
+    slug: example-set-selected
 ---
 
 ## Configuration Options

--- a/src/components/radar/readme.md
+++ b/src/components/radar/readme.md
@@ -1,11 +1,11 @@
 ---
 title: Radar Chart
 description: This page describes Radar Chart.
+demo:
+  pages:
+  - name: Standard Radar Chart
+    slug: example-index
 ---
-
-## Configuration Options
-
-1. Radar Chart Main Example [View Example]( ../components/radar/example-index)
 
 ## Code Example
 

--- a/src/components/radios/readme.md
+++ b/src/components/radios/readme.md
@@ -6,7 +6,7 @@ demo:
   - name: Radio Button Example
     slug: example-index
   - name: Horizontal Radio Button Example
-    slug: example-index
+    slug: example-horizontal
   - name: Dirty Flag
     slug: test-dirty
   - name: Validation

--- a/src/components/slider/readme.md
+++ b/src/components/slider/readme.md
@@ -1,6 +1,6 @@
 ---
 title: Slider Component
-description: This page describes Slider Component .
+description: This page describes Slider Component.
 demo:
   pages:
   - name: Main Example

--- a/src/components/sparkline/readme.md
+++ b/src/components/sparkline/readme.md
@@ -1,13 +1,15 @@
 ---
 title: Sparklines
 description: This page describes Sparklines.
+demo:
+  pages:
+  - name: Standard Sparkline Chart
+    slug: example-index
+  - name: Example showing Get Selected value
+    slug: example-get-selected
+  - name: Example showing Set Selected value
+    slug: example-set-selected
 ---
-
-## Configuration Options
-
-1. Sparklines Main Example [View Example]( ../components/sparkline/example-index)
-2. Example showing Get Selected value [View Example]( ../components/sparkline/example-get-selected)
-3. Example showing Set Selected value [View Example]( ../components/sparkline/example-set-selected)
 
 ## Spark Line Chart Types
 

--- a/src/components/splitter/readme.md
+++ b/src/components/splitter/readme.md
@@ -1,13 +1,15 @@
 ---
-title: Splitter Component 
+title: Splitter Component
 description: This page describes Splitter Component .
+demo:
+  pages:
+  - name: Main Example
+    slug: example-index
+  - name: Splitter Element in Left Pane
+    slug: example-splitter-left
+  - name: Events
+    slug: example-events
 ---
-
-## Configuration Examples
-
-1. Main [View Example](../components/splitter/example-index)
-2. Splitter Element in Left Pane [View Example](../components/splitter/example-splitter-left)
-3. Events [View Example](../components/splitter/example-events)
 
 ## Code Example
 

--- a/src/components/stepchart/readme.md
+++ b/src/components/stepchart/readme.md
@@ -1,12 +1,13 @@
 ---
 title: Step Chart  
 description: This page describes Step Chart.
+demo:
+  pages:
+  - name: Standard Step Chart
+    slug: example-index
+  - name: Custom Colors
+    slug: example-colors
 ---
-
-## Configuration Options
-
-1. Step Chart Examples in a Card/Widget [View Example]( ../components/stepchart/example-index)
-1. Custom Colors [View Example]( ../components/stepchart/example-colors)
 
 ## Behavior Guidelines
 

--- a/src/components/switch/readme.md
+++ b/src/components/switch/readme.md
@@ -6,7 +6,7 @@ demo:
   - name: Main Switch Example
     slug: example-index
   - name: Alternate Alignment
-    slug: example-alignment)
+    slug: example-alignment
   - name: Two Column Layout
     slug: example-two-columns
 ---

--- a/src/components/tabs/readme.md
+++ b/src/components/tabs/readme.md
@@ -11,8 +11,6 @@ demo:
     slug: example-dismissible-tabs
   - name: Dropdown Tabs
     slug: example-dropdown-tabs
-  - name: "`updateCount()` Demo"
-    slug: example-update-count-api
   - name: "`changeTabOnHashChange` Setting with Callback Demo"
     slug: example-url-hash-change
   - name: "`beforeActivate` Callback example"

--- a/src/components/targeted-achievement/readme.md
+++ b/src/components/targeted-achievement/readme.md
@@ -1,13 +1,15 @@
 ---
 title: Targeted Achievement Chart
 description: This page describes Targeted Achievement Chart.
+demo:
+  pages:
+  - name: Main Target to Achievement Example (shows 3 examples)
+    slug: example-index
+  - name: Showing Percentage Text
+    slug: example-percent-text
+  - name: Used on a Datagrid
+    slug: example-datagrid
 ---
-
-## Configuration Options
-
-1. Main Target to Achievement Example showing 3 examples [View Example]( ../components/targeted-achievement/example-index)
-2. Grid Example, this chart is available as a formatter.  [View Example]( ../components/datagrid/test-targeted-achievement.html)
-3. Example showing Percent Text [View Example]( ../components/targeted-achievement/example-percent-text)
 
 ### Dataset Settings
 

--- a/src/components/textarea/readme.md
+++ b/src/components/textarea/readme.md
@@ -1,11 +1,11 @@
 ---
 title: Textarea Component
-description: This page describes Textarea Component .
+description: This page describes Textarea Component.
+demo:
+  pages:
+  - name: Main Examples
+    slug: example-index
 ---
-
-## Configuration Details
-
-1. [Text Area  Examples]( ../components/textarea/example-index)
 
 ## Behavior Guidelines
 

--- a/src/components/trackdirty/readme.md
+++ b/src/components/trackdirty/readme.md
@@ -1,11 +1,11 @@
 ---
 title: Trackdirty
 description: This page describes Trackdirty.
+demo:
+  pages:
+  - name: Main Example
+    slug: example-index
 ---
-
-## Configuration Details
-
-1. Default Trackdirty Example [View Example]( ../components/trackdirty/example-index)
 
 ## Code Example
 

--- a/src/components/validation/readme.md
+++ b/src/components/validation/readme.md
@@ -1,17 +1,23 @@
 ---
 title: Validation
 description: This page describes Validation.
+demo:
+  pages:
+  - name: Main Validation Examples
+    slug: example-index
+  - name: Disabled Form
+    slug: example-form-disabled
+  - name: Multiple Validation Errors on a Field
+    slug: example-multiple-errors
+  - name: Legacy Short Fields
+    slug: example-short-fields
+  - name: Manually adding an Error
+    slug: example-standalone-error
+  - name: Enabling a Button on Valid
+    slug: example-validation-form
+  - name: Validating on Form Submit
+    slug: example-validation-on-submit
 ---
-
-## Configuration Options
-
-1. Validation Example [View Example]( ../components/validation/example-index)
-1. Disabled Form [View Example]( ../components/validation/example-form-disabled)
-1. Multiple Validation Errors on a Field [View Example]( ../components/validation/example-multiple-errors)
-1. Legacy Short Fields [View Example]( ../components/validation/example-short-fields)
-1. Manually adding an Error [View Example]( ../components/validation/example-standalone-error)
-1. Enabling a Button on Valid [View Example]( ../components/validation/example-validation-form)
-1. Validating on Form Submit [View Example]( ../components/validation/example-validation-on-submit)
 
 ## Code Example - Auto
 

--- a/src/components/visibility/readme.md
+++ b/src/components/visibility/readme.md
@@ -1,11 +1,12 @@
 ---
-title: Visibility CSS Classes 
-description: This page describes Visibility CSS Classes .
+title: Visibility CSS Classes
+description: This page describes Visibility CSS Classes.
+demo:
+  pages:
+  - name: All Examples
+    slug: example-index
+  - name: Multiple classes at once
+    slug: example-multiple-visibility-classes
 ---
 
 The Soho visibility classes allow elements to become conditionally visible or hidden based on breakpoint size.  They also provide a way to conveniently change the CSS `display` property on a per-breakpoint basis.
-
-## Configuration Examples
-
-1. [All Examples]( ../components/visibility/example-index)
-2. [Multiple classes at once]( ../components/visibility/example-multiple-visibility-classes)


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Many links to examples on https://design.infor.com/ are broken due to missing demo names/slugs in the top of all the `readme.md` files.  This PR fixes them.

**Related github/jira issue (required)**:
https://jira.infor.com/browse/SOHO-7993

**Steps necessary to review your pull request (required)**:
- pull this branch
- check various new HTML files, such as http://localhost:4000/components/searchfield/example-header-compact.html to make sure the examples display.

**NOTE:** when running the docs generator locally, the documentation files' links to each example are broken.  They should be fine when this is deployed to the server.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->