### PR TITLE
548  - Added a fix to not strip ng from text

### DIFF
--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -1544,7 +1544,7 @@ Editor.prototype = {
     }
 
     // Remove "ng-" directives and "ng-" classes
-    s = s.replace(/(ng-\w+-\w+="(.|\n)*?"|ng-\w+="(.|\n)*?"|ng-(\w+-\w+)|ng-(\w+))/g, '');
+    s = s.replace(/\sng-[a-z-]+/, '');
 
     // Remove comments
     s = s.replace(/<!--(.*?)-->/gm, '');

--- a/test/components/editor/editor-api.func-spec.js
+++ b/test/components/editor/editor-api.func-spec.js
@@ -1,0 +1,53 @@
+import { Editor } from '../../../src/components/editor/editor';
+
+const editorHTML = require('../../../app/views/components/editor/example-index.html');
+const svg = require('../../../src/components/icons/svg.html');
+
+let editorEl;
+let svgEl;
+let editorObj;
+
+describe('Editor API', () => {
+  beforeEach(() => {
+    editorEl = null;
+    svgEl = null;
+    editorObj = null;
+    document.body.insertAdjacentHTML('afterbegin', svg);
+    document.body.insertAdjacentHTML('afterbegin', editorHTML);
+    editorEl = document.body.querySelector('.editor');
+    svgEl = document.body.querySelector('.svg-icons');
+    editorObj = new Editor(editorEl);
+  });
+
+  afterEach(() => {
+    editorObj.destroy();
+    editorEl.parentNode.removeChild(editorEl);
+    svgEl.parentNode.removeChild(svgEl);
+
+    const rowEl = document.body.querySelector('.row');
+    rowEl.parentNode.removeChild(rowEl);
+  });
+
+  it('Should be defined on jQuery object', () => {
+    expect(editorObj).toEqual(jasmine.any(Object));
+  });
+
+  it('Should support pasting plain text', () => {
+    const startHtml = '<meta charset="utf-8"><span> cutting-edge</span>';
+    const endHtml = '<meta charset="utf-8"><span> cutting-edge</span>';
+
+    expect(editorObj.getCleanedHtml(startHtml)).toEqual(endHtml);
+  });
+
+  it('Should strip ng attributes on paste', () => {
+    let startHtml = '<meta charset="utf-8" ng-test><span> cutting-edge</span>';
+    let endHtml = '<meta charset="utf-8"><span> cutting-edge</span>';
+
+    expect(editorObj.getCleanedHtml(startHtml)).toEqual(endHtml);
+
+    startHtml = '<meta charset="utf-8" ng-app><span> cutting-edge</span>';
+    endHtml = '<meta charset="utf-8"><span> cutting-edge</span>';
+
+    expect(editorObj.getCleanedHtml(startHtml)).toEqual(endHtml);
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

548 was failed QA because 'ng' is removed from all text when pasting. This fixes that

**Related github/jira issue (required)**:
Closes #548

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/editor/example-index.html
- copy any text with ng in it
- paste
