### PR TITLE
702 - Fix for App Menu Searchfield's clear button

### DIFF
--- a/src/components/applicationmenu/applicationmenu.js
+++ b/src/components/applicationmenu/applicationmenu.js
@@ -129,6 +129,9 @@ ApplicationMenu.prototype = {
           item.highlightTarget = 'text';
           return item;
         },
+        clearResultsCallback() {
+          self.accordionAPI.unfilter();
+        },
         displayResultsCallback(results, done) {
           return self.filterResultsCallback(results, done);
         }

--- a/src/components/searchfield/searchfield.js
+++ b/src/components/searchfield/searchfield.js
@@ -740,6 +740,15 @@ SearchField.prototype = {
       }
     });
 
+    // Setup a listener for the Clearable behavior, if applicable
+    if (self.settings.clearable) {
+      self.element.on(`cleared.${this.id}`, () => {
+        if (self.autocomplete) {
+          self.autocomplete.closeList();
+        }
+      });
+    }
+
     // Override the 'click' listener created by Autocomplete (which overrides the
     // default Popupmenu method) to act differntly when the More Results link is activated.
     self.element.on(`listopen.${this.id}`, (e, items) => {
@@ -748,7 +757,7 @@ SearchField.prototype = {
       // Visual indicator class
       self.wrapper.addClass('popup-is-open');
 
-      list.off('click').on(`click.${this.id}`, 'a', (thisE) => {
+      list.on(`click.${this.id}`, 'a', (thisE) => {
         const a = $(thisE.currentTarget);
         let ret = a.text().trim();
         const isMoreLink = a.hasClass('more-results');
@@ -783,21 +792,17 @@ SearchField.prototype = {
 
       // Override the focus event created by the Autocomplete control to make the more link
       // and no-results link blank out the text inside the input.
-      list.find('.more-results, .no-results').off('focus').on(`focus.${this.id}`, function () {
+      list.find('.more-results, .no-results').on(`focus.${this.id}`, function () {
         const anchor = $(this);
         list.find('li').removeClass('is-selected');
         anchor.parent('li').addClass('is-selected');
         self.element.val('');
       });
+    }).on(`listclose.${this.id}`, () => {
+      const list = $('#autocomplete-list');
 
-      // Setup a listener for the Clearable behavior, if applicable
-      if (self.settings.clearable) {
-        self.element.on(`cleared.${this.id}`, () => {
-          if (self.autocomplete) {
-            self.autocomplete.closeList();
-          }
-        });
-      }
+      list.off(`click.${this.id}`);
+      list.off(`focus.${this.id}`);
     });
 
     return this;

--- a/src/components/searchfield/searchfield.js
+++ b/src/components/searchfield/searchfield.js
@@ -785,8 +785,11 @@ SearchField.prototype = {
         }
 
         self.element.trigger('selected', [a, ret]);
-        self.element.data('popupmenu').close();
-        // e.preventDefault();
+
+        const popup = self.element.data('popupmenu');
+        if (popup) {
+          popup.close();
+        }
         return false;
       });
 

--- a/test/components/autocomplete/autocomplete-api.func-spec.js
+++ b/test/components/autocomplete/autocomplete-api.func-spec.js
@@ -121,4 +121,25 @@ describe('Autocomplete API', () => {
 
     expect(autocompleteAPI.listIsOpen()).toBeFalsy();
   });
+
+  it('can fire a callback when the autocomplete list closes', () => {
+    let wasCalled = false;
+    function clearResultsCallback() {
+      wasCalled = true;
+    }
+
+    autocompleteAPI.updated({
+      showAllResults: true,
+      clearResultsCallback
+    });
+
+    autocompleteAPI.openList('new', statesData);
+
+    expect(autocompleteAPI.listIsOpen()).toBeTruthy();
+
+    autocompleteAPI.closeList();
+
+    // The `clearResultsCallback` should have been triggered through the autocomplete `closeList()` method.
+    expect(wasCalled).toBeTruthy();
+  });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
A regression was found where searchfield components inside of application menus would not reset the menu's filtering when the clear button was clicked.  This PR fixes that bug.

**Related github/jira issue (required)**:
Closes #702 

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp.
- open http://localhost:4000/components/applicationmenu/example-filterable.html
- In the app menu's searchfield, type "history".  The app menu should filter all results out except for the "History" header.
- Click the X button to clear the searchfield's contents.

After clicking the X, all of the accordion's items present.

Also, make sure the functional tests pass.  A new Autocomplete functional test was added for a new setting that helps ensure the accordion's filtering is reset when the `cleared` event occurs.