### PR TITLE
662 - Fixed modal x button

### DIFF
--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -292,10 +292,17 @@
     margin: 25px auto 5px;
   }
 
+  > .modal-buttonset {
+    .btn-close {
+      position: relative;
+      bottom: 0;
+    }
+  }
+
   .btn-close {
     position: absolute;
     right: 0;
-    bottom: 0;
+    top: 0;
 
     .icon {
       width: 16px;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
--> 
I reverted the `.modal-content .btn-close` to `top: 0` and created a new css rule specific only inside of the modal-buttonset class.

```
 > .modal-buttonset {
    .btn-close {
      position: relative;
      bottom: 0;
    }
  }
```

So this solution will also fixed the issue in nested modal https://github.com/infor-design/enterprise/pull/602



**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise/issues/662

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Run http://localhost:4000/components/modal/example-close-btn.html
- Click Show Modal button
- X button should now be on the top-right of the modal

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
