### PR TITLE
753 - Fix Dropdown/Multiselect tests that were missing `await`

### DIFF
--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -133,7 +133,7 @@ describe('Dropdown example-index tests', () => {
       .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('ul[role="listbox"]'))), config.waitsFor);
     const dropdownSearchEl = element(by.id('dropdown-search'));
     await dropdownSearchEl.click();
-    element(by.id('dropdown-search')).clear().sendKeys('Colorado');
+    await element(by.id('dropdown-search')).clear().sendKeys('Colorado');
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('.is-focused i'))), config.waitsFor);
 

--- a/test/components/multiselect/multiselect.e2e-spec.js
+++ b/test/components/multiselect/multiselect.e2e-spec.js
@@ -185,8 +185,7 @@ describe('Multiselect example-index tests', () => {
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(multiselectEl), config.waitsFor);
     await multiselectEl.click();
-    const multiselectSearchEl = element(by.id('dropdown-search'));
-    await multiselectSearchEl.click();
+    await element(by.id('dropdown-search')).click();
     await browser.driver.switchTo().activeElement().clear();
     await element(by.id('dropdown-search')).sendKeys('Colorado');
     await browser.driver


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Attempting to fix a couple of sporadically failing e2e tests by ensuring they are properly setup for `async`/`await`.

**Related github/jira issue (required)**:
#753

**Steps necessary to review your pull request (required)**:
Pull this branch and run the e2e tests.  Ensure there are no timeouts on the two tests that are changed.
