### PR TITLE
376 - fixes focus state using tab and keyboard arrows

### DIFF
--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -406,7 +406,6 @@ $subheader-height: 60px;
     }
 
     &:focus:not(.hide-focus) {
-      box-shadow: none;
       color: $header-button-focus-color;
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
The problem here was the styling. The hide focus api & classes are working properly. 

Just remove the `box-shadow: none;` in _header.scss (line:409)

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise/issues/376

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

- Run http://localhost:4000/patterns/navigation-popupmenu.html
- Click on the dropdown for "Page Two Title"
- When the user clicks on the drop down the the focus should be enabled on the dropdown button.
- Try to also navigate using arrow keys and tab. 

**File Change/s**

**M** - src/components/header/_header.scss

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
