### PR TITLE
547 - Spinbox alignment off in iOS, Firefox

### DIFF
--- a/src/components/spinbox/_spinbox.scss
+++ b/src/components/spinbox/_spinbox.scss
@@ -164,14 +164,24 @@ input::-webkit-inner-spin-button {
   }
 
   .spinbox {
-    height: 26px;
-    margin-bottom: 0;
+    height: auto;
+    line-height: normal; // initial value declaration is 16px from "_typgraphy.scss" at "input.is-firefox"
+    padding: 5px;
   }
 
   .spinbox-control {
     height: inherit;
     padding: 4px 7px;
     width: 25px;
+  }
+}
+
+// Override for iOS to correctly align ".spinbox" as child of  ".field-short"
+.ios {
+  .field-short {
+    .spinbox {
+      padding-top: 6px;
+    }
   }
 }
 

--- a/src/components/spinbox/_spinbox.scss
+++ b/src/components/spinbox/_spinbox.scss
@@ -185,6 +185,15 @@ input::-webkit-inner-spin-button {
   }
 }
 
+// Override for IE to correctly align ".spinbox" as child of  ".field-short"
+.ie {
+  .field-short {
+    .spinbox {
+      height: 25px;
+    }
+  }
+}
+
 //RTL Styles
 html[dir='rtl'] {
   .spinbox-control {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Unaddressed misalignment on iOS and Firefox discovered in QA.

**Related github/jira issue (required)**:
Closes #547 
Related to [this comment](http://github.com/infor-design/enterprise/issues/547#issuecomment-413833103)

**Steps necessary to review your pull request (required)**:
- Pull down and run app.
- Test http://localhost:4000/components/validation/example-short-fields in iOS (Xcode Simulator) and Firefox.
- Ensure all `.spinbox input` located as child of `field-short` class are aligned properly.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
