### PR TITLE
Fixes #529 Added eventing fix and fixed an error

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -8,6 +8,7 @@
  *
  * Flags:
  * --verbose       - Log all details
+ * --livereload    - Enable livereload
  *
  * NOTE: More than likely there is a command in the package.json
  * to run this script with NPM.

--- a/app/src/js/middleware/option-handler.js
+++ b/app/src/js/middleware/option-handler.js
@@ -67,8 +67,8 @@ module.exports = function (app, defaults) {
       res.opts.enableLiveReloadVM = true;
       res.opts.enableLiveReload = false;
     }
-    console.log(req.hostname);
-
+    logger('info', req.hostname);
+    logger('info', req);
     next();
   };
 };

--- a/app/src/js/middleware/option-handler.js
+++ b/app/src/js/middleware/option-handler.js
@@ -62,13 +62,24 @@ module.exports = function (app, defaults) {
       res.opts.nonce = Math.random().toString(12).replace(/[^a-z0-9]+/g, '').substr(0, 8);
     }
 
+    let useLiveReload = false;
+    process.argv.forEach((val) => {
+      if (val === '--livereload') {
+        useLiveReload = true;
+      }
+    });
+
     // Disable live reload for IE
-    if (req.hostname === '10.0.2.2') {
+    if (req.hostname === '10.0.2.2' && useLiveReload) {
       res.opts.enableLiveReloadVM = true;
       res.opts.enableLiveReload = false;
     }
-    logger('info', req.hostname);
-    logger('info', req);
+
+    if (!useLiveReload) {
+      res.opts.enableLiveReloadVM = false;
+      res.opts.enableLiveReload = false;
+    }
+
     next();
   };
 };

--- a/app/src/js/middleware/option-handler.js
+++ b/app/src/js/middleware/option-handler.js
@@ -63,11 +63,11 @@ module.exports = function (app, defaults) {
     }
 
     // Disable live reload for IE
-
     if (req.hostname === '10.0.2.2') {
       res.opts.enableLiveReloadVM = true;
       res.opts.enableLiveReload = false;
     }
+    console.log(req.hostname);
 
     next();
   };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     "start": "npm run build  && node app/server.js",
     "quickstart": "npx grunt demo && node app/server.js",
+    "quickstart:livereload": "npx grunt demo && node app/server.js --livereload",
     "build": "npx grunt",
     "stop": "./scripts/stop.sh",
     "watch": "npm run build -- watch",

