### PR TITLE
671 - Fixes whitespace in tablist in a card

### DIFF
--- a/app/views/components/cards/test-tabs-card.html
+++ b/app/views/components/cards/test-tabs-card.html
@@ -1,4 +1,4 @@
-<div class="two-thirds column">
+<div class="two-thirds column row">
     <div class="card">
       <div class="card-header">
           <h2 class="widget-title">Card Title</h2>

--- a/app/views/components/cards/test-tabs-card.html
+++ b/app/views/components/cards/test-tabs-card.html
@@ -1,0 +1,48 @@
+<div class="two-thirds column">
+    <div class="card">
+      <div class="card-header">
+          <h2 class="widget-title">Card Title</h2>
+          <button class="btn-actions" type="button">
+            <span class="audible">Actions</span>
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use xlink:href="#icon-more"></use>
+            </svg>
+          </button>
+          <ul class="popupmenu">
+            <li><a href="#">Action One</a></li>
+            <li><a href="#">Action Two</a></li>
+          </ul>
+
+      </div>
+      <div class="card-content">
+        <div id="tabs-normal" class="tab-container">
+          <ul class="tab-list">
+            <li class="tab"><a href="#tabs-normal-contracts">Contracts</a></li>
+            <li class="tab"><a href="#tabs-normal-opportunities">Opportunities</a></li>
+            <li class="tab is-selected"><a href="#tabs-normal-attachments">Attachments</a></li>
+            <li class="tab"><a href="#tabs-normal-contacts">Contacts</a></li>
+            <li class="tab"><a href="#tabs-normal-notes">Notes</a></li>
+          </ul>
+        </div>
+        <div class="tab-panel-container">
+          <div id="tabs-normal-contracts" class="tab-panel">
+            <p>Facilitate cultivate monetize, seize e-services peer-to-peer content integrateAJAX-enabled user-centric strategize. Mindshare; repurpose integrate global addelivery leading-edge frictionless, harness real-time plug-and-play standards-compliant 24/7 enterprise strategize robust infomediaries: functionalities back-end. Killer disintermediate web-enabled ubiquitous empower relationships, solutions, metrics architectures.</p>
+          </div>
+          <div id="tabs-normal-opportunities" class="tab-panel">
+            <p>Bricks-and-clicks? Evolve ubiquitous matrix B2B 24/365 vertical 24/365 platforms standards-compliant global leverage dynamic 24/365 intuitive ROI seamless rss-capable. Cutting-edge grow morph web services leverage; ROI, unleash reinvent innovative podcasts citizen-media networking.</p>
+          </div>
+          <div id="tabs-normal-attachments" class="tab-panel">
+            <p>Frictionless webservices, killer open-source innovate, best-of-breed, whiteboard interactive back-end optimize capture dynamic front-end. Initiatives ubiquitous 24/7 enhance channels B2B drive frictionless web-readiness generate recontextualize widgets applications. Sexy sticky matrix, user-centred, rich user-centric: peer-to-peer podcasting networking addelivery optimize streamline integrated proactive: granular morph.</p>
+          </div>
+          <div id="tabs-normal-contacts" class="tab-panel top-padding">
+            <p>Bricks-and-clicks? Evolve ubiquitous matrix B2B 24/365 vertical 24/365 platforms standards-compliant global leverage dynamic 24/365 intuitive ROI seamless rss-capable. Cutting-edge grow morph web services leverage; ROI, unleash reinvent innovative podcasts citizen-media networking.</p>
+          </div>
+          <div id="tabs-normal-notes" class="tab-panel">
+            <p>Post incentivize; rich-clientAPIs customized revolutionize 24/365 killer incentivize integrate intuitive utilize!</p>
+          </div>
+        </div>
+
+
+      </div>
+    </div>
+  </div>

--- a/src/components/tabs/_tabs-horizontal.scss
+++ b/src/components/tabs/_tabs-horizontal.scss
@@ -3,6 +3,17 @@
 
 $horizontal-tabs-height: 40px;
 
+.has-more-button.tab-container.horizontal {
+  &::after {
+    background-image: linear-gradient(
+      to right,
+      rgba($body-bg-color, 0),
+      rgba($body-bg-color, 1)
+    );
+    height: ($horizontal-tabs-height - 1px);
+  }
+}
+
 .tab-container.horizontal {
   border-bottom: 1px solid $tab-border-color;
 
@@ -11,15 +22,6 @@ $horizontal-tabs-height: 40px;
       to right,
       rgba($body-bg-color, 1),
       rgba($body-bg-color, 0)
-    );
-    height: ($horizontal-tabs-height - 1px);
-  }
-
-  &::after {
-    background-image: linear-gradient(
-      to right,
-      rgba($body-bg-color, 0),
-      rgba($body-bg-color, 1)
     );
     height: ($horizontal-tabs-height - 1px);
   }

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -236,6 +236,14 @@
   }
 }
 
+//This will force the fade edge to move in the tab list when the button is visible
+.has-more-button.tab-container.horizontal,
+.has-more-button.tab-container.header-tabs {
+  &::after {
+    right: 51px;
+  }
+}
+
 // Common styles between Horizontal and Header tabs
 .tab-container.horizontal,
 .tab-container.header-tabs {
@@ -267,7 +275,7 @@
   // Background fade on the right edge
   // Fade colors are determined by pattern/implementation (see different tab CSS files for definitions)
   &::after {
-    right: 51px; // bleed into the tab list (width of this element + 1 for border)
+    right: 0; // bleed into the tab list (width of this element + 1 for border) & eliminate unncessary white space
   }
 
   &.scrolled-left::after,


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
The issue is very inconsistent when resizing the browser and it flickers.

I changed the right: 51px to right: 0; to eliminate the white space when the button arrow is not yet visible.

This is under the `.tab-container` and `.horizontal` container.
```
&::after {
    right: 0; // bleed into the tab list (width of this element + 1 for border) & eliminate unncessary white space
  }
```

Then I created a css rule where I will back the position of the fade edge in the tab list so that it will not overlap when the button arrow is visible.

```
.has-more-button.tab-container.horizontal,
.has-more-button.tab-container.header-tabs {
  &::after {
    right: 51px;
  }
}
```

I created a test page for this,

http://localhost:4000/components/cards/test-tabs-card.html

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise/issues/671

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Run http://localhost:4000/components/cards/test-tabs-card.html
- Try to play it around by resizing the browser. Check the behavior of the fade edge and the button arrow until it appears.
- White space shouldn't come anymore.

**File/s**
**N** - app/views/components/cards/test-tabs-card.html
**M** - src/components/tabs/_tabs.scss

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
