### PR TITLE
SOHO-8075 389 Fixed visual appearance identical for key/click with ac…

### DIFF
--- a/app/views/components/datagrid/test-editable-actionable-mode.html
+++ b/app/views/components/datagrid/test-editable-actionable-mode.html
@@ -1,0 +1,186 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <div role="toolbar" class="toolbar">
+
+      <div class="title">
+        Data Grid Header Title
+        <span class="datagrid-result-count">(N Results)</span>
+      </div>
+
+      <div class="buttonset">
+          <button type="button" id="toggle-row-status" class="btn">
+            <span>Add Row Status</span>
+          </button>
+          <button type="button" id="validate" class="btn-menu">
+            <span>Validate</span>
+          </button>
+          <ul class="popupmenu">
+            <li><a href="#" data-action="specific-row-error">Specific Row Error</a></li>
+            <li><a href="#" data-action="all-cells-in-row">All Cells in Row</a></li>
+            <li><a href="#" data-action="all-rows-and-cells">All Rows and Cells</a></li>
+            <li class="separator"></li>
+            <li><a href="#" data-action="clear-specific-row-error">Clear Specific Row Error</a></li>
+            <!-- <li><a href="#" data-action="clear-all-cells-in-row">Clear All Cells in Row</a></li> -->
+            <li><a href="#" data-action="clear-all-rows-and-cells">Clear All Rows and Cells</a></li>
+          </ul>
+        <button class="btn-icon" type="button" id="add-btn">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-add"></use>
+          </svg>
+          <span class="audible">Add</span>
+        </button>
+      </div>
+
+      <div class="more">
+        <button class="btn-actions" type="button">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-more"></use>
+          </svg>
+          <span class="audible">More Actions</span>
+        </button>
+        <ul class="popupmenu">
+          <li class="single-selectable-section"></li>
+          <li class="heading">Row Height</li>
+          <li class="is-selectable"><a data-option="row-short" href="#">Short</a></li>
+          <li class="is-selectable"><a data-option="row-medium" href="#">Medium</a></li>
+          <li class="is-selectable is-checked"><a data-option="row-normal" href="#">Normal</a></li>
+        </ul>
+
+      </div>
+    </div>
+
+    <div class="contextual-toolbar toolbar is-hidden">
+      <div class="title selection-count">1 Selected</div>
+      <div class="buttonset">
+        <button class="btn-icon" type="button" id="remove-btn">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-delete"></use>
+          </svg>
+          <span class="audible">Remove</span>
+        </button>
+      </div>
+    </div>
+
+    <div id="datagrid"></div>
+  </div>
+</div>
+
+<script>
+  var gridApi = null;
+
+  $('body').one('initialized', function () {
+         var grid,
+          columns = [],
+          data = [];
+
+        // Some Sample Data
+        data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  '<svg/onload=alert(1)>', quantity: 1, price: 210.99, status: 'OK', orderDate:  '', portable: false, action: 1, description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning'});
+        data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, status: '', orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false, action: 1, description: 'The kit has an air blow gun that can be used for cleaning'});
+        data.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity:  '', portable: true, quantity: null, price: 120.992, status: null, orderDate: new Date(2014, 6, 3), action: 2});
+        data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', portable: true, quantity: 3, price: null, status: 'OK', orderDate: new Date(2015, 3, 3), action: 3, description: 'Compressor comes with with air tool kit'});
+        data.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 1});
+        data.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', portable: false, quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 2});
+        data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 2});
+
+        //Define Columns for the Grid.
+        // columns.push({ id: 'rowStatus', sortable: false, resizable: false, formatter: Formatters.Status, align: 'center'});
+        columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
+        columns.push({ id: 'id', name: 'Row Id', field: 'id', formatter: Formatters.Readonly});
+        columns.push({ id: 'productName', hidden: true, name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input});
+        columns.push({ id: 'activity', name: 'Activity', field: 'activity', required: true, editor: Editors.Input, validate: 'required'});  //maxLength: 2
+        columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', align: 'right', editor: Editors.Input, mask: '###', isEditable: function (row, cell, value, col, item) {
+            //For this fake logic just disable odd rows
+            return (row % 2 === 0);
+          }});
+        columns.push({ id: 'portable', name: 'Portable', field: 'portable', align: 'center', formatter: Formatters.Checkbox, editor: Editors.Checkbox});
+        columns.push({ id: 'price', name: 'Price', field: 'price', align: 'right', formatter: Formatters.Decimal, validate: 'required', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input});
+        columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date , validate: 'required date'});
+        columns.push({ id: 'action', name: 'Action', field: 'action', formatter: Formatters.Dropdown, editor: Editors.Dropdown, validate: 'required',
+        options: [{id: '', label: '', value: -1}, {id: 'oh1', label: 'On Hold', value: 1}, {id: 'sh1', label: 'Shipped', value: 2} , {id: 'ac1', label: 'Action', value: 3}]
+        });
+
+        //Init and get the api for the grid
+        grid = $('#datagrid').datagrid({
+          columns: columns,
+          dataset: data,
+          actionableMode: true,
+          editable: true,
+          clickToSelect: false,
+          selectable: 'multiple',
+          toolbar: {title: 'Data Grid Header Title', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: true,  collapsibleFilter: true},
+          paging: true,
+          pagesize: 5,
+          pagesizes: [2, 5, 6],
+        }).on('cellchange', function (e, args) {
+          console.log('cellchange', args);
+        }).on('rowadd', function (e, args) {
+          console.log(e, args);
+        }).on('rowremove', function (e, args) {
+          console.log(e, args);
+        });
+
+        gridApi = $('#datagrid').data('datagrid');
+
+        //Example row status
+        $('#toggle-row-status').on('click', function () {
+          var btn = $(this).find('span');
+          var status = {
+            add: 'Add Row Status',
+            remove: 'Remove Row Status'
+          };
+          if (btn.text() === status.add) {
+            btn.text(status.remove);
+            gridApi.rowStatus(0, 'error', 'Error');
+            gridApi.rowStatus(0, 'error', 'Error 2');
+            gridApi.rowStatus(0, 'error', 'Error 3');
+            gridApi.rowStatus(1, 'alert', 'Alert');
+            gridApi.rowStatus(2, 'info', 'Info');
+            gridApi.rowStatus(3, 'in-progress', 'inProgress');
+            gridApi.rowStatus(4, 'confirm', 'Confirm');
+            gridApi.rowStatus(5, 'dirty');
+            gridApi.rowStatus(6, 'new', 'new');
+            gridApi.rowStatus(6, 'error', 'This row has errors');
+          } else {
+            btn.text(status.add);
+            gridApi.resetRowStatus();
+          }
+        });
+
+      window.data = data;
+  });
+
+  var newId = 8;
+  //Add Code for Add and icon-delete
+  $('#add-btn').on('click', function () {
+    gridApi.addRow({ id: newId++, productId: 2642206, productName: 'New Product'});
+    console.log(gridApi.settings.dataset[1]);
+  });
+
+  //Add Code for Add and icon-delete
+  $('#remove-btn').on('click', function () {
+    gridApi.removeSelected();
+  });
+
+  //A few other ways
+  $('#validate').on('selected', function (e, args) {
+    var action = args.attr('data-action');
+
+    if (action === 'specific-row-error') {
+      gridApi.showRowError(2, 'This row has a custom error message.', 'error');
+    }
+    if (action === 'all-cells-in-row') {
+      gridApi.validateRow(2);
+    }
+    if (action === 'all-rows-and-cells') {
+      gridApi.validateAll();
+    }
+    if (action === 'clear-specific-row-error') {
+      gridApi.clearRowError(2);
+    }
+    if (action === 'clear-all-rows-and-cells') {
+      gridApi.clearAllErrors();
+    }
+  });
+
+</script>

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -6252,6 +6252,13 @@ Datagrid.prototype = {
           } else {
             self.setActiveCell(row, cell);
           }
