### PR TITLE
321 Added validation to prevent closing of modal when target element …

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -590,7 +590,10 @@ Modal.prototype = {
           this.element.find('.btn-modal-primary:enabled').length) {
         e.stopPropagation();
         e.preventDefault();
-        this.element.find('.btn-modal-primary:enabled').trigger('click');
+
+        if (!target.hasClass('fileupload')) {
+          this.element.find('.btn-modal-primary:enabled').trigger('click');
+        }
       }
     });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Fixed issue regarding modal popup being closed when file uploader is focused and Enter key is pressed
- http://localhost:4000/components/modal/test-fileupload.html

**Steps necessary to review your pull request (required)**:
- Click on Show Modal button to show modal
- Hit Tab key until file uploader is focused
- Hit Enter key
- Modal popup should no longer be closed