### PR TITLE
Reverse incorrect icons

### DIFF
--- a/src/components/icons/svg.html
+++ b/src/components/icons/svg.html
@@ -814,13 +814,12 @@
     </symbol>
 
     <symbol id="icon-plusminus-folder-closed" viewBox="1 1 18 18">
-      <path d="M16 10c.553 0 1-.447 1-1 0-.553-.447-1-1-1h-14c-.553 0-1 .447-1 1 0 .553.447 1 1 1h14z"></path>
-    </symbol>
-
-    <symbol id="icon-plusminus-folder-open" viewBox="1 1 18 18">
       <path d="M16 8h-6v-6c0-.552-.448-1-1-1s-1 .448-1 1v6h-6c-.552 0-1 .448-1 1s.448 1 1 1h6v6c0 .552.448 1 1 1s1-.448 1-1v-6h6c.552 0 1-.448 1-1s-.448-1-1-1"></path>
     </symbol>
 
+    <symbol id="icon-plusminus-folder-open" viewBox="1 1 18 18">
+      <path d="M16 10c.553 0 1-.447 1-1 0-.553-.447-1-1-1h-14c-.553 0-1 .447-1 1 0 .553.447 1 1 1h14z"></path>
+    </symbol>
 
     <symbol id="icon-business-object" viewBox="0 0 32 32">
       <path fill="#6DC80D" d="M21,7c-4.9,0-9,4-9,9c0,4.9,4,9,9,9c4.9,0,9-4,9-9C30,11,26,7,21,7z M21,21.4c-3,0-5.4-2.4-5.4-5.4 c0-3,2.4-5.4,5.4-5.4c3,0,5.4,2.4,5.4,5.4C26.5,19,24,21.4,21,21.4z"></path>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Icons on the tree when in + - mode are reversed.

**Related github/jira issue (required)**:
Closes #685

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/tree/example-plus-minus-folders.html
- expand and collapse nodes 
- notice that the + means its closed and the - means it is open the icons were inverted
