### PR TITLE
649 - Set Timezones to New_York

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
   - npm install -g grunt-cli
   - npm install
 before_script:
+  - export TZ=America/New_York
   - if [ $TEST_SUITE != lint ]; then npm run build; fi
 script:
   - if [ $TEST_SUITE = e2e ]; then (npm run quickstart &) && sleep 5; fi

--- a/test/protractor.ci.bs.conf.js
+++ b/test/protractor.ci.bs.conf.js
@@ -40,7 +40,7 @@ exports.config = {
     'browserstack.video': true,
     'browserstack.local': false,
     'browserstack.networkLogs': false,
-    'browserstack.timezone': 'America/New_York',
+    'browserstack.timezone': 'New_York',
     build: browserstackBuildID,
     name: `${theme} theme ci:bs e2e tests`,
     project: 'ids-enterprise-e2e-ci'


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
We are attempting to get all the tests working on the same timezone, in the case, America_New_York which is UTC -4:00. Tests are fired the next day, and that makes tests failed, as they are reporting the next day as the next next day.

| Timezone       | UTC |
| ------------- |:-------------:|
| Default  |	0:00 |

So, let's try setting everything to the expected timezone.

| Timezone       | UTC |
| ------------- |:-------------:|
| America/New_York |	−05:00 (or -4:00 DST)

https://en.wikipedia.org/wiki/List_of_tz_database_time_zones

https://www.browserstack.com/automate/capabilities
<img width="1017" alt="screen shot 2018-08-23 at 11 05 51 am" src="https://user-images.githubusercontent.com/1667967/44533934-99446f80-a6c4-11e8-913f-ee922352a3ff.png">


**Related github/jira issue (required)**:
#649 

**Steps necessary to review your pull request (required)**:
Make sure timezone is being set correctly, and continue to monitor cron jobs, and BrowserStack reports