### PR TITLE
Q/A - Searchfield: Fixed missing `selected` event trigger on input elements

### DIFF
--- a/src/components/searchfield/searchfield.js
+++ b/src/components/searchfield/searchfield.js
@@ -1393,6 +1393,8 @@ SearchField.prototype = {
    * @param  {object} anchor the link object
    */
   handleCategorySelected(e, anchor) {
+    this.element.trigger('selected', [anchor]);
+
     // Only change the text and searchfield size if we can
     if (!this.settings.showCategoryText) {
       return;

--- a/test/components/searchfield/searchfield-events.func-spec.js
+++ b/test/components/searchfield/searchfield-events.func-spec.js
@@ -1,0 +1,56 @@
+import { SearchField } from '../../../src/components/searchfield/searchfield';
+
+const exampleHTML = require('../../../app/views/components/searchfield/test-selected-event.html');
+const svgHTML = require('../../../src/components/icons/svg.html');
+
+let searchfieldInputEl;
+let searchfieldAPI;
+let svgEl;
+let rowEl;
+
+describe('Searchfield Events', () => {
+  beforeEach(() => {
+    searchfieldInputEl = null;
+    searchfieldAPI = null;
+    svgEl = null;
+    rowEl = null;
+
+    document.body.insertAdjacentHTML('afterbegin', svgHTML);
+    document.body.insertAdjacentHTML('afterbegin', exampleHTML);
+
+    svgEl = document.body.querySelector('.svg-icons');
+    rowEl = document.body.querySelector('.row');
+    searchfieldInputEl = document.body.querySelector('.searchfield');
+    searchfieldInputEl.removeAttribute('data-options');
+    searchfieldInputEl.classList.add('no-init');
+
+    searchfieldAPI = new SearchField(searchfieldInputEl, {
+      categories: [
+        { name: 'Animals', id: 'animals', value: 'an', checked: true },
+        { name: 'Baby', id: 'baby', value: 'ba', checked: false },
+        { name: 'Clothing', id: 'clothing', value: 'cl', checked: false },
+        { name: 'Images', id: 'images', value: 'im', checked: false },
+        { name: 'People', id: 'people', value: 'pe', checked: false },
+        { name: 'Places', id: 'places', value: 'pl', checked: false }
+      ]
+    });
+  });
+
+  afterEach(() => {
+    searchfieldAPI.destroy();
+    svgEl.parentNode.removeChild(svgEl);
+    searchfieldInputEl.parentNode.removeChild(searchfieldInputEl);
+    rowEl.parentNode.removeChild(rowEl);
+  });
+
+  it('triggers a `selected` event on the searchfield element when a category is selected', () => {
+    const spyEvent = spyOnEvent($(searchfieldInputEl), 'selected');
+    const popupmenuAPI = searchfieldAPI.categoryButton.data('popupmenu');
+
+    popupmenuAPI.open();
+    const selectItem = document.body.querySelectorAll('.popupmenu a');
+    $(selectItem[2]).trigger('click');
+
+    expect(spyEvent).toHaveBeenTriggered();
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR: 
- Adds back a missing `selected` event trigger on Searchfield input elements that happens when a Category is selected.  This was a regression that came about during the merging of Toolbar Searchfield and Searchfield APIs.
- Added a test to demonstrate that the event is being fired.

**Related github/jira issue (required)**:

Closes #287

**Steps necessary to review your pull request (required)**:

Pull this branch and:
- open http://localhost:4000/components/searchfield/test-selected-event.html and choose a category from the Searchfield's category dropdown.  A toast should appear once the menu is closed, and in the Dev Console, a log statement containing the clicked anchor should appear.
- run the Searchfield Event functional test

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
