### PR TITLE
Fix for - Hierarchy control selection event firing multiple times when paging. #654

### DIFF
--- a/src/components/hierarchy/hierarchy.js
+++ b/src/components/hierarchy/hierarchy.js
@@ -174,6 +174,8 @@ Hierarchy.prototype = {
       const isAction = target.is('a') && target.parent().parent().is('ul.popupmenu');
       let eventType = 'selected';
 
+      e.stopImmediatePropagation();
+
       $('.is-selected').removeClass('is-selected');
       $(`#${nodeId}`).addClass('is-selected');
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes selection event fires multiple times (stacks up) when paging back and forth.

**Related github/jira issue (required)**:
Closes 654

**Steps necessary to review your pull request (required)**:
Add code change and then..
1. Go to http://localhost:4000/components/hierarchy/example-paging.html
2. Expand a leaf
3. Go back
4. Expand again

In the network observe the request is fetched one time after expanded a second time

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
