### PR TITLE
400 - Tooltips directly on icons via hover/longpress

### DIFF
--- a/app/views/components/icons/example-tooltips.html
+++ b/app/views/components/icons/example-tooltips.html
@@ -1,0 +1,29 @@
+<div class="row">
+  <div class="six columns">
+    <h2>Icon Example: Tooltips</h2>
+    <p>Related Issue: <a class="hyperlink" href="https://github.com/infor-design/enterprise/issues/400" target="_blank">Github #400</a></p>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="two columns">
+    <svg class="icon" focusable="true" role="presentation" title="Send to Trashcan">
+      <use xlink:href="#icon-delete"></use>
+    </svg>
+  </div>
+  <div class="two columns">
+    <svg class="icon" focusable="true" role="presentation" title="Send to Inbox">
+      <use xlink:href="#icon-mail"></use>
+    </svg>
+  </div>
+  <div class="two columns">
+    <svg class="icon" focusable="true" role="presentation" title="View Settings">
+      <use xlink:href="#icon-settings"></use>
+    </svg>
+  </div>
+  <div class="two columns">
+    <svg class="icon" focusable="true" role="presentation" title="Save to Disk">
+      <use xlink:href="#icon-save"></use>
+    </svg>
+  </div>
+</div>

--- a/app/views/components/icons/example-tooltips.html
+++ b/app/views/components/icons/example-tooltips.html
@@ -7,22 +7,22 @@
 
 <div class="row top-padding">
   <div class="two columns">
-    <svg class="icon" focusable="true" role="presentation" title="Send to Trashcan">
+    <svg id="standalone-delete-icon" class="icon" focusable="true" role="presentation" title="Send to Trashcan">
       <use xlink:href="#icon-delete"></use>
     </svg>
   </div>
   <div class="two columns">
-    <svg class="icon" focusable="true" role="presentation" title="Send to Inbox">
+    <svg id="standalone-mail-icon" class="icon" focusable="true" role="presentation" title="Send to Inbox">
       <use xlink:href="#icon-mail"></use>
     </svg>
   </div>
   <div class="two columns">
-    <svg class="icon" focusable="true" role="presentation" title="View Settings">
+    <svg id="standalone-settings-icon" class="icon" focusable="true" role="presentation" title="View Settings">
       <use xlink:href="#icon-settings"></use>
     </svg>
   </div>
   <div class="two columns">
-    <svg class="icon" focusable="true" role="presentation" title="Save to Disk">
+    <svg id="standalone-save-icon" class="icon" focusable="true" role="presentation" title="Save to Disk">
       <use xlink:href="#icon-save"></use>
     </svg>
   </div>

