### PR TITLE
547 - Spinboxes not aligned correctly

### DIFF
--- a/src/components/spinbox/_spinbox.scss
+++ b/src/components/spinbox/_spinbox.scss
@@ -164,7 +164,7 @@ input::-webkit-inner-spin-button {
   }
 
   .spinbox {
-    height: inherit;
+    height: 26px;
     margin-bottom: 0;
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The spinbox height is not aligned to the height of it's side buttons when wrapped inside a .field-short class. This causes the spinbox to seem misaligned with the side buttons.

**Related github/jira issue (required)**:
Closes #547.

**Steps necessary to review your pull request (required)**:
Pull this branch and run the app. Open http://localhost:4000/components/validation/example-short-fields.html. Visually ensure the spinbox is the same height as it's surrounding plus and minus buttons.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
