### PR TITLE
701 - submenu cutoff

### DIFF
--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -2159,10 +2159,12 @@ PopupMenu.prototype = {
     }
 
     this.menu.find('.submenu').children('a').each((i, item) => {
-      const text = $(item).find('span').text();
+      const spantext = $(item).find('span').text();
+      const text = spantext || $(item).text();
       $(item).find('span, svg').remove();
       $(item).text(text);
     });
+    this.menu.find('.submenu').removeClass('submenu');
 
     function unwrapPopup(menu) {
       const thisWrapper = menu.parent();

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -5,7 +5,7 @@ requireHelper('rejection');
 
 jasmine.getEnv().addReporter(browserStackErrorReporter);
 
-describe('Datagrid example-index tests', () => {
+describe('Datagrid index tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/example-index');
 
@@ -48,5 +48,46 @@ describe('Datagrid example-index tests', () => {
     cellEl = await browser.driver.switchTo().activeElement();
 
     expect(await cellEl.getAttribute('aria-colindex')).toBe('1');
+  });
+});
+
+describe('Datagrid contextmenu tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/test-contextmenu');
+
+    const datagridEl = await element(by.id('readonly-datagrid'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should show context menu', async () => {
+    const td = await element(by.css('#readonly-datagrid tr:first-child td:first-child')).getLocation();
+    await browser.actions()
+      .mouseMove(td)
+      .click(protractor.Button.RIGHT)
+      .perform();
+
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.css('#grid-actions-menu'))), config.waitsFor);
+
+    expect(await element(by.css('#grid-actions-menu > li:nth-child(1)')).getText()).toBe('Action One');
+    expect(await element(by.css('#grid-actions-menu > li:nth-child(1)')).isDisplayed()).toBeTruthy();
+
+    expect(await element(by.css('#grid-actions-menu > li:nth-child(3)')).getText()).toBe('Action Three');
+    expect(await element(by.css('#grid-actions-menu > li:nth-child(3)')).isDisplayed()).toBeTruthy();
+
+    expect(await element(by.css('#grid-actions-menu .submenu .popupmenu')).isDisplayed()).toBeFalsy();
+
+    browser.actions().mouseMove(element(by.css('#grid-actions-menu .submenu'))).perform();
+
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.css('#grid-actions-menu .submenu .popupmenu'))), config.waitsFor);
+
+    expect(await element(by.css('#grid-actions-menu .submenu ul > li:nth-child(1)')).getText()).toBe('Action Four');
+    expect(await element(by.css('#grid-actions-menu .submenu ul > li:nth-child(1)')).isDisplayed()).toBeTruthy();
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Regression solved when reopening submenus on a popup menu using immediate mode.

**Related github/jira issue (required)**:
Closes #701

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-contextmenu.html
- right click the grid
- click out
- right click again (submenu should now be shown)