### PR TITLE
Fixed unnecessary hover in datepicker

### DIFF
--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -1378,6 +1378,7 @@ DatePicker.prototype = {
     const self = this;
 
     elem[0].style.backgroundColor = '';
+    elem.off('mouseenter.legend mouseleave.legend');
 
     if (hex) {
       // set color on elem at .3 of provided color as per design
@@ -1388,11 +1389,11 @@ DatePicker.prototype = {
       const hoverColor = self.hexToRgba(hex, 0.7);
 
       // handle hover states
-      elem.on('mouseenter', function () {
+      elem.on('mouseenter.legend', function () {
         const thisElem = $(this);
         thisElem[0].style.backgroundColor = hoverColor;
         thisElem.find('span')[0].style.backgroundColor = 'transparent';
-      }).on('mouseleave', function () {
+      }).on('mouseleave.legend', function () {
         const thisElem = $(this);
         thisElem[0].style.backgroundColor = normalColor;
         thisElem.find('span')[0].style.backgroundColor = '';


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
The issue occur in the hover state in datepicker, were it added a new event each time and it didn't clear it. So the behavior still exist even in the other months.

**Fixed**
Added an ```.off``` method in the ```setLegendColor```.
```
elem.off('mouseenter.legend mouseleave.legend');
```

Then, in the handle hover states, we should add the namespace
```
elem.on('mouseenter.legend', function () {
        const thisElem = $(this);
        thisElem[0].style.backgroundColor = hoverColor;
        thisElem.find('span')[0].style.backgroundColor = 'transparent';
      }).on('mouseleave.legend', function () {
        const thisElem = $(this);
        thisElem[0].style.backgroundColor = normalColor;
        thisElem.find('span')[0].style.backgroundColor = '';
      });
``` 

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise/issues/514

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

- go to http://localhost:4000/components/datepicker/example-legend.html
-  Open the datepicker
- As you notice, the dates January 12, 18, 19, 24 & 25 are already marked with colored legends.
- Move to the next month which is February. No dates are marked in the weekdays. Now, hover your mouse in the dates that are in the same place previously as the marked dates in January.
- Those date should not be marked by just hovering.

**File Changes**
- **M** src/components/datepicker/datepicker.js
<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
