### PR TITLE
NG-136 - Add a type check to fix broken NG tests

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -622,6 +622,9 @@ Dropdown.prototype = {
     // selected.  Use the internal storage of selected values instead.
     if (this.settings.reload === 'typeahead') {
       selectedFilterMethod = function (i, opt) {
+        if (!self.selectedValues) {
+          return false;
+        }
         return self.selectedValues.indexOf(opt.value) > -1;
       };
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds a better type check to a particular spot in the Dropdown component code that detects previously selected values.

**Related github/jira issue (required)**:
Fixes a problem that's failing e2e tests on the CI in infor-design/enterprise-ng#136
Originally part of changes in #267

**Steps necessary to review your pull request (required)**:
- Run the Dropdown e2e tests in this project.
- Use the `/dist` folder built by this branch and build/test the Angular components to ensure its e2e tests all pass.
