### PR TITLE
297 Removed data-init=false attribute from lookup with dirty tracking

### DIFF
--- a/app/views/components/lookup/test-states.html
+++ b/app/views/components/lookup/test-states.html
@@ -25,7 +25,7 @@
 
     <div class="field">
       <label for="dirty" class="label">Dirty Tracking</label>
-      <input id="dirty" data-init="false" class="lookup" name="dirty" type="text" data-trackdirty="true">
+      <input id="dirty" class="lookup" name="dirty" type="text" data-trackdirty="true">
     </div>
 
     <div class="field">


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Fixed issue regarding dirty indicator not showing up on lookup
- Removed data-init='false' attribute from lookup element with dirty tracking
- http://localhost:4000/components/lookup/test-states.html

**Related github/jira issue (required)**:
Closes #297 

**Steps necessary to review your pull request (required)**:
- Open the dirty tracking lookup field
- Select different compressor
- Dirty tracking should now be displayed