--- a/src/components/initialize/initialize.js
+++ b/src/components/initialize/initialize.js
@@ -103,7 +103,7 @@ const PLUGIN_MAPPINGS = [
   ['editor'],
 
   // Tooltips
-  ['tooltip', 'button[title], span[title], .hyperlink[title]'],
+  ['tooltip', 'button[title], span[title], .hyperlink[title], .icon[title]'],
 
   // Tree
   ['tree'],

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -1,5 +1,6 @@
 import * as debug from '../../utils/debug';
 import { utils } from '../../utils/utils';
+import { Environment as env } from '../../utils/environment';
 import { Locale } from '../locale/locale';
 
 // jQuery components
@@ -112,6 +113,10 @@ Tooltip.prototype = {
       this.element.removeAttr('title');
     }
 
+    if (this.settings.trigger === 'hover') {
+      this.element.addClass('longpress-target');
+    }
+
     this.isPopover = (this.settings.content !== null && typeof this.settings.content === 'object') || this.settings.popover === true;
 
     this.settings.closebutton = !!((this.settings.closebutton || this.element.data('closebutton')));
@@ -195,18 +200,21 @@ Tooltip.prototype = {
 
     if (this.settings.trigger === 'hover' && !this.settings.isError) {
       ((this.element.is('.dropdown, .multiselect')) ? this.activeElement : this.element)
-        .on('mouseenter.tooltip', () => {
+        .on(`mouseenter.${COMPONENT_NAME}`, () => {
           timer = setTimeout(() => {
             self.show();
           }, delay);
         })
-        .on('mouseleave.tooltip mousedown.tooltip click.tooltip mouseup.tooltip', () => {
+        .on(`mouseleave.${COMPONENT_NAME} click.${COMPONENT_NAME}`, () => {
           clearTimeout(timer);
           setTimeout(() => {
             self.hide();
           }, delay);
         })
-        .on('updated.tooltip', () => {
+        .on(`longpress.${COMPONENT_NAME}`, () => {
+          self.show();
+        })
+        .on(`updated.${COMPONENT_NAME}`, () => {
           self.updated();
         });
     }
@@ -220,7 +228,7 @@ Tooltip.prototype = {
     }
 
     if (this.settings.trigger === 'click') {
-      this.element.on('click.tooltip', () => {
+      this.element.on(`click.${COMPONENT_NAME}`, () => {
         toggleTooltipDisplay();
       });
     }
@@ -233,10 +241,11 @@ Tooltip.prototype = {
 
     const isFocusable = this.settings.trigger === 'focus';
     if (isFocusable) {
-      this.element.on('focus.tooltip', () => {
-        self.show();
-      })
-        .on('blur.tooltip', () => {
+      this.element
+        .on(`focus.${COMPONENT_NAME}`, () => {
+          self.show();
+        })
+        .on(`blur.${COMPONENT_NAME}`, () => {
           if (!self.settings.keepOpen) {
             self.hide();
           }
@@ -244,7 +253,7 @@ Tooltip.prototype = {
     }
 
     // Close the popup/tooltip on orientation changes (but not when keyboard is open)
-    $(window).on('orientationchange.tooltip', () => {
+    $(window).on(`orientationchange.${COMPONENT_NAME}`, () => {
       // Match every time.
       if (self.tooltip.hasClass('is-hidden')) {
         return;
@@ -556,28 +565,31 @@ Tooltip.prototype = {
      */
     this.element.trigger('show', [this.tooltip]);
 
+    const mouseUpEventName = env.features.touch ? 'touchend' : 'mouseup';
+
     setTimeout(() => {
-      $(document).on('mouseup.tooltip', (e) => {
-        const target = $(e.target);
+      $(document)
+        .on(`${mouseUpEventName}.${COMPONENT_NAME}`, (e) => {
+          const target = $(e.target);
 
-        if (self.settings.isError || self.settings.trigger === 'focus') {
-          return;
-        }
+          if (self.settings.isError || self.settings.trigger === 'focus') {
+            return;
+          }
 
-        if (target.is(self.element) && target.is('svg.icon')) {
-          return;
-        }
+          if (target.is(self.element) && target.is('svg.icon')) {
+            return;
+          }
 
-        if ($('#editor-popup').length && $('#colorpicker-menu').length) {
-          return;
-        }
+          if ($('#editor-popup').length && $('#colorpicker-menu').length) {
+            return;
+          }
 
-        if (target.closest('.popover').length === 0 &&
-            target.closest('.dropdown-list').length === 0) {
-          self.hide(e);
-        }
-      })
-        .on('keydown.tooltip', (e) => {
+          if (target.closest('.popover').length === 0 &&
+              target.closest('.dropdown-list').length === 0) {
+            self.hide(e);
+          }
+        })
+        .on(`keydown.${COMPONENT_NAME}`, (e) => {
           if (e.which === 27 || self.settings.isError) {
             self.hide();
           }
@@ -590,13 +602,13 @@ Tooltip.prototype = {
       }
 
       if (window.orientation === undefined) {
-        $('body').on('resize.tooltip', () => {
+        $('body').on(`resize.${COMPONENT_NAME}`, () => {
           self.hide();
         });
       }
 
       // Hide on Page scroll
-      $('body').on('scroll.tooltip', () => {
+      $('body').on(`scroll.${COMPONENT_NAME}`, () => {
         self.hide();
       });
 
@@ -614,7 +626,7 @@ Tooltip.prototype = {
 
       // Click to close
       if (self.settings.isError) {
-        self.tooltip.on('click.tooltip', () => {
+        self.tooltip.on(`click.${COMPONENT_NAME}`, () => {
           self.hide();
         });
       }
@@ -781,12 +793,20 @@ Tooltip.prototype = {
    * @returns {void}
    */
   detachOpenEvents() {
-    this.tooltip.off('click.tooltip');
-    $(document).off('mouseup.tooltip');
-    $('body').off('resize.tooltip scroll.tooltip');
-    this.element.closest('.modal-body-wrapper').off('scroll.tooltip');
-    this.element.closest('.scrollable').off('scroll.tooltip');
-    this.element.closest('.datagrid-body').off('scroll.tooltip');
+    this.tooltip.off(`click.${COMPONENT_NAME}`);
+
+    $(document).off([
+      `keydown.${COMPONENT_NAME}`,
+      `mouseup.${COMPONENT_NAME}`,
+      `touchend.${COMPONENT_NAME}`].join(' '));
+
+    $('body').off([
+      `resize.${COMPONENT_NAME}`,
+      `scroll.${COMPONENT_NAME}`].join(' '));
+
+    this.element.closest('.modal-body-wrapper').off(`scroll.${COMPONENT_NAME}`);
+    this.element.closest('.scrollable').off(`scroll.${COMPONENT_NAME}`);
+    this.element.closest('.datagrid-body').off(`scroll.${COMPONENT_NAME}`);
   },
 
   /**
@@ -808,10 +828,18 @@ Tooltip.prototype = {
       this.tooltip.data('place').destroy();
     }
 
-    this.element.off('mouseenter.tooltip mouseleave.tooltip mousedown.tooltip click.tooltip mouseup.tooltip updated.tooltip focus.tooltip blur.tooltip');
+    this.element.off([
+      `mouseenter.${COMPONENT_NAME}`,
+      `mouseleave.${COMPONENT_NAME}`,
+      `longpress.${COMPONENT_NAME}`,
+      `click.${COMPONENT_NAME}`,
+      `updated.${COMPONENT_NAME}`,
+      `focus.${COMPONENT_NAME}`,
+      `blur.${COMPONENT_NAME}`].join(' '));
+
     this.detachOpenEvents();
 
-    $(window).off('orientationchange.tooltip');
+    $(window).off(`orientationchange.${COMPONENT_NAME}`);
 
     return this;
   },

--- a/test/components/tooltip/tooltip.e2e-spec.js
+++ b/test/components/tooltip/tooltip.e2e-spec.js
@@ -1,0 +1,23 @@
+const { browserStackErrorReporter } = requireHelper('browserstack-error-reporter');
+const utils = requireHelper('e2e-utils');
+const config = require('../../helpers/e2e-config.js');
+
+requireHelper('rejection');
+
+jasmine.getEnv().addReporter(browserStackErrorReporter);
+
+describe('Tooltips on icons', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/icons/example-tooltips');
+  });
+
+  it('should display when hovering the icon', async () => {
+    await browser.actions()
+      .mouseMove(await element(by.id('standalone-delete-icon')))
+      .perform();
+
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('.tooltip')).getText()).toEqual('Send to Trashcan');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
A feature request was made for allowing tooltips to be present on standalone icons.  This PR enables tooltips on icons during a mouse hover, or a long press on a touch screen, even if the icon isn't focusable by normal means.

**Related github/jira issue (required)**:
Closes #400 

**Steps necessary to review your pull request (required)**:
Pull this branch and run the demo app... then:

_Retest hover on desktop:_
- open http://localhost:4000/components/icons/example-tooltips.html in a desktop browser
- mouseover one of the in-page icons
- a tooltip should show containing some text describing the icons

_Test the longpress for icons in a mobile browser (iOS Safari/Android Chrome):_
- open http://localhost:4000/components/icons/example-tooltips.html in a mobile browser
- long press one of the in-page icons
- a tooltip should show containing some text describing the icons
- tap anywhere else in the page
- the tooltip should disappear

There is a new e2e test for the hover display.  We can't add mobile-specific e2e tests yet, so I'm punting on a longpress test for now (raised in #553)