### PR TITLE
308 Added clearing of search text on ctrl + backspace

### DIFF
--- a/src/components/searchfield/searchfield.js
+++ b/src/components/searchfield/searchfield.js
@@ -1007,6 +1007,10 @@ SearchField.prototype = {
       e.preventDefault();
     }
 
+    if (e.ctrlKey && key === 8) {
+      this.element.val('');
+    }
+
     if (key === 9) { // Tab
       this.handleSafeBlur();
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Added new validation to handle ctrl + backspace
- Cleared search text on ctrl + backspace
- http://localhost:4000/components/searchfield/example-clearable.html

Closes #308 

**Steps necessary to review your pull request (required)**:
- In the search field, select "Northern Mariana Island Territory"
- Move the cursor before the word "Northern"
- Press alt+delete (Mac) or ctrl+backspace (Windows) keys
- All contents should now be cleared