### PR TITLE
424 Prevented expanding of row templates on search

### DIFF
--- a/app/views/components/datagrid/test-expand-row-on-search.html
+++ b/app/views/components/datagrid/test-expand-row-on-search.html
@@ -1,0 +1,61 @@
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+{{={{{ }}}=}}
+
+<script>
+  $('body').one('initialized', function () {
+
+      var grid,
+        columns = [],
+        data = [];
+
+      // Some Sample Data
+      data.push({ id: 1, productId: 2142201, sku: '<b>SKU #9000001-237</b>', productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+      data.push({ id: 2, productId: 2241202, sku: '<b>SKU #9000001-236</b>', productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+      data.push({ id: 3, productId: 2342203, sku: '<b>SKU #9000001-235</b>', productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+      data.push({ id: 4, productId: 2445204, sku: '<b>SKU #9000001-234</b>', productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+      data.push({ id: 5, productId: 2542205, sku: '<b>SKU #9000001-233</b>', productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+      data.push({ id: 5, productId: 2642205, sku: '<b>SKU #9000001-232</b>', productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+      data.push({ id: 6, productId: 2642206, sku: '<b>SKU #9000001-231</b>', productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+
+      //Define Columns for the Grid.
+
+      columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Expander, filterType: 'text', textOverflow: 'ellipsis', width: 300, hideable: false});
+      columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', filterType: 'text', formatter: Formatters.Hyperlink});
+      columns.push({ id: 'activity', name: 'Activity', field: 'activity', filterType: 'text'});
+      columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity'});
+
+      var rowTemplate = '<div class="datagrid-cell-layout"><div class="img-placeholder"><svg class="icon" focusable="false" aria-hidden="true" role="presentation"><use xlink:href="#icon-camera"></use></svg></div></div>'+
+                        '<div class="datagrid-cell-layout"><p class="datagrid-row-heading">Expandable Content Area</p>' +
+                        '<p class="datagrid-row-micro-text">{{{sku}}}</p>'+
+                        '<span class="datagrid-wrapped-text">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only...</span>'+
+                        '<a class="hyperlink" href="https://design.infor.com/" target="_blank" >Read more</a>';
+
+      //Init and get the api for the grid
+      grid = $('#datagrid').datagrid({
+        columns: columns,
+        idProperty:'officeId',
+        dataset: data,
+        filterable: true,
+        rowTemplate: rowTemplate,
+        toolbar: {title: 'Data Grid Header Title', collapsibleFilter: true,
+        results: true, keywordFilter: true, actions: true, exportToExcel: true, rowHeight: true, personalize: true},
+        expandRowOnSearch: false
+      });
+
+      grid.on('expandrow', function (e, args) {
+        console.log('expandrow', args);
+      });
+
+      grid.on('collapserow', function (e, args) {
+        console.log('collapserow', args);
+      });
+
+});
+
+</script>

--- a/app/views/components/datagrid/test-expand-row-on-search.html
+++ b/app/views/components/datagrid/test-expand-row-on-search.html
@@ -45,7 +45,7 @@
         rowTemplate: rowTemplate,
         toolbar: {title: 'Data Grid Header Title', collapsibleFilter: true,
         results: true, keywordFilter: true, actions: true, exportToExcel: true, rowHeight: true, personalize: true},
-        expandRowOnSearch: false
+        searchExpandableRow: false
       });
 
       grid.on('expandrow', function (e, args) {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5252,8 +5252,9 @@ Datagrid.prototype = {
       row.find('td').each(function () {
         const cell = $(this);
         const cellText = cell.text().toLowerCase();
+        const isSearchExpandableRow = self.settings.searchExpandableRow ? true : !row.hasClass('datagrid-expandable-row');
 
-        if (cellText.indexOf(term) > -1 && !row.hasClass('datagrid-expandable-row')) {
+        if (cellText.indexOf(term) > -1 && isSearchExpandableRow) {
           found = true;
           cell.find('*').each(function () {
             if (this.innerHTML === this.textContent) {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -97,7 +97,7 @@ const COMPONENT_NAME = 'datagrid';
  * @param {object}   [settings.emptyMessage.title='No Data Available']
  * @param {object}   [settings.emptyMessageinfor='']
  * @param {object}   [settings.emptyMessage.icon='icon-empty-no-data']
- * @param {boolean}  [settings.expandRowOnSearch=true]
+ * @param {boolean}  [settings.expandRowOnSearch=true] If true enable expanding of row on search
  * An empty message will be displayed when there is no rows in the grid. This accepts an object of the form
  * emptyMessage: {title: 'No Data Available', info: 'Make a selection on the list above to see results',
  * icon: 'icon-empty-no-data', button: {text: 'xxx', click: <function>}} set this to null for no message

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -97,7 +97,7 @@ const COMPONENT_NAME = 'datagrid';
  * @param {object}   [settings.emptyMessage.title='No Data Available']
  * @param {object}   [settings.emptyMessageinfor='']
  * @param {object}   [settings.emptyMessage.icon='icon-empty-no-data']
- * @param {boolean}  [settings.expandRowOnSearch=true] If true enable expanding of row on search
+ * @param {boolean}  [settings.searchExpandableRow=true] If true enable expanding of row on search
  * An empty message will be displayed when there is no rows in the grid. This accepts an object of the form
  * emptyMessage: {title: 'No Data Available', info: 'Make a selection on the list above to see results',
  * icon: 'icon-empty-no-data', button: {text: 'xxx', click: <function>}} set this to null for no message
@@ -170,7 +170,7 @@ const DATAGRID_DEFAULTS = {
   onEditCell: null,
   onExpandRow: null,
   emptyMessage: { title: (Locale ? Locale.translate('NoData') : 'No Data Available'), info: '', icon: 'icon-empty-no-data' },
-  expandRowOnSearch: true
+  searchExpandableRow: true
 };
 
 function Datagrid(element, settings) {
@@ -5253,7 +5253,7 @@ Datagrid.prototype = {
         const cell = $(this);
         const cellText = cell.text().toLowerCase();
 
-        if (cellText.indexOf(term) > -1) {
+        if (cellText.indexOf(term) > -1 && !row.hasClass('datagrid-expandable-row')) {
           found = true;
           cell.find('*').each(function () {
             if (this.innerHTML === this.textContent) {
@@ -5270,7 +5270,7 @@ Datagrid.prototype = {
       // Hide non matching rows and non detail rows
       if (!found && !row.find('.datagrid-row-detail').length) {
         row.addClass('is-filtered').hide();
-      } else if (self.settings.expandRowOnSearch && found && row.is('.datagrid-expandable-row') && term !== '') {
+      } else if (self.settings.searchExpandableRow && found && row.is('.datagrid-expandable-row') && term !== '') {
         row.prev().show();
         row.prev().find('.datagrid-expand-btn').addClass('is-expanded');
         row.prev().find('.plus-minus').addClass('active');

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -97,6 +97,7 @@ const COMPONENT_NAME = 'datagrid';
  * @param {object}   [settings.emptyMessage.title='No Data Available']
  * @param {object}   [settings.emptyMessageinfor='']
  * @param {object}   [settings.emptyMessage.icon='icon-empty-no-data']
+ * @param {boolean}  [settings.expandRowOnSearch=true]
  * An empty message will be displayed when there is no rows in the grid. This accepts an object of the form
  * emptyMessage: {title: 'No Data Available', info: 'Make a selection on the list above to see results',
  * icon: 'icon-empty-no-data', button: {text: 'xxx', click: <function>}} set this to null for no message
@@ -168,7 +169,8 @@ const DATAGRID_DEFAULTS = {
   onDestroyCell: null,
   onEditCell: null,
   onExpandRow: null,
-  emptyMessage: { title: (Locale ? Locale.translate('NoData') : 'No Data Available'), info: '', icon: 'icon-empty-no-data' }
+  emptyMessage: { title: (Locale ? Locale.translate('NoData') : 'No Data Available'), info: '', icon: 'icon-empty-no-data' },
+  expandRowOnSearch: true
 };
 
 function Datagrid(element, settings) {
@@ -5241,6 +5243,7 @@ Datagrid.prototype = {
    * @returns {void}
    */
   highlightSearchRows(term) {
+    const self = this;
     // Move across all visible cells and rows, highlighting
     this.tableBody.find('tr').each(function () {
       let found = false;
@@ -5267,6 +5270,12 @@ Datagrid.prototype = {
       // Hide non matching rows and non detail rows
       if (!found && !row.find('.datagrid-row-detail').length) {
         row.addClass('is-filtered').hide();
+      } else if (self.settings.expandRowOnSearch && found && row.is('.datagrid-expandable-row') && term !== '') {
+        row.prev().show();
+        row.prev().find('.datagrid-expand-btn').addClass('is-expanded');
+        row.prev().find('.plus-minus').addClass('active');
+        row.addClass('is-expanded').css('display', 'table-row');
+        row.find('.datagrid-row-detail').css('height', 'auto');
       }
     });
   },

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5264,15 +5264,9 @@ Datagrid.prototype = {
         }
       });
 
-      // Hide non matching rows
-      if (!found) {
+      // Hide non matching rows and non detail rows
+      if (!found && !row.find('.datagrid-row-detail').length) {
         row.addClass('is-filtered').hide();
-      } else if (found && row.is('.datagrid-expandable-row') && term !== '') {
-        row.prev().show();
-        row.prev().find('.datagrid-expand-btn').addClass('is-expanded');
-        row.prev().find('.plus-minus').addClass('active');
-        row.addClass('is-expanded').css('display', 'table-row');
-        row.find('.datagrid-row-detail').css('height', 'auto');
       }
     });
   },

--- a/test/components/datagrid/datagrid-settings.func-spec.js
+++ b/test/components/datagrid/datagrid-settings.func-spec.js
@@ -100,7 +100,8 @@ describe('Datagrid Settings', () => {
       onDestroyCell: null,
       onEditCell: null,
       onExpandRow: null,
-      emptyMessage: { title: (Locale ? Locale.translate('NoData') : 'No Data Available'), info: '', icon: 'icon-empty-no-data' }
+      emptyMessage: { title: (Locale ? Locale.translate('NoData') : 'No Data Available'), info: '', icon: 'icon-empty-no-data' },
+      expandRowOnSearch: true
     };
     datagridObj = new Datagrid(datagridEl, { dataset: data, columns });
   });

--- a/test/components/datagrid/datagrid-settings.func-spec.js
+++ b/test/components/datagrid/datagrid-settings.func-spec.js
@@ -101,7 +101,7 @@ describe('Datagrid Settings', () => {
       onEditCell: null,
       onExpandRow: null,
       emptyMessage: { title: (Locale ? Locale.translate('NoData') : 'No Data Available'), info: '', icon: 'icon-empty-no-data' },
-      expandRowOnSearch: true
+      searchExpandableRow: true
     };
     datagridObj = new Datagrid(datagridEl, { dataset: data, columns });
   });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Prevented expanding of row templates on data grid search
- Updated validation for hiding data grid rows
- http://localhost:4000/components/datagrid/example-expandable-row.html

**Steps necessary to review your pull request (required)**:
- Open search filter on upper right side of data grid
- Use 'lo' as keyword and hit Enter
- Row template should no longer be expanded

Closes #424