### PR TITLE
505 - Fixes layout issue in nested modal

### DIFF
--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -295,7 +295,7 @@
   .btn-close {
     position: absolute;
     right: 0;
-    top: 0;
+    bottom: 0;
 
     .icon {
       width: 16px;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Changed the `top: 0;` to `bottom: 0;` in _modal.scss (line: 298)

```
  .btn-close {
    position: absolute;
    right: 0;
    bottom: 0;

    .icon {
      width: 16px;
    }
  }
```

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise/issues/505

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Run http://localhost:4000/components/contextualactionpanel/test-nested.html
- Click Contextual Action Panel button
- Click Show Nested Modal button, Close Button should be underneath of the content.

**File Change/s**

**M** - src/components/modal/_modal.scss

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
