### PR TITLE
277 Fixed issue regarding tab content still being displayed after hid…

### DIFF
--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -2666,8 +2666,15 @@ Tabs.prototype = {
     const tab = this.doGetTab(e, tabId);
 
     if (tab.is('.is-selected')) {
-      this.activatePreviousTab(tabId);
+      if (tab.prevAll('li.tab').not('.hidden').length > 0) {
+        this.select($(tab.prevAll('li.tab').not('.hidden')[0]).find('a')[0].hash);
+      } else if (tab.nextAll('li.tab').not('.hidden').length > 0) {
+        this.select($(tab.nextAll('li.tab').not('.hidden')[0]).find('a')[0].hash);
+      }
+    } else {
+      this.select($(this.element.find('li.tab.is-selected')[0]).find('a')[0].hash);
     }
+
     tab.addClass('hidden');
     this.focusBar();
     this.positionFocusState();
@@ -2684,6 +2691,9 @@ Tabs.prototype = {
     const tab = this.doGetTab(e, tabId);
 
     tab.removeClass('hidden');
+
+    this.select($(this.element.find('li.tab.is-selected')[0]).find('a')[0].hash);
+
     this.focusBar();
     this.positionFocusState();
     return this;

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -1776,6 +1776,29 @@ Tabs.prototype = {
   },
 
   /**
+   * Takes a tab ID and activates an adjacent available tab
+   * @param {object} e event object
+   * @param {string} tabId the tab ID
+   */
+  activateAdjacentTab(e, tabId) {
+    const tab = this.doGetTab(e, tabId);
+
+    if (typeof e === 'string') {
+      tabId = e;
+    }
+
+    if (tab.is('.is-selected')) {
+      if (tab.prevAll('li.tab').not('.hidden').not('.is-disabled').length > 0) {
+        this.select($(tab.prevAll('li.tab').not('.hidden').not('.is-disabled')[0]).find('a')[0].hash);
+      } else if (tab.nextAll('li.tab').not('.hidden').length > 0) {
+        this.select($(tab.nextAll('li.tab').not('.hidden').not('.is-disabled')[0]).find('a')[0].hash);
+      }
+    } else {
+      this.select($(this.element.find('li.tab.is-selected')[0]).find('a')[0].hash);
+    }
+  },
+
+  /**
    * Takes a tab ID and returns a jquery object containing the previous available tab
    * If an optional target Tab (li) is provided, use this to perform activation events
    * @param {string} tabId the tab ID
@@ -2665,15 +2688,7 @@ Tabs.prototype = {
   hide(e, tabId) {
     const tab = this.doGetTab(e, tabId);
 
-    if (tab.is('.is-selected')) {
-      if (tab.prevAll('li.tab').not('.hidden').length > 0) {
-        this.select($(tab.prevAll('li.tab').not('.hidden')[0]).find('a')[0].hash);
-      } else if (tab.nextAll('li.tab').not('.hidden').length > 0) {
-        this.select($(tab.nextAll('li.tab').not('.hidden')[0]).find('a')[0].hash);
-      }
-    } else {
-      this.select($(this.element.find('li.tab.is-selected')[0]).find('a')[0].hash);
-    }
+    this.activateAdjacentTab(e, tabId);
 
     tab.addClass('hidden');
     this.focusBar();
@@ -2708,12 +2723,8 @@ Tabs.prototype = {
   disableTab(e, tabId) {
     const tab = this.doGetTab(e, tabId);
 
-    if (tab.is('.is-selected')) {
-      if (typeof e === 'string') {
-        tabId = e;
-      }
-      this.activatePreviousTab(tabId);
-    }
+    this.activateAdjacentTab(e, tabId);
+
     tab.addClass('is-disabled');
     this.focusBar();
     this.positionFocusState();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Fixed issue regarding tab content still being displayed after hiding selected tab
- http://localhost:4000/components/tabs/example-hidden-tabs.html

**Related github/jira issue (required)**:
Closes #277 

**Steps necessary to review your pull request (required)**:
- Click Show Hidden Tabs button
- Go to Tab # 5, contents of Tab # 5 will be shown
- Click Hide Tabs 2 and 5 button while still on Tab # 5
- Another tab should now be selected
