### PR TITLE
358 - X close icon for closing modals

### DIFF
--- a/app/views/components/modal/example-close-btn.html
+++ b/app/views/components/modal/example-close-btn.html
@@ -1,0 +1,68 @@
+<div class="row">
+	<div class="twelve columns">
+
+		<button class="btn-secondary" type="button" id="add-context">Show Modal</button><br/><br/>
+
+		<!-- Modal Example -->
+		<div id="modal-add-context" class="hidden">
+			<div class="field">
+				<label for="subject">Problem</label>
+				<input type="text" id="subject" name="subject" />
+			</div>
+
+      <div class="field">
+        <label for="location" class="label">Location</label>
+        <select id="location" name="location" class="dropdown">
+          <option value="N">North</option>
+          <option value="S">South</option>
+          <option value="E">East</option>
+          <option value="W">West</option>
+        </select>
+      </div>
+
+			<div class="field">
+				<label for="notes-max">Notes (maxlength)</label>
+				<textarea id="notes-max" class="textarea" maxlength="90" name="notes-max">Line One</textarea>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<script>
+var modals = {
+    'add-context': {
+      'title': 'Add Context',
+      'id': 'my-id',
+      'content': $('#modal-add-context'),
+      'showCloseBtn': true
+    },
+  },
+
+  setModal = function (opt) {
+    opt = $.extend({
+      buttons: [{
+        text: 'Cancel',
+      //  id: 'modal-button-1',
+        click: function(e, modal) {
+          modal.close();
+        }
+      }, {
+        text: 'Save',
+      //  id: 'modal-button-2',
+        click: function(e, modal) {
+          modal.close();
+        },
+        validate: false,
+        isDefault: true
+      }]
+    }, opt);
+
+    $('body').modal(opt);
+  };
+
+  $('#add-context').on('click', function () {
+    setModal(modals[this.id]);
+  });
+
+</script>

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -214,6 +214,7 @@
 }
 
 .modal-content {
+  position: relative;
   background: $modal-bg-color;
   border: 1px solid $modal-border-color;
   border-radius: 2px;
@@ -289,6 +290,12 @@
     display: block;
     font-size: 1.5rem;
     margin: 25px auto 5px;
+  }
+
+  .btn-close {
+    position: absolute;
+    top: 0px;
+    right: 0px;
   }
 
   .message {

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -447,5 +447,10 @@ html[dir='rtl'] {
     .message {
       text-align: right;
     }
+
+    .btn-close {
+      right: auto;
+      left: 0px;
+    }
   }
 }

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1,5 +1,6 @@
 import * as debug from '../../utils/debug';
 import { utils } from '../../utils/utils';
+import { Locale } from '../../../src/components/locale/locale';
 
 // jQuery components
 import '../button/button.jquery';
@@ -22,8 +23,9 @@ const COMPONENT_NAME = 'modal';
 * @param {string} [settings.id=null] Optionally tag a dialog with an id.
 * @param {number} [settings.frameHeight=180] Optional extra height to add.
 * @param {number} [settings.frameWidth=46] Optional extra width to add.
-* @param {boolean} [settings.useFlexToolbar] If true the new flex toolbar will be used (For CAP)
 * @param {function} [settings.beforeShow=null] A call back function that can be used to return data for the modal.
+* @param {boolean} [settings.useFlexToolbar] If true the new flex toolbar will be used (For CAP)
+* @param {boolean} [settings.showCloseBtn] If true, show a close icon button on the top right of the modal.
 * return the markup in the response and this will be shown in the modal. The busy indicator will be shown while waiting for a response.
 */
 const MODAL_DEFAULTS = {
@@ -37,7 +39,8 @@ const MODAL_DEFAULTS = {
   frameHeight: 180,
   frameWidth: 46,
   beforeShow: null,
-  useFlexToolbar: false
+  useFlexToolbar: false,
+  showCloseBtn: false
 };
 
 function Modal(element, settings) {
@@ -124,6 +127,18 @@ Modal.prototype = {
           '</div>' +
         '</div>' +
       '</div>');
+
+
+    if (this.settings.showCloseBtn) {
+      const closeBtn = $(`
+        <button type="button" class="btn-icon btn-close" title="${Locale.translate('Close')}" aria-hidden="true">
+          ${$.createIcon('close')}
+          <span class="audible">${Locale.translate('Close')}</span>
+        </button>
+      `);
+      this.element.find('.modal-content').append(closeBtn);
+      closeBtn.on('click', () => this.close());
+    }
 
     if (this.settings.id) {
       this.element.attr('id', this.settings.id);

--- a/test/components/modal/modal.e2e-spec.js
+++ b/test/components/modal/modal.e2e-spec.js
@@ -116,6 +116,20 @@ describe('Modal open example-modal tests on click', () => {
   });
 });
 
+describe('Modal example-close-btn tests', () => {
+  it('Should close the modal via the x close icon', async () => {
+    await utils.setPage('/components/modal/example-close-btn');
+
+    const modalBtn = await element(by.id('add-context'));
+    await modalBtn.click();
+    expect(await element(by.css('body')).getAttribute('class')).toContain('modal-engaged');
+
+    const closeBtn = await element(by.css('button.btn-close'));
+    await closeBtn.click();
+    expect(await element(by.css('body')).getAttribute('class')).not.toContain('modal-engaged');
+  });
+});
+
 describe('Modal example-validation tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/modal/example-validation');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- [x] New settings option to show an x close icon for closing modals
- [x] Added a test template for testing 
- [x] Added a simple e2e for testing the x button

**Related github/jira issue (required)**:
Closes #358

**Steps necessary to review your pull request (required)**:
open localhost:4000/components/modal/example-close-btn.html and try the x close icon

> Note: Fixed requested changes in #359, had to do another PR coz accidentally used a master branch on that previous one

