### PR TITLE
SOHO-7816 - Fixed select-all was causing frozen browser with Multiselect

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -2004,6 +2004,9 @@ Dropdown.prototype = {
     this.previousActiveDescendant = last.value || '';
 
     this.pseudoElem[0].querySelector('span').textContent = text;
+    if (text.length > 1000) {
+      text = `${text.substring(0, 1000)}...`;
+    }
     this.searchInput[0].value = text;
     this.updateItemIcon(last);
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

With Chrome on Windows select-all was causing frozen browser with Multiselect

**Related github/jira issue (required)**:
https://jira.infor.com/browse/SOHO-7816

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/multiselect/test-select-all-performance
- Open above link with Windows / Chrome
- Click on multiselect “Bods” to open
- Click on first item in list “Select All”
- It should not take much time select all items
- Do same to clear the items
- See should not take much longer to clear all either

closes #117 