### PR TITLE
245 - Longpress to open Context Menus

### DIFF
--- a/app/views/components/contextmenu/example-index.html
+++ b/app/views/components/contextmenu/example-index.html
@@ -5,7 +5,7 @@
   </div>
 </div>
 
-<div class="row hidden">
+<div class="row">
   <div class="twelve columns">
 
     <ul id="action-popupmenu" data-init="false" class="popupmenu">

--- a/app/views/components/contextmenu/test-input-fields.html
+++ b/app/views/components/contextmenu/test-input-fields.html
@@ -1,14 +1,17 @@
 <div class="row">
-  <div class="six columns">
-    <h2>Context Menu Example</h2>
-    <p>Right-click (Long-press on Mobile) anywhere on the page to open a context menu</p>
-  </div>
-</div>
-
-<div class="row hidden">
   <div class="twelve columns">
 
-    <ul id="action-popupmenu" data-init="false" class="popupmenu">
+    <div class="field">
+      <label for="input-menu">Label</label>
+      <input type="text" data-options="{trigger:'rightClick'}" data-popupmenu="action-popupmenu" value="Right Click Me" id="input-menu">
+    </div>
+
+    <div class="field">
+      <label for="input-menu2">Label2</label>
+      <input type="text"  data-options="{trigger:'rightClick'}" data-popupmenu="action-popupmenu" value="Right Click Me" id="input-menu2">
+    </div>
+
+    <ul id="action-popupmenu" class="popupmenu">
       <li><a href="#">Cut</a></li>
       <li><a href="#">Copy</a></li>
       <li><a href="#">Paste</a></li>
@@ -49,11 +52,5 @@
     </ul>
 
   </div>
-</div>
 
-<script id="test-script">
-  $('body').popupmenu({
-    menu: 'action-popupmenu',
-    trigger: 'rightClick'
-  });
-</script>
+</div>

--- a/src/behaviors/longpress/longpress.js
+++ b/src/behaviors/longpress/longpress.js
@@ -51,7 +51,7 @@ LongPress.prototype = {
         id: `${BEHAVIOR_NAME}-timer`,
         duration: math.convertDelayToFPS(this.settings.delay),
         timeoutCallback() {
-          self.fire(target);
+          self.fire(target, e);
         }
       });
       renderLoop.register(this.timer);
