### PR TITLE
soho-7747 fix the display on IE

### DIFF
--- a/src/components/typography/_typography.scss
+++ b/src/components/typography/_typography.scss
@@ -332,6 +332,9 @@ small,
 
   .data-description {
     flex-basis: auto;
+    line-height: 34px;
+    -ms-overflow-style: -ms-autohiding-scrollbar;
+    overflow: auto;
     white-space: nowrap;
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added css properties like overflow, line-height and the microsoft css proprietary ms-overflow-styling for IE. This will allow the label to be display properly with the input/lookup field both on IE and Chrome

**Related github/jira issue (required)**:
[SOHO-7747](https://github.com/infor-design/enterprise/issues/252)

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/form/test-flex.html
http://localhost:4000/components/form/test-flex.html?locale=ar-SA
- both lookup field and label should be displayed properly side by side
- Lookup/input field can accept user inputs and should not be moved or scrolled.
- Long labeled descriptions should have scrollbar to view hidden texts