### PR TITLE
245 and 555 - Fixes for cutoff popupmenus and incorrect active states on fields with options

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1439,7 +1439,7 @@ Dropdown.prototype = {
     selectText();
 
     // Set focus back to the element
-    if (env.browser.isIE10 || env.browser.isIE11) {
+    if (env.browser.isIE10() || env.browser.isIE11()) {
       setTimeout(() => {
         input[0].focus();
       }, 0);

--- a/src/components/field-options/field-options.js
+++ b/src/components/field-options/field-options.js
@@ -114,6 +114,13 @@ FieldOptions.prototype = {
     const removeFocused = (elem) => {
       (elem || this.element).removeClass('is-focused');
     };
+    const canActive = (e) => {
+      let r = isFocus(this.element);
+      r = datepicker && datepicker.isOpen() ? false : r;
+      r = timepicker && timepicker.isOpen() ? false : r;
+      r = dropdown && dropdown.isOpen() ? false : r;
+      return r;
+    }
     const doActive = () => {
       self.element.add(self.trigger).add(self.field).add(self.fieldParent)
         .addClass('is-active');
@@ -175,9 +182,15 @@ FieldOptions.prototype = {
     // In desktop environments, the button should only display when the field is in use.
     if (env.features.touch) {
       this.field.addClass('visible');
-      this.trigger.on(`beforeopen.${COMPONENT_NAME}`, () => {
+      this.trigger.on(`beforeopen.${COMPONENT_NAME}`, (e) => {
+        if (!canActive(e)) {
+          return;
+        }
         doActive();
-      }).on(`close.${COMPONENT_NAME}`, () => {
+      }).on(`close.${COMPONENT_NAME}`, (e) => {
+        if (!canUnactive(e)) {
+          return;
+        }
         doUnactive();
       });
     } else {
@@ -329,8 +342,8 @@ FieldOptions.prototype = {
       .on(`selected.${COMPONENT_NAME}`, () => {
         this.popupmenuApi.settings.returnFocus = true;
       })
-      .on(`close.${COMPONENT_NAME}`, (e, isCancelled) => {
-        if (canUnactive(e) && isCancelled) {
+      .on(`close.${COMPONENT_NAME}`, (e) => {
+        if (canUnactive(e)) {
           doUnactive();
         }
       });

--- a/src/components/field-options/field-options.js
+++ b/src/components/field-options/field-options.js
@@ -363,15 +363,15 @@ FieldOptions.prototype = {
           e.stopPropagation();
         }
       });
-
-      this.element
-        .on(`listopened.${COMPONENT_NAME}`, () => {
-          doActive();
-        })
-        .on(`listclosed.${COMPONENT_NAME}`, () => {
-          doUnactive();
-        });
     }
+
+    this.element
+      .on(`listopened.${COMPONENT_NAME}`, () => {
+        doActive();
+      })
+      .on(`listclosed.${COMPONENT_NAME}`, () => {
+        doUnactive();
+      });
 
     return this;
   }, // END: Handle Events -------------------------------------------------

--- a/src/components/field-options/field-options.js
+++ b/src/components/field-options/field-options.js
@@ -115,11 +115,11 @@ FieldOptions.prototype = {
       (elem || this.element).removeClass('is-focused');
     };
     const doActive = () => {
-      this.element.add(this.trigger).add(this.field).add(this.fieldParent)
+      self.element.add(self.trigger).add(self.field).add(self.fieldParent)
         .addClass('is-active');
     };
     const doUnactive = () => {
-      this.element.add(this.trigger).add(this.field).add(this.fieldParent)
+      self.element.add(self.trigger).add(self.field).add(self.fieldParent)
         .removeClass('is-active');
     };
     const canUnactive = (e) => {
@@ -175,6 +175,11 @@ FieldOptions.prototype = {
     // In desktop environments, the button should only display when the field is in use.
     if (env.features.touch) {
       this.field.addClass('visible');
+      this.trigger.on(`beforeopen.${COMPONENT_NAME}`, () => {
+        doActive();
+      }).on(`close.${COMPONENT_NAME}`, () => {
+        doUnactive();
+      });
     } else {
       this.field.removeClass('visible');
       this.field
@@ -411,6 +416,7 @@ FieldOptions.prototype = {
     ].join(' '));
 
     this.trigger.off([
+      `beforeopen.${COMPONENT_NAME}`,
       `click.${COMPONENT_NAME}`,
       `focusin.${COMPONENT_NAME}`,
       `focusout.${COMPONENT_NAME}`,

--- a/src/components/field-options/field-options.js
+++ b/src/components/field-options/field-options.js
@@ -114,13 +114,13 @@ FieldOptions.prototype = {
     const removeFocused = (elem) => {
       (elem || this.element).removeClass('is-focused');
     };
-    const canActive = (e) => {
+    const canActive = () => {
       let r = isFocus(this.element);
       r = datepicker && datepicker.isOpen() ? false : r;
       r = timepicker && timepicker.isOpen() ? false : r;
       r = dropdown && dropdown.isOpen() ? false : r;
       return r;
-    }
+    };
     const doActive = () => {
       self.element.add(self.trigger).add(self.field).add(self.fieldParent)
         .addClass('is-active');

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -844,21 +844,6 @@ PopupMenu.prototype = {
         e.stopPropagation();
         self.updated(settings);
       });
-
-    // Media Query Listener to detect a menu closing on mobile devices that change orientation.
-    /*
-    if (window.matchMedia) {
-      this.matchMedia = window.matchMedia('(orientation: landscape)');
-      this.mediaQueryListener = function () {
-        // Match every time.
-        if (!self.menu.hasClass('is-open')) {
-          return;
-        }
-        self.handleCloseEvent();
-      };
-      this.matchMedia.addListener(this.mediaQueryListener);
-    }
-    */
   },
 
   handleKeys() {
@@ -1526,7 +1511,14 @@ PopupMenu.prototype = {
     this.settings.beforeOpen(response, callbackOpts);
   },
 
-  open(e, ajaxReturn) {
+  /**
+   * Opens the popupmenu, including repopulating data and setting up visual delays, if necessary.
+   * @param {jQuery.Event} e the event that caused the menu to open
+   * @param {boolean} ajaxReturn set to true if the open routine should not include a source call
+   * @param {boolean} useDelay set to true if the menu should open on a delay (used in mobile environments where a software keybord is present)
+   * @returns {void}
+   */
+  open(e, ajaxReturn, useDelay) {
     const self = this;
     /**
      * Fires before open.
@@ -1546,6 +1538,16 @@ PopupMenu.prototype = {
       canOpen = this.callSource(e, true);
 
       if (this.settings.beforeOpen) {
+        return;
+      }
+    }
+
+    // If there's no explicit run of this method without this flag, setup a delay and re-run the open method
+    if (!useDelay) {
+      if (env.os.name === 'ios') {
+        setTimeout(() => {
+          self.open(e, ajaxReturn, true);
+        }, 400);
         return;
       }
     }

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -2108,20 +2108,19 @@ PopupMenu.prototype = {
 
     delete this.openedWithTouch;
 
-    if (noFocus) {
+    if (noFocus || !this.settings.returnFocus || env.features.touch) {
       return;
     }
 
-    if (this.settings.returnFocus) {
-      if (typeof this.settings.returnFocus === 'function') {
-        this.settings.returnFocus(this, {
-          triggerElement: this.element[0],
-          menuElement: this.menu[0]
-        });
-      } else {
-        this.element.focus();
-      }
+    if (typeof this.settings.returnFocus === 'function') {
+      this.settings.returnFocus(this, {
+        triggerElement: this.element[0],
+        menuElement: this.menu[0]
+      });
+      return;
     }
+
+    this.element.focus();
   },
 
   /**

--- a/src/layouts/_layouts.scss
+++ b/src/layouts/_layouts.scss
@@ -56,6 +56,12 @@ body.no-scroll {
   height: 100%;
 }
 
+.ios {
+  body.no-scroll {
+    max-height: 100%;
+  }
+}
+
 // Two Column Layout
 .two-column {
   font-size: 0;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR addresses some mobile usability issues that came up as a result of the work on #245 (and related #555):

- Popupmenus that open up while a software keyboard is visible on screen would sometimes become half-sized or cut off.  Often the menus were positioned in a way that covered the trigger buttons, due to a timing issue that was causing the menus to open during the keyboard animations.
- Active states of input fields and field-options buttons would sometimes remain if a field options menu was opened, and focus was set on an outside input field.
- It was sometimes possible to incorrectly scroll out of bounds on an iOS device (read: the blue header was not always present on-screen because it had been unexpectedly scrolled out of view, even if the body tag explicitly had a `.no-scroll` CSS class set).

**Related github/jira issues (required)**:
Fixes #245
Fixes #555

**Steps necessary to review your pull request (required)**:
Pull this branch and run the demoapp.  Then:

_For popupmenu related changes:_
- open http://localhost:4000/components/field-options/example-input-fields on iOS
- focus the middle input field
- tap the middle input field's field options button
- the keyboard should roll out, and a menu should open up aligned to underneath the field options button.

_For testing active state changes:_
- open http://localhost:4000/components/field-options/example-input-fields on iOS
- focus any input field
- tap the input field's field options button
- focus any other input field
- the active state (blue border) on both the input field and the field options button should disappear.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
