### PR TITLE
597 - Fixed body click to close contextmenu again

### DIFF
--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -765,7 +765,10 @@ PopupMenu.prototype = {
         return;
       }
 
-      self.holdingDownClick = true;
+      const allowedOS = ['android', 'ios'];
+      if (allowedOS.indexOf(env.os.name) > -1) {
+        self.holdingDownClick = true;
+      }
 
       doOpen(e);
     }
@@ -1474,7 +1477,6 @@ PopupMenu.prototype = {
         return;
       }
     }
-
 
     const response = function (content) {
       const existingMenuItems = targetMenu.children();

--- a/test/components/popupmenu/popupmenu.e2e-spec.js
+++ b/test/components/popupmenu/popupmenu.e2e-spec.js
@@ -8,6 +8,32 @@ const axePageObjects = requireHelper('axe-page-objects');
 
 jasmine.getEnv().addReporter(browserStackErrorReporter);
 
+describe('Contextmenu index tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/contextmenu/example-index');
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should open on click and close on click out', async () => {
+    const popupmenu = await element(by.id('action-popupmenu'));
+    await browser.actions().click(protractor.Button.RIGHT).perform();
+    await browser.driver.sleep(config.waitsFor);
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(popupmenu), config.waitsFor);
+
+    expect(await element(by.id('action-popupmenu')).getAttribute('class')).toContain('is-open');
+
+    await browser.actions().click(protractor.Button.Left).perform();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.invisibilityOf(popupmenu), config.waitsFor);
+
+    expect(await popupmenu.getAttribute('class')).not.toContain('is-open');
+  });
+});
+
 describe('Popupmenu example-selectable tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/popupmenu/example-selectable');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

As per notes on 597, found clickout was no longer working

**Related github/jira issue (required)**:
Closes #597

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/contextmenu/example-index.html
- right click to open
- click on body to close

Also confirm long press still works on android and ios
