### PR TITLE
331 disabled closing of modal on enter key if target is not a button

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -604,7 +604,7 @@ Modal.prototype = {
         e.stopPropagation();
         e.preventDefault();
 
-        if (!target.hasClass('fileupload')) {
+        if ($(target).is(':button')) {
           this.element.find('.btn-modal-primary:enabled').trigger('click');
         }
       }

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -604,7 +604,7 @@ Modal.prototype = {
         e.stopPropagation();
         e.preventDefault();
 
-        if ($(target).is(':button')) {
+        if (!target.hasClass('fileupload') && !$(target).is(':input')) {
           this.element.find('.btn-modal-primary:enabled').trigger('click');
         }
       }

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -604,7 +604,7 @@ Modal.prototype = {
         e.stopPropagation();
         e.preventDefault();
 
-        if (!target.hasClass('fileupload') && !$(target).is(':input')) {
+        if ((!target.hasClass('fileupload') && !$(target).is(':input')) || target.hasClass('colorpicker')) {
           this.element.find('.btn-modal-primary:enabled').trigger('click');
         }
       }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Disabled closing of modal on enter key if target is not a button
- http://localhost:4000/components/modal/example-index.html

**Related github/jira issue (required)**:
Closes #331 

**Steps necessary to review your pull request (required)**:
- Click "Show Modal" button to display modal box
- Type in "test" on input field
- Hit Enter key
- Modal box should no longer close upon hitting Enter key
