### PR TITLE
347 - Revert config.waitFor to config.waitsFor which fails on BS

### DIFF
--- a/test/components/listview/listview.e2e-spec.js
+++ b/test/components/listview/listview.e2e-spec.js
@@ -11,7 +11,7 @@ describe('Listview example-singleselect tests', () => {
     await utils.setPage('/components/listview/example-singleselect');
     const listviewEl = await element(by.id('period-end'));
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(listviewEl), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(listviewEl), config.waitsFor);
   });
 
   if (utils.isChrome() && utils.isCI()) {
@@ -37,11 +37,11 @@ describe('Listview example-singleselect tests', () => {
     const listviewItemEl = await element(by.css('li[aria-posinset="1"]'));
     listviewItemEl.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-selected="true"]')).isPresent()).toBeTruthy();
     await browser.driver
-      .wait(protractor.ExpectedConditions.textToBePresentInElement(element(by.className('selection-count')), '1 Selected'), config.waitFor);
+      .wait(protractor.ExpectedConditions.textToBePresentInElement(element(by.className('selection-count')), '1 Selected'), config.waitsFor);
 
     expect(await element(by.className('selection-count')).getText()).toContain('1 Selected');
   });
@@ -50,14 +50,14 @@ describe('Listview example-singleselect tests', () => {
     const listviewItemEl = await element(by.css('li[aria-posinset="1"]'));
     listviewItemEl.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-selected="true"]')).isPresent()).toBeTruthy();
     expect(await element(by.className('selection-count')).getText()).toContain('1 Selected');
 
     listviewItemEl.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="false"]'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="false"]'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-selected="false"]')).isPresent()).toBeTruthy();
   });
@@ -68,15 +68,15 @@ describe('Listview example-singleselect tests', () => {
     const listviewItemElTwo = await element(by.css('li[aria-posinset="2"]'));
     await listviewEl.sendKeys(protractor.Key.TAB);
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-posinset="1"][aria-selected="true"]')).isPresent()).toBeTruthy();
     await listviewItemElOne.sendKeys(protractor.Key.ARROW_DOWN);
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitsFor);
     await listviewItemElTwo.sendKeys(protractor.Key.ARROW_DOWN);
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-posinset="3"].is-selected')).isPresent()).toBeTruthy();
     expect(await element(by.className('selection-count')).getText()).toContain('1 Selected');
@@ -88,7 +88,7 @@ describe('Listview example-multiselect tests', () => {
     await utils.setPage('/components/listview/example-multiselect');
     const listviewEl = await element(by.id('multiselect-listview'));
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(listviewEl), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(listviewEl), config.waitsFor);
   });
 
   if (utils.isChrome() && utils.isCI()) {
@@ -114,11 +114,11 @@ describe('Listview example-multiselect tests', () => {
     const listviewItemEl = await element(by.css('li[aria-posinset="1"]'));
     listviewItemEl.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-selected="true"]'))).toBeTruthy();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.className('selection-count'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.className('selection-count'))), config.waitsFor);
 
     expect(await element(by.className('selection-count')).getText()).toContain('1 Selected');
   });
@@ -127,14 +127,14 @@ describe('Listview example-multiselect tests', () => {
     const listviewItemEl = await element(by.css('li[aria-posinset="1"]'));
     listviewItemEl.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="true"].is-selected'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-selected="true"]'))).toBeTruthy();
     expect(await element(by.className('selection-count')).getText()).toContain('1 Selected');
 
     listviewItemEl.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="false"]'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="false"]'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-selected="false"]'))).toBeTruthy();
   });
@@ -143,7 +143,7 @@ describe('Listview example-multiselect tests', () => {
     it('Should mouseover 1st, and change background-color', async () => {
       const listviewItemElOne = await element(by.css('li[aria-posinset="1"]'));
       await browser.driver
-        .wait(protractor.ExpectedConditions.presenceOf(listviewItemElOne), config.waitFor);
+        .wait(protractor.ExpectedConditions.presenceOf(listviewItemElOne), config.waitsFor);
       await browser.driver.actions().mouseMove(listviewItemElOne).perform();
       await browser.driver.sleep(config.sleep);
       // Value returned will be as the browser interprets it, tricky to form a proper assertion
@@ -156,10 +156,10 @@ describe('Listview example-multiselect tests', () => {
     const listviewItemElThree = await element(by.css('li[aria-posinset="3"]'));
     listviewItemElOne.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-posinset="1"].is-selected'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-posinset="1"].is-selected'))), config.waitsFor);
     listviewItemElThree.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-posinset="3"].is-selected'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-posinset="3"].is-selected'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-posinset="1"].is-selected')).isPresent()).toBeTruthy();
     expect(await element(by.css('li[aria-posinset="1"][aria-selected="true"]'))).toBeTruthy();
