### PR TITLE
Set timezone to Eastern Standard (Americas/New_York)

### DIFF
--- a/test/protractor.ci.bs.conf.js
+++ b/test/protractor.ci.bs.conf.js
@@ -37,9 +37,10 @@ exports.config = {
     'browserstack.user': process.env.BROWSERSTACK_USERNAME,
     'browserstack.key': process.env.BROWSERSTACK_ACCESS_KEY,
     'browserstack.debug': true,
-    'browserstack.video' : true,
+    'browserstack.video': true,
     'browserstack.local': false,
-    'browserstack.networkLogs' : false,
+    'browserstack.networkLogs': false,
+    'browserstack.timezone': 'America/New_York',
     build: browserstackBuildID,
     name: `${theme} theme ci:bs e2e tests`,
     project: 'ids-enterprise-e2e-ci'


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Attempts to fix failing datetime tests on BS by specifying eastern US timezone (America/New_York), as we not sure what the default timezone is.

**Steps necessary to review your pull request (required)**:
Check bs cron tests in the morning.

Screenshot of timezone passed correctly... and link to test.
<img width="322" alt="screen shot 2018-08-20 at 4 07 20 pm" src="https://user-images.githubusercontent.com/1667967/44363791-34ee9980-a493-11e8-814e-df6562fe445b.png">
https://automate.browserstack.com/builds/6eeace5179d6524a50f94db121afe12aa59dccc8/sessions/c638dd3ceb0d4016dc76e0412578e0029f4b43f9
