### PR TITLE
588 - Popupmenu submenu fix for flickering issue

### DIFF
--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -1469,7 +1469,12 @@ PopupMenu.prototype = {
     // Use a different menu, if applicable
     if (DOM.isElement(contextElement) && $(contextElement).is('.popupmenu, .submenu')) {
       targetMenu = $(contextElement);
+      // Skip calling external source if submenu is already open
+      if (contextElement.hasClass('is-open')) {
+        return;
+      }
     }
+
 
     const response = function (content) {
       const existingMenuItems = targetMenu.children();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added a condition to skip calling external source if submenu is already open. This prevents the rerender of the submenu which causes the flicker.

**Related github/jira issue (required)**:
Closes #588 

**Steps necessary to review your pull request (required)**:
open localhost:4000/components/popupmenu/example-ajax.html or localhost:4000/components/popupmenu/test-ajax-submenu.html then follow the steps/actions in #588
