### PR TITLE
Fixing more tooltip on programmatically created more action buttons on toolbar

### DIFF
--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -153,7 +153,6 @@ Toolbar.prototype = {
         }<span class="audible">${Locale.translate('MoreActions')}</span>`)
         .attr('title', Locale.translate('More'))
         .appendTo(moreContainer);
-      this.more = $(this.more).initialize();
     }
 
     // Reference all interactive items in the toolbar

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -151,7 +151,9 @@ Toolbar.prototype = {
       this.more = $('<button class="btn-actions" type="button"></button>')
         .html(`${$.createIcon({ icon: 'more' })
         }<span class="audible">${Locale.translate('MoreActions')}</span>`)
+        .attr('title', Locale.translate('More'))
         .appendTo(moreContainer);
+      this.more = $(this.more).initialize();
     }
 
     // Reference all interactive items in the toolbar


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixing an error where the tooltip "More.." wouldn't appear when the more actions button was created programmatically in toolbar

**Related github/jira issue (required)**:
Closes #345 

**Steps necessary to review your pull request (required)**:
1. After pulling in my change, go to /toolbar/example-index.html and hover over the ... button in the toolbar in the content area:
![image](https://user-images.githubusercontent.com/22107636/42650607-73f2daae-85d2-11e8-9dcf-bdfec0a8a75d.png)

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
