### PR TITLE
Add fix for #724

### DIFF
--- a/src/components/autocomplete/autocomplete.js
+++ b/src/components/autocomplete/autocomplete.js
@@ -541,7 +541,7 @@ Autocomplete.prototype = {
       if (deferredStatus === false) {
         return dfd.reject(searchTerm);
       }
-      return dfd.resolve(xssUtils.ensureAlphaNumeric(searchTerm), response);
+      return dfd.resolve(xssUtils.stripTags(searchTerm), response);
     }
 
     this.loadingTimeout = setTimeout(() => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The security rules in autocomplete are two strict and removing special characters. Relaxing them to only remove tags.

**Related github/jira issue (required)**:
Closes #724

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/autocomplete/test-xss-security.html
- open dev tools
- stop debugger on 
```
openList(term, items) {
    if (this.element.is('[disabled], [readonly]') || this.isLoading()) {
      return;
    }
```
- type a / in the input
- watch the term 
