### PR TITLE
422 - Fixes styling disabled search field

### DIFF
--- a/app/views/components/listview/test-search-disabled.html
+++ b/app/views/components/listview/test-search-disabled.html
@@ -1,0 +1,43 @@
+<div class="row">
+        <div class="four columns">
+      
+          <div class="card">
+            <div class="card-header">
+              <h2 class="card-title">Tasks</h2>
+              <button class="btn-actions" type="button">
+                <span class="audible">Actions</span>
+                <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                  <use xlink:href="#icon-more"></use>
+                </svg>
+              </button>
+              <ul class="popupmenu">
+                <li><a href="#">Add new action item</a></li>
+                <li><a href="#">Regular action</a></li>
+                <li><a href="#">Individual Action</a></li>
+              </ul>
+            </div>
+      
+            <div class="card-content">
+              <div class="listview-search">
+                <label class="audible" for="gridfilter">Search</label>
+                <input class="searchfield" placeholder="Search My Alerts" name="searchfield" id="gridfilter" data-options="{clearable: true}" disabled="true">
+              </div>
+      
+              <div class="listview" id="search-listview" data-options="{template: 'search-tmpl', source: '{{basepath}}api/tasks', searchable: true}"></div>
+      
+              {{={{{ }}}=}}
+              <script id="search-tmpl" type="text/html">
+                  <ul>
+                    {{#dataset}}
+                       <li>
+                        <p>{{desc}}</p>
+                      </li>
+                    {{/dataset}}
+                  </ul>
+              </script>
+            </div>
+          </div>
+      
+        </div>
+      </div>
+      

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -67,18 +67,11 @@ $cubic-bezier-ease: cubic-bezier(.17, .04, .03, .94);
     padding-left: 34px;
     padding-right: 34px;
     @include transition(background-color 300ms $cubic-bezier-ease,
-      border-color 300ms $cubic-bezier-ease);
-    
-    &:disabled {
-      cursor: not-allowed;
+    border-color 300ms $cubic-bezier-ease);
+    opacity: $searchfield-disabled-opacity;
 
-      &:hover {
-        border-color: #bdbdbd;
-      }
-
-      ~ svg.icon {
-        fill: #bdbdbd;
-      }
+    ~ svg.icon {
+      fill: $searchfiled-disabled-icon-color;
     }
   }
 
@@ -211,7 +204,7 @@ $cubic-bezier-ease: cubic-bezier(.17, .04, .03, .94);
     }
 
     .searchfield {
-      border-color: $input-hover-border-color;
+      border-color: $searchfiled-disabled-border-color;
     }
 
     &.has-categories {

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -68,6 +68,18 @@ $cubic-bezier-ease: cubic-bezier(.17, .04, .03, .94);
     padding-right: 34px;
     @include transition(background-color 300ms $cubic-bezier-ease,
       border-color 300ms $cubic-bezier-ease);
+    
+    &:disabled {
+      cursor: not-allowed;
+
+      &:hover {
+        border-color: #bdbdbd;
+      }
+
+      ~ svg.icon {
+        fill: #bdbdbd;
+      }
+    }
   }
 
   // This variation is used on white-backgrounds (usually in list-detail, listviews, or builder pattern)

--- a/src/themes/dark-theme.scss
+++ b/src/themes/dark-theme.scss
@@ -643,6 +643,10 @@ $searchfield-header-text-color: $white;
 $searchfield-header-placeholder-text-color: $slate04;
 $searchfield-header-icon-color: $header-button-color;
 
+$searchfield-disabled-opacity: .5;
+$searchfiled-disabled-border-color: #c8cbd4;
+$searchfiled-disabled-icon-color: #4a4a4a;
+
 //Image Border Color
 $image-border-color: $slate04;
 $image-background-color: $slate04;

--- a/src/themes/high-contrast-theme.scss
+++ b/src/themes/high-contrast-theme.scss
@@ -669,6 +669,10 @@ $searchfield-header-text-color: $white;
 $searchfield-header-placeholder-text-color: $graphite03;
 $searchfield-header-icon-color: $header-button-color;
 
+$searchfield-disabled-opacity: .5;
+$searchfiled-disabled-border-color: #c8cbd4;
+$searchfiled-disabled-icon-color: #a5a5a5;
+
 //Image Border Color
 $image-border-color: $graphite03;
 $image-background-color: $graphite03;

--- a/src/themes/light-theme.scss
+++ b/src/themes/light-theme.scss
@@ -8,3 +8,8 @@
 
 // Core Controls
 @import '../core/controls';
+
+// Searchfield
+$searchfield-disabled-opacity: .5;
+$searchfiled-disabled-border-color: #c8cbd4;
+$searchfiled-disabled-icon-color: $graphite03;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
There's no styling rule when input field is disabled.
Added styles in searchfield (disabled).

```
  .searchfield {
    padding-left: 34px;
    padding-right: 34px;
    @include transition(background-color 300ms $cubic-bezier-ease,
      border-color 300ms $cubic-bezier-ease);
    
    &:disabled {
      cursor: not-allowed;

      &:hover {
        border-color: #bdbdbd;
      }

      ~ svg.icon {
        fill: #bdbdbd;
      }
    }
  }
```

Not sure if that's the color that you wanted, since I do not see the attached pictures in the issue (https://github.com/infor-design/enterprise/issues/422)

I created a test template for this: `/components/listview/test-search-disabled.html`

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise/issues/422

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

- Run [http://localhost:4000/components/listview/test-search-disabled.html](http://localhost:4000/components/listview/test-search-disabled.html)
- Hover on the search field. You will see the changes in icon being greyed out, disabled cursor, border color also in grey.

**File Changes**

- **M** src/components/searchfield/_searchfield.scss
- **New file** app/views/components/listview/test-search-disabled.html

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
