### PR TITLE
245 - add longpress behavior

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -112,6 +112,7 @@ router.get('/performance-tests', (req, res, next) => {
 // ======================================
 //  Components Routes
 // ======================================
+app.use('/behaviors', generalRoute);
 app.use('/components', generalRoute);
 app.use('/patterns', generalRoute);
 app.use('/examples', generalRoute);

--- a/app/views/behaviors/longpress/example-index.html
+++ b/app/views/behaviors/longpress/example-index.html
@@ -12,7 +12,9 @@
       <span>Test Button</span>
     </button>
   </div>
+</div>
 
+<div class="row top-padding">
   <div class="four columns">
     <label for="test-dropdown">Test Dropdown</label>
     <select id="test-dropdown" class="dropdown">
@@ -21,7 +23,9 @@
       <option>Go</option>
     </select>
   </div>
+</div>
 
+<div class="row top-padding">
   <div class="four columns">
     <label for="test-slider">Test Slider</label>
     <input id="test-slider" value="10" class="slider" type="range" data-tooltip-content="['']" data-tooltip-persist="true" />

--- a/app/views/behaviors/longpress/example-index.html
+++ b/app/views/behaviors/longpress/example-index.html
@@ -1,0 +1,38 @@
+<div class="row">
+  <div class="six columns">
+    <h2>LongPress Behavior</h2>
+    <p>Original Issue: <a class="hyperlink" href="https://github.com/infor-design/enterprise/issues/245" target="_blank">#245</a></p>
+    <p>Hold down the mouse button, or longpress via touch anywhere on the page to trigger a 'longpress' event that shows up in the developer console.</p>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="four columns">
+    <button id="test-button" class="btn-primary">
+      <span>Test Button</span>
+    </button>
+  </div>
+
+  <div class="four columns">
+    <label for="test-dropdown">Test Dropdown</label>
+    <select id="test-dropdown" class="dropdown">
+      <option>Ready</option>
+      <option>Set</option>
+      <option>Go</option>
+    </select>
+  </div>
+
+  <div class="four columns">
+    <label for="test-slider">Test Slider</label>
+    <input id="test-slider" value="10" class="slider" type="range" data-tooltip-content="['']" data-tooltip-persist="true" />
+  </div>
+</div>
+
+<script id="test-script">
+  $('body').on('longpress', function(e) {
+    var target = e.target;
+    if (console && console.dir) {
+      console.dir(target);
+    }
+  });
+</script>

--- a/app/views/behaviors/longpress/test-e2e-overlay-toggle.html
+++ b/app/views/behaviors/longpress/test-e2e-overlay-toggle.html
@@ -1,0 +1,34 @@
+<div class="row">
+  <div class="six columns">
+    <h2 id="page-title">LongPress Behavior Test: Overlay</h2>
+    <p>Original Issue: <a class="hyperlink" href="https://github.com/infor-design/enterprise/issues/245" target="_blank">#245</a></p>
+    <p>Hold down the mouse button, or longpress via touch anywhere on the page to toggle a red overlay.  Note that this test corresponds to one of the LongPress behavior's end-to-end tests.</p>
+  </div>
+</div>
+
+<style id="test-style">
+  .test-overlay {
+    background-color: #ff0000;
+    bottom: 0;
+    display: none;
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+
+  .test-overlay.visible {
+    display: block;
+  }
+</style>
+
+<script id="test-script">
+  $('body').on('initialized', function() {
+    $(this).append('<div id="test-overlay" class="test-overlay"></div>');
+
+    $(this).on('longpress.test', function() {
+      $('#test-overlay').toggleClass('visible');
+    });
+  });
+</script>

--- a/app/views/behaviors/longpress/test-e2e-overlay-toggle.html
+++ b/app/views/behaviors/longpress/test-e2e-overlay-toggle.html
@@ -2,7 +2,7 @@
   <div class="six columns">
     <h2 id="page-title">LongPress Behavior Test: Overlay</h2>
     <p>Original Issue: <a class="hyperlink" href="https://github.com/infor-design/enterprise/issues/245" target="_blank">#245</a></p>
-    <p>Hold down the mouse button, or longpress via touch anywhere on the page to toggle a red overlay.  Note that this test corresponds to one of the LongPress behavior's end-to-end tests.</p>
+    <p>Hold down the mouse button, or longpress via touch anywhere on the page to toggle a red overlay.  Note that this test corresponds to one of the LongPress behavior's end-to-end tests.  Also note that on this test, the event handler will return false if the target is a paragraph, hyperlink, or header text node.</p>
   </div>
 </div>
 
@@ -24,10 +24,18 @@
 </style>
 
 <script id="test-script">
+  const ignoredTagNames = ['A', 'P', 'H2', 'SPAN', 'DIV'];
+
   $('body').on('initialized', function() {
+    // Add the red test overlay
     $(this).append('<div id="test-overlay" class="test-overlay"></div>');
 
-    $(this).on('longpress.test', function() {
+    // Add a `.longpress-target` CSS class to test nodes.
+    // This prevents touch callouts from appearing on any text nodes, and from touch-based text selection occuring.
+    $(this).find(ignoredTagNames.join(', ').toLowerCase()).addClass('longpress-target');
+
+    // Setup the longpress event
+    $(this).on('longpress.test', function(e) {
       $('#test-overlay').toggleClass('visible');
     });
   });

--- a/src/behaviors/longpress/longpress.js
+++ b/src/behaviors/longpress/longpress.js
@@ -6,7 +6,7 @@ const BEHAVIOR_NAME = 'longpress';
 
 // Default LongPress settings
 const LONGPRESS_DEFAULTS = {
-  delay: 600,
+  delay: 400,
   mouseEvents: false
 };
 

--- a/src/behaviors/longpress/longpress.js
+++ b/src/behaviors/longpress/longpress.js
@@ -6,13 +6,19 @@ const BEHAVIOR_NAME = 'longpress';
 
 // Default LongPress settings
 const LONGPRESS_DEFAULTS = {
-  delay: 300
+  delay: 600,
+  mouseEvents: false
 };
 
 /**
  * @class LongPress
  * @constructor
- * @param {Object} settings incoming settings
+ * @param {Object} [settings] incoming settings
+ * @param {Number} [settings.delay] the amount of time that should pass between the touch start, and
+ *  the trigger of the "longpress" event.
+ * @param {boolean} [settings.mouseEvents] if true, will setup longpress capability against mouse events
+ *  as well as touch events.  If false, only touch events will be enabled, excluding mice from triggering
+ *  the event.
  */
 function LongPress(settings) {
   this.settings = utils.mergeSettings(this.element, settings, LONGPRESS_DEFAULTS);
@@ -89,12 +95,14 @@ LongPress.prototype = {
    */
   getInputEventNames() {
     const isTouch = env.features.touch;
+    const useMouse = this.settings.mouseEvents;
+    const testCondition = isTouch || !useMouse;
 
     return {
-      mousedown: isTouch ? 'touchstart' : 'mousedown',
-      mouseout: isTouch ? 'touchcancel' : 'mouseout',
-      mouseup: isTouch ? 'touchend' : 'mouseup',
-      mousemove: isTouch ? 'touchmove' : 'mousemove'
+      mousedown: testCondition ? 'touchstart' : 'mousedown',
+      mouseout: testCondition ? 'touchcancel' : 'mouseout',
+      mouseup: testCondition ? 'touchend' : 'mouseup',
+      mousemove: testCondition ? 'touchmove' : 'mousemove'
     };
   },
 
@@ -106,6 +114,9 @@ LongPress.prototype = {
     if (settings) {
       this.settings = utils.mergeSettings(this.element, settings, this.settings);
     }
+
+    this.teardown();
+    this.init();
   },
 
   /**

--- a/src/behaviors/longpress/longpress.js
+++ b/src/behaviors/longpress/longpress.js
@@ -45,7 +45,7 @@ LongPress.prototype = {
         id: `${BEHAVIOR_NAME}-timer`,
         duration: math.convertDelayToFPS(this.settings.delay),
         timeoutCallback() {
-          self.fireLongpressEvent(target);
+          self.fire(target);
         }
       });
       renderLoop.register(this.timer);
@@ -62,11 +62,10 @@ LongPress.prototype = {
   },
 
   /**
-   * @private
    * @param {HTMLElement} target the target element on which to trigger the event
    * @returns {void}
    */
-  fireLongpressEvent(target) {
+  fire(target) {
     $(target).trigger(`${BEHAVIOR_NAME}`);
   },
 

--- a/src/behaviors/longpress/longpress.js
+++ b/src/behaviors/longpress/longpress.js
@@ -1,0 +1,132 @@
+import { utils, math } from '../../utils/utils';
+import { Environment as env } from '../../utils/environment';
+import { renderLoop, RenderLoopItem } from '../../utils/renderloop';
+
+const BEHAVIOR_NAME = 'longpress';
+
+// Default LongPress settings
+const LONGPRESS_DEFAULTS = {
+  delay: 300
+};
+
+/**
+ * @class LongPress
+ * @constructor
+ * @param {Object} settings incoming settings
+ */
+function LongPress(settings) {
+  this.settings = utils.mergeSettings(this.element, settings, LONGPRESS_DEFAULTS);
+  return this.init();
+}
+
+LongPress.prototype = {
+
+  /**
+   * @property {RenderLoopItem} [timer=null]
+   */
+  timer: null,
+
+  /**
+   * @private
+   * @returns {void}
+   */
+  init() {
+    const evts = this.getInputEventNames();
+    const self = this;
+
+    // User touches the screen.
+    // If this goes uninterrupted for the defined duration, it causes a
+    // `longpress` event to trigger on the target element.
+    $(document).on(`${evts.mousedown}.${BEHAVIOR_NAME}`, (e) => {
+      const target = e.target;
+
+      // Add a timer to the renderLoop
+      this.timer = new RenderLoopItem({
+        id: `${BEHAVIOR_NAME}-timer`,
+        duration: math.convertDelayToFPS(this.settings.delay),
+        timeoutCallback() {
+          self.fireLongpressEvent(target);
+        }
+      });
+      renderLoop.register(this.timer);
+    });
+
+    // User moves or releases the touch, causing the timer to be cancelled.
+    $(document).on([
+      `${evts.mouseup}.${BEHAVIOR_NAME}`,
+      `${evts.mouseout}.${BEHAVIOR_NAME}`,
+      `${evts.mousemove}.${BEHAVIOR_NAME}`
+    ].join(' '), () => {
+      this.killTimer();
+    });
+  },
+
+  /**
+   * @private
+   * @param {HTMLElement} target the target element on which to trigger the event
+   * @returns {void}
+   */
+  fireLongpressEvent(target) {
+    $(target).trigger(`${BEHAVIOR_NAME}`);
+  },
+
+  /**
+   * @private
+   * @returns {void}
+   */
+  killTimer() {
+    if (!this.timer) {
+      return;
+    }
+
+    // Kill the renderloop item with no call to the timeout callback
+    this.timer.destroy(true);
+    this.timer = null;
+  },
+
+  /**
+   * @private
+   * @returns {object} containing desired event names
+   */
+  getInputEventNames() {
+    const isTouch = env.features.touch;
+
+    return {
+      mousedown: isTouch ? 'touchstart' : 'mousedown',
+      mouseout: isTouch ? 'touchcancel' : 'mouseout',
+      mouseup: isTouch ? 'touchend' : 'mouseup',
+      mousemove: isTouch ? 'touchmove' : 'mousemove'
+    };
+  },
+
+  /**
+   * @param {object} settings updated incoming settings
+   * @returns {void}
+   */
+  updated(settings) {
+    if (settings) {
+      this.settings = utils.mergeSettings(this.element, settings, this.settings);
+    }
+  },
+
+  /**
+   * @returns {void}
+   */
+  teardown() {
+    const evts = this.getInputEventNames();
+
+    this.killTimer();
+
+    $(document).off([
+      `${evts.mousedown}.${BEHAVIOR_NAME}`,
+      `${evts.mouseup}.${BEHAVIOR_NAME}`,
+      `${evts.mouseout}.${BEHAVIOR_NAME}`,
+      `${evts.mousemove}.${BEHAVIOR_NAME}`
+    ].join(' '));
+  }
+};
+
+// Setup a single instance of the LongPress behavior for export
+const longPress = new LongPress();
+
+export { longPress, BEHAVIOR_NAME };

--- a/src/behaviors/longpress/longpress.scss
+++ b/src/behaviors/longpress/longpress.scss
@@ -1,0 +1,4 @@
+.longpress-target {
+  @include css3(user-select, none);
+  -webkit-touch-callout: none;
+}

--- a/src/core/_controls.scss
+++ b/src/core/_controls.scss
@@ -83,6 +83,9 @@
 @import '../components/treemap/treemap';
 @import '../components/line/line';
 
+// Behaviors
+@import '../behaviors/longpress/longpress';
+
 // Patterns
 @import '../components/homepage/homepage';
 @import '../components/signin/signin';

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,9 @@ import { renderLoop, RenderLoopItem } from './utils/renderloop';
 renderLoop.start();
 export { renderLoop, RenderLoopItem };
 
+// LongPress needs a single instance of itself
+export { longPress } from './behaviors/longpress/longpress';
+
 // Theme/Personalization need single instances of themselves
 export { theme } from './components/personalize/personalize';
 export { personalization } from './components/personalize/personalize.bootstrap';

--- a/src/utils/environment.js
+++ b/src/utils/environment.js
@@ -11,6 +11,10 @@ const Environment = {
 
   browser: {},
 
+  features: {
+    touch: (('ontouchstart' in window) || (navigator.MaxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0))
+  },
+
   os: {},
 
   rtl: $('html').attr('dir') === 'rtl',

--- a/test/behaviors/longpress/longpress-events.func-spec.js
+++ b/test/behaviors/longpress/longpress-events.func-spec.js
@@ -1,0 +1,28 @@
+import { longPress } from '../../../src/behaviors/longpress/longpress';
+
+const longpressHTML = require('../../../app/views/behaviors/longpress/example-index.html');
+const svg = require('../../../src/components/icons/svg.html');
+
+let svgEl;
+
+describe('Longpress events', () => {
+  beforeEach(() => {
+    svgEl = null;
+    document.body.insertAdjacentHTML('afterbegin', longpressHTML);
+    document.body.insertAdjacentHTML('afterbegin', svg);
+    svgEl = document.body.querySelector('.svg-icons');
+  });
+
+  afterEach(() => {
+    svgEl.parentNode.removeChild(svgEl);
+  });
+
+  it('can be triggered on an element', () => {
+    const spyEvent = spyOnEvent('#test-button', 'longpress');
+    const testButtonEl = document.querySelector('#test-button');
+
+    longPress.fire(testButtonEl);
+
+    expect(spyEvent).toHaveBeenTriggered();
+  });
+});

--- a/test/behaviors/longpress/longpress-events.func-spec.js
+++ b/test/behaviors/longpress/longpress-events.func-spec.js
@@ -25,4 +25,16 @@ describe('Longpress events', () => {
 
     expect(spyEvent).toHaveBeenTriggered();
   });
+
+  it('can be updated with new settings', () => {
+    const newSettings = {
+      delay: 1500,
+      mouseEvents: true
+    };
+
+    longPress.updated(newSettings);
+
+    expect(longPress.settings.delay).toEqual(1500);
+    expect(longPress.settings.mouseEvents).toEqual(true);
+  });
 });

--- a/test/behaviors/longpress/longpress.e2e-spec.js
+++ b/test/behaviors/longpress/longpress.e2e-spec.js
@@ -1,0 +1,29 @@
+const { browserStackErrorReporter } = requireHelper('browserstack-error-reporter');
+const utils = requireHelper('e2e-utils');
+const config = requireHelper('e2e-config');
+requireHelper('rejection');
+
+jasmine.getEnv().addReporter(browserStackErrorReporter);
+
+describe('LongPress events', () => {
+  beforeEach(async () => {
+    await utils.setPage('/behaviors/longpress/test-e2e-overlay-toggle');
+  });
+
+  // TODO: #425
+  // Figure out how to simulate longpress correctly
+  // adapted from:
+  // - https://qeworks.com/questions/question/custom-browser-actions-in-protractor
+  // - https://stackoverflow.com/questions/27300433/protractorangularjsjasmine-test-press-and-hold-item
+  xit('can have handlers attached', async () => {
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('#test-overlay'))), config.waitsFor);
+
+    const titleEl = await element(by.css('#page-title'));
+    await browser.driver.actions().mouseDown(titleEl).perform();
+    await browser.driver.sleep(301);
+    await browser.driver.actions().mouseUp(titleEl).perform();
+
+    expect(await element(by.css('#test-overlay')).getAttribute('class')).toContain('visible');
+  });
+});

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -9,12 +9,14 @@ module.exports = function (config) {
       'dist/js/d3.v4.js',
       'dist/js/sohoxi.js',
       'dist/js/cultures/en-US.js',
+      'test/behaviors/**/*.func-spec.js',
       'test/components/**/*.func-spec.js'
     ],
     exclude: [
       'node_modules'
     ],
     preprocessors: {
+      '**/behaviors/*/*.js': ['webpack', 'sourcemap'],
       '**/components/*/*.js': ['webpack', 'sourcemap'],
     },
     webpack: {

--- a/test/protractor.ci.bs.conf.js
+++ b/test/protractor.ci.bs.conf.js
@@ -8,7 +8,7 @@ const getSpecs = (listSpec) => {
     return listSpec.split(',');
   }
 
-  return ['components/**/*.e2e-spec.js', 'kitchen-sink.e2e-spec.js'];
+  return ['behaviors/**/*.e2e-spec.js', 'components/**/*.e2e-spec.js', 'kitchen-sink.e2e-spec.js'];
 };
 
 const theme = process.env.ENTERPRISE_THEME || 'light'

--- a/test/protractor.ci.conf.js
+++ b/test/protractor.ci.conf.js
@@ -8,7 +8,7 @@ const getSpecs = (listSpec) => {
     return listSpec.split(',');
   }
 
-  return ['components/**/*.e2e-spec.js', 'kitchen-sink.e2e-spec.js'];
+  return ['behaviors/**/*.e2e-spec.js', 'components/**/*.e2e-spec.js', 'kitchen-sink.e2e-spec.js'];
 };
 
 exports.config = {

--- a/test/protractor.local.bs.conf.js
+++ b/test/protractor.local.bs.conf.js
@@ -9,7 +9,7 @@ const getSpecs = (listSpec) => {
     return listSpec.split(',');
   }
 
-  return ['components/**/*.e2e-spec.js', 'kitchen-sink.e2e-spec.js'];
+  return ['behaviors/**/*.e2e-spec.js', 'components/**/*.e2e-spec.js', 'kitchen-sink.e2e-spec.js'];
 };
 
 const theme = process.env.ENTERPRISE_THEME || 'light'

--- a/test/protractor.local.debug.conf.js
+++ b/test/protractor.local.debug.conf.js
@@ -8,7 +8,7 @@ const getSpecs = (listSpec) => {
     return listSpec.split(',');
   }
 
-  return ['components/**/*.e2e-spec.js', 'kitchen-sink.e2e-spec.js'];
+  return ['behaviors/**/*.e2e-spec.js', 'components/**/*.e2e-spec.js', 'kitchen-sink.e2e-spec.js'];
 };
 
 exports.config = {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds document-level event handlers for touch events that can detect when a user holds down a touch for a specified duration.  Once the duration is met without interruption, a `longpress` event is fired on the target element where the touch began.

**Related github/jira issue (required)**:
#245

**Steps necessary to review your pull request (required)**:
Pull this branch, build, and run the demo app.  Then:

- Open http://localhost:4000/behaviors/longpress/example-index in a mobile browser (Android, iOS) with a dev tools console connected.
- Long press the screen for at least 400 miliseconds
- In the console, a log statement should be created with a reference to the element that the `longpress` event originated on.

Additionally:
- Open http://localhost:4000/behaviors/longpress/test-e2e-overlay-toggle in a mobile browser (Android, iOS)
- Long press anywhere on the screen for at least 400 miliseconds.
- The screen should turn completely red.
- Long press again
- The screen should return to normal
- On Android devices (Chrome), long press on any text node.  The screen should turn red and no touch callouts should display.

Additionally there are new functional tests for the behavior.  There are also unfinished e2e tests that need to be fleshed out, and will not run on desktop-based CIs.
