### PR TITLE
673 - dropdown selected item

### DIFF
--- a/app/views/components/validation/example-short-fields.html
+++ b/app/views/components/validation/example-short-fields.html
@@ -52,7 +52,7 @@
 
     <div class="field-short">
       <label for="dd-custom">Custom</label>
-      <select id="dd-custom" data-validate="test" class="dropdown" style="width: 15px;">
+      <select id="dd-custom" data-validate="test" class="dropdown" style="width: 40px;">
         <option value="" selected></option>
         <option value="1">1</option>
         <option value="b">B</option>
@@ -101,7 +101,7 @@
 
     <div class="field-short">
       <label for="ms-custom">Custom</label>
-      <select id="ms-custom" data-validate="test" class="multiselect" style="width: 15px;" multiple>
+      <select id="ms-custom" data-validate="test" class="multiselect" style="width: 40px;" multiple>
         <option value="" selected></option>
         <option value="1">1</option>
         <option value="b">B</option>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Unable to view selected item in dropdown as inline style width was too small. Increased to 40px for dropdown and multiselect for adequate visibility of selected item on close of dropdown and multiselect.

**Related github/jira issue (required)**:
Closes #673 

**Steps necessary to review your pull request (required)**:
- Pull associated branch.
- `npm start` to run app.
- Browse to [URL](http://localhost:4000/components/validation/example-short-fields.html)
- Ensure visibility of selected item in dropdown and multiselect "Custom" fields
