### PR TITLE
228 add right alignment support for datagrid lookup text

### DIFF
--- a/app/views/components/datagrid/test-right-aligned-lookup.html
+++ b/app/views/components/datagrid/test-right-aligned-lookup.html
@@ -1,0 +1,119 @@
+<div class="row">
+  <div class="twelve columns">
+    <div role="toolbar" class="toolbar">
+
+      <div class="title">
+        Data Grid Header Title
+        <span class="datagrid-result-count">(N Results)</span>
+      </div>
+
+      <div class="buttonset">
+        <label class="audible" for="searchfield-01">Keyword Search</label>
+        <input id="searchfield-01" name="searchfield-01" class="searchfield" />
+      </div>
+      <div class="more">
+        <button class="btn-actions" type="button">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-more"></use>
+          </svg>
+          <span class="audible">More Actions</span>
+        </button>
+        <ul class="popupmenu">
+          <li><a href="#">Option One</a></li>
+          <li><a href="#">Option Two</a></li>
+          <li><a href="#">Option Three</a></li>
+          <li class="separator single-selectable-section"></li>
+          <li class="heading">Row Height</li>
+          <li class="is-selectable"><a data-option="row-short" href="#">Short</a></li>
+          <li class="is-selectable"><a data-option="row-medium" href="#">Medium</a></li>
+          <li class="is-selectable is-checked"><a data-option="row-normal" href="#">Normal</a></li>
+        </ul>
+
+      </div>
+    </div>
+
+    <div id="datagrid">
+
+    </div>
+  </div>
+</div>
+
+<script>
+  var gridApi = null;
+
+  $('body').one('initialized', function () {
+    var grid,
+        data = [],
+        columns = [],
+
+        //lookup data
+        lookupOptions,
+        lookupData = [],
+        lookupColumns = [];
+
+         // Some Sample Data for Lookup
+         lookupData.push({ id: 1, productId: 201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+          lookupData.push({ id: 2, productId: 202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+          lookupData.push({ id: 3, productId: 203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+          lookupData.push({ id: 4, productId: 204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+          lookupData.push({ id: 5, productId: 205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+          lookupData.push({ id: 5, productId: 205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+          lookupData.push({ id: 6, productId: 206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+
+          //Define Columns for the Lookup Grid.
+          lookupColumns.push({ id: 'productId', name: 'Product Id', field: 'productId', width: 140});
+          lookupColumns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', width: 250, formatter: Formatters.Hyperlink});
+          lookupColumns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', width: 125});
+          lookupColumns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', width: 125});
+          lookupColumns.push({ id: 'price', name: 'Price', field: 'price', width: 125, formatter: Formatters.Decimal});
+          lookupColumns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+
+          lookupOptions = {
+            // field: 'productId',
+            field: function (row, field, grid) {
+              return row.productId;
+            },
+            match: function (value, row, field, grid) {
+              return (row.productId) === value;
+            },
+            editable: false,
+            options: {
+              columns: lookupColumns,
+              dataset: lookupData,
+              selectable: 'single', //multiselect or single
+              toolbar: {title: 'Products', results: true, dateFilter: false ,keywordFilter: false, advancedFilter: true, actions: true, views: true , rowHeight: true}
+            }
+          };
+
+    // Some Sample Data
+    data.push({ id: 1, productId: 201, productName: 'Compressor', activity:  '<svg/onload=alert(1)>', quantity: 1, price: 210.99, status: 'OK', orderDate:  new Date(2016, 2, 15, 12, 30, 36), portable: false, action: 'OK' });
+        data.push({ id: 2, productId: 202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, status: '', orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false, action: 'OK' });
+        data.push({ id: 3, productId: 203, productName: 'Portable Compressor', activity:  'Inspect and Repair', portable: true, quantity: 1, price: 120.992, status: null, orderDate: new Date(2014, 6, 3), action: 'On Hold' });
+        data.push({ id: 4, productId: 204, productName: 'Another Compressor', activity:  'Assemble Paint', portable: true, quantity: 3, price: null, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'OK' });
+        data.push({ id: 5, productId: 205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold' });
+        data.push({ id: 6, productId: 205, productName: 'Air Compressors', activity:  'Inspect and Repair', portable: false, quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold' });
+        data.push({ id: 7, productId: 206, productName: 'Some Compressor', activity:  'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold' });
+
+        //Define Columns for the Grid.
+        columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input });
+        columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, editorOptions: lookupOptions, lookupAlign: 'right' });
+        columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, align: 'right', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###.000' });
+        columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date5 });
+        columns.push({ id: 'action', name: 'Action Item', field: 'action' });
+
+        //Init and get the api for the grid
+        grid = $('#datagrid').datagrid({
+          columns: columns,
+          dataset: data,
+          editable: true,
+          toolbar: {keywordFilter: true, results: true}
+        }).on('cellchange', function (e, args) {
+          console.log(e, args);
+        }).on('rowadd', function (e, args) {
+          console.log(e, args);
+        }).on('rowremove', function (e, args) {
+          console.log(e, args);
+        });
+  });
+
+</script>

--- a/app/views/components/datagrid/test-right-aligned-lookup.html
+++ b/app/views/components/datagrid/test-right-aligned-lookup.html
@@ -1,5 +1,12 @@
 <div class="row">
   <div class="twelve columns">
+    <br />
+    <h3>Grid Example: Api</h3>
+    <p>A visual test showing that a lookup inside the datagrid have a right align option.</p><br />
+  </div>
+</div>
+<div class="row">
+  <div class="twelve columns">
     <div role="toolbar" class="toolbar">
 
       <div class="title">
@@ -7,10 +14,6 @@
         <span class="datagrid-result-count">(N Results)</span>
       </div>
 
-      <div class="buttonset">
-        <label class="audible" for="searchfield-01">Keyword Search</label>
-        <input id="searchfield-01" name="searchfield-01" class="searchfield" />
-      </div>
       <div class="more">
         <button class="btn-actions" type="button">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
@@ -28,13 +31,44 @@
           <li class="is-selectable"><a data-option="row-medium" href="#">Medium</a></li>
           <li class="is-selectable is-checked"><a data-option="row-normal" href="#">Normal</a></li>
         </ul>
-
       </div>
-    </div>
-
-    <div id="datagrid">
 
     </div>
+    <div id="datagrid"></div>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+
+    <div role="toolbar" class="toolbar">
+
+      <div class="title">
+        Data Grid Header Title
+        <span class="datagrid-result-count">(N Results)</span>
+      </div>
+
+      <div class="more">
+        <button class="btn-actions" type="button">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-more"></use>
+          </svg>
+          <span class="audible">More Actions</span>
+        </button>
+        <ul class="popupmenu">
+          <li><a href="#">Option One</a></li>
+          <li><a href="#">Option Two</a></li>
+          <li><a href="#">Option Three</a></li>
+          <li class="separator single-selectable-section"></li>
+          <li class="heading">Row Height</li>
+          <li class="is-selectable"><a data-option="row-short" href="#">Short</a></li>
+          <li class="is-selectable"><a data-option="row-medium" href="#">Medium</a></li>
+          <li class="is-selectable is-checked"><a data-option="row-normal" href="#">Normal</a></li>
+        </ul>
+      </div>
+
+    </div>
+    <div id="datagrid2"></div>
   </div>
 </div>
 
@@ -45,75 +79,75 @@
     var grid,
         data = [],
         columns = [],
+        columns2 = [],
 
         //lookup data
         lookupOptions,
         lookupData = [],
         lookupColumns = [];
 
-         // Some Sample Data for Lookup
-         lookupData.push({ id: 1, productId: 201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
-          lookupData.push({ id: 2, productId: 202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
-          lookupData.push({ id: 3, productId: 203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
-          lookupData.push({ id: 4, productId: 204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
-          lookupData.push({ id: 5, productId: 205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
-          lookupData.push({ id: 5, productId: 205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
-          lookupData.push({ id: 6, productId: 206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+    // Some Sample Data for Lookup
+    lookupData.push({ id: 1, productId: 201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+    lookupData.push({ id: 2, productId: 202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+    lookupData.push({ id: 3, productId: 203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
 
-          //Define Columns for the Lookup Grid.
-          lookupColumns.push({ id: 'productId', name: 'Product Id', field: 'productId', width: 140});
-          lookupColumns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', width: 250, formatter: Formatters.Hyperlink});
-          lookupColumns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', width: 125});
-          lookupColumns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', width: 125});
-          lookupColumns.push({ id: 'price', name: 'Price', field: 'price', width: 125, formatter: Formatters.Decimal});
-          lookupColumns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+    //Define Columns for the Lookup Grid.
+    lookupColumns.push({ id: 'productId', name: 'Product Id', field: 'productId', width: 140});
+    lookupColumns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', width: 250, formatter: Formatters.Hyperlink});
+    lookupColumns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', width: 125});
+    lookupColumns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', width: 125});
+    lookupColumns.push({ id: 'price', name: 'Price', field: 'price', width: 125, formatter: Formatters.Decimal});
+    lookupColumns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
 
-          lookupOptions = {
-            // field: 'productId',
-            field: function (row, field, grid) {
-              return row.productId;
-            },
-            match: function (value, row, field, grid) {
-              return (row.productId) === value;
-            },
-            editable: false,
-            options: {
-              columns: lookupColumns,
-              dataset: lookupData,
-              selectable: 'single', //multiselect or single
-              toolbar: {title: 'Products', results: true, dateFilter: false ,keywordFilter: false, advancedFilter: true, actions: true, views: true , rowHeight: true}
-            }
-          };
+    lookupOptions = {
+      // field: 'productId',
+      field: function (row, field, grid) {
+        return row.productId;
+      },
+      match: function (value, row, field, grid) {
+        return (row.productId) === value;
+      },
+      editable: false,
+      options: {
+        columns: lookupColumns,
+        dataset: lookupData,
+        selectable: 'single', //multiselect or single
+        toolbar: {title: 'Products', results: true, dateFilter: false ,keywordFilter: false, advancedFilter: true, actions: true, views: true , rowHeight: true}
+      }
+    };
 
     // Some Sample Data
     data.push({ id: 1, productId: 201, productName: 'Compressor', activity:  '<svg/onload=alert(1)>', quantity: 1, price: 210.99, status: 'OK', orderDate:  new Date(2016, 2, 15, 12, 30, 36), portable: false, action: 'OK' });
-        data.push({ id: 2, productId: 202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, status: '', orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false, action: 'OK' });
-        data.push({ id: 3, productId: 203, productName: 'Portable Compressor', activity:  'Inspect and Repair', portable: true, quantity: 1, price: 120.992, status: null, orderDate: new Date(2014, 6, 3), action: 'On Hold' });
-        data.push({ id: 4, productId: 204, productName: 'Another Compressor', activity:  'Assemble Paint', portable: true, quantity: 3, price: null, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'OK' });
-        data.push({ id: 5, productId: 205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold' });
-        data.push({ id: 6, productId: 205, productName: 'Air Compressors', activity:  'Inspect and Repair', portable: false, quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold' });
-        data.push({ id: 7, productId: 206, productName: 'Some Compressor', activity:  'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold' });
+    data.push({ id: 2, productId: 202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, status: '', orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false, action: 'OK' });
+    data.push({ id: 3, productId: 203, productName: 'Portable Compressor', activity:  'Inspect and Repair', portable: true, quantity: 1, price: 120.992, status: null, orderDate: new Date(2014, 6, 3), action: 'On Hold' });
 
-        //Define Columns for the Grid.
-        columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input });
-        columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, editorOptions: lookupOptions, lookupAlign: 'right' });
-        columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, align: 'right', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###.000' });
-        columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date5 });
-        columns.push({ id: 'action', name: 'Action Item', field: 'action' });
+    //Define Columns for the Grid.
+    columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, editorOptions: lookupOptions, align: 'right' });
+    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input, align: 'right' });
 
-        //Init and get the api for the grid
-        grid = $('#datagrid').datagrid({
-          columns: columns,
-          dataset: data,
-          editable: true,
-          toolbar: {keywordFilter: true, results: true}
-        }).on('cellchange', function (e, args) {
-          console.log(e, args);
-        }).on('rowadd', function (e, args) {
-          console.log(e, args);
-        }).on('rowremove', function (e, args) {
-          console.log(e, args);
-        });
+    columns2.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, editorOptions: lookupOptions});
+    columns2.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input });
+
+    //Init and get the api for the grid
+    grid = $('#datagrid').datagrid({
+      columns: columns,
+      dataset: data,
+      editable: true,
+      toolbar: {keywordFilter: true, results: true}
+    }).on('cellchange', function (e, args) {
+      console.log(e, args);
+    }).on('rowadd', function (e, args) {
+      console.log(e, args);
+    }).on('rowremove', function (e, args) {
+      console.log(e, args);
+    });
+
+    grid = $('#datagrid2').datagrid({
+      columns: columns2,
+      dataset: data,
+      editable: true,
+      toolbar: {keywordFilter: true, results: true}
+    })
   });
 
 </script>

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1694,7 +1694,7 @@ $datagrid-short-row-height: 23px;
         width: 100%;
 
         .trigger {
-          margin-left: -21px;
+          margin-left: -12px;
           margin-top: 1px;
         }
       }
@@ -1725,7 +1725,7 @@ $datagrid-short-row-height: 23px;
         width: 100%;
 
         &.lookup {
-          width: calc(100% - 21px);
+          width: calc(100% - 29px);
 
           ~.trigger .icon {
             top: calc(50% - 6px);

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -616,6 +616,10 @@ $datagrid-short-row-height: 23px;
                 top: calc(50% - 6px);
                 width: inherit;
               }
+
+              &.align-text-right {
+                width: calc(100% - 28px);
+              }
             }
 
             &.timepicker {
@@ -747,6 +751,13 @@ $datagrid-short-row-height: 23px;
         margin-left: -10px !important;
         margin-top: -5px !important;
       }
+
+      .align-text-right {
+        + .trigger {
+          margin-left: 0 !important;
+          margin-top: -4px !important;
+        }
+      }
     }
     // scss-lint:enable ImportantRule
 
@@ -764,6 +775,16 @@ $datagrid-short-row-height: 23px;
         .icon {
           left: 9px;
           top: 5px;
+        }
+      }
+
+      .align-text-right {
+        &.trigger {
+          width: calc(100% - 16px);
+        }
+
+        + .icon.icon-search-list {
+          left: 3px;
         }
       }
     }
@@ -929,6 +950,12 @@ $datagrid-short-row-height: 23px;
 
           .dropdown-trigger + .icon {
             left: -3px;
+          }
+
+          .trigger {
+            &.align-text-right {
+              width: calc(100% - 21px);
+            }
           }
         }
         // scss-lint:enable NestingDepth
@@ -1104,6 +1131,12 @@ $datagrid-short-row-height: 23px;
         .trigger {
           height: 20px;
         }
+      }
+    }
+
+    .align-text-right {
+      + .icon-search-list {
+        left: 0 !important;
       }
     }
 
@@ -1693,8 +1726,18 @@ $datagrid-short-row-height: 23px;
         vertical-align: top;
         width: 100%;
 
+        .lookup.is-not-editable {
+          + .trigger {
+            margin-left: -10px;
+          }
+
+          &:focus {
+            box-shadow: none;
+          }
+        }
+
         .trigger {
-          margin-left: -12px;
+          margin-left: -21px;
           margin-top: 1px;
         }
       }
@@ -1725,7 +1768,11 @@ $datagrid-short-row-height: 23px;
         width: 100%;
 
         &.lookup {
-          width: calc(100% - 29px);
+          width: calc(100% - 31px);
+
+          &.align-text-right {
+            width: 100%;
+          }
 
           ~.trigger .icon {
             top: calc(50% - 6px);
@@ -1895,6 +1942,10 @@ $datagrid-short-row-height: 23px;
     &.l-right-text {
       .datagrid-cell-wrapper {
         text-align: right;
+
+        .lookup-wrapper {
+          padding-right: 30px;
+        }
       }
     }
 
@@ -2512,6 +2563,12 @@ td .btn-actions {
 .datagrid-trigger-cell {
   &:not(.is-readonly) {
     cursor: pointer;
+  }
+
+  .align-text-right {
+    + .icon.icon-search-list {
+      left: 0;
+    }
   }
 
   .icon {

--- a/src/components/datagrid/datagrid.editors.js
+++ b/src/components/datagrid/datagrid.editors.js
@@ -699,7 +699,7 @@ const editors = {
     this.originalValue = value;
 
     this.init = function () {
-      this.input = $(`<input class="lookup ${column.lookupAlign === 'right' ? 'align-text-right' : ''}" data-init="false" />`).appendTo(container);
+      this.input = $(`<input class="lookup ${column.align === 'right' ? 'align-text-right' : ''}" data-init="false" />`).appendTo(container);
 
       if (column.maxLength) {
         this.input.attr('maxlength', column.maxLength);

--- a/src/components/datagrid/datagrid.editors.js
+++ b/src/components/datagrid/datagrid.editors.js
@@ -699,7 +699,7 @@ const editors = {
     this.originalValue = value;
 
     this.init = function () {
-      this.input = $('<input class="lookup" data-init="false" />').appendTo(container);
+      this.input = $(`<input class="lookup ${column.lookupAlign === 'right' ? 'align-text-right' : ''}" data-init="false" />`).appendTo(container);
 
       if (column.maxLength) {
         this.input.attr('maxlength', column.maxLength);

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -149,7 +149,7 @@ const formatters = {
       formatted = col.editorOptions.field(item, null, null);
     }
 
-    return `<span class="trigger ${col.lookupAlign === 'right' ? 'align-text-right' : ''}">${formatted}</span>${$.createIcon({ icon: 'search-list', classes: ['icon-search-list'] })}`;
+    return `<span class="trigger ${col.align === 'right' ? 'align-text-right' : ''}">${formatted}</span>${$.createIcon({ icon: 'search-list', classes: ['icon-search-list'] })}`;
   },
 
   Decimal(row, cell, value, col) {

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -149,7 +149,7 @@ const formatters = {
       formatted = col.editorOptions.field(item, null, null);
     }
 
-    return `<span class="trigger">${formatted}</span>${$.createIcon({ icon: 'search-list', classes: ['icon-search-list'] })}`;
+    return `<span class="trigger ${col.lookupAlign === 'right' ? 'align-text-right' : ''}">${formatted}</span>${$.createIcon({ icon: 'search-list', classes: ['icon-search-list'] })}`;
   },
 
   Decimal(row, cell, value, col) {

--- a/src/components/typography/_typography.scss
+++ b/src/components/typography/_typography.scss
@@ -293,9 +293,11 @@ small,
   text-align: left;
 }
 
+// scss-lint:disable ImportantRule
 .align-text-right {
-  text-align: right;
+  text-align: right !important;
 }
+// scss-lint:disable ImportantRule
 
 .align-text-enter, //typo backwards compat
 .align-text-center {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input, **align: 'right'** });

Lookup now support the align 'Right' option. Developers have now an option to right aligned the lookup field if needed.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #228 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
http://localhost:4000/components/datagrid/test-right-aligned-lookup.html
- Open link above, look for product id column
- All product id's should be right aligned. Same alignment when you click on any product id number in a row.
- Check lookup field alignment on various heights like short and medium by selecting the  more button on the top right of the datagrid. 

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
