### PR TITLE
555 - Fixed visual bug with pressed state on field options

### DIFF
--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -1,5 +1,6 @@
 import * as debug from '../../utils/debug';
 import { utils } from '../../utils/utils';
+import { Environment as env } from '../../utils/environment';
 import { Locale } from '../locale/locale';
 
 // jQuery components
@@ -141,7 +142,7 @@ Button.prototype = {
         // Start the JS Animation Loop if IE9
         // Or Safari/Firefox has bug with combination like: animation, overflow, position,
         // border-radius etc.)
-        if (!$.fn.cssPropSupport('animation') || self.isSafari || self.isFirefox) {
+        if (!$.fn.cssPropSupport('animation') || self.isSafari && !env.features.touch || self.isFirefox) {
           ripple.removeClass('is-animation');
           self.animateWithJS(ripple);
         } else {

--- a/src/components/field-options/_field-options.scss
+++ b/src/components/field-options/_field-options.scss
@@ -3,6 +3,7 @@
 @mixin trigger-button {
   @include rotate(90);
   //border-radius: top-right | bottom-right | bottom-left | top-left
+  clip-path: inset(0 0 0 0);
   border-radius: 2px 2px 0 0;
   height: 22px;
   left: -10px;
@@ -10,6 +11,7 @@
   min-width: 0;
   min-height: 0;
   opacity: 0;
+  overflow: hidden;
   width: 34px;
 
   &:hover {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes a visual bug in touch environments in [this comment](https://github.com/infor-design/enterprise/issues/555#issuecomment-416288127) where the pressed state of buttons could bleed out from the boundaries of field options buttons.

**Related github/jira issue (required)**:
#555

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp.
- Open http://localhost:4000/components/field-options/example-index on a mobile browser (bug was originally reported on iOS devices)
- Tap any field options button
- Observe that the field options buttons no longer have a blue, circular "ripple" effect that bleeds outside of the buttons' edge - the circle should be contained by the button and not bleed.
