### PR TITLE
764 - Fix for context menu example

### DIFF
--- a/app/views/kitchen-sink.html
+++ b/app/views/kitchen-sink.html
@@ -19,7 +19,7 @@
     <h2 class="fieldset-title">Right Click Menu</h2>
   </div>
 </div>
-{{>components/contextmenu/example-index}}
+{{>components/contextmenu/test-input-fields}}
 
 <div class="row">
   <div class="twelve columns">


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes an issue on the demoapp's landing page (The kitchen sink) where it's suddenly possible to right click anywhere for an IDS context menu, which clashes with some other components that implement a right click for some operations.

**Related github/jira issue (required)**:
#764 

**Steps necessary to review your pull request (required)**:
- pull this branch and run the demoapp
- open http://localhost:4000
- scroll down to "Right Click Menu"
- ensure that there are two input fields there that can be right clicked for a context menu.   There should NOT be an explanation to right-click anywhere on the page.