+
+          if (key === 9 && self.settings.actionableMode) {
+            self.makeCellEditable(self.activeCell.rowIndex, cell, e);
+            if (self.isContainTextfield(node) && self.notContainTextfield(node)) {
+              self.quickEditMode = true;
+            }
+          }
           self.quickEditMode = false;
           handled = true;
         }
@@ -6357,6 +6364,7 @@ Datagrid.prototype = {
         if (!self.editor) {
           self.makeCellEditable(self.activeCell.rowIndex, cell, e);
         }
+        e.preventDefault();
       }
 
       // if column have click function to fire [ie. action button]
@@ -7441,7 +7449,7 @@ Datagrid.prototype = {
 
   setNextActiveCell(e) {
     const self = this;
-    if (e.type === 'keydown') {
+    if (e.type === 'keydown' && !self.settings.actionableMode) {
       if (this.settings.actionableMode) {
         setTimeout(() => {
           const evt = $.Event('keydown.datagrid');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Using api setting actionableMode with editable fields were not visually appearing identical

**Related github/jira issue (required)**:

 Closes #389 (formerly) https://jira.infor.com/browse/SOHO-8075

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-editable-actionable-mode
- Open above link
- Use tab key to navigate/edit grid cells
- or use mouse click
- it should look same in both cases