### PR TITLE
SOHO-7481 Added clearable option to dropdown component

### DIFF
--- a/app/views/components/datagrid/example-filter.html
+++ b/app/views/components/datagrid/example-filter.html
@@ -24,8 +24,7 @@
       data.push({ id: 8, productId: null, productName: null, activity:  null, quantity: null, price: null, orderDate: null, action: 'Blank Row', status: 'Confirmed'});
 
       var statuses = [{id:'Confirmed', value:'Confirmed', label:'Confirmed'},
-                      {id:'Error', value:'Error', label:'Error'},
-                      {id:'None', value:'', label:''}];
+                      {id:'Error', value:'Error', label:'Error'}];
 
       var activities = [{id: 'Assemble Paint', value:'Assemble Paint', label: 'Assemble Paint'},
                          {id: '', value: '', label: 'Default Activity'},
@@ -47,7 +46,7 @@
       columns.push({ id: 'quantity', name: 'Qty', field: 'quantity', align: 'right', filterType: 'integer'});
       columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'MM/dd/yyyy', filterType: 'date', width: 250});
       columns.push({ id: 'inStock', name: 'In Stock', field: 'inStock', formatter: Formatters.Checkbox, align: 'center', filterType: 'checkbox'});
-      columns.push({ id: 'status', name: 'Status', align: 'center', field: 'status', formatter: Formatters.Alert, filterType: 'select', editorOptions: {source: testSource1}, options: statuses, ranges: [{'value':'Confirmed', 'classes': 'confirm', text: 'Confirmed'}, {'value':'Error', 'classes': 'error', text: 'Error'}]});
+      columns.push({ id: 'status', name: 'Status', align: 'center', field: 'status', formatter: Formatters.Alert, filterType: 'select', editorOptions: {source: testSource1, clearable: true}, options: statuses, ranges: [{'value':'Confirmed', 'classes': 'confirm', text: 'Confirmed'}, {'value':'Error', 'classes': 'error', text: 'Error'}]});
       columns.push({ id: 'price',  name: 'Price', field: 'price', formatter: Formatters.Decimal, filterType: 'decimal', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###,####.000'});
 
       //Supported Filter Types: text, integer, date, select, decimal, checkbox, contents (FUTURE: lookup, percent)

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -39,7 +39,7 @@ const moveSelectedOpts = ['none', 'all', 'group'];
 * Fx 300 for the 300 px size fields. Default is size of the largest data.
 * @param {object} [settings.placementOpts = null]  Gets passed to this control's Place behavior
 * @param {function} [settings.onKeyDown = null]  Allows you to hook into the onKeyDown. If you do you can access the keydown event data. And optionally return false to cancel the keyDown action.
-* @param {object} [settings.clearable = false]  Adds empty option to clear selection
+* @param {boolean} [settings.clearable = false]  Adds empty option to clear selection
 */
 const DROPDOWN_DEFAULTS = {
   closeOnSelect: true,

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -39,6 +39,7 @@ const moveSelectedOpts = ['none', 'all', 'group'];
 * Fx 300 for the 300 px size fields. Default is size of the largest data.
 * @param {object} [settings.placementOpts = null]  Gets passed to this control's Place behavior
 * @param {function} [settings.onKeyDown = null]  Allows you to hook into the onKeyDown. If you do you can access the keydown event data. And optionally return false to cancel the keyDown action.
+* @param {object} [settings.clearable = false]  Adds empty option to clear selection
 */
 const DROPDOWN_DEFAULTS = {
   closeOnSelect: true,
@@ -58,7 +59,8 @@ const DROPDOWN_DEFAULTS = {
   delay: 300,
   maxWidth: null,
   placementOpts: null,
-  onKeyDown: null
+  onKeyDown: null,
+  clearable: false
 };
 
 function Dropdown(element, settings) {
@@ -2353,6 +2355,11 @@ Dropdown.prototype = {
         // If the incoming dataset is different than the one we started with,
         // replace the contents of the list, and rerender it.
         if (!self.isFiltering && !utils.equals(data, self.dataset)) {
+          // If clearable, add new empty option to clear
+          if (self.settings.clearable) {
+            data.unshift({ id: '', value: '', label: '' });
+          }
+
           self.dataset = data;
 
           if (!isManagedByTemplate) {

--- a/test/components/dropdown/dropdown-updates-events.func-spec.js
+++ b/test/components/dropdown/dropdown-updates-events.func-spec.js
@@ -43,7 +43,8 @@ describe('Dropdown updates, events', () => {
       showEmptyGroupHeaders: false,
       showSelectAll: false,
       sourceArguments: {},
-      onKeyDown: null
+      onKeyDown: null,
+      clearable: false
     };
 
     expect(dropdownObj.settings).toEqual(settings);
@@ -65,7 +66,8 @@ describe('Dropdown updates, events', () => {
       showEmptyGroupHeaders: false,
       showSelectAll: false,
       sourceArguments: {},
-      onKeyDown: null
+      onKeyDown: null,
+      clearable: false
     };
 
     dropdownObj.updated();
@@ -91,7 +93,8 @@ describe('Dropdown updates, events', () => {
       showEmptyGroupHeaders: false,
       showSelectAll: false,
       sourceArguments: {},
-      onKeyDown: null
+      onKeyDown: null,
+      clearable: false
     };
     dropdownObj.updated(settings);
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Added clearable option to dropdown component
- Updated example-filter.html on datagrid to use clearable option for dropdown instead of adding a blank option
- http://localhost:4000/components/datagrid/example-filter.html

**Steps necessary to review your pull request (required)**:
- Status filter on header should now have an empty option