@@ -174,7 +174,7 @@ describe('Listview example-multiselect tests', () => {
     const listviewItemElOne = await element(by.css('li[aria-posinset="1"]'));
     await listviewItemElOne.sendKeys(protractor.Key.SPACE);
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-posinset="1"].is-selected'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-posinset="1"].is-selected'))), config.waitsFor);
     await listviewItemElOne.sendKeys(protractor.Key.ARROW_DOWN);
 
     expect(await element(by.css('li[aria-posinset="1"][tabindex="0"]'))).toBeTruthy();
@@ -194,7 +194,7 @@ describe('Listview example-mixed selection tests', () => {
     await utils.setPage('/components/listview/example-mixed-selection');
     const listviewEl = await element(by.id('task-listview'));
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(listviewEl), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(listviewEl), config.waitsFor);
   });
 
   if (!utils.isIE()) {
@@ -217,14 +217,14 @@ describe('Listview example-mixed selection tests', () => {
     const listviewItemInputEl = await element(by.css('li[aria-posinset="1"] .label-text'));
     listviewItemInputEl.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(listviewItemInputEl), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(listviewItemInputEl), config.waitsFor);
 
     expect(await element(by.className('is-selected'))).toBeTruthy();
     expect(await element(by.css('li[aria-selected="true"]'))).toBeTruthy();
 
     listviewItemInputEl.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="false"]'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-selected="false"]'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-selected="false"]'))).toBeTruthy();
   });
@@ -234,10 +234,10 @@ describe('Listview example-mixed selection tests', () => {
     const listviewItemElThree = await element(by.css('li[aria-posinset="3"] .label-text'));
     await listviewItemElOne.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-posinset="1"].is-selected'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-posinset="1"].is-selected'))), config.waitsFor);
     await listviewItemElThree.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-posinset="3"].is-selected'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-posinset="3"].is-selected'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-posinset="1"][aria-selected="true"]'))).toBeTruthy();
     expect(await element(by.css('li[aria-posinset="3"][aria-selected="true"]')).isPresent()).toBeTruthy();
@@ -247,7 +247,7 @@ describe('Listview example-mixed selection tests', () => {
     const listviewItemElOne = await element(by.css('li[aria-posinset="1"]'));
     await listviewItemElOne.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-posinset="1"].is-activated'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-posinset="1"].is-activated'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-posinset="1"][aria-selected="false"]'))).toBeTruthy();
   });
