### PR TITLE
453 - SOHO-6041 show tooltips on disabled inputs and buttons

### DIFF
--- a/app/views/components/button/example-disabled-button-tooltip.html
+++ b/app/views/components/button/example-disabled-button-tooltip.html
@@ -1,0 +1,17 @@
+<div class="row">
+
+  <div class="twelve columns">
+
+    <div class="field">
+      <button class="btn-secondary" type="button" disabled><div title="div title - tooltip">Button</div></button>
+    </div>
+
+    </div>
+
+  </div>
+
+</div>
+
+<script type="text/javascript">
+  $('div[title]').tooltip();
+</script>

--- a/app/views/components/button/example-disabled-button-tooltip.html
+++ b/app/views/components/button/example-disabled-button-tooltip.html
@@ -1,16 +1,108 @@
+
 <div class="row">
+  <div class="six columns">
 
-  <div class="twelve columns">
+    <span class="label">Primary</span>
 
-    <div class="field">
-      <button class="btn-secondary" type="button" disabled><div title="div title - tooltip">Button</div></button>
-    </div>
+    <button class="btn-primary" type="button" title="btn-primary title/tooltip" disabled><div class="disabled-tooltip" title="btn-primary title/tooltip"></div>Action</button><br><br><br>
 
-    </div>
+    <button class="btn-primary" type="button" title="btn-primary svg title/tooltip" disabled>
+      <div class="disabled-tooltip" title="btn-primary svg title/tooltip"></div>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presenatation">
+          <use xlink:href="#icon-alert"></use>
+        </svg>
+        <span>Primary Button</span>
+    </button>
+
+    <br><br><br>
+
+    <span class="label">Secondary</span>
+
+    <button class="btn-secondary" type="button" title="btn-secondary title/tooltip" disabled><div class="disabled-tooltip" title="btn-secondary title/tooltip"></div>Action</button><br><br><br>
+
+    <button class="btn-secondary" type="button" title="btn-secondary svg title/tooltip" disabled>
+      <div class="disabled-tooltip" title="btn-secondary svg title/tooltip"></div>
+      <svg class="icon" focusable="false" aria-hidden="true" role="presenatation">
+        <use xlink:href="#icon-settings"></use>
+      </svg>
+      <span>Secondary Button</span>
+    </button>
+
+    <br><br><br>
+
+    <button class="btn-secondary-border" type="button"  title="btn-secondary-border title/tooltip" disabled>
+      <div class="disabled-tooltip" title="btn-secondary-border title/tooltip"></div>
+      <span>Secondary Border Button</span>
+    </button>
+
+    <br><br><br>
 
   </div>
 
+  <div class="six columns">
+    <span class="label">Tertiary</span>
+
+    <button type="button" class="btn-tertiary" title="btn-tertiary svg title/tooltip" disabled>
+      <div class="disabled-tooltip" title="btn-tertiary svg title/tooltip"></div>
+      <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
+        <use xlink:href="#icon-filter"></use>
+      </svg>
+      <span>Action</span>
+    </button>
+
+    <br><br><br>
+
+    <span class="label">Link</span>
+
+    <button type="button" class="btn btn-link" title="btn-link title/tooltip" disabled>
+      <div class="disabled-tooltip" title="btn-link title/tooltip"></div>
+      <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
+        <use xlink:href="#icon-filter"></use>
+      </svg>
+      <span>Action</span>
+    </button>
+
+    <br><br><br>
+
+    <span class="label">Icon</span>
+
+    <button type="button" class="btn-icon" title="btn-icon title/tooltip" disabled>
+      <div class="disabled-tooltip" title="btn-icon title/tooltip"></div>
+      <span>Date</span>
+      <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
+        <use xlink:href="#icon-calendar"></use>
+      </svg>
+    </button>
+
+    <br><br><br>
+
+    <span class="label">Menu</span>
+
+    <button type="button" id="test" class="btn-menu" title="btn-menu title/tooltip" disabled>
+      <div class="disabled-tooltip" title="btn-menu title/tooltip"></div>
+      <span>Add Item</span>
+    </button>
+    <ul class="popupmenu is-selectable has-icons">
+      <li><a href="#">Create a form</a></li>
+      <li class="separator"></li>
+      <li><a href="#">Spelling...</a></li>
+      <li><a href="#" disabled aria-disabled="true">Solver...</a></li>
+      <li class="separator"></li>
+      <li class="is-checked"><a href="#">Enable Autocomplete</a></li>
+      <li><a href="#">Notification Rules</a></li>
+      <li><a href="#">Protect Sheet Rules</a></li>
+    </ul>
+
+  </div>
+
+  <script>
+    $('#test').on('selected', function (e, args) {
+      console.log(args);
+    });
+  </script>
+
 </div>
+
 
 <script type="text/javascript">
   $('div[title]').tooltip();

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -106,6 +106,17 @@ button {
     padding-left: 0;
     padding-right: 0;
   }
+
+  &[disabled],
+  &[disabled]:hover {
+    .disabled-tooltip {
+      bottom: 0;
+      left: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
+  }
 }
 
 .btn-primary,

--- a/src/components/button/readme.md
+++ b/src/components/button/readme.md
@@ -15,6 +15,8 @@ demo:
     slug: example-with-icons
   - name: Toggle Buttons
     slug: example-toggle-button
+  - name: Disabled Button Tooltip
+    slug: example-disabled-button-tooltip.html
 ---
 
 ## Code Example
@@ -74,3 +76,8 @@ All buttons are assumed to include an icon and a text label. An icon can be adde
 
 - Change class `inforFormButton default` to `btn-primary`
 - Change class `inforFormButton` to `btn-secondary`
+
+## Workaround for title to display as tooltip on disabled buttons
+
+- Disabled elements do not handle events in most browsers. This necessitates the need for an alternate element to handle the `Tooltip.plugin` which adds functionality that strips the title and renders it as a tooltip on the hover event of the element.
+- Include `<div title="{{desired title/tooltip}}}">{{button content}}</div>` as child of `'<button disabled></button>' to allow hover event to engage tooltip functionality, taking title from inner div and displaying as tooltip.

--- a/src/components/button/readme.md
+++ b/src/components/button/readme.md
@@ -80,4 +80,4 @@ All buttons are assumed to include an icon and a text label. An icon can be adde
 ## Workaround for title to display as tooltip on disabled buttons
 
 - Disabled elements do not handle events in most browsers. This necessitates the need for an alternate element to handle the `Tooltip.plugin` which adds functionality that strips the title and renders it as a tooltip on the hover event of the element.
-- Include `<div title="{{desired title/tooltip}}}">{{button content}}</div>` as child of `'<button disabled></button>' to allow hover event to engage tooltip functionality, taking title from inner div and displaying as tooltip.
+- Include `<div title="{{desired title/tooltip}}}">{{button content}}</div>` as child of `<button disabled></button>` to allow hover event to engage tooltip functionality, taking title from inner div and displaying as tooltip.


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Disabled elements are not allowed to handle events in most browsers. A hover event to display element title is desired on disabled inputs and buttons.

**Related github/jira issue (required)**:
Closes #453 

**Steps necessary to review your pull request (required)**:
- Pull branch and run app.
- Visit example page to verify title renders as tooltip: http://localhost:4000/components/button/example-disabled-button-tooltip
- Review documentation for further instruction or documentation on purpose of / reasoning behind this workaround: ./src/components/button/readme.md

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
