### PR TITLE
474 - Fix closing Modals containing Dropdowns with the Escape key in IE11

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1272,6 +1272,9 @@ Dropdown.prototype = {
     const target = $(e.target);
     const key = e.key;
 
+    // "Esc" is used by IE11
+    const isEscapeKey = key === 'Esc' || key === 'Escape';
+
     // Control Keydowns are ignored
     const controlKeys = ['Alt', 'Shift', 'Control', 'Meta'];
     if (controlKeys.indexOf(key) > -1) {
@@ -1314,15 +1317,14 @@ Dropdown.prototype = {
 
     // In nosearch mode, bypass the typeahead autocomplete and pass keydown events
     // along to the list elements
-    if (this.settings.noSearch && key !== 'Escape') {
+    if (this.settings.noSearch && isEscapeKey) {
       if (this.isOpen()) {
         return this.handleKeyDown(target, e);
       }
     }
 
     // Allow some keys to pass through with no changes in functionality
-    const allowedKeys = ['Tab', 'Escape'];
-    if (allowedKeys.indexOf(key) > -1) {
+    if (isEscapeKey || key === 'Tab') {
       return true;
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
A bug was discovered in IE11 where a Contextual Action Panel containing a Dropdown component was still causing the dropdown component to leave behind an open, empty Searchfield when the `Escape` key was used to close the panel.  This PR fixes that problem.

**Related github/jira issue (required)**:
#474

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demo app
- Open IE11 to http://localhost:4000/components/contextualactionpanel/example-index.html
- Click the "Contextual Action Panel" button to open the CAP
- With the first Dropdown component focused, press the `Escape` key to close the CAP.

The CAP should be closed with no Dropdown component artifacts on-screen