### PR TITLE
Added a fix to ensure modal submit is enabled when editors or on the …

### DIFF
--- a/app/views/components/modal/test-validation-editor.html
+++ b/app/views/components/modal/test-validation-editor.html
@@ -2,10 +2,7 @@
 <div class="row top-padding">
   <div class="twelve columns">
 
-    <div class="field">
-      <label for="test-1" class="required">Some value (click text box to open modal)</label>
-      <input type="text" id="test-1" name="test-1" aria-required="true" data-validate="required"/>
-    </div>
+    <button class="btn-secondary" type="button" data-modal="modal-1">Add Context</button>
 
     <div class="modal" id="modal-1">
       <div class="modal-content">
@@ -53,16 +50,3 @@
 
   </div>
 </div>
-
-<script>
-  var test1 = $('#test-1');
-
-  test1.on('click', function () {
-
-    $('body').modal({content: $('#modal-1')})
-      .on('afterclose', function() {
-        test1.focus();
-      });
-
-  });
-</script>

--- a/src/components/validation/validator.js
+++ b/src/components/validation/validator.js
@@ -304,7 +304,10 @@ Validator.prototype = {
         }
         const isVisible = modalField[0].offsetParent !== null;
         if (modalField.is('.required')) {
-          if ((isVisible || modalField.is('select, :checkbox')) && !modalField.val()) {
+          if (isVisible && modalField.is('.editor') && !modalField.html()) {
+            allValid = false;
+          }
+          if ((isVisible || modalField.is('select, :checkbox')) && !modalField.val() && !modalField.is('.editor')) {
             allValid = false;
           }
         }

--- a/test/components/modal/modal.e2e-spec.js
+++ b/test/components/modal/modal.e2e-spec.js
@@ -138,5 +138,54 @@ describe('Modal example-validation tests', () => {
 
       expect(await element(by.className('message-text')).getText()).toEqual('Email address not valid');
     });
+
+    it('Should enable submit', async () => {
+      expect(await element(by.id('submit')).isEnabled()).toBe(false);
+
+      const dropdownEl = await element(by.css('div[aria-controls="dropdown-list"]'));
+      await browser.driver
+        .wait(protractor.ExpectedConditions.presenceOf(dropdownEl), config.waitsFor);
+      await browser.driver.sleep(config.sleep);
+      await dropdownEl.sendKeys(protractor.Key.ARROW_DOWN);
+      await dropdownEl.sendKeys(protractor.Key.ARROW_DOWN);
+      await dropdownEl.sendKeys(protractor.Key.ENTER);
+      await browser.driver.sleep(config.sleep);
+
+      await element(by.id('context-name')).sendKeys('test@test.com');
+      await element(by.id('context-desc')).sendKeys('test description');
+
+      expect(await element(by.id('submit')).isEnabled()).toBe(false);
+    });
   }
+});
+
+describe('Modal example-validation-editor tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/modal/test-validation-editor');
+    const modalEl = await element(by.css('button[data-modal="modal-1"]'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(modalEl), config.waitsFor);
+    await modalEl.sendKeys(protractor.Key.ENTER);
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.className('overlay'))), config.waitsFor);
+  });
+
+  it('Should enable submit after add text to all fields', async () => {
+    expect(await element(by.id('submit')).isEnabled()).toBe(false);
+
+    const dropdownEl = await element.all(by.css('.modal div[aria-controls="dropdown-list"]')).first();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dropdownEl), config.waitsFor);
+    await browser.driver.sleep(config.sleep);
+    await dropdownEl.sendKeys(protractor.Key.ARROW_DOWN);
+    await dropdownEl.sendKeys(protractor.Key.ARROW_DOWN);
+    await dropdownEl.sendKeys(protractor.Key.ENTER);
+    await browser.driver.sleep(config.sleep);
+
+    await element(by.id('context-name')).sendKeys('test@test.com');
+    await element(by.id('context-desc')).sendKeys('test description');
+    await element(by.css('.editor')).sendKeys('test description');
+
+    expect(await element(by.id('submit')).isEnabled()).toBe(false);
+  });
 });

--- a/test/components/modal/modal.e2e-spec.js
+++ b/test/components/modal/modal.e2e-spec.js
@@ -140,6 +140,7 @@ describe('Modal example-validation tests', () => {
     });
 
     it('Should enable submit', async () => {
+      debugger;
       expect(await element(by.id('submit')).isEnabled()).toBe(false);
 
       const dropdownEl = await element(by.css('div[aria-controls="dropdown-list"]'));
@@ -153,8 +154,9 @@ describe('Modal example-validation tests', () => {
 
       await element(by.id('context-name')).sendKeys('test@test.com');
       await element(by.id('context-desc')).sendKeys('test description');
+      await browser.driver.sleep(config.sleep);
 
-      expect(await element(by.id('submit')).isEnabled()).toBe(false);
+      expect(await element(by.id('submit')).isEnabled()).toBe(true);
     });
   }
 });
@@ -185,7 +187,8 @@ describe('Modal example-validation-editor tests', () => {
     await element(by.id('context-name')).sendKeys('test@test.com');
     await element(by.id('context-desc')).sendKeys('test description');
     await element(by.css('.editor')).sendKeys('test description');
+    await browser.driver.sleep(config.sleep);
 
-    expect(await element(by.id('submit')).isEnabled()).toBe(false);
+    expect(await element(by.id('submit')).isEnabled()).toBe(true);
   });
 });

--- a/test/components/modal/modal.e2e-spec.js
+++ b/test/components/modal/modal.e2e-spec.js
@@ -140,7 +140,6 @@ describe('Modal example-validation tests', () => {
     });
 
     it('Should enable submit', async () => {
-      debugger;
       expect(await element(by.id('submit')).isEnabled()).toBe(false);
 
       const dropdownEl = await element(by.css('div[aria-controls="dropdown-list"]'));


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes a "regression" - where the form primary button is not enabled.

**Related github/jira issue (required)**:

Closes #299

**Steps necessary to review your pull request (required)**

http://localhost:4000/components/modal/test-validation-editor.html 
- Note that the test page was renamed to a better name.
- click button to open modal
- fill in all fields
- Submit should enable.
