### PR TITLE
502 - RTL datagrid sort indicator alignment

### DIFF
--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -3130,8 +3130,22 @@ html[dir='rtl'] {
 
   .datagrid-header {
     //Push sort indicator over
-    .sort-indicator {
-      margin: auto 3px 0;
+    .datagrid-column-wrapper {
+      &.l-right-text {
+        .sort-indicator {
+          margin: auto 3px 0;
+          position: absolute;
+          right: 0;
+          top: 3px;
+        }
+      }
+
+      &.l-center-text {
+        .sort-indicator {
+          position: absolute;
+          left: 0;
+        }
+      }
     }
 
     .required::after {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added classes like l-right-text and l-center-text with position absolute to align the sort-indicator on RTL mode

**Related github/jira issue (required)**:
Closes #502 

**Steps necessary to review your pull request (required)**:
1. Open http://localhost:4000/components/datagrid/test-rtl-text.html?locale=ar-SA
1. Check the sort-indicator in datagrid table header particulary the BDO header. 
1. The "All sort" indicator should be vertically and horizontally aligned besides the labels.