### PR TITLE
fix for indeterminate paging not calling previous sometimes

### DIFF
--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -236,22 +236,40 @@ Pager.prototype = {
       }
 
       if (li.is('.pager-prev')) {
-        self.setActivePage(self.activePage - 1, false, 'prev');
+        if (self.settings.indeterminate) {
+          self.activePage = -1; // so setActivePage doesn't skip rendering the row data
+          self.setActivePage(1, false, 'prev');
+        } else {
+          self.setActivePage(self.activePage - 1, false, 'prev');
+        }
         return false;
       }
 
       if (li.is('.pager-next')) {
-        self.setActivePage((self.activePage === -1 ? 0 : self.activePage) + 1, false, 'next');
+        if (self.settings.indeterminate) {
+          self.activePage = -1; // so setActivePage doesn't skip rendering the row data
+          self.setActivePage(1, false, 'next');
+        } else {
+          self.setActivePage((self.activePage === -1 ? 0 : self.activePage) + 1, false, 'next');
+        }
         return false;
       }
 
       if (li.is('.pager-first')) {
+        if (self.settings.indeterminate) {
+          self.activePage = -1; // so setActivePage doesn't skip rendering the row data
+        }
         self.setActivePage(1, false, 'first');
         return false;
       }
 
       if (li.is('.pager-last')) {
-        self.setActivePage(self.pageCount(), false, 'last'); // TODO Calculate Last Page?
+        if (self.settings.indeterminate) {
+          self.activePage = -1; // so setActivePage doesn't skip rendering the row data
+          self.setActivePage(1, false, 'last');
+        } else {
+          self.setActivePage(self.pageCount(), false, 'last'); // TODO Calculate Last Page?
+        }
         return false;
       }
 
