### PR TITLE
Cap sizing issues

### DIFF
--- a/app/views/components/contextualactionpanel/test-jquery-no-flex.html
+++ b/app/views/components/contextualactionpanel/test-jquery-no-flex.html
@@ -1,0 +1,72 @@
+
+<div class="row">
+  <div class="six columns">
+
+    <button type="button" id="js-contextual-panel" class="btn-secondary contextual-action-panel-trigger no-init">
+      Contextual Action Panel (Uses jQuery Settings)
+    </button>
+    <div class="contextual-action-panel">
+      <div class="row">
+        <div class="twelve columns">
+          <div id="modal-datagrid" class="datagrid"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+
+<script>
+  $('body').on('initialized', function () {
+
+    var data = [],
+      columns = [];
+
+    columns.push({ id: 'date', name: 'Date', field: 'date', width: 125, formatter: Formatters.Date});
+    columns.push({ id: 'description', name: 'Description', field: 'description', width: 140, formatter: Formatters.Readonly});
+    columns.push({ id: 'paidBy', name: 'Paid By', field: 'PaidBy', formatter: Formatters.Readonly});
+    columns.push({ id: 'category', name: 'Category', field: 'category', formatter: Formatters.Readonly});
+    columns.push({ id: 'projectWork', name: 'Project Work', field: 'projectWork', formatter: Formatters.Readonly});
+    columns.push({ id: 'resource', name: 'Resource', field: 'resource', formatter: Formatters.Readonly});
+    columns.push({ id: 'amount', name: 'Amount', field: 'amount', formatter: Formatters.Readonly});
+
+    data.push({ date: new Date(2015, 1, 20), description: 'Pending Benefits', paidBy: 'PR', category: '2244 Personnel', projectWork: 'Structural Design', resource: 'Charles Dunn', amount: '$204.00' });
+    data.push({ date: new Date(2015, 1, 24), description: 'Pending Wages', paidBy: 'PR', category: '2244 Personnel', projectWork: 'Structural Design', resource: 'Vendor 3 Meylin Clark', amount: '$146.00' });
+    data.push({ date: new Date(2015, 1, 24), description: 'Apple Computer INC', paidBy: 'AP', category: '2919 Supplies', projectWork: 'Structural Design', resource: 'Vendor 3 Meylin Clark', amount: '$1299.00' });
+    data.push({ date: new Date(2015, 2, 02), description: 'PO #1292', paidBy: 'AP', category: '2244 Personnel', projectWork: 'Structural Design', resource: 'Vendor 3 Meylin Clark', amount: '$398.00' });
+
+    $('#modal-datagrid').datagrid({
+      columns: columns,
+      dataset: data
+    });
+
+    // Build the Settings-based Contextual Action Panel
+    $('#js-contextual-panel').contextualactionpanel({
+      title: 'Expenses: $50,000.00',
+      useFlexToolbar: false,
+      buttons: [
+        {
+          text: 'Currency',
+          cssClass: 'btn',
+          click: function() {
+            //nothing
+          }
+        },
+        {
+          cssClass: 'separator'
+        },
+        {
+          text: 'Close',
+          cssClass: 'btn close-button',
+          icon: '#icon-close',
+          click: function() {
+            $(this).data('modal').close();
+          }
+        }
+      ]
+    });
+
+  });
+
+</script>

--- a/app/views/components/validation/test-range-validation.html
+++ b/app/views/components/validation/test-range-validation.html
@@ -1,0 +1,37 @@
+<div class="row form-responsive">
+  <div class="six columns">
+    <form action="/" method="post">
+      <div class="field">
+        <label for="range" class="label">Range Validator (Only a number between 10 and 100)</label>
+        <input type="text" name="range" id="range" data-validate="range" data-val-range-min="10" data-val-range-max="100" data-mask="###" data-val-range="Must be between 10 and 100." />
+      </div>
+    </form>
+  </div>
+</div>
+
+<script>
+  $(function () {
+    $('body').initialize('en-US');
+
+    $.fn.validation.rules.range = {
+      check: function (value, field) {
+        if (!value) {
+          return true;
+        }
+
+        var min = $(field).attr('data-val-range-min');
+        var max = $(field).attr('data-val-range-max');
+        this.message = $(field).attr('data-val-range');
+
+        value = Number(value.replace(',', ''));
+        min = Number(min);
+        max = Number(max);
+
+        return (value >= min && value <= max);
+      },
+      // commenting this out will result in several repeat errors - maybe need to default this for a better fix
+      type: 'error',
+      message: 'The value must be in range.'
+    };
+  });
+</script>

