### PR TITLE
Remove stepprocess from documentation

### DIFF
--- a/docs/sitemap.yml
+++ b/docs/sitemap.yml
@@ -159,8 +159,6 @@ sections:
       slug: contextualactionpanel
     - name: Signin
       slug: signin
-    - name: Step Process
-      slug: stepprocess
 - name: Charts
   pages:
   - name: Getting Start with Charts


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Stepprocess isn't in the repo under `components/`, it is the only one under plugins, which does not get documented an uploaded to design.infor.com therefore causing a 404 because it IS listed in the sitemap.

**Related github/jira issue (required)**:
infor-design/website/issues/622

**Steps necessary to review your pull request (required)**:
1. Go to https://design.infor.com/code/ids-enterprise/latest and make sure you do not see "step process"
