### PR TITLE
318 - Run visual regress tests on Chrome, and CI only

### DIFF
--- a/test/components/tabs/tabs-vertical.e2e-spec.js
+++ b/test/components/tabs/tabs-vertical.e2e-spec.js
@@ -72,19 +72,21 @@ describe('Tabs vertical click example-responsive tests', () => {
       .wait(protractor.ExpectedConditions.presenceOf(tabsEl), config.waitsFor);
   });
 
-  it('Should not visual regress on example-responsive at 500px', async () => {
-    const windowSize = await browser.driver.manage().window().getSize();
-    await browser.driver.manage().window().setSize(500, 600);
-    await browser.driver.sleep(config.sleep);
-    const tabsEl = await element(by.id('tabs-vertical'));
-    await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(tabsEl), config.waitsFor);
-    await browser.driver.sleep(config.waitsFor);
+  if (utils.isChrome() && utils.isCI()) {
+    it('Should not visual regress on example-responsive at 500px', async () => {
+      const windowSize = await browser.driver.manage().window().getSize();
+      await browser.driver.manage().window().setSize(500, 600);
+      await browser.driver.sleep(config.sleep);
+      const tabsEl = await element(by.id('tabs-vertical'));
+      await browser.driver
+        .wait(protractor.ExpectedConditions.presenceOf(tabsEl), config.waitsFor);
+      await browser.driver.sleep(config.waitsFor);
 
-    expect(await browser.protractorImageComparison.checkElement(tabsEl, 'tabs-vertical-500px')).toEqual(0);
-    await browser.driver.manage().window().setSize(windowSize.width, windowSize.height);
-    await browser.driver.sleep(config.sleep);
-  });
+      expect(await browser.protractorImageComparison.checkElement(tabsEl, 'tabs-vertical-500px')).toEqual(0);
+      await browser.driver.manage().window().setSize(windowSize.width, windowSize.height);
+      await browser.driver.sleep(config.sleep);
+    });
+  }
 
   it('Should change to header tabs at 500px then back to vertical tabs at 1200px', async () => {
     const windowSize = await browser.driver.manage().window().getSize();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Prevents this visual regression tests from running on BrowserStack as they should only run on the CI

**Related github/jira issue (required)**:
Related to #318 

**Steps necessary to review your pull request (required)**:
Run `npm run e2e:local:debug`, and checkout https://automate.browserstack.com/builds/7003ac7c3d4d553013e2ba61a33b57f52ffb8180/sessions/e1f1310d5569e5ed0accfdb1609a4f67bac9bf7a
