### PR TITLE
Backing out changes related passive event listeners on touchstart events

### DIFF
--- a/src/utils/environment.js
+++ b/src/utils/environment.js
@@ -234,18 +234,4 @@ Environment.browser.isIE10 = function () {
  */
 Environment.set();
 
-/**
- * Workaround until https://github.com/jquery/jquery/issues/2871 is fixed
- */
-if (Environment.browser.name === 'chrome') {
-  jQuery.event.special.touchstart = {
-    setup(_, ns, handle) {
-      if (ns.includes('noPreventDefault')) {
-        this.addEventListener('touchstart', handle, { passive: false });
-      } else {
-        this.addEventListener('touchstart', handle, { passive: true });
-      }
-    }
-  };
-}
 export { Environment };


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Backing out some changes made to remove the `console.warn` for passive event listeners on `touchstart` events.  This unfortunately caused some breakage on the ListBuilder component in #742. 

**Related github/jira issue (required)**:
#414 

**Steps necessary to review your pull request (required)**:
pull this branch and run the demoapp, then:

- open http://localhost:4000/components/listbuilder/example-index.html
- ensure that the ListBuilder component invoked by checking any of the toolbar buttons, and selecting/deslecting the ListBuilder items.