--- a/src/components/autocomplete/autocomplete.js
+++ b/src/components/autocomplete/autocomplete.js
@@ -285,6 +285,7 @@ Autocomplete.prototype = {
       attachToBody: true,
       autoFocus: false,
       returnFocus: false,
+      triggerSelect: false,
       placementOpts: {
         parent: this.element,
         callback: afterPlaceCallback
@@ -385,7 +386,6 @@ Autocomplete.prototype = {
       popup.close();
     }
 
-    this.currentDataSet = null;
     this.element.trigger('listclose');
     $('#autocomplete-list').parent('.popupmenu-wrapper').remove();
     $('#autocomplete-list').remove();

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -375,12 +375,7 @@ ListView.prototype = {
           break;
         case 'string':
           if (s.indexOf('http') === 0 || s.indexOf('/') === 0) {
-            $.ajax({
-              url: s,
-              async: false,
-              dataType: 'json',
-              success: done
-            });
+            $.getJSON(s, done);
           }
           return;
         default:

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -26,6 +26,7 @@ const COMPONENT_NAME = 'popupmenu';
  * @param {function} [settings.beforeOpen]  Callback that can be used for populating the contents of the menu.
  * @param {string} [settings.ariaListbox=false]   Switches aria to use listbox construct instead of menu construct (internal).
  * @param {string} [settings.eventObj]  Can pass in the event object so you can do a right click with immediate.
+ * @param {string} [settings.triggerSelect]  If false select event will not be triggered.
  * @param {string} [settings.showArrow]  If true you can explicitly set an arrow on the menu.
  * @param {boolean|function} [settings.returnFocus]  If set to false, focus will not be
   returned to the calling element. Can also be defined as a callback that can determine how
@@ -50,6 +51,7 @@ const POPUPMENU_DEFAULTS = {
   eventObj: undefined,
   returnFocus: true,
   showArrow: null,
+  triggerSelect: true,
   placementOpts: new PlacementObject({
     containerOffsetX: 10,
     containerOffsetY: 10,
@@ -1129,7 +1131,7 @@ PopupMenu.prototype = {
     // Trigger a selected event containing the anchor that was selected
     // If an event object is not passed to `handleItemClick()`, assume it was due to this
     // event being triggered already, making it not necessary to re-trigger it.
-    if (e) {
+    if (e && this.settings.triggerSelect) {
       if (selectionResult.length === 1) {
         selectionResult.push(undefined);
       }

--- a/test/components/autocomplete/autocomplete.e2e-spec.js
+++ b/test/components/autocomplete/autocomplete.e2e-spec.js
@@ -78,8 +78,14 @@ describe('Autocomplete example-index tests', () => {
         .wait(protractor.ExpectedConditions.invisibilityOf(await element(by.id('autocomplete-list'))), config.waitsFor);
 
       expect(await element(by.id('autocomplete-default')).getAttribute('value')).toEqual('New Jersey');
+
+      await utils.checkForErrors();
     });
   }
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
 
   xit('Should clear a dirty autocomplete field with `alt + backspace/del`', async () => {
     await clickOnAutocomplete();

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -299,6 +299,7 @@ describe('Datepicker Month Year Changer Tests', () => {
 
     const testDate = new Date();
     testDate.setMonth(testDate.getMonth() + 1);
+    testDate.setTime(testDate.getTime() + testDate.getTimezoneOffset() * 60 * 1000);
 
     expect(await element(by.id('date-field-normal')).getAttribute('value')).toEqual(`${(testDate.getMonth())}/1/${testDate.getFullYear()}`);
   });

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -280,15 +280,18 @@ describe('Datepicker Month Year Changer Tests', () => {
     await dropdownEl.sendKeys(protractor.Key.ARROW_DOWN);
     await dropdownEl.sendKeys(protractor.Key.ARROW_DOWN);
     await dropdownEl.sendKeys(protractor.Key.ENTER);
+    await browser.driver.sleep(config.sleep);
 
     const yearEl = await element(by.css('#year-dropdown + .dropdown-wrapper div[aria-controls="dropdown-list"]'));
     await yearEl.sendKeys(protractor.Key.ARROW_DOWN);
     await yearEl.sendKeys(protractor.Key.ARROW_DOWN);
     await yearEl.sendKeys(protractor.Key.ARROW_DOWN);
     await yearEl.sendKeys(protractor.Key.ENTER);
+    await browser.driver.sleep(config.sleep);
 
     const prevButtonEl = await element(by.css('.prev.btn-icon'));
     await prevButtonEl.sendKeys(protractor.Key.ENTER);
+    await browser.driver.sleep(config.sleep);
 
     const lastButtonEl = await element(by.css('.next.btn-icon'));
     await lastButtonEl.sendKeys(protractor.Key.ENTER);

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -275,6 +275,7 @@ describe('Datepicker Month Year Changer Tests', () => {
   it('Should be able to change month and year from the pickers', async () => {
     const datepickerEl = await element(by.id('date-field-normal'));
     await datepickerEl.sendKeys(protractor.Key.ARROW_DOWN);
+    await browser.driver.sleep(config.sleep);
 
     const dropdownEl = await element(by.css('#month-dropdown + .dropdown-wrapper div[aria-controls="dropdown-list"]'));
     await dropdownEl.sendKeys(protractor.Key.ARROW_DOWN);
@@ -295,14 +296,14 @@ describe('Datepicker Month Year Changer Tests', () => {
 
     const lastButtonEl = await element(by.css('.next.btn-icon'));
     await lastButtonEl.sendKeys(protractor.Key.ENTER);
-
     await browser.driver.sleep(config.sleep);
+
     const buttonEl = await element.all(by.css('.calendar-table td:not(.alternate)')).first();
     await buttonEl.click();
+    await browser.driver.sleep(config.sleep);
 
     const testDate = new Date();
     testDate.setMonth(testDate.getMonth() + 1);
-    testDate.setTime(testDate.getTime() + testDate.getTimezoneOffset() * 60 * 1000);
 
     expect(await element(by.id('date-field-normal')).getAttribute('value')).toEqual(`${(testDate.getMonth())}/1/${testDate.getFullYear()}`);
   });

--- a/test/helpers/e2e-utils.js
+++ b/test/helpers/e2e-utils.js
@@ -12,5 +12,10 @@ module.exports = {
     const pageurl = `${browser.baseUrl + url}?theme=${browser.params.theme}`;
     await browser.waitForAngularEnabled(false);
     await browser.driver.get(pageurl);
+  },
+  checkForErrors: async () => {
+    await browser.manage().logs().get('browser').then((browserLog) => {
+      expect(browserLog.length).toEqual(0);
+    });
   }
 };

--- a/test/helpers/e2e-utils.js
+++ b/test/helpers/e2e-utils.js
@@ -16,7 +16,7 @@ module.exports = {
   checkForErrors: async () => {
     await browser.manage().logs().get('browser').then((browserLog) => {
       for (let i = 0; i < browserLog.length; i++) {
-        console.log(browserLog[i].level.name, browserLog[i].index); //eslint-disable-line
+        console.log(browserLog[i].level.name, browserLog[i].message); //eslint-disable-line
       }
       expect(browserLog.length).toEqual(0);
     });

--- a/test/helpers/e2e-utils.js
+++ b/test/helpers/e2e-utils.js
@@ -15,6 +15,9 @@ module.exports = {
   },
   checkForErrors: async () => {
     await browser.manage().logs().get('browser').then((browserLog) => {
+      for (let i = 0; i < browserLog.length; i++) {
+        console.log(browserLog[i].level.name, browserLog[i].index); //eslint-disable-line
+      }
       expect(browserLog.length).toEqual(0);
     });
   }

--- a/test/kitchen-sink.e2e-spec.js
+++ b/test/kitchen-sink.e2e-spec.js
@@ -32,6 +32,10 @@ describe('Kitchen-sink tests', () => {
       });
     }
 
+    it('Should not have errors', async () => {
+      await utils.checkForErrors();
+    });
+
     it('Should change themes', async () => {
       const buttonChangerEl = await element(by.css('.page-changer'));
       await browser.driver


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes an error when selecting elements from a autocomplete list. In addition to the error i found the select event goes off twice (one time with no data), so added an option to popupmenu to skip this.

Also added a new util to check the console for errors. This can be used in all the e2e tests to check for any errors. Added one test to catch stuff on the kitchen sink page.

**Related github/jira issue (required)**:

Closes #529 

**Steps necessary to review your pull request (required)**:

http://localhost:4000/components/autocomplete/example-index.html#
- type a
- pick one
- check the console for event data (and no more error)

Check e2e Tests