### PR TITLE
344 - Squash Lookup Selector Warning Message

### DIFF
--- a/test/components/lookup/lookup.e2e-spec.js
+++ b/test/components/lookup/lookup.e2e-spec.js
@@ -248,7 +248,7 @@ describe('Lookup index tests', () => {
   });
 
   it('Should have an enabled modal cancel button', async () => {
-    const buttonEl = await element(by.className('trigger'));
+    const buttonEl = await element.all(by.className('trigger')).first();
     await buttonEl.click();
 
     await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.className('btn-modal'))), config.waitsFor);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Protractor was logging this warning:
```sh
[10:16:36] W/element - more than one element found for locator By(css selector, .trigger) - the first result will be used
```
This fix squashes the warning messages by specifying that we select the very first element w/the class of trigger.

**Related github/jira issue (required)**:
Relates to #344, #486 
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->

**Steps necessary to review your pull request (required)**:
Reran focused on the spec in question

> Should have an enabled modal cancel button

 `npm run e2e:ci`