### PR TITLE
333 - Colorpicker keyboard open, and selection e2e tests

### DIFF
--- a/test/components/colorpicker/colorpicker.e2e-spec.js
+++ b/test/components/colorpicker/colorpicker.e2e-spec.js
@@ -32,11 +32,47 @@ describe('Colorpicker example-index tests', () => {
     expect(await element(by.css('#background-color.is-open')).isDisplayed()).toBe(true);
   });
 
+  it('Should open popup on keyboard down', async () => {
+    const colorInputEl = await element(by.css('#background-color'));
+    await colorInputEl.click();
+    await colorInputEl.sendKeys(protractor.Key.ARROW_DOWN);
+
+    expect(await element(by.css('#background-color.is-open')).isDisplayed()).toBe(true);
+  });
+
   it('Should pick color from picker', async () => {
     await element(by.css('#background-color + .trigger .icon')).click();
     await element(by.css('#colorpicker-menu li:first-child a:first-child')).click();
 
     expect(await element(by.id('background-color')).getAttribute('value')).toEqual('#1A1A1A');
+  });
+
+  it('Should pick color from picker on keyboard enter', async () => {
+    const colorInputEl = await element(by.id('background-color'));
+    await colorInputEl.click();
+    await colorInputEl.sendKeys(protractor.Key.ARROW_DOWN);
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.id('colorpicker-menu'))), config.waitsFor);
+    await browser.driver.actions().sendKeys(protractor.Key.ARROW_UP).perform();
+    await browser.driver.actions().sendKeys(protractor.Key.ARROW_UP).perform();
+    await browser.driver.actions().sendKeys(protractor.Key.ARROW_LEFT).perform();
+    await browser.driver.actions().sendKeys(protractor.Key.ARROW_LEFT).perform();
+    await browser.driver.actions().sendKeys(protractor.Key.ARROW_LEFT).perform();
+    await browser.driver.actions().sendKeys(protractor.Key.ARROW_LEFT).perform();
+    await browser.driver.actions().sendKeys(protractor.Key.ENTER).perform();
+
+    expect(await element(by.id('background-color')).getAttribute('value')).toEqual('#1A1A1A');
+  });
+
+  it('Should set color from manual entry of #898989', async () => {
+    const colorInputEl = await element(by.id('background-color'));
+    await colorInputEl.click();
+    await colorInputEl.clear();
+    await colorInputEl.sendKeys('898989');
+    await colorInputEl.sendKeys(protractor.Key.ENTER);
+
+    expect(await element(by.id('background-color')).getAttribute('value')).toEqual('#898989');
+    expect(await element.all(by.className('swatch')).first().getAttribute('style')).toBe('background-color: rgb(137, 137, 137);');
   });
 
   it('Should pick clear color from picker', async () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- [x] Verify user can tab in, and arrow for each color
- [x] Verify user can click Enter key to save the color
- [x] Verify user can manually enter the color key number

**Related github/jira issue (required)**:
Related to #333