### PR TITLE
624 - Make space key work again 

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -6369,7 +6369,6 @@ Datagrid.prototype = {
         if (!self.editor) {
           self.makeCellEditable(self.activeCell.rowIndex, cell, e);
         }
-        e.preventDefault();
       }
 
       // if column have click function to fire [ie. action button]


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Sometime this version space key broke when entering data in a datagrid cell. This fixes that.

**Related github/jira issue (required)**:
Closes #624 

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/example-editable.html
- click into activity cell
- type "this is a space"
Spaces will work