### PR TITLE
Give .teardown additional time complete for testing

### DIFF
--- a/test/components/tabs/tabs-api.func-spec.js
+++ b/test/components/tabs/tabs-api.func-spec.js
@@ -378,26 +378,30 @@ describe('Tabs API', () => {
     expect(document.querySelectorAll('.tab')[2].innerText).toEqual('Contacts');
   });
 
-  it('Should teardown tabs', () => {
+  it('Should teardown tabs', (done) => {
     const tabs = tabsObj.teardown();
-
-    expect(tabs).toEqual(jasmine.any(Object));
-    expect(document.querySelectorAll('.tab')[2].classList).not.toContain('is-selected');
-    expect(document.querySelectorAll('[aria-expanded="true"]').length).toEqual(0);
-    expect(document.querySelectorAll('[aria-selected="true"]').length).toEqual(0);
-    // Teardown interferes with afterEach script, so we restore Tabs instance
-    tabsObj = new Tabs(tabsEl);
+    setTimeout(() => {
+      expect(tabs).toEqual(jasmine.any(Object));
+      expect(document.querySelectorAll('.tab')[2].classList).not.toContain('is-selected');
+      expect(document.querySelectorAll('[aria-expanded="true"]').length).toEqual(0);
+      expect(document.querySelectorAll('[aria-selected="true"]').length).toEqual(0);
+      // Teardown interferes with afterEach script, so we restore Tabs instance
+      tabsObj = new Tabs(tabsEl);
+      done();
+    }, 1000);
   });
 
-  it('Should destroy tabs', () => {
+  it('Should destroy tabs', (done) => {
     tabsObj.destroy();
     const empty = {};
-
-    expect(document.querySelectorAll('.tab')[2].classList).not.toContain('is-selected');
-    expect(document.querySelectorAll('[aria-expanded="true"]').length).toEqual(0);
-    expect(document.querySelectorAll('[aria-selected="true"]').length).toEqual(0);
-    expect(tabsObj.element.data()).toEqual(empty);
-    // Teardown interferes with afterEach script, so we restore Tabs instance
-    tabsObj = new Tabs(tabsEl);
+    setTimeout(() => {
+      expect(document.querySelectorAll('.tab')[2].classList).not.toContain('is-selected');
+      expect(document.querySelectorAll('[aria-expanded="true"]').length).toEqual(0);
+      expect(document.querySelectorAll('[aria-selected="true"]').length).toEqual(0);
+      expect(tabsObj.element.data()).toEqual(empty);
+      // Teardown interferes with afterEach script, so we restore Tabs instance
+      tabsObj = new Tabs(tabsEl);
+      done();
+    }, 1000);
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Periodically on the CI, tests of the .teardown & .destroy fail. This fix should allow additional time (~1s) for .teardown completion.
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->

**Related github/jira issue (required)**:
Closes #239 
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->

**Steps necessary to review your pull request (required)**:
Run `npm run functional:ci` several times please  (I have rebuilt on the CI a bunch of times)
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->