@@ -69,10 +69,11 @@ LongPress.prototype = {
 
   /**
    * @param {HTMLElement} target the target element on which to trigger the event
+   * @param {jQuery.Event} [e=undefined] the original event, if applicable
    * @returns {void}
    */
-  fire(target) {
-    $(target).trigger(`${BEHAVIOR_NAME}`);
+  fire(target, e) {
+    $(target).trigger(`${BEHAVIOR_NAME}`, [e]);
   },
 
   /**

--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -3,9 +3,11 @@
 
 // Contains the main popupmenu UL for positioning.
 .popupmenu-wrapper {
+  @include css3(user-select, none);
   display: inline-block;
   left: -9999px;
   position: fixed;
+  -webkit-touch-callout: none;
   z-index: 4000;
 
   .arrow,

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -1,4 +1,5 @@
 import * as debug from '../../utils/debug';
+import { Environment as env } from '../../utils/environment';
 import { utils } from '../../utils/utils';
 import { stringUtils } from '../../utils/string';
 import { DOM } from '../../utils/dom';
@@ -67,7 +68,6 @@ const POPUPMENU_DEFAULTS = {
 function PopupMenu(element, settings) {
   this.settings = utils.mergeSettings(element, settings, POPUPMENU_DEFAULTS);
   this.element = $(element);
-  this.isOldIe = $('html').is('.ie11, .ie10, .ie9');
   debug.logTimeStart(COMPONENT_NAME);
   this.init();
   debug.logTimeEnd(COMPONENT_NAME);
@@ -102,7 +102,7 @@ PopupMenu.prototype = {
    * @returns {boolean} whether or not the reading/writing direction is RTL
    */
   isRTL() {
-    return $('html').attr('dir') === 'rtl';
+    return env.rtl;
   },
 
   /**
@@ -756,7 +756,7 @@ PopupMenu.prototype = {
       e.preventDefault();
 
       if (self.keydownThenClick) {
-        self.keydownThenClick = undefined;
+        delete self.keydownThenClick;
         return;
       }
 
@@ -764,6 +764,8 @@ PopupMenu.prototype = {
       if (e.button > btn || self.element.is(':disabled')) {
         return;
       }
+
+      self.holdingDownClick = true;
 
       doOpen(e);
     }
@@ -780,11 +782,35 @@ PopupMenu.prototype = {
       // Right-Click activation
       if (!leftClick) {
         this.menu.parent().on('contextmenu.popupmenu', disableBrowserContextMenu);
-        this.element
-          .on('contextmenu.popupmenu', (e) => {
-            disableBrowserContextMenu(e);
-            contextMenuHandler(e);
-          });
+
+        const disallowedOS = ['android', 'ios'];
+        if (disallowedOS.indexOf(env.os.name) === -1) {
+          // Normal desktop operation
+          this.element
+            .on('contextmenu.popupmenu', (e) => {
+              disableBrowserContextMenu(e);
+              contextMenuHandler(e);
+            });
+        } else {
+          // Touch-based operation on a mobile device
+          this.element
+            .on('touchstart.popupmenu', (e) => {
+              // iOS needs this prevented to prevent its own longpress feature in Safari
+              if (env.os.name === 'ios') {
+                e.preventDefault();
+              }
+              $(e.target)
+                .addClass('longpress-target');
+            })
+            .on('touchend.popupmenu', (e) => {
+              $(e.target)
+                .removeClass('longpress-target');
+            })
+            .on('longpress.popupmenu', (e, originalE) => {
+              self.openedWithTouch = true;
+              contextMenuHandler(originalE);
+            });
+        }
       }
     }
 
@@ -817,6 +843,7 @@ PopupMenu.prototype = {
       });
 
     // Media Query Listener to detect a menu closing on mobile devices that change orientation.
+    /*
     if (window.matchMedia) {
       this.matchMedia = window.matchMedia('(orientation: landscape)');
       this.mediaQueryListener = function () {
@@ -824,10 +851,11 @@ PopupMenu.prototype = {
         if (!self.menu.hasClass('is-open')) {
           return;
         }
-        self.close();
+        self.handleCloseEvent();
       };
       this.matchMedia.addListener(this.mediaQueryListener);
     }
+    */
   },
 
   handleKeys() {
@@ -1231,14 +1259,18 @@ PopupMenu.prototype = {
       return {};
     }
 
-    if (e.pageX || e.pageY) {
+    if (e.changedTouches) {
+      const touch = e.changedTouches[0];
+      x = touch.pageX;
+      y = touch.pageY;
+    } else if (e.pageX || e.pageY) {
       x = e.pageX;
       y = e.pageY;
     } else if (e.clientX || e.clientY) {
       x = e.clientX + document.body.scrollLeft +
-                         document.documentElement.scrollLeft;
+        document.documentElement.scrollLeft;
       y = e.clientY + document.body.scrollTop +
-                         document.documentElement.scrollTop;
+        document.documentElement.scrollTop;
     }
 
     return {
@@ -1568,6 +1600,11 @@ PopupMenu.prototype = {
           return;
         }
 
+        if (self.holdingDownClick) {
+          delete self.holdingDownClick;
+          return;
+        }
+
         // Click functionality will toggle the menu - otherwise it closes and opens
         if ($(thisE.target).is(self.element)) {
           return;
@@ -1581,7 +1618,7 @@ PopupMenu.prototype = {
       // in desktop environments, close the list on viewport resize
       if (window.orientation === undefined) {
         $('body').on('resize.popupmenu', () => {
-          self.close();
+          self.handleCloseEvent();
         });
       }
 
@@ -1605,7 +1642,7 @@ PopupMenu.prototype = {
 
       if (self.settings.trigger === 'rightClick') {
         self.element.on('click.popupmenu touchend.popupmenu', () => {
-          self.close();
+          self.handleCloseEvent();
         });
       }
     }, 300);
@@ -1688,6 +1725,19 @@ PopupMenu.prototype = {
         self.element.triggerHandler('afteropen', [self.menu]);
       }, 1);
     }
+  },
+
+  /**
+   * Only allows a menu to close if a key is no longer being pressed
+   * @private
+   * @returns {void}
+   */
+  handleCloseEvent() {
+    if (this.holdingDownClick) {
+      return;
+    }
+
+    this.close();
   },
 
   /**
@@ -1952,10 +2002,6 @@ PopupMenu.prototype = {
 
     this.menu.off('click.popupmenu touchend.popupmenu touchcancel.popupmenu');
 
-    if (this.settings.trigger === 'rightClick') {
-      this.element.off('click.popupmenu touchend.popupmenu');
-    }
-
     $('iframe').each(function () {
       const frame = $(this);
       try {
@@ -1996,7 +2042,13 @@ PopupMenu.prototype = {
       wrapper[0].style.width = '';
     }
 
-    this.menu.find('.submenu').off('mouseenter mouseleave').removeClass('is-submenu-open');
+    this.menu.find('.submenu')
+      .off([
+        'mouseenter.popupmenu',
+        'mouseleave.popupmenu'
+      ].join(' '))
+      .removeClass('is-submenu-open');
+
     if (menu[0]) {
       menu[0].style.left = '';
       menu[0].style.top = '';
@@ -2007,8 +2059,23 @@ PopupMenu.prototype = {
     this.menu.find('.is-focused').removeClass('is-focused');
 
     // Close all events
-    $(document).off(`keydown.popupmenu.${this.id} click.popupmenu.${this.id} mousemove.popupmenu.${this.id}`);
-    this.menu.off('click.popupmenu touchend.popupmenu touchcancel.popupmenu mouseenter.popupmenu mouseleave.popupmenu');
+    $(document).off([
+      `keydown.popupmenu.${this.id}`,
+      `click.popupmenu.${this.id}`,
+      `mousemove.popupmenu.${this.id}`,
+      `touchend.popupmenu.${self.id}`
+    ].join(' '));
+
+    this.menu.off([
+      'click.popupmenu',
+      'touchend.popupmenu',
+      'touchcancel.popupmenu',
+      'mouseenter.popupmenu',
+      'mouseleave.popupmenu'].join(' '));
+
+    // Get rid of internal flags that check for how the menu was opened
+    delete this.keydownThenClick;
+    delete this.holdingDownClick;
 
     /**
      * Fires when close.
@@ -2024,6 +2091,15 @@ PopupMenu.prototype = {
     if (this.settings.trigger === 'immediate') {
       this.destroy();
     }
+
+    // On text input targets, don't refocus the input if the opening event was called by a touch
+    if (this.element[0].tagName === 'INPUT' && this.openedWithTouch) {
+      this.element.removeClass('longpress-target');
+      delete this.openedWithTouch;
+      return;
+    }
+
+    delete this.openedWithTouch;
 
     if (noFocus) {
       return;
@@ -2103,10 +2179,6 @@ PopupMenu.prototype = {
       delete self.wrapperPlace;
     }
     wrapper.off().remove();
-
-    if (this.matchMedia) {
-      this.matchMedia.removeListener(this.mediaQueryListener);
-    }
 
     if (this.menu[0]) {
       $.removeData(this.menu[0], 'trigger');

--- a/test/components/popupmenu/popupmenu.func-spec.js
+++ b/test/components/popupmenu/popupmenu.func-spec.js
@@ -2,7 +2,7 @@ import { PopupMenu } from '../../../src/components/popupmenu/popupmenu';
 
 const popupmenuHTML = require('../../../app/views/components/popupmenu/example-index.html');
 const popupmenuSelectableHTML = require('../../../app/views/components/popupmenu/example-selectable.html');
-const popupmenuContextMenuHTML = require('../../../app/views/components/contextmenu/example-index.html');
+const popupmenuContextMenuHTML = require('../../../app/views/components/contextmenu/test-input-fields.html');
 const popupmenuIconHTML = require('../../../app/views/components/popupmenu/example-icons.html');
 const svg = require('../../../src/components/icons/svg.html');
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds functionality to the popupmenu's context menu configuration that allows for a "longpress" to replace the `contextmenu` event behavior on a touch device.  Long-pressing the screen on an iOS or Android device replaces what would be right-clicking with a mouse in a desktop environment.

**Related github/jira issue (required)**:
#245 

**Steps necessary to review your pull request (required)**:
Pull this branch and run the demoapp.  Then:

_In a desktop browser:_
- open http://localhost:4000/components/contextmenu/example-index
- right-click anywhere in the page
- the context menu should open

_In a mobile browser (iOS Safari or Android Chrome):_
- open http://localhost:4000/components/contextmenu/example-index
- long-press the screen anywhere on the page for at least 400ms
- the context menu should open

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->