### PR TITLE
SOHO-5888 fix display inside tabs and containers

### DIFF
--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -2101,7 +2101,7 @@ $datagrid-short-row-height: 23px;
 
         + .icon {
           right: 4px;
-          top: -2px;
+          top: -2px !important;
         }
 
         &.is-disabled {
@@ -2522,6 +2522,10 @@ td .btn-actions {
 .datagrid-checkbox-wrapper {
   @include font-size(12);
   position: relative;
+
+  & + .datagrid-filter-wrapper {
+    display: none;
+  }
 }
 
 //Grid Expand Button
@@ -3095,7 +3099,7 @@ html[dir='rtl'] {
     .handle,
     .is-draggable-target {
       display: none;
-      font-size: 2.6em;
+      font-size: 3.1rem;
       height: $datagrid-header-height;
       left: 0;
       margin: 0;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- For css prioritization, added tag 'important' on the dropdown icon top position.
- To achieved the checkbox vertically centered. datagrid-filter-wrapper should be display none if checkbox is present.
- Adjusted the handle font-size to rem to avoid issues in regards to parent's styling inheritance. 3.1rem is the equivalent value of the previous handle icon font-size 2.6em inside the class row with 1.2rem or 12px font-size.

**Related github/jira issue (required)**:
SOHO-5888

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-in-containers.html
- Open the above page, Check the vertical and horizontal alignment of the checkbox. It should be centered
- Dropdown icon should be vertically centered on the right side.
- Handle icon should be properly display
