### PR TITLE
496 - Add click, keyboard paging tests for Blockgrid

### DIFF
--- a/test/components/blockgrid/blockgrid.e2e-spec.js
+++ b/test/components/blockgrid/blockgrid.e2e-spec.js
@@ -192,3 +192,48 @@ describe('Blockgrid example-text tests', () => {
     expect(await element(by.css('p')).isPresent()).toBeTruthy();
   });
 });
+
+describe('Blockgrid example-paging tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/blockgrid/example-paging');
+  });
+
+  it('Should select block, navigate to 2nd page, navigate back, block should still be selected', async () => {
+    const blockEl1 = await element.all(by.css('.block.is-selectable')).get(1);
+    const firstPageNumEl = await element.all(by.css('.pager-toolbar li')).get(1);
+    const secondPageNumEl = await element.all(by.css('.pager-toolbar li')).get(2);
+    await blockEl1.click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('.is-selected'))), config.waitsFor);
+    await secondPageNumEl.click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element.all(by.css('.block.is-selectable')).get(4)), config.waitsFor);
+    await firstPageNumEl.click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element.all(by.css('.block.is-selectable')).get(1)), config.waitsFor);
+
+    expect(await element.all(by.css('.block.is-selectable')).get(1).getAttribute('class')).toContain('is-selected');
+  });
+
+  it('Should navigate to 2nd page, navigate back via keyboard', async () => {
+    const blockEl1 = await element.all(by.css('.block.is-selectable')).get(1);
+    await blockEl1.sendKeys(protractor.Key.TAB);
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('.is-selected'))), config.waitsFor);
+    await browser.driver.actions().sendKeys(protractor.Key.SPACE).perform();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.css('.block.is-selected'))), config.waitsFor);
+    await browser.driver.actions().sendKeys(protractor.Key.TAB).perform();
+    await browser.driver.actions().sendKeys(protractor.Key.ARROW_RIGHT).perform();
+    await browser.driver.actions().sendKeys(protractor.Key.ENTER).perform();
+    await browser.driver.actions().sendKeys(protractor.Key.TAB).perform();
+    await browser.driver.actions().sendKeys(protractor.Key.TAB).perform();
+    await browser.driver.actions().sendKeys(protractor.Key.TAB).perform();
+    await browser.driver.actions().sendKeys(protractor.Key.ENTER).perform();
+    await browser.driver.sleep(config.waitsFor);
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element.all(by.css('.block.is-selectable')).get(1)), config.waitsFor);
+
+    expect(await element.all(by.css('.block.is-selectable')).get(2).getAttribute('class')).toContain('is-selected');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Tests click, and keyboard paging of Blockgrid

**Related github/jira issue (required)**:
Relates to #496 

**Steps necessary to review your pull request (required)**:
Isolated test, and run `npm run e2e:local:debug`, and navigate the new instance of Chrome, or just run `npm run e2e:ci`