### PR TITLE
466 - Tab key no longer causes Dropdown lists to open

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1324,6 +1324,12 @@ Dropdown.prototype = {
       }
     }
 
+    // Allow some keys to pass through with no changes in functionality
+    const allowedKeys = ['Tab'];
+    if (allowedKeys.indexOf(key) > -1) {
+      return true;
+    }
+
     // handle `onKeyDown` callback
     if (this.settings.onKeyDown) {
       const ret = this.settings.onKeyDown(e);

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -142,6 +142,27 @@ describe('Dropdown example-index tests', () => {
       // SearchInput should display "New Jersey" and not just " Jersey"
       expect(await element(by.id('dropdown-search')).getAttribute('value')).toEqual('New Jersey');
     });
+
+    it('Should close an open list and tab to the next element without re-opening', async () => {
+      const dropdownEl = await element(by.css('div[aria-controls="dropdown-list"]'));
+      await browser.driver
+        .wait(protractor.ExpectedConditions.presenceOf(dropdownEl), config.waitsFor);
+      await dropdownEl.click();
+
+      // Wait for the list to open
+      await browser.driver
+        .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('ul[role="listbox"]'))), config.waitsFor);
+      const dropdownSearchEl = element(by.id('dropdown-search'));
+
+      // First key press causes the menu to close
+      await dropdownSearchEl.sendKeys(protractor.Key.TAB);
+
+      // Second key press causes the focus to shift away
+      await element(by.css('div[aria-controls="dropdown-list"]')).sendKeys(protractor.Key.TAB);
+
+      // The Dropdown Pseudo element should no longer have focus
+      expect(await browser.driver.switchTo().activeElement().getAttribute('class')).not.toContain('dropdown');
+    });
   }
 });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
A bug was discovered by @tmcconechy where a Dropdown would unexpectedly open its list of selectable options after pressing `Tab` or `Shift + Tab` to navigate away.

**Related github/jira issue (required)**:
- Caused by changes in #267
- Closes #466 

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp
- Open http://localhost:4000/components/dropdown/example-index
- Focus the Dropdown element (by keyboard, or by clicking on it)
- If the list is open, press tab to close the list
- Press tab to navigate away

The list should remain closed and focus should be on a different element in the page.