@@ -258,7 +258,7 @@ describe('Listview example-search tests', () => {
     await utils.setPage('/components/listview/example-search');
     const listviewEl = await element(by.id('search-listview'));
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(listviewEl), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(listviewEl), config.waitsFor);
   });
 
   if (!utils.isIE()) {
@@ -272,12 +272,12 @@ describe('Listview example-search tests', () => {
   it('Should hide unmatching items based on search term, and highlight pattern', async () => {
     const searchListviewEl = await element(by.id('gridfilter'));
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(searchListviewEl), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(searchListviewEl), config.waitsFor);
     await searchListviewEl.click();
     await browser.driver.switchTo().activeElement().clear();
     await browser.driver.switchTo().activeElement().sendKeys('to');
     await browser.driver
-      .wait(protractor.ExpectedConditions.textToBePresentInElementValue(await element(by.id('gridfilter')), 'to'), config.waitFor);
+      .wait(protractor.ExpectedConditions.textToBePresentInElementValue(await element(by.id('gridfilter')), 'to'), config.waitsFor);
 
     expect(await element(by.css('li[aria-posinset="2"]')).getText()).toContain('Update pending quotes and send out again to customers.');
     expect(await element(by.css('li[aria-posinset="2"]')).isDisplayed()).toBeTruthy();
@@ -292,7 +292,7 @@ describe('Listview example-paging tests', () => {
     await utils.setPage('/components/listview/example-paging');
     const listviewPagerEl = await element(by.css('.pager-toolbar.is-listview'));
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(listviewPagerEl), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(listviewPagerEl), config.waitsFor);
   });
 
   if (!utils.isIE()) {
@@ -307,7 +307,7 @@ describe('Listview example-paging tests', () => {
     const listviewPagerEl = await element.all(by.css('.pager-toolbar li')).get(2);
     await listviewPagerEl.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.visibilityOf(element(by.css('li[aria-posinset="4"] .listview-heading'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.visibilityOf(element(by.css('li[aria-posinset="4"] .listview-heading'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-posinset="4"] .listview-heading')).getText()).toContain('Maplewood St. Resurfacing');
   });
@@ -316,7 +316,7 @@ describe('Listview example-paging tests', () => {
     const listviewPagerNextEl = await element(by.css('.pager-next'));
     await listviewPagerNextEl.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.visibilityOf(element(by.css('li[aria-posinset="4"] .listview-heading'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.visibilityOf(element(by.css('li[aria-posinset="4"] .listview-heading'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-posinset="4"] .listview-heading')).getText()).toContain('Maplewood St. Resurfacing');
   });
@@ -329,7 +329,7 @@ describe('Listview example-paging tests', () => {
     await listviewPagerNextEl.click();
     await listviewPagerPrevEl.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.visibilityOf(element(by.css('li[aria-posinset="7"] .listview-heading'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.visibilityOf(element(by.css('li[aria-posinset="7"] .listview-heading'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-posinset="7"] .listview-heading')).getText()).toContain('Beechtree Dr. Resurfacing');
   });
@@ -340,7 +340,7 @@ describe('Listview example-index tests', () => {
     await utils.setPage('/components/listview/example-index');
     const listviewEl = await element(by.id('task-listview'));
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(listviewEl), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(listviewEl), config.waitsFor);
   });
 
   it('Should do nothing on a disabled item', async () => {
@@ -356,7 +356,7 @@ describe('Listview example-paging-clientside tests', () => {
     await utils.setPage('/components/listview/example-paging-clientside');
     const listviewPagerEl = await element(by.css('.pager-toolbar.is-listview'));
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(listviewPagerEl), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(listviewPagerEl), config.waitsFor);
   });
 
   if (!utils.isIE()) {
@@ -371,7 +371,7 @@ describe('Listview example-paging-clientside tests', () => {
     const listviewPagerEl = await element.all(by.css('.pager-toolbar li')).get(2);
     listviewPagerEl.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.visibilityOf(element(by.css('li[aria-posinset="12"] .listview-heading'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.visibilityOf(element(by.css('li[aria-posinset="12"] .listview-heading'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-posinset="12"] .listview-heading')).getText()).toContain('Maplewood St. Resurfacing');
   });
@@ -380,7 +380,7 @@ describe('Listview example-paging-clientside tests', () => {
     const listviewPagerNextEl = await element(by.css('.pager-next'));
     listviewPagerNextEl.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.visibilityOf(element(by.css('li[aria-posinset="12"] .listview-heading'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.visibilityOf(element(by.css('li[aria-posinset="12"] .listview-heading'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-posinset="12"] .listview-heading')).getText()).toContain('Maplewood St. Resurfacing');
   });
@@ -392,7 +392,7 @@ describe('Listview example-paging-clientside tests', () => {
     await listviewPagerNextEl.click();
     await listviewPagerPrevEl.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-posinset="11"] .listview-heading'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li[aria-posinset="11"] .listview-heading'))), config.waitsFor);
 
     expect(await element(by.css('li[aria-posinset="11"] .listview-heading')).isDisplayed()).toBeTruthy();
     expect(await element(by.css('li[aria-posinset="11"] .listview-heading')).getText()).toContain('Fort Woods Swimming Pool');
@@ -404,7 +404,7 @@ describe('Listview remove-clear tests', () => {
     await utils.setPage('/components/listview/remove-clear');
     const listviewMultiSelectEl = await element(by.id('multiselect-listview'));
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(listviewMultiSelectEl), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(listviewMultiSelectEl), config.waitsFor);
   });
 
   if (!utils.isIE()) {
@@ -424,7 +424,7 @@ describe('Listview remove-clear tests', () => {
     await listviewItemElThree.click();
     await listviewItemElFour.click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('li[aria-posinset="4"].is-selected'))), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('li[aria-posinset="4"].is-selected'))), config.waitsFor);
 
     expect(await element(by.className('status')).getText()).toContain('3 of 12 items selected');
     await listviewRemove.click();
@@ -438,7 +438,7 @@ describe('Listview example-header-totals` tests', () => {
     await utils.setPage('/components/listview/example-header-totals');
     const listviewButtonToggleEl = await element(by.css('.listview-header button'));
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(listviewButtonToggleEl), config.waitFor);
+      .wait(protractor.ExpectedConditions.presenceOf(listviewButtonToggleEl), config.waitsFor);
   });
 
   if (!utils.isIE()) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
 Fixes failed BrowerStack test on nightly test
> (Marked via REST API : Should remove selected items, and update status pane)
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->

**Related github/jira issue (required)**:
Relates to #347 corrections
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->

**Steps necessary to review your pull request (required)**:
You can review tests I ran on BS, or just isolate the tests, and run on Chrome, `npm run e2e:local:bs`
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
