### PR TITLE
743 - Allow CORS from Demoapp REST endpoints

### DIFF
--- a/app/src/js/routes/data.js
+++ b/app/src/js/routes/data.js
@@ -20,7 +20,11 @@ const JSON_REGEX = /\.json$/i;
 // Handles the sending of an incoming JSON file
 function sendJSONFile(filepath, req, res, next) {
   const data = getJSONFile(`${filepath}.json`);
-  res.setHeader('Content-Type', 'application/json');
+  res.set({
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Origin, X-Requested-With, Content-Type, Accept',
+    'Content-Type': 'application/json'
+  });
   res.json(data);
   next();
 }
@@ -32,6 +36,11 @@ function getDataFilePath(filename) {
 
 // Calls out to an external piece of middleware that will pass JS data.
 function handleJSFile(jsFilename, req, res, next) {
+  res.set({
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Origin, X-Requested-With, Content-Type, Accept'
+  });
+  
   const middleware = require(jsFilename);
   return middleware(req, res, next);
 }


### PR DESCRIPTION
**Related github/jira issue (required)**:
Fixes #743

**Steps necessary to review your pull request (required)**:
Pull this branch and run the demoapp, then:

- open http://localhost:4000/components/dropdown/example-index
- open a dev tools console
- check this page's response headers.  Ensure there are no `Access-Control-Allow-Origin` or `Access-Control-Allow-Headers` headers.
- then, open http://localhost:4000/api/states
- check this page's response headers.  Ensure there are `Access-Control-Allow-Origin` and `Access-Control-Allow-Headers` headers passed.
