### PR TITLE
521 - Dropdown list checkmark overlapping text

### DIFF
--- a/app/views/components/applicationmenu/example-top-level-buttons.html
+++ b/app/views/components/applicationmenu/example-top-level-buttons.html
@@ -29,7 +29,7 @@
               <use xlink:href="#icon-dropdown"></use>
             </svg>
           </button>
-          <ul class="popupmenu">
+          <ul class="popupmenu is-selectable">
             <li><a href="#">Learner</a></li>
             <li class="is-checked"><a href="#">Author</a></li>
             <li><a href="#">Administrator</a></li>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Add 'is-selectable' class to '.popupmenu' element to allow proper spacing for checkmark left of text.

**Related github/jira issue (required)**:
Closes #521.

**Steps necessary to review your pull request (required)**:
Pull branch and run app. Open example page located in pro0ject at ./app/views/components/applicationmenu/example-top-level-buttons.html by putting http://localhost:4000/components/applicationmenu/example-top-level-buttons.html into browser. Confirm checkmark no longer overlaps text and maintains correct spacing.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
