### PR TITLE
491 - Clean reset and PR for Color palette not closing on no color choice

### DIFF
--- a/src/components/colorpicker/colorpicker.js
+++ b/src/components/colorpicker/colorpicker.js
@@ -320,12 +320,8 @@ ColorPicker.prototype = {
       return;
     }
 
-    if (menu.length) {
-      $(document).trigger($.Event('keydown', { keyCode: 27, which: 27 })); // escape
-
-      if (this.isPickerOpen) {
-        return;
-      }
+    if (menu.length && this.isPickerOpen) {
+      return;
     }
 
     // Append Color Menu
@@ -349,7 +345,6 @@ ColorPicker.prototype = {
     };
 
     // Show Menu
-
     this.element
       .popupmenu(popupmenuOpts)
       .on('open.colorpicker', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Modal will not close on press of dropdown arrow. Only colorpicker will close.

**Related github/jira issue (required)**:
Closes #491 .
Also remedied a small whitespace issue.
Still to add is keypress functionality mentioned in comments to related issue and specifically [here](https://github.com/infor-design/enterprise/issues/491#issuecomment-415541832).

**Steps necessary to review your pull request (required)**:
Pull branch, run app, hit [url test page](http://localhost:4000/components/colorpicker/test-modal.html).
- Click button to show modal
- Click dropdown arrow to show colorpicker.
- Click dropdown arrow again to close colorpicker.

**Additional context**
See comments on old PR: #660 

