### PR TITLE
371 datagrid nested link click

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4566,6 +4566,11 @@ Datagrid.prototype = {
         return;
       }
 
+      if (target.parents('td').length > 1) {
+        e.preventDefault(); // stop nested clicks from propagating
+        e.stopPropagation();
+      }
+
       /**
       * Fires after a row is clicked.
       * @event click
@@ -7348,7 +7353,7 @@ Datagrid.prototype = {
     }
 
     // Find the cell if it exists
-    self.activeCell.node = self.cellNode((isGroupRow ? rowElem : (rowIndex > -1 ? rowIndex : rowNum)), (cell)).attr('tabindex', '0');
+    self.activeCell.node = self.cellNode((isGroupRow || rowElem ? rowElem : (rowIndex > -1 ? rowIndex : rowNum)), cell).attr('tabindex', '0');
 
     if (self.activeCell.node && prevCell.node.length === 1) {
       self.activeCell.row = rowNum;

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -468,7 +468,7 @@ Datagrid.prototype = {
       * @property {object} args.oldValue - Always an empty object added for consistent api.
       */
       self.element.triggerHandler('addrow', args);
-    }, 10);
+    }, 100);
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Stopped nested clicks from propagating
- http://localhost:4000/components/datagrid/example-nested-grids.html

**Related github/jira issue (required)**:
Closes #371 

**Steps necessary to review your pull request (required)**:
- Expand 4th row, click on any of the links inside nested grid
- Before, the cells on the outer grid is being focused instead of the clicked cells
- Now, the cells containing the clicked links should now be selected