@@ -369,15 +387,13 @@ Pager.prototype = {
 
     // If any of the following conditions are met, don't rerender the pages.
     // Only rerender the pager bar.
-    if (!this.settings.indeterminate) {
-      if (pageNum === undefined ||
+    if (pageNum === undefined ||
         pageNum === 0 ||
         isNaN(pageNum) ||
         pageNum > this.pageCount() ||
         (pageNum === this.activePage && !force)) {
-        this.renderBar(pagingInfo);
-        return this.activePage;
-      }
+      this.renderBar(pagingInfo);
+      return this.activePage;
     }
 
     this.activePage = pageNum;

--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -369,13 +369,15 @@ Pager.prototype = {
 
     // If any of the following conditions are met, don't rerender the pages.
     // Only rerender the pager bar.
-    if (pageNum === undefined ||
+    if (!this.settings.indeterminate) {
+      if (pageNum === undefined ||
         pageNum === 0 ||
         isNaN(pageNum) ||
         pageNum > this.pageCount() ||
         (pageNum === this.activePage && !force)) {
-      this.renderBar(pagingInfo);
-      return this.activePage;
+        this.renderBar(pagingInfo);
+        return this.activePage;
+      }
     }
 
     this.activePage = pageNum;

--- a/test/components/datagrid/datagrid-paging.func-spec.js
+++ b/test/components/datagrid/datagrid-paging.func-spec.js
@@ -1,0 +1,381 @@
+/* eslint-disable jasmine/no-focused-tests */
+import { Datagrid } from '../../../src/components/datagrid/datagrid';
+import { Formatters } from '../../../src/components/datagrid/datagrid.formatters';
+
+const datagridHTML = require('../../../app/views/components/datagrid/example-index.html');
+const svg = require('../../../src/components/icons/svg.html');
+const sampleData = require('../../../app/data/datagrid-sample-data');
+
+require('../../../src/components/locale/cultures/en-US.js');
+
+let datagridEl;
+let svgEl;
+let datagridObj;
+
+// Define Columns for the Grid.
+const columns = [];
+columns.push({ id: 'productId', name: 'Id', field: 'productId', reorderable: true, formatter: Formatters.Text, width: 100, filterType: 'Text' });
+columns.push({ id: 'productName', name: 'Product Name', field: 'productName', reorderable: true, formatter: Formatters.Hyperlink, width: 300, filterType: 'Text' });
+columns.push({ id: 'activity', name: 'Activity', field: 'activity', reorderable: true, filterType: 'Text' });
+columns.push({ id: 'hidden', hidden: true, name: 'Hidden', field: 'hidden', filterType: 'Text' });
+columns.push({ id: 'price', align: 'right', name: 'Actual Price', field: 'price', reorderable: true, formatter: Formatters.Decimal, numberFormat: { minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'currency', currencySign: '$' } });
+columns.push({ id: 'percent', align: 'right', name: 'Actual %', field: 'percent', reorderable: true, formatter: Formatters.Decimal, numberFormat: { minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'percent' } });
+columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', reorderable: true, formatter: Formatters.Date, dateFormat: 'M/d/yyyy' });
+columns.push({ id: 'phone', name: 'Phone', field: 'phone', reorderable: true, filterType: 'Text', formatter: Formatters.Text });
+
+describe('Datagrid Paging API', () => {
+  const Locale = window.Soho.Locale;
+
+  describe('Check Indeterminate Paging using DataGrid source API', () => {
+    beforeEach(() => {
+      datagridEl = null;
+      svgEl = null;
+      datagridObj = null;
+      document.body.insertAdjacentHTML('afterbegin', svg);
+      document.body.insertAdjacentHTML('afterbegin', datagridHTML);
+      datagridEl = document.body.querySelector('#datagrid');
+      svgEl = document.body.querySelector('.svg-icons');
+
+      Locale.set('en-US');
+    });
+
+    afterEach(() => {
+      datagridObj.destroy();
+      datagridEl.parentNode.removeChild(datagridEl);
+      svgEl.parentNode.removeChild(svgEl);
+
+      const rowEl = document.body.querySelector('.row');
+      rowEl.parentNode.removeChild(rowEl);
+    });
+
+    it('test initial data load', (done) => {
+      // build a source function
+      const dataSourceContainer = {
+        dataSource: (request, response) => {
+          request.firstPage = true;
+          request.lastPage = false;
+          response(sampleData, request);
+        }
+      };
+
+      // build a spy to ensure the dataSource is called
+      const dataSourceSpy = spyOn(dataSourceContainer, 'dataSource').and.callThrough();
+
+      // build the dataGrid object with a source option. This should to cause the
+      // source() to be called with a request.type === 'initial'
+      const options = { columns, paging: true, pagesize: 5, indeterminate: true, source: dataSourceContainer.dataSource }; // eslint-disable-line max-len
+      datagridObj = new Datagrid(datagridEl, options);
+
+      // wait for any timeouts to complete to ensure the source function is called.
+      setTimeout(() => {
+        // ensure it's been called with a request.type of 'initial'
+        expect(dataSourceSpy).toHaveBeenCalled();
+        expect(dataSourceSpy.calls.mostRecent().args[0].type).toBeDefined();
+        expect(dataSourceSpy.calls.mostRecent().args[0].type).toEqual('initial');
+        done();
+      }, 1);
+    });
+
+    it('test using triggerSource(\'first\')', (done) => {
+      // build a source callback function
+      const dataSourceContainer = {
+        dataSource: (request, response) => {
+          request.firstPage = request.type === 'first';
+          request.lastPage = false;
+          response(sampleData, request);
+        }
+      };
+
+      // build a spy to ensure the dataSource is called
+      const dataSourceSpy = spyOn(dataSourceContainer, 'dataSource').and.callThrough();
+
+      // build the dataGrid object with a source option. This should to cause the
+      // source() to be called with a request.type === 'initial'
+      const options = { columns, paging: true, pagesize: 5, indeterminate: true, source: dataSourceContainer.dataSource }; // eslint-disable-line max-len
+      datagridObj = new Datagrid(datagridEl, options);
+
+      // wait for any timeouts to complete to ensure the source function is called.
+      setTimeout(() => {
+        datagridObj.triggerSource('first', () => {
+          // ensure it's been called with a request.type of 'first'
+          expect(dataSourceSpy).toHaveBeenCalled();
+          expect(dataSourceSpy.calls.mostRecent().args[0].type).toBeDefined();
+          expect(dataSourceSpy.calls.mostRecent().args[0].type).toEqual('first');
+          done();
+        });
+      }, 1);
+    });
+
+    it('test using triggerSource(\'last\')', (done) => {
+      // build a source callback function
+      const dataSourceContainer = {
+        dataSource: (request, response) => {
+          request.firstPage = false;
+          request.lastPage = request.type === 'last';
+          response(sampleData, request);
+        }
+      };
+
+      // build a spy to ensure the dataSource is called
+      const dataSourceSpy = spyOn(dataSourceContainer, 'dataSource').and.callThrough();
+
+      // build the dataGrid object with a source option. This should to cause the
+      // source() to be called with a request.type === 'initial'
+      const options = { columns, paging: true, pagesize: 5, indeterminate: true, source: dataSourceContainer.dataSource }; // eslint-disable-line max-len
+      datagridObj = new Datagrid(datagridEl, options);
+
+      // wait for any timeouts to complete to ensure the source function is called.
+      setTimeout(() => {
+        datagridObj.triggerSource('first', () => {
+          // ensure it's been called with a request.type of 'first'
+          expect(dataSourceSpy).toHaveBeenCalled();
+          expect(dataSourceSpy.calls.mostRecent().args[0].type).toBeDefined();
+          expect(dataSourceSpy.calls.mostRecent().args[0].type).toEqual('first');
+          done();
+        });
+      }, 1);
+    });
+
+    it('test using triggerSource(\'next\')', (done) => {
+      // build a source function
+      const dataSourceContainer = {
+        dataSource: (request, response) => {
+          request.firstPage = false;
+          request.lastPage = request.type === 'next';
+          response(sampleData, request);
+        }
+      };
+
+      // build a spy to ensure the dataSource is called
+      const dataSourceSpy = spyOn(dataSourceContainer, 'dataSource').and.callThrough();
+
+      // build the dataGrid object with a source option. This should to cause the
+      // source() to be called with a request.type === 'initial'
+      const options = { columns, paging: true, pagesize: 5, indeterminate: true, source: dataSourceContainer.dataSource }; // eslint-disable-line max-len
+      datagridObj = new Datagrid(datagridEl, options);
+
+      // wait for any timeouts to complete to ensure the source function is called.
+      setTimeout(() => {
+        datagridObj.triggerSource('next', () => {
+          // ensure it's been called with a request.type of 'initial'
+          expect(dataSourceSpy).toHaveBeenCalled();
+          expect(dataSourceSpy.calls.mostRecent().args[0].type).toBeDefined();
+          expect(dataSourceSpy.calls.mostRecent().args[0].type).toEqual('next');
+          done();
+        });
+      }, 1);
+    });
+
+    it('test using triggerSource(\'prev\')', (done) => {
+      // build a source function
+      const dataSourceContainer = {
+        dataSource: (request, response) => {
+          request.firstPage = request.type === 'prev';
+          request.lastPage = false;
+          response(sampleData, request);
+        }
+      };
+
+      // build a spy to ensure the dataSource is called
+      const dataSourceSpy = spyOn(dataSourceContainer, 'dataSource').and.callThrough();
+
+      // build the dataGrid object with a source option. This should to cause the
+      // source() to be called with a request.type === 'initial'
+      const options = { columns, paging: true, pagesize: 5, indeterminate: true, source: dataSourceContainer.dataSource }; // eslint-disable-line max-len
+      datagridObj = new Datagrid(datagridEl, options);
+
+      // wait for any timeouts to complete to ensure the source function is called.
+      setTimeout(() => {
+        datagridObj.triggerSource('prev', () => {
+          // ensure it's been called with a request.type of 'prev'
+          expect(dataSourceSpy).toHaveBeenCalled();
+          expect(dataSourceSpy.calls.mostRecent().args[0].type).toBeDefined();
+          expect(dataSourceSpy.calls.mostRecent().args[0].type).toEqual('prev');
+          done();
+        });
+      }, 1);
+    });
+
+    it('test using first paging bar button', (done) => {
+      // build a source function
+      const dataSourceContainer = {
+        dataSource: (request, response) => {
+          request.firstPage = request.type === 'first';
+          request.lastPage = false;
+          response(sampleData, request);
+        }
+      };
+
+      // build a spy to ensure the dataSource is called
+      const dataSourceSpy = spyOn(dataSourceContainer, 'dataSource').and.callThrough();
+
+      // build the dataGrid object with a source option. This should to cause the
+      // source() to be called with a request.type === 'initial'
+      const options = { columns, paging: true, pagesize: 5, indeterminate: true, source: dataSourceContainer.dataSource }; // eslint-disable-line max-len
+      datagridObj = new Datagrid(datagridEl, options);
+
+      // wait for any timeouts to complete to ensure the source data is loaded
+      // and the paging bar is rendered
+      setTimeout(() => {
+        // get first button and click it
+        const buttonEl = document.body.querySelector('li.pager-first a');
+        const buttonClickSpy = spyOnEvent(buttonEl, 'click.button');
+        buttonEl.click();
+
+        // wait for any timeouts to complete
+        setTimeout(() => {
+          expect(buttonClickSpy).toHaveBeenTriggered();
+
+          // ensure it's been called with a request.type of 'first'
+          expect(dataSourceSpy).toHaveBeenCalled();
+          expect(dataSourceSpy.calls.mostRecent().args[0].type).toBeDefined();
+          expect(dataSourceSpy.calls.mostRecent().args[0].type).toEqual('first');
+          done();
+        }, 500);
+      }, 1);
+    });
+
+    it('test using last paging bar button', (done) => {
+      // build a source function
+      const dataSourceContainer = {
+        dataSource: (request, response) => {
+          request.firstPage = false;
+          request.lastPage = request.type === 'last';
+          response(sampleData, request);
+        }
+      };
+
+      // build a spy to ensure the dataSource is called
+      const dataSourceSpy = spyOn(dataSourceContainer, 'dataSource').and.callThrough();
+
+      // build the dataGrid object with a source option. This should to cause the
+      // source() to be called with a request.type === 'initial'
+      const options = { columns, paging: true, pagesize: 5, indeterminate: true, source: dataSourceContainer.dataSource }; // eslint-disable-line max-len
+      datagridObj = new Datagrid(datagridEl, options);
+
+      // wait for any timeouts to complete to ensure the source data is loaded
+      // and the paging bar is rendered
+      setTimeout(() => {
+        // get first button and click it
+        const buttonEl = document.body.querySelector('li.pager-last a');
+        const buttonClickSpy = spyOnEvent(buttonEl, 'click.button');
+        buttonEl.click();
+
+        // wait for any timeouts to complete
+        setTimeout(() => {
+          expect(buttonClickSpy).toHaveBeenTriggered();
+
+          // ensure it's been called with a request.type of 'first'
+          expect(dataSourceSpy).toHaveBeenCalled();
+          expect(dataSourceSpy.calls.mostRecent().args[0].type).toBeDefined();
+          expect(dataSourceSpy.calls.mostRecent().args[0].type).toEqual('last');
+          // expect(dataSourceSpy).toHaveBeenCalledWith(jasmine.objectContaining({ type: 'last' }));
+          done();
+        }, 500);
+      }, 1);
+    });
+
+    it('test using next paging bar button', (done) => {
+      // build a source function
+      const dataSourceContainer = {
+        dataSource: (request, response) => {
+          request.firstPage = false;
+          request.lastPage = request.type === 'last';
+          response(sampleData, request);
+        }
+      };
+
+      // build a spy to ensure the dataSource is called
+      const dataSourceSpy = spyOn(dataSourceContainer, 'dataSource').and.callThrough();
+
+      // build the dataGrid object with a source option. This should to cause the
+      // source() to be called with a request.type === 'initial'
+      const options = { columns, paging: true, pagesize: 5, indeterminate: true, source: dataSourceContainer.dataSource }; // eslint-disable-line max-len
+      datagridObj = new Datagrid(datagridEl, options);
+
+      // wait for any timeouts to complete to ensure the source data is loaded
+      // and the paging bar is rendered
+      setTimeout(() => {
+        // get first button and click it
+        const buttonEl = document.body.querySelector('li.pager-last a');
+        const buttonClickSpy = spyOnEvent(buttonEl, 'click.button');
+        buttonEl.click();
+
+        // wait for any timeouts to complete
+        setTimeout(() => {
+          expect(buttonClickSpy).toHaveBeenTriggered();
+
+          // ensure it's been called with a request.type of 'first'
+          expect(dataSourceSpy).toHaveBeenCalled();
+          expect(dataSourceSpy.calls.mostRecent().args[0].type).toBeDefined();
+          expect(dataSourceSpy.calls.mostRecent().args[0].type).toEqual('last');
+          done();
+        }, 500);
+      }, 1);
+    });
+
+    it('test using last paging bar button', (done) => {
+      // build a source function
+      const dataSourceContainer = {
+        dataSource: (request, response) => {
+          request.firstPage = false;
+          request.lastPage = request.type === 'last';
+          response(sampleData, request);
+        }
+      };
+
+      // build a spy to ensure the dataSource is called
+      const dataSourceSpy = spyOn(dataSourceContainer, 'dataSource').and.callThrough();
+
+      // build the dataGrid object with a source option. This should to cause the
+      // source() to be called with a request.type === 'initial'
+      const options = { columns, paging: true, pagesize: 5, indeterminate: true, source: dataSourceContainer.dataSource }; // eslint-disable-line max-len
+      datagridObj = new Datagrid(datagridEl, options);
+
+      // wait for any timeouts to complete to ensure the source data is loaded
+      // and the paging bar is rendered
+      setTimeout(() => {
+        // get first button and click it
+        const buttonEl = document.body.querySelector('li.pager-last a');
+        const buttonClickSpy = spyOnEvent(buttonEl, 'click.button');
+        buttonEl.click();
+
+        // wait for any timeouts to complete
+        setTimeout(() => {
+          expect(buttonClickSpy).toHaveBeenTriggered();
+
+          // ensure it's been called with a request.type of 'first'
+          expect(dataSourceSpy).toHaveBeenCalled();
+          expect(dataSourceSpy.calls.mostRecent().args[0].type).toBeDefined();
+          expect(dataSourceSpy.calls.mostRecent().args[0].type).toEqual('last');
+          done();
+        }, 500);
+      }, 1);
+    });
+  });
+
+  describe('Check DataGrid.loadData with paging events', () => {
+    beforeEach(() => {
+      datagridEl = null;
+      svgEl = null;
+      datagridObj = null;
+      document.body.insertAdjacentHTML('afterbegin', svg);
+      document.body.insertAdjacentHTML('afterbegin', datagridHTML);
+      datagridEl = document.body.querySelector('#datagrid');
+      svgEl = document.body.querySelector('.svg-icons');
+
+      Locale.set('en-US');
+    });
+
+    afterEach(() => {
+      datagridObj.destroy();
+      datagridEl.parentNode.removeChild(datagridEl);
+      svgEl.parentNode.removeChild(svgEl);
+
+      const rowEl = document.body.querySelector('.row');
+      rowEl.parentNode.removeChild(rowEl);
+    });
+
+    // todo: implement me
+  });
+});

--- a/test/components/datagrid/datagrid-paging.func-spec.js
+++ b/test/components/datagrid/datagrid-paging.func-spec.js
@@ -280,7 +280,7 @@ describe('Datagrid Paging API', () => {
       const dataSourceContainer = {
         dataSource: (request, response) => {
           request.firstPage = false;
-          request.lastPage = request.type === 'last';
+          request.lastPage = request.type === 'next';
           response(sampleData, request);
         }
       };
@@ -297,7 +297,7 @@ describe('Datagrid Paging API', () => {
       // and the paging bar is rendered
       setTimeout(() => {
         // get first button and click it
-        const buttonEl = document.body.querySelector('li.pager-last a');
+        const buttonEl = document.body.querySelector('li.pager-next a');
         const buttonClickSpy = spyOnEvent(buttonEl, 'click.button');
         buttonEl.click();
 
@@ -308,18 +308,18 @@ describe('Datagrid Paging API', () => {
           // ensure it's been called with a request.type of 'first'
           expect(dataSourceSpy).toHaveBeenCalled();
           expect(dataSourceSpy.calls.mostRecent().args[0].type).toBeDefined();
-          expect(dataSourceSpy.calls.mostRecent().args[0].type).toEqual('last');
+          expect(dataSourceSpy.calls.mostRecent().args[0].type).toEqual('next');
           done();
         }, 500);
       }, 1);
     });
 
-    it('test using last paging bar button', (done) => {
+    it('test using previous paging bar button', (done) => {
       // build a source function
       const dataSourceContainer = {
         dataSource: (request, response) => {
-          request.firstPage = false;
-          request.lastPage = request.type === 'last';
+          request.firstPage = request.type === 'prev';
+          request.lastPage = false;
           response(sampleData, request);
         }
       };
@@ -336,7 +336,7 @@ describe('Datagrid Paging API', () => {
       // and the paging bar is rendered
       setTimeout(() => {
         // get first button and click it
-        const buttonEl = document.body.querySelector('li.pager-last a');
+        const buttonEl = document.body.querySelector('li.pager-prev a');
         const buttonClickSpy = spyOnEvent(buttonEl, 'click.button');
         buttonEl.click();
 
@@ -347,7 +347,7 @@ describe('Datagrid Paging API', () => {
           // ensure it's been called with a request.type of 'first'
           expect(dataSourceSpy).toHaveBeenCalled();
           expect(dataSourceSpy.calls.mostRecent().args[0].type).toBeDefined();
-          expect(dataSourceSpy.calls.mostRecent().args[0].type).toEqual('last');
+          expect(dataSourceSpy.calls.mostRecent().args[0].type).toEqual('prev');
           done();
         }, 500);
       }, 1);

--- a/test/components/datagrid/datagrid-paging.func-spec.js
+++ b/test/components/datagrid/datagrid-paging.func-spec.js
@@ -90,7 +90,7 @@ describe('Datagrid Paging API', () => {
       const dataSourceSpy = spyOn(dataSourceContainer, 'dataSource').and.callThrough();
 
       // build the dataGrid object with a source option. This should to cause the
-      // source() to be called with a request.type === 'initial'
+      // source() to be called with a request.type === 'first'
       const options = { columns, paging: true, pagesize: 5, indeterminate: true, source: dataSourceContainer.dataSource }; // eslint-disable-line max-len
       datagridObj = new Datagrid(datagridEl, options);
 
@@ -120,7 +120,7 @@ describe('Datagrid Paging API', () => {
       const dataSourceSpy = spyOn(dataSourceContainer, 'dataSource').and.callThrough();
 
       // build the dataGrid object with a source option. This should to cause the
-      // source() to be called with a request.type === 'initial'
+      // source() to be called with a request.type === 'first'
       const options = { columns, paging: true, pagesize: 5, indeterminate: true, source: dataSourceContainer.dataSource }; // eslint-disable-line max-len
       datagridObj = new Datagrid(datagridEl, options);
 
@@ -150,14 +150,14 @@ describe('Datagrid Paging API', () => {
       const dataSourceSpy = spyOn(dataSourceContainer, 'dataSource').and.callThrough();
 
       // build the dataGrid object with a source option. This should to cause the
-      // source() to be called with a request.type === 'initial'
+      // source() to be called with a request.type === 'next'
       const options = { columns, paging: true, pagesize: 5, indeterminate: true, source: dataSourceContainer.dataSource }; // eslint-disable-line max-len
       datagridObj = new Datagrid(datagridEl, options);
 
       // wait for any timeouts to complete to ensure the source function is called.
       setTimeout(() => {
         datagridObj.triggerSource('next', () => {
-          // ensure it's been called with a request.type of 'initial'
+          // ensure it's been called with a request.type of 'next'
           expect(dataSourceSpy).toHaveBeenCalled();
           expect(dataSourceSpy.calls.mostRecent().args[0].type).toBeDefined();
           expect(dataSourceSpy.calls.mostRecent().args[0].type).toEqual('next');
@@ -180,7 +180,7 @@ describe('Datagrid Paging API', () => {
       const dataSourceSpy = spyOn(dataSourceContainer, 'dataSource').and.callThrough();
 
       // build the dataGrid object with a source option. This should to cause the
-      // source() to be called with a request.type === 'initial'
+      // source() to be called with a request.type === 'prev'
       const options = { columns, paging: true, pagesize: 5, indeterminate: true, source: dataSourceContainer.dataSource }; // eslint-disable-line max-len
       datagridObj = new Datagrid(datagridEl, options);
 
@@ -210,7 +210,7 @@ describe('Datagrid Paging API', () => {
       const dataSourceSpy = spyOn(dataSourceContainer, 'dataSource').and.callThrough();
 
       // build the dataGrid object with a source option. This should to cause the
-      // source() to be called with a request.type === 'initial'
+      // source() to be called with a request.type === 'first'
       const options = { columns, paging: true, pagesize: 5, indeterminate: true, source: dataSourceContainer.dataSource }; // eslint-disable-line max-len
       datagridObj = new Datagrid(datagridEl, options);
 
@@ -249,7 +249,7 @@ describe('Datagrid Paging API', () => {
       const dataSourceSpy = spyOn(dataSourceContainer, 'dataSource').and.callThrough();
 
       // build the dataGrid object with a source option. This should to cause the
-      // source() to be called with a request.type === 'initial'
+      // source() to be called with a request.type === 'last'
       const options = { columns, paging: true, pagesize: 5, indeterminate: true, source: dataSourceContainer.dataSource }; // eslint-disable-line max-len
       datagridObj = new Datagrid(datagridEl, options);
 
@@ -289,7 +289,7 @@ describe('Datagrid Paging API', () => {
       const dataSourceSpy = spyOn(dataSourceContainer, 'dataSource').and.callThrough();
 
       // build the dataGrid object with a source option. This should to cause the
-      // source() to be called with a request.type === 'initial'
+      // source() to be called with a request.type === 'next'
       const options = { columns, paging: true, pagesize: 5, indeterminate: true, source: dataSourceContainer.dataSource }; // eslint-disable-line max-len
       datagridObj = new Datagrid(datagridEl, options);
 
@@ -328,7 +328,7 @@ describe('Datagrid Paging API', () => {
       const dataSourceSpy = spyOn(dataSourceContainer, 'dataSource').and.callThrough();
 
       // build the dataGrid object with a source option. This should to cause the
-      // source() to be called with a request.type === 'initial'
+      // source() to be called with a request.type === 'last'
       const options = { columns, paging: true, pagesize: 5, indeterminate: true, source: dataSourceContainer.dataSource }; // eslint-disable-line max-len
       datagridObj = new Datagrid(datagridEl, options);
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Issue: When paging is indeterminate prev page was never called when starting a datagrid mid page
What I did: Removed the drawing optimization for indeterminate paging since pagNum can't really change when paging is indeterminate, it isn't relevant to indeterminate paging. 

**Related github/jira issue (required)**:
Closes #567

**Steps necessary to review your pull request (required)**:
See git hub issue for these details.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
