### PR TITLE
Added fix for not running source

### DIFF
--- a/app/views/components/autocomplete/example-searchfield.html
+++ b/app/views/components/autocomplete/example-searchfield.html
@@ -3,7 +3,7 @@
 
       <div class="field">
         <label for="searchfield">Search</label>
-        <input id="searchfield" name="searchfield" class="searchfield" data-autocomplete="source"/>
+        <input id="searchfield" name="searchfield" class="searchfield"/>
       </div>
 
     </div>

--- a/src/components/datagrid/datagrid.editors.js
+++ b/src/components/datagrid/datagrid.editors.js
@@ -802,7 +802,7 @@ const editors = {
     this.originalValue = value;
 
     this.init = function () {
-      this.input = $('<input class="autocomplete datagrid-autocomplete" data-autocomplete="source" />').appendTo(container);
+      this.input = $('<input class="autocomplete datagrid-autocomplete" />').appendTo(container);
 
       if (!column.editorOptions) {
         column.editorOptions = {};

--- a/src/components/searchfield/searchfield.js
+++ b/src/components/searchfield/searchfield.js
@@ -190,7 +190,7 @@ SearchField.prototype = {
     // NOTE: The `source` setting can be modified due to a conflict between a legacy Soho attribute,
     // `data-autocomplete`, having the same value as jQuery's `$.data('autocomplete')`.
     const autocompleteDataAttr = this.element.attr('data-autocomplete');
-    if (autocompleteDataAttr) {
+    if (autocompleteDataAttr && autocompleteDataAttr !== 'source') {
       this.settings.source = autocompleteDataAttr;
       this.element.removeAttr('data-autocomplete');
       $.removeData(this.element, 'autocomplete');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

It was reported that example http://localhost:3000/components/autocomplete/example-searchfield.html didnt work. On examination it wasnt that bad of a regression, just an older example that needed updating. Did some cleanup to resolve.

**Related github/jira issue (required)**:
Closes #714 

**Steps necessary to review your pull request (required)**:
http://localhost:3000/components/autocomplete/example-searchfield.html
- focus and type 'm'
- after that the list should show some items

For good measure try the state column on this example as well.
http://localhost:4000/components/datagrid/test-editable-autocomplete.html
