### PR TITLE
NG#51 - Fixing an issue when clearing datepicker with backspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ids-enterprise",
   "slug": "ids-enterprise",
-  "version": "4.10.0-dev",
+  "version": "4.11.0-dev",
   "description": "Infor Design System (IDS) Enterprise Components for the web",
   "repository": {
     "type": "git",

--- a/src/components/mask/mask-input.js
+++ b/src/components/mask/mask-input.js
@@ -159,10 +159,10 @@ MaskInput.prototype = {
           return false;
         }
 
-        // in Windows 7 IE11, change event doesn't fire for some unknown reason.
+        // in IE11 or Edge, change event doesn't fire for some unknown reason.
         // Added this for backwards compatility with this OS/Browser combo.
         // See http://jira.infor.com/browse/SOHO-6895
-        if (self._hasChangedValue() && self._isWin7IE11()) {
+        if (self._hasChangedValue() && self._isEdgeIE()) {
           $(self.element).trigger('change');
         }
       }
@@ -314,20 +314,17 @@ MaskInput.prototype = {
     return os === 'android';
   },
 
-  /**
-   * Same as the Android method, but for IE 11 on Windows 7
-   * TODO: deprecate eventually (v4.4.0?)
-   * @private
-   * @returns {boolean} whether or not the current device is running Windows 7
-   *  using the IE11 browser.
-   */
-  _isWin7IE11() {
-    const browser = env && env.browser && env.browser.name ? env.browser.name : '';
-    const version = env.browser.version ? env.browser.version : '';
-    const isWin7 = window.navigator.userAgent.indexOf('Windows NT 6.1') !== -1;
+    /**
+     * Determine if browser is IE11 or Edge
+     * @private
+     * @returns {boolean} whether or not the current device is using IE11
+	 * or Edge
+     */
+    _isEdgeIE: function  _isEdgeIE() {
+      const browser = env && env.browser && env.browser.name ? env.browser.name : '';
 
-    return browser === 'ie' && version === '11' && isWin7;
-  },
+      return browser === 'ie' || browser === 'edge';
+    },
 
   /**
    * Checks the current value of this masked input against it's stored "previousMaskResult"


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
We found as noted on #51 that the change event was not firing when a user will backspace out a field on the datepicker (using a mask). Because of this data can be lost.

**Related github/jira issue (required)**:
Closes infor-design/enterprise#51

**Steps necessary to review your pull request (required)**:
- follow the steps on the ng issue after building this project and copying it over to ids-enterprise-nt
