### PR TITLE
389 - Fixed locale js error and dropdown editor with Datagrid

### DIFF
--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1838,20 +1838,31 @@ $datagrid-short-row-height: 23px;
         // scss-lint:enable NestingDepth
 
         &:focus {
-          box-shadow: none;
+          // scss-lint:disable ImportantRule
+          box-shadow: none !important;
           outline: none;
 
           &.is-not-editable {
             border-color: transparent;
           }
+          // scss-lint:enable ImportantRule
         }
       }
 
       //Drop Down
       .dropdown {
         border: medium none;
-        line-height: inherit;
+        line-height: normal;
         padding: 0 20px;
+        width: calc(100% - 30px);
+
+        &:focus {
+          box-shadow: none;
+        }
+      }
+
+      .dropdown-wrapper {
+        margin-top: 4px;
       }
 
       //Text Area
@@ -1867,6 +1878,8 @@ $datagrid-short-row-height: 23px;
       }
 
       .icon {
+        left: auto;
+        top: 5px;
         visibility: visible;
       }
 
@@ -3014,8 +3027,14 @@ html[dir='rtl'] {
       text-align: left;
     }
 
-    td.is-editing .datepicker ~ .icon {
-      margin-right: -8px;
+    td.is-editing {
+      .datepicker ~ .icon {
+        margin-right: -8px;
+      }
+
+      .dropdown-wrapper .icon {
+        left: 14px;
+      }
     }
   }
 
@@ -3029,6 +3048,12 @@ html[dir='rtl'] {
 
     .trigger {
       text-align: right;
+    }
+  }
+
+  .datagrid-dropdown-list {
+    .icon {
+      right: -8px;
     }
   }
 

--- a/src/components/datagrid/datagrid.editors.js
+++ b/src/components/datagrid/datagrid.editors.js
@@ -439,8 +439,10 @@ const editors = {
       const self = this;
 
       // Check if isClick or cell touch and just open the list
-      this.input.trigger('openlist');
-      this.input.parent().find('div.dropdown').focus();
+      if (event.type === 'click') {
+        this.input.trigger('openlist');
+      }
+      this.input[0].parentNode.querySelector('div.dropdown').focus();
 
       this.input.off('listclosed').on('listclosed', (e, type) => {
         grid.commitCellEdit(self.input);

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -317,6 +317,10 @@ const Locale = {  // eslint-disable-line
       value = tDate3;
     }
 
+    if (!value) {
+      return undefined;
+    }
+
     // TODO: Can we handle this if (this.dff.state()==='pending')
     const data = this.currentLocale.data;
     let pattern;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Using keys to date picker editor to create validation error was generating js error then focusing out from grid. Dropdown editor was opening it self with focus so this PR will fix those issues with Datagrid.

**Related github/jira issue (required)**:
#389
https://jira.infor.com/browse/SOHO-8075

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/example-editable.html
- Open above link
- Open developer tools
- Use keyboard to get to grid
- Press F2 to toggles actionableMode "true"
- Use tab key to get date picker editor cell
- Type "00/00/0000" and press tab
- It should make validation error here and go to next cell (dropdown editor)
- See dropdown editor should not open (it should be focused state only, use arrow down key to open)
- See console should not be any js error