### PR TITLE
245 - example of field options being used to display context menus

### DIFF
--- a/app/views/components/contextmenu/example-field-options.html
+++ b/app/views/components/contextmenu/example-field-options.html
@@ -1,0 +1,1 @@
+{{> components/field-options/example-input-fields}}

--- a/app/views/components/field-options/example-input-fields.html
+++ b/app/views/components/field-options/example-input-fields.html
@@ -1,0 +1,124 @@
+<ul id="action-popupmenu" data-init="false" class="popupmenu">
+  <li><a href="#">Cut</a></li>
+  <li><a href="#">Copy</a></li>
+  <li><a href="#">Paste</a></li>
+  <li>
+    <a href="#">Paste Special</a>
+    <ul class="popupmenu">
+      <li><a href="#">Sub Menu 1</a></li>
+      <li><a href="#">Sub Menu 2</a></li>
+      <li class="separator"></li>
+      <li>
+        <a href="#">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-settings"></use>
+          </svg>
+          Settings
+        </a>
+      </li>
+    </ul>
+  </li>
+  <li class="separator"></li>
+  <li><a href="#">Name and project range</a></li>
+  <li class="is-disabled"><a id='x' href="#" disabled>Insert comment</a></li>
+  <li class="is-disabled"><a href="#" disabled>Insert note</a></li>
+  <li><a href="#">Clear notes</a></li>
+  <li class="separator single-selectable-section"></li>
+  <li class="heading">Additional Options</li>
+  <li class="is-selectable is-checked"><a href="#">Conditional formatting</a></li>
+  <li class="is-selectable"><a href="#">Data validation</a></li>
+  <li class="separator"></li>
+  <li>
+    <a href="#">
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use xlink:href="#icon-settings"></use>
+      </svg>
+      Settings
+    </a>
+  </li>
+</ul>
+
+<!-- xs -->
+<div class="row top-padding">
+  <div class="one-half column">
+    <div class="field">
+      <label for="input-xs">Input XS</label>
+      <input id="input-xs" type="text" class="input-xs field-options" />
+
+      <button id="input-xs-fieldopts" class="btn-actions btn-menu" type="button" data-options='{ "menu": "action-popupmenu" }'>
+        <span class="audible">Actions for Extra-small Input Field</span>
+        <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
+          <use xlink:href="#icon-more"/>
+        </svg>
+      </button>
+    </div>
+  </div>
+</div>
+
+<!-- sm -->
+<div class="row">
+  <div class="one-half column">
+    <div class="field">
+      <label for="input-sm">Input SM</label>
+      <input id="input-sm" type="text" class="input-sm field-options" />
+
+      <button id="input-sm-fieldopts" class="btn-actions btn-menu" type="button" data-options='{ "menu": "action-popupmenu" }'>
+        <span class="audible">Actions for Small Input Field</span>
+        <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
+          <use xlink:href="#icon-more"/>
+        </svg>
+      </button>
+    </div>
+  </div>
+</div>
+
+<!-- md -->
+<div class="row">
+  <div class="one-half column">
+    <div class="field">
+      <label for="input-md">Input MD</label>
+      <input id="input-md" type="text" class="input-md field-options" />
+
+      <button id="input-md-fieldopts" class="btn-actions btn-menu" type="button" data-options='{ "menu": "action-popupmenu" }'>
+        <span class="audible">Actions for Medium Input Field</span>
+        <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
+          <use xlink:href="#icon-more"/>
+        </svg>
+      </button>
+    </div>
+  </div>
+</div>
+
+<!-- Large -->
+<div class="row">
+  <div class="one-half column">
+    <div class="field">
+      <label for="input-lg">Input LG</label>
+      <input id="input-lg" type="text" class="input-lg field-options" />
+
+      <button id="input-lg-fieldopts" class="btn-actions btn-menu" type="button" data-options='{ "menu": "action-popupmenu" }'>
+        <span class="audible">Actions for Large Input Field</span>
+        <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
+          <use xlink:href="#icon-more"/>
+        </svg>
+      </button>
+    </div>
+  </div>
+</div>
+
+<!-- Full -->
+<div class="row">
+  <div class="one-half column">
+    <div class="field">
+      <label for="input-full">Input Full</label>
+      <input id="input-full" type="text" class="input-full field-options" />
+
+      <button id="input-full-fieldopts" class="btn-actions btn-menu" type="button" data-options='{ "menu": "action-popupmenu" }'>
+        <span class="audible">Actions for Full-sized Input Field</span>
+        <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
+          <use xlink:href="#icon-more"/>
+        </svg>
+      </button>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added an example to show off the concept of using Field Options as a means to display a context menu.

**Related github/jira issue (required)**:
#245 (longpress behavior)
#555 (touch-enabled field options)

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp
- open http://localhost:4000/components/contextmenu/example-field-options.html
- all examples should show a working context menu attached to each field options button

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->