### PR TITLE
519 - Fix for prematurely closing application menus

### DIFF
--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -1390,7 +1390,8 @@ Accordion.prototype = {
       const type = getElementType(element);
 
       // Trigger a document click since we stop propgation, to close any open menus/popups.
-      $('body').trigger('click');
+      $('body').children().not('.application-menu').closeChildren();
+
       return self[`handle${type}Click`](e, element);
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
A bug was discovered in the application menu where clicking any item inside the menu's boundaries would cause the menu to close.

**Related github/jira issue (required)**:
Originally fixed in #324
Fixes #519 

**Steps necessary to review your pull request (required)**:
Pull this branch and run the demoapp, then:

*Testing the original issue*
- open http://localhost:4000/components/accordion/test-with-contextmenu.html
- expand the first header
- right click the header to open a popupmenu
- close the accordion header

The Popupmenu menu should close

*Testing the new application menu bug*
- open http://localhost:4000/components/applicationmenu/example-index.html
- Resize the browser viewport to fit beneath the Mobile breakpoint (767px or less)
- Open the Application Menu using the hamburger
- Click/Tap on any of the accordion headers, or expand/collapse buttons

The items should remain selected without closing the app menu.

paging @vonnyw