### PR TITLE
371 Fixed issue regarding incorrect focusing of cells when clicking a…

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4390,7 +4390,7 @@ Datagrid.prototype = {
    * @param  {boolean} includeGroups If true groups are taken into account.
    * @returns {object} The dom node
    */
-  cellNode(row, cell, includeGroups) {
+  cellNode(row, cell, includeGroups, targetLevel) {
     let cells = null;
     let rowNode = null;
 
@@ -4411,7 +4411,7 @@ Datagrid.prototype = {
       return $();
     }
 
-    cells = rowNode.find('td');
+    cells = $(rowNode[targetLevel]).find('td');
     return cells.eq(cell >= cells.length ? cells.length - 1 : cell);
   },
 
@@ -4578,7 +4578,9 @@ Datagrid.prototype = {
       * @property {object} args.originalEvent The original event object.
       */
       self.triggerRowEvent('click', e, true);
-      self.setActiveCell(target.closest('td'));
+
+      const targetLevel = target.parents('.datagrid-expandable-row').length;
+      self.setActiveCell(target.closest('td'), null, targetLevel);
 
       // Dont Expand rows or make cell editable when clicking expand button
       if (target.is('.datagrid-expand-btn')) {
@@ -7291,7 +7293,7 @@ Datagrid.prototype = {
   },
 
   // Update a specific Cell
-  setActiveCell(row, cell) {
+  setActiveCell(row, cell, targetLevel) {
     const self = this;
     const prevCell = self.activeCell;
     let rowElem = row;
@@ -7348,7 +7350,7 @@ Datagrid.prototype = {
     }
 
     // Find the cell if it exists
-    self.activeCell.node = self.cellNode((isGroupRow ? rowElem : (rowIndex > -1 ? rowIndex : rowNum)), (cell)).attr('tabindex', '0');
+    self.activeCell.node = self.cellNode((isGroupRow ? rowElem : (rowIndex > -1 ? rowIndex : rowNum)), (cell), null, targetLevel).attr('tabindex', '0');
 
     if (self.activeCell.node && prevCell.node.length === 1) {
       self.activeCell.row = rowNum;

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4394,6 +4394,7 @@ Datagrid.prototype = {
   cellNode(row, cell, includeGroups, targetLevel) {
     let cells = null;
     let rowNode = null;
+    targetLevel = targetLevel || 0;
 
     if (row instanceof jQuery) {
       rowNode = row;

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4388,6 +4388,7 @@ Datagrid.prototype = {
    * @param  {number} row The row index.
    * @param  {number} cell The cell index.
    * @param  {boolean} includeGroups If true groups are taken into account.
+   * @param  {number} targetLevel The level of the nested grid (0 is not nested).
    * @returns {object} The dom node
    */
   cellNode(row, cell, includeGroups, targetLevel) {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4413,7 +4413,7 @@ Datagrid.prototype = {
       return $();
     }
 
-    cells = $(rowNode[targetLevel]).find('td');
+    cells = rowNode.length <= targetLevel ? rowNode.find('td') : $(rowNode[targetLevel]).find('td');
     return cells.eq(cell >= cells.length ? cells.length - 1 : cell);
   },
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7351,7 +7351,7 @@ Datagrid.prototype = {
     }
 
     // Find the cell if it exists
-    self.activeCell.node = self.cellNode((isGroupRow ? rowElem : (rowIndex > -1 ? rowIndex : rowNum)), (cell), null, targetLevel).attr('tabindex', '0');
+    self.activeCell.node = self.cellNode((isGroupRow ? rowElem : (rowIndex > -1 ? rowIndex : rowNum)), (cell), false, targetLevel).attr('tabindex', '0');
 
     if (self.activeCell.node && prevCell.node.length === 1) {
       self.activeCell.row = rowNum;

--- a/test/components/datagrid/datagrid-validation.func-spec.js
+++ b/test/components/datagrid/datagrid-validation.func-spec.js
@@ -250,7 +250,7 @@ describe('Datagrid Validation API', () => {
       expect(document.body.querySelectorAll('tbody tr')[2].querySelector('td[aria-colindex="4"]').querySelectorAll('.icon-error').length).toEqual(1);
 
       const rowNode = datagridObj.dataRowNode(2);
-      const node = datagridObj.cellNode(rowNode, 3);
+      const node = datagridObj.cellNode(rowNode, 3, 0);
 
       datagridObj.clearNodeErrors(node, 'error');
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Fixed issue regarding incorrect focusing of cell when clicking 'a' tags on nested grids
- Added a new 'targetLevel' parameter for setActiveCell and cellNodes functions
- Issue was caused because more than 1 row node was being found when searching for aria-rowindex with a specific index
- http://localhost:4000/components/datagrid/example-nested-grids.html

**Related github/jira issue (required)**:
Closes #371 

**Steps necessary to review your pull request (required)**:
- Expand 4th row, click on any of the links inside nested grid
- Before, the cells on the outer grid is being focused instead of the clicked cells
- Now, the cells containing the clicked links should now be selected
