### PR TITLE
555 - Permanently enable the Field Options button's visibility on touch-based devices

### DIFF
--- a/app/views/components/field-options/example-index.html
+++ b/app/views/components/field-options/example-index.html
@@ -410,9 +410,6 @@
         fullWidth: true
       }
     }
-  }).on('change', function (e, args) {
-    console.log(args[0]);
-  })
-  .fieldoptions();
+  }).fieldoptions();
 
 </script>

--- a/src/components/field-options/_field-options.scss
+++ b/src/components/field-options/_field-options.scss
@@ -37,7 +37,7 @@
 }
 
 .field-options {
-  max-width: $field-md;
+  max-width: ($field-md - 40px);
   width: calc(100% - 40px);
 
   &.input-xs {
@@ -219,6 +219,11 @@
     }
   }
 
+  .dropdown,
+  .multiselect {
+    max-width: ($field-md - 40px);
+  }
+
   .searchfield-wrapper {
     box-shadow: none;
 
@@ -233,6 +238,14 @@
     .btn-actions {
       left: -8px;
       width: 36px;
+    }
+  }
+
+  .textarea {
+    width: ($field-md - 40px);
+
+    ~ .btn-actions {
+      left: auto;
     }
   }
 }
@@ -492,6 +505,7 @@ html[dir='rtl'] {
 
     &.textarea {
       ~ .btn-actions {
+        left: 0;
         margin-left: inherit;
         margin-right: -6px;
         right: auto;
@@ -538,7 +552,9 @@ html[dir='rtl'] {
       right: -8px;
     }
 
-    .colorpicker-container {
+    //heremans
+    .colorpicker-container,
+    .textarea {
       ~ .btn-actions {
         //border-radius: top-right | bottom-right | bottom-left | top-left
         border-radius: 0 0 2px 2px;

--- a/src/components/field-options/_field-options.scss
+++ b/src/components/field-options/_field-options.scss
@@ -70,7 +70,7 @@
     padding: 0 5px;
   }
 
-  &:hover {
+  &.visible {
     ~ .btn-actions {
       opacity: 1;
     }
@@ -288,12 +288,24 @@
       }
     }
   }
+
+  &.visible {
+    .btn-actions {
+      opacity: 1;
+    }
+  }
 }
 
 // Hover effect ================================================================
 .field.visible {
   .btn-actions {
     opacity: 1;
+  }
+
+  &.is-fieldoptions {
+    .btn-actions {
+      opacity: 1;
+    }
   }
 }
 

--- a/src/components/field-options/_field-options.scss
+++ b/src/components/field-options/_field-options.scss
@@ -291,7 +291,7 @@
 }
 
 // Hover effect ================================================================
-.field.is-hover {
+.field.visible {
   .btn-actions {
     opacity: 1;
   }

--- a/src/components/field-options/_field-options.scss
+++ b/src/components/field-options/_field-options.scss
@@ -248,6 +248,12 @@
       left: auto;
     }
   }
+
+  &.is-disabled {
+    .btn-actions:not(.is-checkbox) {
+      display: none;
+    }
+  }
 }
 
 // Fieldset (Summary Form) =====================================================

--- a/src/components/field-options/field-options.js
+++ b/src/components/field-options/field-options.js
@@ -172,6 +172,10 @@ FieldOptions.prototype = {
       this.field.removeClass('visible');
       this.field
         .on(`mouseover.${COMPONENT_NAME}`, () => {
+          if (this.element.prop('disabled') || this.element.closest('is-disabled').length) {
+            return;
+          }
+
           if (this.field[0].className.indexOf('visible') < 0) {
             this.field[0].classList.add('visible');
           }

--- a/src/components/field-options/field-options.js
+++ b/src/components/field-options/field-options.js
@@ -44,6 +44,11 @@ FieldOptions.prototype = {
     this.field = this.element.closest('.field, .radio-group');
     this.targetElem = this.element;
 
+    const label = this.field.find('label');
+    if (label) {
+      this.label = label;
+    }
+
     // In some cases, adjust the target element
     if (this.element[0].className.match(/(dropdown|multiselect)/)) {
       this.targetElem = this.element.data('dropdown').pseudoElem;
@@ -89,6 +94,7 @@ FieldOptions.prototype = {
    * @returns {object} The api
    */
   handleEvents() {
+    const self = this;
     const datepicker = this.element.data('datepicker');
     const timepicker = this.element.data('timepicker');
     const dropdown = this.element.data('dropdown');
@@ -173,17 +179,17 @@ FieldOptions.prototype = {
       this.field.removeClass('visible');
       this.field
         .on(`mouseover.${COMPONENT_NAME}`, () => {
-          if (this.element.prop('disabled') || this.element.closest('is-disabled').length) {
+          if (self.element.prop('disabled') || self.element.closest('is-disabled').length) {
             return;
           }
 
-          if (this.field[0].className.indexOf('visible') < 0) {
-            this.field[0].classList.add('visible');
+          if (self.field[0].className.indexOf('visible') < 0) {
+            self.field[0].classList.add('visible');
           }
         })
         .on(`mouseout.${COMPONENT_NAME}`, () => {
-          if (this.field[0].className.indexOf('visible') > -1) {
-            this.field[0].classList.remove('visible');
+          if (self.field[0].className.indexOf('visible') > -1) {
+            self.field[0].classList.remove('visible');
           }
         });
     }

--- a/src/components/field-options/field-options.js
+++ b/src/components/field-options/field-options.js
@@ -52,6 +52,8 @@ FieldOptions.prototype = {
       this.targetElem = this.field.find('.fileupload[type="text"]');
     }
 
+    this.field.addClass('is-fieldoptions');
+
     this.fieldParent = this.element.closest('.field').parent();
     this.trigger = this.field.find('.btn-actions');
 
@@ -94,7 +96,6 @@ FieldOptions.prototype = {
     const isCheckbox = this.element.is('.checkbox');
     const isFileupload = this.element.is('.fileupload');
     const isSearchfield = this.element.is('.searchfield');
-    const isSpinbox = this.element.is('.spinbox');
     const isColorpicker = this.element.is('.colorpicker');
     const isRadio = this.element.closest('.radio-group').length > 0;
     const isFieldset = this.element.is('.data') && this.element.closest('.summary-form').length > 0;
@@ -210,7 +211,6 @@ FieldOptions.prototype = {
     }
     // Move trigger(action-button) in to lookup-wrapper
     if (lookup || isColorpicker) {
-      this.field.addClass('is-fieldoptions');
       this.field.on(`click.${COMPONENT_NAME}`, '.lookup-wrapper .trigger, .colorpicker-container .trigger', () => {
         doActive();
       });
@@ -224,7 +224,6 @@ FieldOptions.prototype = {
     }
     // Checkbox add parent css class
     if (isCheckbox) {
-      this.field.addClass('is-fieldoptions');
       this.trigger.addClass('is-checkbox');
     }
     // Bind fileupload events
@@ -236,13 +235,8 @@ FieldOptions.prototype = {
         doActive();
       });
     }
-    // Spinbox add parent css class
-    if (isSpinbox) {
-      this.field.addClass('is-fieldoptions');
-    }
     // Move trigger(action-button) in to searchfield-wrapper
     if (isSearchfield) {
-      this.field.addClass('is-fieldoptions');
       setTimeout(() => {
         this.trigger.add(this.trigger.next('.popupmenu'))
           .appendTo(this.element.closest('.searchfield-wrapper'));

--- a/src/components/field-options/field-options.js
+++ b/src/components/field-options/field-options.js
@@ -163,14 +163,21 @@ FieldOptions.prototype = {
     this.hoverElem = isSpinbox ? this.element.add(this.field.find('.down, .up')) : this.targetElem;
     this.hoverElem = isColorpicker ? this.element.add(this.field.find('.colorpicker-container, .swatch, .trigger')) : this.hoverElem;
 
-    // Set is-hover for field
-    this.hoverElem
-      .on(`mouseenter.${COMPONENT_NAME}`, () => {
-        this.field.addClass('is-hover');
-      })
-      .on(`mouseleave.${COMPONENT_NAME}`, () => {
-        this.field.removeClass('is-hover');
-      });
+    // Set field-options visibility.
+    // In touch environments, the button should always be visible.
+    // In desktop environments, the button should only display when the field is in use.
+    if (env.features.touch) {
+      this.field.addClass('visible');
+    } else {
+      this.field.removeClass('visible');
+      this.hoverElem
+        .on(`mouseenter.${COMPONENT_NAME}`, () => {
+          this.field.addClass('visible');
+        })
+        .on(`mouseleave.${COMPONENT_NAME}`, () => {
+          this.field.removeClass('visible');
+        });
+    }
 
     // Adjust stack order for dropdown
     if (dropdown) {

--- a/src/components/field-options/field-options.js
+++ b/src/components/field-options/field-options.js
@@ -162,6 +162,7 @@ FieldOptions.prototype = {
     // Update hover element
     this.hoverElem = isSpinbox ? this.element.add(this.field.find('.down, .up')) : this.targetElem;
     this.hoverElem = isColorpicker ? this.element.add(this.field.find('.colorpicker-container, .swatch, .trigger')) : this.hoverElem;
+    this.hoverElem = isRadio || isCheckbox ? this.field : this.targetElem;
 
     // Set field-options visibility.
     // In touch environments, the button should always be visible.

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -367,7 +367,7 @@ textarea {
   min-height: 90px;
   overflow: auto;
   padding: 10px;
-  width: 362px;
+  width: $textarea-size;
 
   &.resizable {
     resize: vertical;
@@ -399,7 +399,7 @@ textarea {
 
   display: block;
   min-height: auto;
-  width: 362px;
+  width: $textarea-size;
 
   &.almost-empty {
     color: $error-color;
@@ -869,7 +869,7 @@ label,
     width: calc(100% - 40px);
 
     &.textarea {
-      max-width: 362px;
+      max-width: $textarea-size;
 
       ~ .btn-tertiary {
         margin-left: 2px;

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -800,6 +800,9 @@ $blockgrid-focus-border-color: $color-primary;
 $treemap-title-bg-color: $slate06;
 $treemap-title-color: #ffffff;
 
+// Textarea
+$textarea-size: 362px;
+
 // Breakpoint sizes - Grid
 $breakpoint-phone: 320px;
 $breakpoint-slim: 400px;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Previously, mobile devices had difficulty using Field Options buttons due to their dependency on hover and focus events.  This PR sets up a touch-device mode, which permanently displays the field options button in environments where a touch screen is present.

**Related github/jira issue (required)**:
Closes #555

**Steps necessary to review your pull request (required)**:
Pull this branch and run the demoapp, then:

_In a desktop browser:_
- open http://localhost:4000/components/field-options/example-index
- hover each field and ensure that the field options button for each is displayed
- focus each field and ensure that the field options button for each is displayed

_In a mobile browser:_
- open http://localhost:4000/components/field-options/example-index
- ensure that the field options button is permanently displayed next to each field, and can be accessed with a tap.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->