--- a/src/components/contextualactionpanel/contextualactionpanel.js
+++ b/src/components/contextualactionpanel/contextualactionpanel.js
@@ -180,7 +180,8 @@ ContextualActionPanel.prototype = {
       } else if (!buttonset.length) {
         const toolbarCSSClass = this.settings.useFlexToolbar ? 'flex-toolbar' : 'toolbar';
         const toolbarTitleSection = this.settings.useFlexToolbar ? `<div class="toolbar-section title"><h2>${this.settings.title}</h2></div>` : '';
-        const toolbarButtonsetSection = '<div class="toolbar-section buttonset"></div>';
+        const toolbarButtonsetCSSClass = this.settings.useFlexToolbar ? 'toolbar-section buttonset' : 'buttonset';
+        const toolbarButtonsetSection = `<div class="${toolbarButtonsetCSSClass}"></div>`;
         const toolbarSearchfieldSection = this.settings.useFlexToolbar && hasSearchfield ? '<div class="toolbar-section search"></div>' : '';
         const toolbarHTML = `<div class="${toolbarCSSClass}">
           ${toolbarTitleSection}

--- a/src/components/validation/readme.md
+++ b/src/components/validation/readme.md
@@ -51,7 +51,7 @@ Its possible to skip fields that are normally validated from validation. You can
 
 ## Validation Types
 
-There are four standard validation types, and they can be extended or altered if required, error, alert, confirm, info. The type should be defined on the rule, but error is used if it is not defined.
+There are four standard validation types, and they can be extended or altered if required, error, alert, confirm, info. The type should be defined on the rule or duplicate messages may appear.
 
 ```javascript
 $.fn.validation.rules.customWarningRule = {
@@ -64,7 +64,7 @@ $.fn.validation.rules.customWarningRule = {
 };
 ```
 
-Each type is style differntly and can be defined if the formValidation passes or errors based on the rules result. This is defined via the errorsForm on the validation type.
+Each type is style differently and can be defined if the formValidation passes or errors based on the rules result. This is defined via the errorsForm on the validation type.
 
 ```javascript
 $.fn.validation.ValidationTypes.alert = { type: 'alert', title: 'Alert', errorsForm: false };
@@ -97,4 +97,4 @@ There are a few built in validation rules you can use.
 
 ## Upgrading from 3.X
 
-This api is backwards compatible.
+This api is (mostly) backwards compatible.

--- a/test/components/contextualactionpanel/contextualactionpanel.e2e-spec.js
+++ b/test/components/contextualactionpanel/contextualactionpanel.e2e-spec.js
@@ -1,0 +1,48 @@
+const { browserStackErrorReporter } = requireHelper('browserstack-error-reporter');
+const config = requireHelper('e2e-config');
+const utils = requireHelper('e2e-utils');
+requireHelper('rejection');
+
+jasmine.getEnv().addReporter(browserStackErrorReporter);
+
+describe('CAP jquery context tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/contextualactionpanel/example-jquery.html');
+  });
+
+  it('Should open popup on click', async () => {
+    await element(by.id('js-contextual-panel')).click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('#contextual-action-modal-1')).isDisplayed()).toBe(true);
+  });
+
+  it('Should not overflow buttons uneccessarily', async () => {
+    await element(by.id('js-contextual-panel')).click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('#modal-button-1')).isDisplayed()).toBe(true);
+    expect(await element(by.css('#modal-button-3')).isDisplayed()).toBe(true);
+  });
+});
+
+describe('CAP jquery context tests no-flex', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/contextualactionpanel/test-jquery-no-flex.html');
+  });
+
+  it('Should open popup on click no-flex', async () => {
+    await element(by.id('js-contextual-panel')).click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('#contextual-action-modal-1')).isDisplayed()).toBe(true);
+  });
+
+  it('Should not overflow buttons uneccessarily no-flex', async () => {
+    await element(by.id('js-contextual-panel')).click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('#modal-button-1')).isDisplayed()).toBe(true);
+    expect(await element(by.css('#modal-button-3')).isDisplayed()).toBe(true);
+  });
+});

--- a/test/components/validation/validation.e2e-spec.js
+++ b/test/components/validation/validation.e2e-spec.js
@@ -133,13 +133,13 @@ describe('Validation alert on parent', () => {
 
   it('Should render icon on parent', async () => {
     const expander = await element(by.css('.expandable-expander'));
-    expander.click();
+    await expander.click();
 
     const emailEl = await element(by.id('date-field'));
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(emailEl), config.waitsFor);
 
-    emailEl.click();
+    await emailEl.click();
     await emailEl.sendKeys('10');
     await emailEl.sendKeys(protractor.Key.TAB);
     await browser.driver.sleep(config.sleep);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The Cap after changes early this sprint will now show buttons incorrectly in overflow if the flex toolbar option is not used.

Additional: Added a validation test / example and changed a comment related to a problem seen on that example.

**Related github/jira issue (required)**:

Closes #338

**Steps necessary to review your pull request (required)**:

1. test these two pages http://localhost:4000/components/contextualactionpanel/example-jquery.html and http://localhost:4000/components/contextualactionpanel/example-jquery.html
1. open the panel
1. both should have two visible buttons on the left of the modal.

**Additional Info**:

@bthharper @EdwardCoyle 