### PR TITLE
Fix for 614 - Hierarchy - Need a way to dynamically update actions in leaf action menu

### DIFF
--- a/app/views/components/hierarchy/example-context-menu-with-details.html
+++ b/app/views/components/hierarchy/example-context-menu-with-details.html
@@ -19,6 +19,16 @@
   $('#hierarchy').on('selected', function(event, eventInfo) {
     console.log(event, eventInfo);
 
+    // dynamically update the actions menu
+    // replaces existing actions with new actions
+    if (eventInfo.isActionsEvent) {
+      const currentActions = eventInfo.data.menu.actions;
+      const newActions = [{value: 'Delete'}, {value: 'Move'}];
+      const updatedActions = currentActions.concat(newActions);
+
+      $(this).data('hierarchy').updateActions(eventInfo, updatedActions)
+    }
+
     if (eventInfo.isActionEvent) {
       alert(JSON.stringify(eventInfo.actionReference));
     }

--- a/src/components/hierarchy/hierarchy.js
+++ b/src/components/hierarchy/hierarchy.js
@@ -235,12 +235,31 @@ Hierarchy.prototype = {
   },
 
   /**
+   * @public
+   * @param eventInfo eventType, target, data, ect..
+   * @param newActions new actions to be appended to the menu
+   */
+  updateActions(eventInfo, updatedActions) {
+    const leaf = $(eventInfo.targetInfo.target).closest('.leaf');
+    const nodeData = eventInfo.data;
+    const popupMenu = $(leaf).find('.popupmenu');
+    const lineItemsToRemove = popupMenu.find('li').not(':eq(0)');
+
+    $(lineItemsToRemove).each((idx, item) => {
+      $(item).remove();
+    });
+
+    nodeData.menu.actions = updatedActions;
+    popupMenu.append(this.getActionMenuItems(nodeData));
+  },
+
+  /**
    * @private
    * @param {object} data associated with leaf
    * @param {leaf} leaf jQuery reference in DOM
    */
   buildActionsMenu(data, leaf) {
-    const popupMenu = leaf.find('.popupmenu');
+    const popupMenu = $(leaf).find('.popupmenu');
     const template = [];
 
     // Reset & rebuild
@@ -252,14 +271,22 @@ Hierarchy.prototype = {
     }
 
     if (data.menu.actions) {
-      // Ignoring next line. Eslint expects template literals vs string concat.
-      // However template literals break JSON.stringify() in this case
-      // eslint-disable-next-line
-      const items = `${data.menu.actions.map(a => "<li><a href='" + a.url + "' data-action-reference='" + JSON.stringify(a.data) + "'>" + a.value + "</a></li>").join('')}`;
-      template.push(items);
+      template.push(this.getActionMenuItems(data));
     }
 
     template.forEach((i) => { popupMenu.append(i); });
+  },
+
+  /**
+   * @private
+   * @param data the data to be iterated
+   * @returns {string} returns list items as a string
+   */
+  getActionMenuItems(data) {
+    // Ignoring next line. Eslint expects template literals vs string concat.
+    // However template literals break JSON.stringify() in this case
+    // eslint-disable-next-line
+    return `${data.menu.actions.map(a => "<li><a href='" + a.url + "' data-action-reference='" + JSON.stringify(a.data) + "'>" + a.value + "</a></li>").join('')}`;
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adds the ability to update the actions menu on a specific leaf.

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise/issues/614

**Steps necessary to review your pull request (required)**:
-  With suggested changes. Navigate to http://localhost:4000/components/hierarchy/example-context-menu-with-details.html
- Action menu will have two new actions ("Delete, Move") which were added after the initial render.