### PR TITLE
474 - Escape key causing the Dropdown to re-open it's list unexpectedly

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1318,7 +1318,7 @@ Dropdown.prototype = {
     }
 
     // Allow some keys to pass through with no changes in functionality
-    const allowedKeys = ['Tab'];
+    const allowedKeys = ['Tab', 'Escape'];
     if (allowedKeys.indexOf(key) > -1) {
       return true;
     }

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -163,6 +163,27 @@ describe('Dropdown example-index tests', () => {
       // The Dropdown Pseudo element should no longer have focus
       expect(await browser.driver.switchTo().activeElement().getAttribute('class')).not.toContain('dropdown');
     });
+
+    it('Should not allow the escape key to re-open a closed menu', async () => {
+      const dropdownEl = await element(by.css('div[aria-controls="dropdown-list"]'));
+      await browser.driver
+        .wait(protractor.ExpectedConditions.presenceOf(dropdownEl), config.waitsFor);
+      await dropdownEl.click();
+
+      // Wait for the list to open
+      await browser.driver
+        .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('ul[role="listbox"]'))), config.waitsFor);
+      const dropdownSearchEl = element(by.id('dropdown-search'));
+
+      // First key press causes the menu to close
+      await dropdownSearchEl.sendKeys(protractor.Key.ESCAPE);
+
+      // Second key press should do nothing
+      await element(by.css('div[aria-controls="dropdown-list"]')).sendKeys(protractor.Key.ESCAPE);
+
+      // The Dropdown Pseudo element should no longer have focus
+      expect(await browser.driver.switchTo().activeElement().getAttribute('class')).not.toContain('is-open');
+    });
   }
 });
 

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -152,7 +152,7 @@ describe('Dropdown example-index tests', () => {
       // Wait for the list to open
       await browser.driver
         .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('ul[role="listbox"]'))), config.waitsFor);
-      const dropdownSearchEl = element(by.id('dropdown-search'));
+      const dropdownSearchEl = await element(by.id('dropdown-search'));
 
       // First key press causes the menu to close
       await dropdownSearchEl.sendKeys(protractor.Key.TAB);
@@ -173,7 +173,7 @@ describe('Dropdown example-index tests', () => {
       // Wait for the list to open
       await browser.driver
         .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('ul[role="listbox"]'))), config.waitsFor);
-      const dropdownSearchEl = element(by.id('dropdown-search'));
+      const dropdownSearchEl = await element(by.id('dropdown-search'));
 
       // First key press causes the menu to close
       await dropdownSearchEl.sendKeys(protractor.Key.ESCAPE);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
There was previously an issue where pressing the escape key on a closed Dropdown component would unexpectedly cause the list to open, due to changes in keyboard handling with its typeahead feature.  This was very obvious when closing Contextual Action Panel components that contained Dropdowns in their content area.  This PR fixes this problem.

**Related github/jira issue (required)**:
- Caused by changes in #267 
- Closes #474 

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp
- Open http://localhost:4000/components/contextualactionpanel/example-trigger.html
- Click the button to open the CAP
- Press the `Escape` key to close the CAP.
- The CAP should be closed, and there should not be an open Dropdown component visible on the page.

Additionally, there's a new Dropdown e2e test for the escape key problem that should pass when running `npm run e2e:ci`