### PR TITLE
647 - [Mac Safari] fix for menus prematurely closing while holding "ctrl" key

### DIFF
--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -1646,12 +1646,6 @@ PopupMenu.prototype = {
        * @property {object} this menu instance
        */
       self.element.triggerHandler('open', [self.menu]);
-
-      if (self.settings.trigger === 'rightClick') {
-        self.element.on('click.popupmenu touchend.popupmenu', () => {
-          self.handleCloseEvent();
-        });
-      }
     }, 300);
 
     // Hide on iFrame Clicks - only works if on same domain

--- a/test/components/popupmenu/popupmenu.e2e-spec.js
+++ b/test/components/popupmenu/popupmenu.e2e-spec.js
@@ -18,19 +18,26 @@ describe('Contextmenu index tests', () => {
   });
 
   it('Should open on click and close on click out', async () => {
-    const popupmenu = await element(by.id('action-popupmenu'));
-    await browser.actions().click(protractor.Button.RIGHT).perform();
-    await browser.driver.sleep(config.waitsFor);
+    const textLocation = await element(by.css('#maincontent > div:nth-child(1) > div > p ')).getLocation();
+    await browser.actions()
+      .mouseMove(textLocation)
+      .click(protractor.Button.RIGHT)
+      .perform();
+
     await browser.driver
-      .wait(protractor.ExpectedConditions.visibilityOf(popupmenu), config.waitsFor);
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('action-popupmenu'))), config.waitsFor);
 
     expect(await element(by.id('action-popupmenu')).getAttribute('class')).toContain('is-open');
 
-    await browser.actions().click(protractor.Button.Left).perform();
-    await browser.driver
-      .wait(protractor.ExpectedConditions.invisibilityOf(popupmenu), config.waitsFor);
+    await browser.actions()
+      .mouseMove({ x: 20, y: 80 })
+      .click(protractor.Button.LEFT)
+      .perform();
 
-    expect(await popupmenu.getAttribute('class')).not.toContain('is-open');
+    await browser.driver
+      .wait(protractor.ExpectedConditions.invisibilityOf(await element(by.id('action-popupmenu'))), config.waitsFor);
+
+    expect(await element(by.id('action-popupmenu')).getAttribute('class')).not.toContain('is-open');
   });
 });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
A regression bug was reported in Mac Safari, where Popupmenus were closing before they were supposed to if a user was holding down the `Ctrl` key while clicking (The Mac OSX eqivalent of a PC's right click).  This PR fixes that issue.

**Related github/jira issue (required)**:
Fixes #647

**Steps necessary to review your pull request (required)**:
Pull the branch and run the demoapp.  Then:

- Open http://localhost:4000/components/contextmenu/example-index in Mac Safari
- use `Ctrl` + click to open a context menu anywhere in the page.
- release the `Ctrl` key.  The menu should not close, and should remain open.

Additionally, the tester should also check that inside the context menu, clicking on the top-level menu item "Paste Special" (which is the submenu trigger) does not close the menu.  Clicking on this item or pressing "Enter" while the keyboard is focused on this item should do nothing.  Before this PR, doing either of those things would close the menu prematurely, which was a related regression bug to this one.
