### PR TITLE
SOHO-7909 - Fixed filtered select all was not working with Lookup

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5204,7 +5204,8 @@ Datagrid.prototype = {
 
     for (let i = 0, l = dataset.length; i < l; i++) {
       const idx = this.pagingRowIndex(i);
-      if (this.filterRowRendered || (this.filterExpr[0] && this.filterExpr[0].keywordSearch)) {
+      if (this.filterRowRendered ||
+        (this.filterExpr && this.filterExpr[0] && this.filterExpr[0].keywordSearch)) {
         if (!dataset[i].isFiltered) {
           rows.push(idx);
         }

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5204,7 +5204,7 @@ Datagrid.prototype = {
 
     for (let i = 0, l = dataset.length; i < l; i++) {
       const idx = this.pagingRowIndex(i);
-      if (this.filterRowRendered) {
+      if (this.filterRowRendered || (this.filterExpr[0] && this.filterExpr[0].keywordSearch)) {
         if (!dataset[i].isFiltered) {
           rows.push(idx);
         }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Using keyword search rows to select all, was selected all rows instead only filtered results

**Related github/jira issue (required)**:
https://jira.infor.com/browse/SOHO-7909

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/lookup/example-multiselect
- Open above link
- Click on lookup field to open modal
- Type "205" and press Enter key in search field
- It should filter with two results (Product Id - 2542205 and 2642205)
- Click on checkbox in header to select all (both rows)
- Click modal button "Apply"
- It should close the lookup modal
- In lookup field should add those selected items (Product Id - 2542205 and 2642205)