### PR TITLE
548 - Fix paste and IE errors

### DIFF
--- a/src/utils/environment.js
+++ b/src/utils/environment.js
@@ -237,14 +237,15 @@ Environment.set();
 /**
  * Workaround until https://github.com/jquery/jquery/issues/2871 is fixed
  */
-jQuery.event.special.touchstart = {
-  setup(_, ns, handle) {
-    if (ns.includes('noPreventDefault')) {
-      this.addEventListener('touchstart', handle, { passive: false });
-    } else {
-      this.addEventListener('touchstart', handle, { passive: true });
+if (Environment.browser.name === 'chrome') {
+  jQuery.event.special.touchstart = {
+    setup(_, ns, handle) {
+      if (ns.includes('noPreventDefault')) {
+        this.addEventListener('touchstart', handle, { passive: false });
+      } else {
+        this.addEventListener('touchstart', handle, { passive: true });
+      }
     }
-  }
-};
-
+  };
+}
 export { Environment };


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This code causes an error when running IE. It in the end made it appear like paste was not working.
This should fix it as the warnings where chrome specific.

**Related github/jira issue (required)**:

Fixes #548

**Steps necessary to review your pull request (required)**:
- run IE
- check console for now errors
- paste in the editor with ctrl-c
