### PR TITLE
First pass at replacing some color palette color variables with token variables

### DIFF
--- a/app/src/sass/_directory.scss
+++ b/app/src/sass/_directory.scss
@@ -13,7 +13,7 @@
 
 .directory-listing {
   .icon {
-    fill: $azure07;
+    fill: $color-primary-alt;
 
     &.example {
       fill: $ruby05;

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -1388,7 +1388,7 @@ html[dir='rtl'] {
 .is-safari {
   .accordion-header {
     &.has-chevron {
-      > [class^="btn"] {
+      > [class^='btn'] {
         height: 45px;
         left: 0;
         margin: 0;

--- a/src/components/badges/_badges.scss
+++ b/src/components/badges/_badges.scss
@@ -72,7 +72,7 @@
     }
 
     &:focus:not(.hide-focus) {
-      border-color: $primary-color;
+      border-color: $color-primary;
       box-shadow: $focus-box-shadow;
       outline: none;
       -moz-outline-style: none;
@@ -89,7 +89,7 @@
     padding: 0 10px;
 
     &:focus:not(.hide-focus) {
-      border-color: $primary-color;
+      border-color: $color-primary;
       box-shadow: $focus-box-shadow;
       outline: none;
       -moz-outline-style: none;

--- a/src/components/badges/_badges.scss
+++ b/src/components/badges/_badges.scss
@@ -52,7 +52,7 @@
 
   &.graphite03,
   &.graphite02 {
-    color: $badge-neutral-color;
+    color: $pill-neutral-bg-color;
   }
 
   &.round {

--- a/src/components/bullet/_bullet.scss
+++ b/src/components/bullet/_bullet.scss
@@ -10,7 +10,7 @@
   }
 
   .marker {
-    stroke: $primary-color;
+    stroke: $color-primary;
     stroke-width: 2px;
   }
 

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -773,7 +773,7 @@ html[lang^='fr-'] {
   }
 
   &:focus {
-    box-shadow: 0 0 0 1px $body-bg-color, 0 0 0 2px $primary-color, $focus-box-shadow;
+    box-shadow: 0 0 0 1px $body-bg-color, 0 0 0 2px $color-primary, $focus-box-shadow;
   }
 
   &:disabled {

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -507,7 +507,7 @@ a.btn-close {
 
   &.has-content {
     .icon {
-      fill: $azure06;
+      fill: $color-primary;
     }
 
     &:hover .icon {

--- a/src/components/calendar/_calendar.scss
+++ b/src/components/calendar/_calendar.scss
@@ -80,7 +80,7 @@
     @include font-size(11);
 
     background-color: $azure02;
-    border-left: 5px solid $azure07;
+    border-left: 5px solid $color-primary-alt;
     border-radius: 3px;
     color: $font-color-extrahighcontrast;
     cursor: pointer;

--- a/src/components/circlepager/_circlepager.scss
+++ b/src/components/circlepager/_circlepager.scss
@@ -34,7 +34,7 @@
     .btn-next,
     .btn-previous {
       background-color: $graphite10;
-      border: 1px solid $graphite04;
+      border: 1px solid $color-default-alt;
       border-radius: 50%;
       display: none;
       height: 32px;
@@ -47,7 +47,7 @@
       z-index: 1001;
 
       .icon {
-        fill: $graphite04;
+        fill: $icon-fill;
         height: 18px;
         width: 18px;
       }
@@ -151,9 +151,9 @@
 
         &.is-active {
           background-color: $graphite10;
-          border: 1px solid $graphite04;
+          border: 1px solid $color-default-alt;
           border-radius: 2px;
-          color: $graphite04;
+          color: $color-default-alt;
           cursor: default;
           display: inline-block;
           height: auto;
@@ -162,12 +162,12 @@
 
           &:hover {
             background-color: $graphite10;
-            border-color: $graphite04;
+            border-color: $color-default-alt;
           }
 
           &:focus {
             background-color: $graphite10;
-            border-color: $graphite04;
+            border-color: $color-default-alt;
           }
         }
       }

--- a/src/components/colorpicker/_colorpicker.scss
+++ b/src/components/colorpicker/_colorpicker.scss
@@ -277,7 +277,7 @@
   }
 
   .swatch {
-    background-color: $graphite04;
+    background-color: $color-default-alt;
     display: block;
     height: 20px;
     width: 20px;

--- a/src/components/colorpicker/_colorpicker.scss
+++ b/src/components/colorpicker/_colorpicker.scss
@@ -181,11 +181,11 @@
     }
 
     &:hover:not(:disabled) .icon {
-      fill: $primary-color;
+      fill: $color-primary;
     }
 
     &:active .icon {
-      fill: $primary-color;
+      fill: $color-primary;
     }
 
     &.is-empty,
@@ -241,7 +241,7 @@
 
       &:focus {
         box-shadow: $focus-box-shadow;
-        outline: 1px solid $primary-color;
+        outline: 1px solid $color-primary;
       }
 
       &.is-selected {

--- a/src/components/counts/_counts.scss
+++ b/src/components/counts/_counts.scss
@@ -24,7 +24,7 @@
 
   // No Color Class.
   .count[class=count] {
-    background-color: $graphite04;
+    background-color: $color-default-alt;
   }
 
   .title {

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -2891,7 +2891,7 @@ td .btn-actions {
   }
 
   .icon {
-    fill: $graphite10;
+    fill: $text-color;
     margin-top: 9px;
     right: 2px;
 

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1130,7 +1130,7 @@ $datagrid-short-row-height: 23px;
     line-height: $datagrid-row-height;
 
     &.is-active-row {
-      outline: 1px solid $primary-color;
+      outline: 1px solid $color-primary;
       outline-offset: -1px;
 
       td {
@@ -1401,7 +1401,7 @@ $datagrid-short-row-height: 23px;
     }
 
     &.rowstatus-row-info {
-      @include rowstatus($primary-color);
+      @include rowstatus($color-primary);
     }
 
     &.rowstatus-row-in-progress {
@@ -1436,7 +1436,7 @@ $datagrid-short-row-height: 23px;
       box-shadow: $datagrid-cell-focus-box-shadow;
 
       .datagrid-cell-wrapper {
-        border: 1px solid $primary-color;
+        border: 1px solid $color-primary;
       }
     }
 
@@ -1659,7 +1659,7 @@ $datagrid-short-row-height: 23px;
       position: relative;
 
       .datagrid-cell-wrapper {
-        border: 1px solid $primary-color;
+        border: 1px solid $color-primary;
         left: 0;
         position: absolute;
         text-overflow: initial;
@@ -2312,7 +2312,7 @@ $datagrid-short-row-height: 23px;
 
     &:focus,
     &.is-focused {
-      border: 1px solid $primary-color;
+      border: 1px solid $color-primary;
       box-shadow: $focus-box-shadow;
     }
 
@@ -3559,7 +3559,7 @@ html[dir='rtl'] {
 
         td {
           .datagrid-cell-wrapper {
-            border-color: $primary-color;
+            border-color: $color-primary;
             border-style: solid;
             border-width: 1px 0;
           }

--- a/src/components/drag/_drag.scss
+++ b/src/components/drag/_drag.scss
@@ -22,7 +22,7 @@
   @include no-select;
 
   background: transparent none repeat scroll 0 0;
-  border: 1px solid $primary-color;
+  border: 1px solid $color-primary;
   cursor: e-resize;
   height: inherit;
   left: 48px;

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -72,7 +72,7 @@ $subheader-height: 60px;
     }
 
     &:focus:not(.hide-focus) {
-      box-shadow: 0 0 0 2px $azure07, 0 0 0 3px $white, $header-focus-box-shadow;
+      box-shadow: 0 0 0 2px $color-primary-alt, 0 0 0 3px $white, $header-focus-box-shadow;
 
       &:active {
         box-shadow: none;

--- a/src/components/hierarchy/_hierarchy.scss
+++ b/src/components/hierarchy/_hierarchy.scss
@@ -254,7 +254,7 @@ $hierarchy-line-width: 1.34px; //Fixes zoom somewhat
     }
 
     .image-placeholder {
-      border: 2px solid $graphite04;
+      border: 2px solid $color-default-alt;
     }
 
     .detail {

--- a/src/components/hierarchy/_hierarchy.scss
+++ b/src/components/hierarchy/_hierarchy.scss
@@ -73,7 +73,7 @@ $hierarchy-line-width: 1.34px; //Fixes zoom somewhat
           top: 55px;
 
           button {
-            background: $primary-color;
+            background: $color-primary;
             color: $white;
             display: block;
             margin: 0 auto;

--- a/src/components/hyperlinks/_hyperlinks.scss
+++ b/src/components/hyperlinks/_hyperlinks.scss
@@ -188,7 +188,7 @@ p .hyperlink {
   }
 
   .timestamp {
-    color: $graphite04;
+    color: $link-disabled-color;
     display: block;
     font-size: 12px;
     margin: 0;

--- a/src/components/hyperlinks/_hyperlinks.scss
+++ b/src/components/hyperlinks/_hyperlinks.scss
@@ -158,7 +158,7 @@ p .hyperlink {
     line-height: 25px;
 
     svg {
-      fill: $primary-color;
+      fill: $color-primary;
       height: 16px;
       left: 6px;
       margin-right: 2px;

--- a/src/components/icons/_icons.scss
+++ b/src/components/icons/_icons.scss
@@ -33,7 +33,7 @@ svg.icon-dirty,
 }
 
 .icon-info-field {
-  fill: $primary-color;
+  fill: $color-primary;
 }
 
 .field {
@@ -531,8 +531,8 @@ svg.icon-dirty {
   }
 
   &.checkmark-selected {
-    background-color: $primary-color;
-    border-color: $primary-color;
+    background-color: $color-primary;
+    border-color: $color-primary;
 
     &::after {
       border-color: $inverse-color $inverse-color $inverse-color transparent;

--- a/src/components/icons/_icons.scss
+++ b/src/components/icons/_icons.scss
@@ -4,7 +4,7 @@
 // Svg Styles
 .icon {
   display: inline-block;
-  fill: $graphite04;
+  fill: $icon-fill;
   height: 18px; //Older ones at 32 but now based on 40
   position: relative;
   width: 22px;

--- a/src/components/icons/_icons.scss
+++ b/src/components/icons/_icons.scss
@@ -645,7 +645,7 @@ html[dir='rtl'] {
 
 .icon-empty-state {
   display: inline-block;
-  fill: $azure06; // Themable Empty Icons
+  fill: $color-primary; // Themable Empty Icons
   height: 65px;
   position: relative;
   width: 65px;

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -580,14 +580,14 @@ label,
 
 // Text Selection
 ::selection {
-  background: $primary-color;
+  background: $color-primary;
   color: $inverse-color;
   fill: $inverse-color;
   -webkit-text-fill-color: $inverse-color;
 }
 
 ::-moz-selection {
-  background: $primary-color;
+  background: $color-primary;
   color: $inverse-color;
   fill: $inverse-color;
   -webkit-text-fill-color: $inverse-color;

--- a/src/components/listview/_listview.scss
+++ b/src/components/listview/_listview.scss
@@ -141,7 +141,7 @@
     }
 
     &:focus {
-      border-color: $primary-color !important;
+      border-color: $color-primary !important;
       box-shadow: 0 0 4px 1px $focus-box-shadow-color;
       outline: none;
 
@@ -617,7 +617,7 @@
 
     &.has-focus {
       input {
-        border: 1px solid $primary-color;
+        border: 1px solid $color-primary;
       }
     }
   }

--- a/src/components/pager/_pager.scss
+++ b/src/components/pager/_pager.scss
@@ -208,7 +208,7 @@ li + .pager-count {
     margin: -1px;
 
     &:focus {
-      border-color: $primary-color;
+      border-color: $color-primary;
       box-shadow: $focus-box-shadow;
     }
 

--- a/src/components/pager/_pager.scss
+++ b/src/components/pager/_pager.scss
@@ -89,7 +89,7 @@
       }
 
       .audible {
-        color: $graphite10;
+        color: $text-color;
       }
     }
 

--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -522,7 +522,7 @@
 
     &.btn-primary {
       background-color: $popover-bg-color;
-      color: $primary-color;
+      color: $color-primary;
 
       &:hover {
         border: 1px solid transparent;

--- a/src/components/processindicator/_processindicator.scss
+++ b/src/components/processindicator/_processindicator.scss
@@ -5,7 +5,7 @@
 
 $indicator-darkest: $azure08;
 $indicator-darker: $color-primary-alt;
-$indicator-lighter: $azure06;
+$indicator-lighter: $color-primary;
 $indicator-lightest: $azure05;
 $indicator-warning: $alert-red;  //$ruby06
 $indicator-blank: $graphite02;

--- a/src/components/processindicator/_processindicator.scss
+++ b/src/components/processindicator/_processindicator.scss
@@ -7,7 +7,7 @@ $indicator-darkest: $azure08;
 $indicator-darker: $color-primary-alt;
 $indicator-lighter: $color-primary;
 $indicator-lightest: $azure05;
-$indicator-warning: $alert-red;  //$ruby06
+$indicator-warning: $alert-red;
 $indicator-blank: $graphite02;
 
 $indicator-size: 1.3em;

--- a/src/components/processindicator/_processindicator.scss
+++ b/src/components/processindicator/_processindicator.scss
@@ -4,7 +4,7 @@
 // Also see: /sass/controls/_timeline.scss
 
 $indicator-darkest: $azure08;
-$indicator-darker: $azure07;
+$indicator-darker: $color-primary-alt;
 $indicator-lighter: $azure06;
 $indicator-lightest: $azure05;
 $indicator-warning: $alert-red;  //$ruby06

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -9,7 +9,7 @@
 }
 
 @mixin searchfield-text-style-hover() {
-  color: $primary-color;
+  color: $color-primary;
   font-weight: $font-weight-bold;
 
   @include font-size(14);
@@ -182,11 +182,11 @@ $cubic-bezier-ease: cubic-bezier(0.17, 0.04, 0.03, 0.94);
 
     &.has-focus {
       .btn {
-        border-color: $primary-color;
+        border-color: $color-primary;
       }
 
       .searchfield {
-        border-color: $primary-color;
+        border-color: $color-primary;
       }
     }
 

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -363,7 +363,7 @@ $cubic-bezier-ease: cubic-bezier(0.17, 0.04, 0.03, 0.94);
 
   background-color: $searchfield-context-bg;
   border: 0;
-  border-top: 1px solid $azure07;
+  border-top: 1px solid $color-primary-alt;
 
   &.alternate {
     background-color: $searchfield-context-alt-bg;

--- a/src/components/slider/_slider.scss
+++ b/src/components/slider/_slider.scss
@@ -317,7 +317,7 @@ input[type='range'] {
 }
 
 .slider-range {
-  background-color: $primary-color;
+  background-color: $color-primary;
   cursor: pointer;
   display: block;
   position: absolute;

--- a/src/components/toast/_toast.scss
+++ b/src/components/toast/_toast.scss
@@ -115,7 +115,7 @@
 }
 
 .toast-progress {
-  background-color: $primary-color;
+  background-color: $color-primary;
   bottom: 0;
   height: 3px;
   left: 0;

--- a/src/components/typography/_typography.scss
+++ b/src/components/typography/_typography.scss
@@ -274,7 +274,7 @@ small,
 .info-text {
   @include font-size(11);
 
-  color: $azure07;
+  color: $color-primary-alt;
   font-weight: $font-weight-bold;
 }
 

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -52,10 +52,10 @@ $inverse-color: $button-primary-text-color;
 $font-color-extrahighcontrast: $graphite10;
 $font-color-highcontrast: $graphite08;
 $font-color: $graphite06;
-$font-color-lowcontrast: $graphite04;
+$font-color-lowcontrast: $color-default-alt;
 $label-color: $graphite06;
-$label-disabled-color: $graphite04;
-$disabled-color: $graphite04;
+$label-disabled-color: $color-default-alt;
+$disabled-color: $color-default-alt;
 $signin-title-color: $graphite07;
 
 // New Text Colors
@@ -78,7 +78,7 @@ $hr-bottom-color: $white;
 
 // Circle Pager
 $circlepager-bg-color: transparent;
-$circlepager-border-color: $graphite04;
+$circlepager-border-color: $color-default-alt;
 $circlepager-hover-bg-color: transparent;
 $circlepager-hover-border-color: $graphite08;
 $circlepager-focus-bg-color: transparent;
@@ -139,7 +139,7 @@ $badge-neutral-hover-icon-color: $pill-neutral-hover-icon-color;
 // Popup Menu
 $popupmenu-color: $font-color-extrahighcontrast;
 $popupmenu-icon-color: $graphite06;
-$popupmenu-heading-color: $graphite04;
+$popupmenu-heading-color: $color-default-alt;
 $popupmenu-bg-color: $button-primary-text-color;
 $popupmenu-border-color: $graphite03;
 $popupmenu-box-shadow: 0 2px 5px $drop-shadow-depth;
@@ -166,7 +166,7 @@ $tertiary-btn-dark-active-color: $white;
 
 // Secondary with Border
 $secondary-border-btn-color:  $graphite06;
-$secondary-border-btn-border-color: $graphite04;
+$secondary-border-btn-border-color: $color-default-alt;
 $secondary-border-btn-hover-color:  $graphite10;
 $secondary-border-btn-hover-border-color: $graphite10;
 $secondary-border-btn-ripple-color: #8dc9e6;
@@ -204,7 +204,7 @@ $trigger-icon-fill-light-color: $graphite05;
 $trigger-hover-color: $graphite10;
 $trigger-active-color: $color-primary;
 $trigger-focus-color: $color-primary;
-$trigger-disabled-color: $graphite04;
+$trigger-disabled-color: $color-default-alt;
 
 //List View
 $listview-bg-color: $button-primary-text-color;
@@ -213,13 +213,13 @@ $listview-hover-bg-color: $list-hover-color;
 $listview-border-color: $graphite03;
 $listview-color: $graphite10;
 $listview-secondary-color: $graphite06;
-$listview-tertiary-color: $graphite04;
+$listview-tertiary-color: $color-default-alt;
 $listview-disabled-color: $input-disabled-color;
 $listview-selected-text-color: $graphite06;
 
 $listview-header-bg-color: #e4e4e4;
 $listview-header-color: $graphite05;
-$listview-subhead-color: $graphite04;
+$listview-subhead-color: $color-default-alt;
 
 $listview-toolbar-button-text-color: $button-link-text-color;
 $listview-toolbar-button-icon-color: $button-link-text-color;
@@ -258,7 +258,7 @@ $toolbar-separator-color: $graphite03;
 $fieldfilter-border-side-color: transparent;
 
 // Formatter Toolbar
-$formatter-toolbar-separator-color: $graphite04;
+$formatter-toolbar-separator-color: $color-default-alt;
 
 //Contextual Toolbar
 $contextual-toolbar-bg-color: $color-primary;
@@ -266,7 +266,7 @@ $contextual-toolbar-color: $button-primary-text-color;
 $contextual-toolbar-button-color: rgba($button-primary-text-color, 0.8);
 $contextual-toolbar-button-hover-color: rgba($button-primary-text-color, 1);
 $contextual-toolbar-button-disabled-color: rgba($button-primary-text-color, 0.3);
-$contextual-panel-seperator-bg-color: $graphite04;
+$contextual-panel-seperator-bg-color: $color-default-alt;
 
 // Swaplist
 $swaplist-bg-color: $graphite01;
@@ -295,14 +295,14 @@ $datepicker-selected-bg-color: $color-primary;
 $datepicker-selected-color: $button-primary-text-color;
 $datepicker-today-color: $graphite10;
 $datepicker-hover-bg-color: $graphite01;
-$datepicker-disabled-icon-color: $graphite04;
+$datepicker-disabled-icon-color: $color-default-alt;
 $datepicker-disabled-border-color: $graphite03;
 $datepicker-disabled-bg-color: $graphite01;
 $datepicker-disabled-color: $graphite03;
 $datepicker-default-width: 150px;
 
 //Time Picker
-$timepicker-disabled-icon-color: $graphite04;
+$timepicker-disabled-icon-color: $color-default-alt;
 $timepicker-disabled-border-color: $graphite03;
 $timepicker-disabled-color: $graphite03;
 
@@ -313,7 +313,7 @@ $colorpicker-swatch-border-color: $graphite02;
 $colorpicker-checkmark-one-color: $graphite05;
 $colorpicker-checkmark-two-color: $white;
 $colorpicker-popup-bg-color: $white;
-$colorpicker-popup-border-color: $graphite04;
+$colorpicker-popup-border-color: $color-default-alt;
 
 // Fileupload
 $fileupload-primary-color: $graphite10;
@@ -338,7 +338,7 @@ $fileupload-status-color: $white;
 $fileupload-status-hover-color: $white;
 $fileupload-cancel-bg-color: $graphite06;
 $fileupload-cancel-hover-bg-color: $graphite10;
-$fileupload-disabled-icon-color: $graphite04;
+$fileupload-disabled-icon-color: $color-default-alt;
 $fileupload-disabled-border-color: $graphite03;
 $fileupload-disabled-bg-color: $graphite01;
 $fileupload-disabled-color: $graphite03;
@@ -385,7 +385,7 @@ $focus-shadow: rgba(0, 0, 0, 0.3);
 $switch-checked-color: $color-primary;
 $switch-checked-hover-color: $color-primary-alt;
 $switch-checked-bg-color: $azure03;
-$switch-unchecked-bar-color: $graphite04;
+$switch-unchecked-bar-color: $color-default-alt;
 $switch-unchecked-border-color: $graphite03;
 $switch-unchecked-bg-color: $white;
 $switch-unchecked-color: $font-color;
@@ -393,7 +393,7 @@ $switch-unchecked-pressed-bg-color: $white;
 $switch-disabled-border-color: $graphite03;
 $switch-disabled-bg-color: $graphite02;
 $switch-disabled-bar-color: $graphite03;
-$switch-disabled-label-color: $graphite04;
+$switch-disabled-label-color: $color-default-alt;
 $switch-focus-box-shadow: 0 0 0 3px $focus-color, 0 0 0 4px $color-primary, 0 0 4px 6px rgba(54, 138, 192, 0.3);
 $switch-hover-box-shadow: 0 2px 5px $focus-shadow;
 
@@ -402,10 +402,10 @@ $editor-bg-color: transparent;
 $editor-border-color: $input-border-color;
 $editor-hover-border-color: $input-hover-border-color;
 $editor-focus-border-color: $input-focus-border-color;
-$editor-line-number-color: $graphite04;
+$editor-line-number-color: $color-default-alt;
 $editor-color: $input-color;
 $editor-toolbar-bg-color: $graphite02;
-$editor-middle-border-color: $graphite04;
+$editor-middle-border-color: $color-default-alt;
 $editor-btn-color: $graphite06;
 $editor-btn-hover-color: $graphite10;
 $editor-btn-active-color: $color-primary;
@@ -427,19 +427,19 @@ $pager-hover-color: $font-color-extrahighcontrast;
 $pager-disabled-color: $graphite02;
 
 //Slider
-$slider-bg-color: $graphite04;
+$slider-bg-color: $color-default-alt;
 $slider-active-bg-color: $color-primary;
 $slider-labels-color: $graphite06;
 $slider-disabled-color: $graphite02;
 $slider-disabled-active-bg-color: $graphite03;
-$slider-disabled-labels-color: $graphite04;
+$slider-disabled-labels-color: $color-default-alt;
 $slider-disabled-handle-color: $graphite03;
 $slider-disabled-range-color: $graphite03;
 $slider-readonly-color: $graphite05;
 $slider-readonly-active-bg-color: $graphite06;
 $slider-readonly-labels-color: $graphite06;
 $slider-readonly-handle-color: $graphite05;
-$slider-readonly-range-color: $graphite04;
+$slider-readonly-range-color: $color-default-alt;
 $slider-hover-shadow: 0 2px 5px 0 rgba($black, 0.2);
 
 //Modal
@@ -493,9 +493,9 @@ $accordion-highcontrast-text-decoration: none;
 
 $accordion-disabled-bg-color: transparent;
 $accordion-disabled-border-color: $slate03;
-$accordion-disabled-text-color: $graphite04;
+$accordion-disabled-text-color: $color-default-alt;
 $accordion-disabled-pane-bg-color: transparent;
-$accordion-disabled-pane-text-color: $graphite04;
+$accordion-disabled-pane-text-color: $color-default-alt;
 
 $accordion-header-filtered-children-background-color: $graphite09;
 $accordion-filtered-background-color: transparent;
@@ -552,13 +552,13 @@ $vertical-tab-sidebar-bg-color: $body-bg-color-primary;
 $vertical-tab-sidebar-border-color: $graphite02;
 
 //Multi-tabs
-$mutlitabs-section-border-color: $graphite04;
+$mutlitabs-section-border-color: $color-default-alt;
 $mutlitabs-section-alt-bg-color: $white;
 $mutlitabs-section-alt-border-color: $graphite02;
 
 //Charts
 $chart-line-color: $graphite02;
-$chart-line-color-axis: $graphite04;
+$chart-line-color-axis: $color-default-alt;
 $chart-font-color: $graphite06;
 $chart-font-color-inverse: $graphite08;
 $chart-bar-stroke: $white;
@@ -574,7 +574,7 @@ $datagrid-header-border-color: $graphite03;
 $datagrid-header-hover-color: $graphite08;
 $datagrid-header-active-color: $graphite08;
 $datagrid-header-checkbox-border-color: $graphite03;
-$datagrid-sort-icon-color: $graphite04;
+$datagrid-sort-icon-color: $color-default-alt;
 $datagrid-sort-icon-sorted-color: $white;
 $datagrid-required-icon-color: $white;
 
@@ -603,7 +603,7 @@ $datagrid-list-sort-icon-color: $color-default;
 $datagrid-list-sort-icon-hover-color: $graphite05;
 $datagrid-header-focus-bg-color: $datagrid-header-bg-color;
 $datagrid-header-focus-border-color: $white;
-$datagrid-list-header-checkbox-border-color: $graphite04;
+$datagrid-list-header-checkbox-border-color: $color-default-alt;
 $datagrid-list-header-active-color: $color-default;
 
 $datagrid-filter-border-color: $slate04;
@@ -644,20 +644,20 @@ $tree-focus-border-color: $color-primary;
 $tree-active-bg-color: #d7e8f2;
 $tree-icon-color: $graphite06;
 $tree-link-color: $graphite06;
-$tree-disabled-color: $graphite04;
+$tree-disabled-color: $color-default-alt;
 $tree-hover-color: $graphite10;
 $tree-hover-icon-color: $graphite10;
 
 //Progress
 $progress-bg-color: transparent;
-$progress-border-color: $graphite04;
+$progress-border-color: $color-default-alt;
 $progress-bar-bg-color: $color-primary;
 
 //Chart Progress Bar
 $chart-progressbar-bg-color: $color-default;
-$chart-progressbar-bg-color-dark: $graphite04;
+$chart-progressbar-bg-color-dark: $color-default-alt;
 $chart-progressbar-completed-fill: $emerald07;
-$chart-progressbar-target-fill: $graphite04;
+$chart-progressbar-target-fill: $color-default-alt;
 $chart-progressbar-primary-fill: $color-primary;
 $chart-progressbar-dark-fill: $graphite06;
 $chart-targeted-achievement-bg-color: $color-default;
@@ -666,14 +666,14 @@ $chart-targeted-achievement-bg-color: $color-default;
 $timeline-indicator-color: $color-default;
 $timeline-indicator-processing-color: $color-primary;
 $timeline-indicator-complete-color: $color-primary;
-$timeline-line-color: $graphite04;
+$timeline-line-color: $color-default-alt;
 $timeline-header-color: $color-primary;
 
 //Wizard
 $wizard-default-bg: $body-bg-color-primary;
 $wizard-bar-bg: $color-default;
 $wizard-color: $graphite06;
-$wizard-disabled-color: $graphite04;
+$wizard-disabled-color: $color-default-alt;
 $wizard-active-color: $color-primary;
 $wizard-active-text-color: $color-primary;
 $wizard-focus-box-shadow: 0 0 0 1px $color-primary;
@@ -692,7 +692,7 @@ $searchfield-border-color: $graphite03;
 $searchfield-icon-color: $button-link-text-color;
 $searchfield-text-color: $button-link-text-color;
 $searchfield-lighter-bg-color: $graphite01;
-$searchfield-lighter-text-color: $graphite04;
+$searchfield-lighter-text-color: $color-default-alt;
 $searchfield-active-icon-color: $color-primary-alt;
 
 $searchfield-alt-bg-color: $white;
@@ -702,7 +702,7 @@ $searchfield-context-bg: $graphite01;
 $searchfield-context-alt-bg: $white;
 $searchfield-context-border-color: $graphite03;
 $searchfield-context-box-shadow-color: $graphite03;
-$searchfield-context-icon-color: $graphite04;
+$searchfield-context-icon-color: $color-default-alt;
 $searchfield-context-text-color: $font-color;
 
 $searchfield-card-bg-color: $graphite01;
@@ -778,7 +778,7 @@ $module-tabs-disabled-text-color: $azure04;
 $composite-tabs-text-color: $graphite06;
 $composite-tabs-bg-color: $graphite02;
 $composite-tabs-border-color: $graphite05;
-$composite-tabs-focus-state-color: $graphite04;
+$composite-tabs-focus-state-color: $color-default-alt;
 $composite-tabs-panel-bg-color: $white;
 
 // Splitter

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -19,7 +19,7 @@ $header-button-focus-color: rgba($white, 1);
 $header-button-hover-color: rgba($white, 1);
 $header-button-disabled-color: rgba($white, 0.3);
 $header-primary-btn-background-color: $azure05;
-$header-primary-btn-background-hover-color: $azure06;
+$header-primary-btn-background-hover-color: $color-primary;
 $header-text-color: $white;
 $header-disabled-color: $slate05;
 $header-focus-box-shadow:  0 0 4px 3px rgba(255, 255, 255, 0.3);
@@ -144,7 +144,7 @@ $popupmenu-bg-color: $button-primary-text-color;
 $popupmenu-border-color: $graphite03;
 $popupmenu-box-shadow: 0 2px 5px $drop-shadow-depth;
 $popupmenu-checked-color: $color-primary;
-$popupmenu-checked-color-inverse: $azure06;
+$popupmenu-checked-color-inverse: $color-primary;
 $popupmenu-hover-color: $graphite02;
 
 // Dark UI Popupmenu
@@ -240,7 +240,7 @@ $listview-search-disabled-icon-color: $graphite02;
 // Listbuilder
 $listbuilder-bg-color: $panel-bg-color;
 $listbuilder-bg-color-hover: $graphite02;
-$listbuilder-bg-color-selected: $azure06;
+$listbuilder-bg-color-selected: $color-primary;
 $listbuilder-border-color: $input-border-color;
 $listbuilder-border-color-focus: $color-primary;
 $listbuilder-icon-color-hover: $graphite10;
@@ -271,9 +271,9 @@ $contextual-panel-seperator-bg-color: $graphite04;
 // Swaplist
 $swaplist-bg-color: $graphite01;
 $swaplist-bg-color-hover: $graphite02;
-$swaplist-bg-color-selected: $azure06;
+$swaplist-bg-color-selected: $color-primary;
 $swaplist-border-color: $graphite06;
-$swaplist-border-color-hover: $azure06;
+$swaplist-border-color-hover: $color-primary;
 $swaplist-border-color-focus: $color-primary;
 $swaplist-border-color-card: $graphite03;
 $swaplist-icon-color: $graphite06;
@@ -290,8 +290,8 @@ $datepicker-icon-active-color: $trigger-active-color;
 $datepicker-month-year-color: $graphite10;
 $datepicker-alternate-month-color: $graphite03;
 $datepicker-day-color: $graphite06;
-$datepicker-focus-border-color: $azure06;
-$datepicker-selected-bg-color: $azure06;
+$datepicker-focus-border-color: $color-primary;
+$datepicker-selected-bg-color: $color-primary;
 $datepicker-selected-color: $button-primary-text-color;
 $datepicker-today-color: $graphite10;
 $datepicker-hover-bg-color: $graphite01;
@@ -621,8 +621,8 @@ $datagrid-list-filter-color: $slate10;
 $datagrid-list-filter-hover-color: $slate10;
 $datagrid-list-filter-icon-color: $slate04;
 $datagrid-list-filter-disabled-color: $slate03;
-$datagrid-list-filter-focus-color: $azure06;
-$datagrid-list-filter-active-color: $azure06;
+$datagrid-list-filter-focus-color: $color-primary;
+$datagrid-list-filter-active-color: $color-primary;
 
 $datagrid-rowgroup-header: $graphite01;
 $datagrid-rowgroup-color: $graphite06;
@@ -639,7 +639,7 @@ $tree-selected-bg-color: $graphite02;
 $tree-placeholder-color: $white;
 $tree-isover-bg-color: $azure01;
 $tree-isover-border-color: $azure04;
-$tree-placeholder-bg-color: $azure06;
+$tree-placeholder-bg-color: $color-primary;
 $tree-focus-border-color: $color-primary;
 $tree-active-bg-color: #d7e8f2;
 $tree-icon-color: $graphite06;
@@ -651,7 +651,7 @@ $tree-hover-icon-color: $graphite10;
 //Progress
 $progress-bg-color: transparent;
 $progress-border-color: $graphite04;
-$progress-bar-bg-color: $azure06;
+$progress-bar-bg-color: $color-primary;
 
 //Chart Progress Bar
 $chart-progressbar-bg-color: $graphite03;
@@ -761,7 +761,7 @@ $header-breadcrumb-border-color: $graphite03;
 
 // Module Tabs
 $module-tabs-bg-color: $azure08;
-$module-tabs-x-border-color: $azure06;
+$module-tabs-x-border-color: $color-primary;
 $module-tabs-y-border-color: $azure09;
 $module-tabs-inactive-bg-color: $azure08;
 $module-tabs-active-bg-color: $color-primary-alt;
@@ -769,7 +769,7 @@ $module-tabs-hover-bg-color: $azure10;
 $module-tabs-inactive-text-color: rgba($white, 0.85);
 $module-tabs-active-text-color: $white;
 $module-tabs-hover-text-color: $white;
-$module-tabs-disabled-bg-color: $azure06;
+$module-tabs-disabled-bg-color: $color-primary;
 $module-tabs-disabled-x-border-color: $azure04;
 $module-tabs-disabled-y-border-color: $color-primary-alt;
 $module-tabs-disabled-text-color: $azure04;

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -49,7 +49,7 @@ $inverse-color: $button-primary-text-color;
 
 // Text Color
 // These are Deprecated. Use "Default, Descriptive, Link, Muted, Alert" ect going forward
-$font-color-extrahighcontrast: $graphite10;
+$font-color-extrahighcontrast: $text-color;
 $font-color-highcontrast: $color-default-contrast;
 $font-color: $graphite06;
 $font-color-lowcontrast: $color-default-alt;
@@ -167,7 +167,7 @@ $tertiary-btn-dark-active-color: $white;
 // Secondary with Border
 $secondary-border-btn-color:  $graphite06;
 $secondary-border-btn-border-color: $color-default-alt;
-$secondary-border-btn-hover-color:  $graphite10;
+$secondary-border-btn-hover-color:  $text-color;
 $secondary-border-btn-hover-border-color: $graphite10;
 $secondary-border-btn-ripple-color: #8dc9e6;
 
@@ -201,7 +201,7 @@ $autocomplete-box-shadow: 0 2px 5px 2px $focus-box-shadow-color;
 $autocomplete-box-shadow-flipped: 0 -2px 5px 2px $focus-box-shadow-color;
 $trigger-icon-fill-color: $graphite06;
 $trigger-icon-fill-light-color: $graphite05;
-$trigger-hover-color: $graphite10;
+$trigger-hover-color: $text-color;
 $trigger-active-color: $color-primary;
 $trigger-focus-color: $color-primary;
 $trigger-disabled-color: $color-default-alt;
@@ -211,7 +211,7 @@ $listview-bg-color: $button-primary-text-color;
 $listview-bg-color-alternate: $graphite01;
 $listview-hover-bg-color: $list-hover-color;
 $listview-border-color: $graphite03;
-$listview-color: $graphite10;
+$listview-color: $text-color;
 $listview-secondary-color: $graphite06;
 $listview-tertiary-color: $color-default-alt;
 $listview-disabled-color: $input-disabled-color;
@@ -243,8 +243,8 @@ $listbuilder-bg-color-hover: $list-hover-color;
 $listbuilder-bg-color-selected: $color-primary;
 $listbuilder-border-color: $input-border-color;
 $listbuilder-border-color-focus: $color-primary;
-$listbuilder-icon-color-hover: $graphite10;
-$listbuilder-text-color: $graphite10;
+$listbuilder-icon-color-hover: $text-color;
+$listbuilder-text-color: $text-color;
 $listbuilder-text-color-selected: $white;
 $listbuilder-input-selection-bg-color: $azure08;
 
@@ -277,23 +277,23 @@ $swaplist-border-color-hover: $color-primary;
 $swaplist-border-color-focus: $color-primary;
 $swaplist-border-color-card: $graphite03;
 $swaplist-icon-color: $graphite06;
-$swaplist-icon-color-hover: $graphite10;
-$swaplist-icon-svg-color: $graphite10;
+$swaplist-icon-color-hover: $text-color;
+$swaplist-icon-svg-color: $text-color;
 $swaplist-icon-svg-color-hover: $black;
 $swaplist-shadow-color: $black;
-$swaplist-title-text-color: $graphite10;
-$swaplist-text-color: $graphite10;
+$swaplist-title-text-color: $text-color;
+$swaplist-text-color: $text-color;
 $swaplist-text-color-selected: $white;
 
 //Date Picker
 $datepicker-icon-active-color: $trigger-active-color;
-$datepicker-month-year-color: $graphite10;
+$datepicker-month-year-color: $text-color;
 $datepicker-alternate-month-color: $color-default;
 $datepicker-day-color: $graphite06;
 $datepicker-focus-border-color: $color-primary;
 $datepicker-selected-bg-color: $color-primary;
 $datepicker-selected-color: $button-primary-text-color;
-$datepicker-today-color: $graphite10;
+$datepicker-today-color: $text-color;
 $datepicker-hover-bg-color: $graphite01;
 $datepicker-disabled-icon-color: $color-default-alt;
 $datepicker-disabled-border-color: $graphite03;
@@ -316,9 +316,9 @@ $colorpicker-popup-bg-color: $white;
 $colorpicker-popup-border-color: $color-default-alt;
 
 // Fileupload
-$fileupload-primary-color: $graphite10;
+$fileupload-primary-color: $text-color;
 $fileupload-secondary-color: $graphite06;
-$fileupload-hover-color: $graphite10;
+$fileupload-hover-color: $text-color;
 $fileupload-completed-color: $emerald08;
 $fileupload-completed-border-color: $emerald08;
 $fileupload-error-color: $color-danger;
@@ -327,7 +327,7 @@ $fileupload-error-border-color: $color-warning;
 $fileupload-border-color: $graphite05;
 $fileupload-droparea-color: $graphite05;
 $fileupload-droparea-bg-color: rgba($graphite02, 0.5);
-$fileupload-droparea-hover-color: $graphite10;
+$fileupload-droparea-hover-color: $text-color;
 $fileupload-droparea-hover-bg-color: $graphite02;
 $fileupload-droparea-hover-border-color: $graphite06;
 $fileupload-droparea-hover-icon-color: $graphite05;
@@ -346,7 +346,7 @@ $fileupload-disabled-color: $graphite03;
 //Spinbox
 $spinbox-active-color: $font-color-extrahighcontrast;
 $spinbox-button-color: transparent;
-$spinbox-hover-color: $graphite10;
+$spinbox-hover-color: $text-color;
 
 //Skip Link
 $skip-link-border-color: $graphite03;
@@ -360,17 +360,17 @@ $icon-empty-bg-color: $icon-fill;
 //Field Set
 $fieldset-border-top-color: $graphite03;
 $fieldset-border-bottom-color: $button-primary-text-color;
-$fieldset-title-color: $graphite10;
+$fieldset-title-color: $text-color;
 
 // Expandable Area
 $expandable-area-border-color: $graphite03;
-$expandable-area-title-color: $graphite10;
+$expandable-area-title-color: $text-color;
 
 // Cardlist
 $cardlist-bg-color: $button-primary-text-color;
 $cardlist-border-color: $graphite03;
-$cardlist-header-color: $graphite10;
-$cardlist-actions-color: $graphite10;
+$cardlist-header-color: $text-color;
+$cardlist-actions-color: $text-color;
 $cardlist-text-color: $font-color;
 
 // Checkboxes
@@ -407,7 +407,7 @@ $editor-color: $input-color;
 $editor-toolbar-bg-color: $graphite02;
 $editor-middle-border-color: $color-default-alt;
 $editor-btn-color: $graphite06;
-$editor-btn-hover-color: $graphite10;
+$editor-btn-hover-color: $text-color;
 $editor-btn-active-color: $color-primary;
 $editor-btn-active-box-shadow: 0 0 0 2px transparent, 0 0 0 1px $color-primary, $focus-box-shadow;
 $editor-top-focus-box-shadow: -2px -2px 3px 0 rgba(54, 138, 192, 0.3);
@@ -448,14 +448,14 @@ $modal-border-color: $graphite03;
 $modal-box-shadow: 0 2px 5px $drop-shadow-depth;
 $modal-btn-color: $graphite06;
 $modal-btn-border-color: $graphite03;
-$modal-btn-hover-color: $graphite10;
+$modal-btn-hover-color: $text-color;
 $modal-btn-primary-color: $color-primary;
 $modal-btn-primary-hover-color: $azure08;
 $modal-btn-primary-disabled-color: $color-primary-alt;
 $modal-btn-disabled-color: $graphite06;
 $modal-btn-disabled-opacity: 0.5;
 $modal-color: $graphite06;
-$modal-primary-color: $graphite10;
+$modal-primary-color: $text-color;
 $modal-secondary-color: $graphite06;
 
 // Accordion
@@ -464,11 +464,11 @@ $accordion-border-color: $graphite02;
 $accordion-toplevel-border-color: $graphite03;
 $accordion-pane-bg-color: $graphite02;
 $accordion-icon-color: $graphite06;
-$accordion-icon-hover-color: $graphite10;
+$accordion-icon-hover-color: $text-color;
 $accordion-text-color: $graphite06;
-$accordion-text-active-color: $graphite10;
+$accordion-text-active-color: $text-color;
 $accordion-hover-border-color: $graphite10;
-$accordion-hover-text-color: $graphite10;
+$accordion-hover-text-color: $text-color;
 
 $accordion-panel-border-color: $graphite02;
 
@@ -578,10 +578,10 @@ $datagrid-sort-icon-color: $color-default-alt;
 $datagrid-sort-icon-sorted-color: $white;
 $datagrid-required-icon-color: $white;
 
-$datagrid-cell-color: $graphite10;
+$datagrid-cell-color: $text-color;
 $datagrid-cell-bg-color: $white;
 $datagrid-cell-readonly-bg-color: $graphite01;
-$datagrid-cell-readonly-color: $graphite10;
+$datagrid-cell-readonly-color: $text-color;
 $datagrid-cell-border-color: $graphite03;
 $datagrid-cell-focus-box-shadow: 0 0 4px 1px rgba(54, 138, 192, 0.4);
 $datagrid-data-color: $font-color-extrahighcontrast;
@@ -634,7 +634,7 @@ $sr-result-bottom-border-color: $hr-top-color;
 $sr-masthead-item-color: $font-color-lowcontrast;
 
 // Tree
-$tree-selected-color: $graphite10;
+$tree-selected-color: $text-color;
 $tree-selected-bg-color: $graphite02;
 $tree-placeholder-color: $white;
 $tree-isover-bg-color: $azure01;
@@ -645,8 +645,8 @@ $tree-active-bg-color: #d7e8f2;
 $tree-icon-color: $graphite06;
 $tree-link-color: $graphite06;
 $tree-disabled-color: $color-default-alt;
-$tree-hover-color: $graphite10;
-$tree-hover-icon-color: $graphite10;
+$tree-hover-color: $text-color;
+$tree-hover-icon-color: $text-color;
 
 //Progress
 $progress-bg-color: transparent;
@@ -736,8 +736,8 @@ $toast-shadow: none; //0 0 5px $drop-shadow-depth;
 $builder-header-bg-color: $slate06;
 
 //About
-$about-header-color: $graphite10;
-$about-text-color: $graphite10;
+$about-header-color: $text-color;
+$about-text-color: $text-color;
 $about-text-border-color: $graphite03;
 $about-text-hover-border-color: $graphite07;
 

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -44,7 +44,7 @@ $focus-box-shadow-spinbox-up: 0 -3px 3px 0 $focus-box-shadow-color,
   3px 0 3px 0 $focus-box-shadow-color;
 
 // Base Colors
-$primary-color: $color-primary;
+$color-primary: $color-primary;
 $inverse-color: $button-primary-text-color;
 
 // Text Color
@@ -810,7 +810,7 @@ $textarea-size: 362px;
 // Calendar
 $calendar-bg-color: $panel-bg-color;
 $calendar-line-color: $graphite02;
-$calendar-selected-border-color: $primary-color;
+$calendar-selected-border-color: $color-primary;
 $calendar-selected-bg-color: $graphite01;
 $calendar-hover-bg-color: $graphite01;
 $calendar-disabled-bg-color: $graphite01;

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -50,7 +50,7 @@ $inverse-color: $button-primary-text-color;
 // Text Color
 // These are Deprecated. Use "Default, Descriptive, Link, Muted, Alert" ect going forward
 $font-color-extrahighcontrast: $graphite10;
-$font-color-highcontrast: $graphite08;
+$font-color-highcontrast: $color-default-contrast;
 $font-color: $graphite06;
 $font-color-lowcontrast: $color-default-alt;
 $label-color: $graphite06;
@@ -80,7 +80,7 @@ $hr-bottom-color: $white;
 $circlepager-bg-color: transparent;
 $circlepager-border-color: $color-default-alt;
 $circlepager-hover-bg-color: transparent;
-$circlepager-hover-border-color: $graphite08;
+$circlepager-hover-border-color: $color-default-contrast;
 $circlepager-focus-bg-color: transparent;
 $circlepager-focus-border-color: $color-primary;
 
@@ -251,7 +251,7 @@ $listbuilder-input-selection-bg-color: $azure08;
 // Toolbar
 $toolbar-standalone-bg-color: $graphite02;
 $toolbar-standalone-border-color: $graphite03;
-$toolbar-standalone-disabled-color: $graphite08;
+$toolbar-standalone-disabled-color: $color-default-contrast;
 $toolbar-separator-color: $graphite03;
 
 // Field Filter
@@ -560,7 +560,7 @@ $mutlitabs-section-alt-border-color: $graphite02;
 $chart-line-color: $graphite02;
 $chart-line-color-axis: $color-default-alt;
 $chart-font-color: $graphite06;
-$chart-font-color-inverse: $graphite08;
+$chart-font-color-inverse: $color-default-contrast;
 $chart-bar-stroke: $white;
 $chart-arc-stroke: $white;
 
@@ -571,8 +571,8 @@ $datagrid-header-bg-color: $slate06;
 $datagrid-nested-header-bg-color: $slate05;
 $datagrid-nested-header-border-color: $graphite03;
 $datagrid-header-border-color: $graphite03;
-$datagrid-header-hover-color: $graphite08;
-$datagrid-header-active-color: $graphite08;
+$datagrid-header-hover-color: $color-default-contrast;
+$datagrid-header-active-color: $color-default-contrast;
 $datagrid-header-checkbox-border-color: $graphite03;
 $datagrid-sort-icon-color: $color-default-alt;
 $datagrid-sort-icon-sorted-color: $white;
@@ -814,7 +814,7 @@ $calendar-selected-border-color: $color-primary;
 $calendar-selected-bg-color: $graphite01;
 $calendar-hover-bg-color: $graphite01;
 $calendar-disabled-bg-color: $graphite01;
-$calendar-disabled-color: $graphite08;
+$calendar-disabled-color: $color-default-contrast;
 
 // Breakpoint sizes - Grid
 $breakpoint-phone: 320px;

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -232,14 +232,14 @@ $listview-full-width-bg-color: $graphite01;
 $listview-full-width-hover-color: $list-hover-color;
 $listview-full-width-border-color: $graphite03;
 
-$listview-search-disabled-color: $graphite02;
+$listview-search-disabled-color: $input-readonly-bg-color;
 $listview-search-disabled-opacity: 0.5;
-$listview-search-disabled-border-color: $graphite02;
-$listview-search-disabled-icon-color: $graphite02;
+$listview-search-disabled-border-color: $input-readonly-bg-color;
+$listview-search-disabled-icon-color: $input-readonly-bg-color;
 
 // Listbuilder
 $listbuilder-bg-color: $panel-bg-color;
-$listbuilder-bg-color-hover: $graphite02;
+$listbuilder-bg-color-hover: $list-hover-color;
 $listbuilder-bg-color-selected: $color-primary;
 $listbuilder-border-color: $input-border-color;
 $listbuilder-border-color-focus: $color-primary;
@@ -270,7 +270,7 @@ $contextual-panel-seperator-bg-color: $graphite04;
 
 // Swaplist
 $swaplist-bg-color: $graphite01;
-$swaplist-bg-color-hover: $graphite02;
+$swaplist-bg-color-hover: $list-hover-color;
 $swaplist-bg-color-selected: $color-primary;
 $swaplist-border-color: $graphite06;
 $swaplist-border-color-hover: $color-primary;
@@ -592,12 +592,12 @@ $datagrid-row-icon-color: $graphite06;
 
 $datagrid-alternate-bg-color: $graphite01;
 $datagrid-alternate-row-hover-color: $graphite02;
-$datagrid-list-header-bg-color: $graphite02;
+$datagrid-list-header-bg-color: $list-hover-color;
 $datagrid-list-header-focus-border-color: $color-primary;
 $datagrid-list-header-box-shadow: 0 0 4px 1px rgba(54, 138, 192, 0.4);
 $datagrid-list-header-border-color: $graphite03;
 $datagrid-list-header-color: $graphite06;
-$datagrid-list-header-hover-color: $graphite02;
+$datagrid-list-header-hover-color: $list-hover-color;
 $datagrid-list-row-hover-color: transparent;
 $datagrid-list-sort-icon-color: $graphite03;
 $datagrid-list-sort-icon-hover-color: $graphite05;

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -73,7 +73,7 @@ $hyperlink-disabled-color: $link-disabled-color;
 $hyperlink-hover-color: $link-hover-color;
 
 // Rules
-$hr-top-color: $graphite03;
+$hr-top-color: $color-default;
 $hr-bottom-color: $white;
 
 // Circle Pager
@@ -288,7 +288,7 @@ $swaplist-text-color-selected: $white;
 //Date Picker
 $datepicker-icon-active-color: $trigger-active-color;
 $datepicker-month-year-color: $graphite10;
-$datepicker-alternate-month-color: $graphite03;
+$datepicker-alternate-month-color: $color-default;
 $datepicker-day-color: $graphite06;
 $datepicker-focus-border-color: $color-primary;
 $datepicker-selected-bg-color: $color-primary;
@@ -308,7 +308,7 @@ $timepicker-disabled-color: $graphite03;
 
 // Color Picker
 $colorpicker-is-empty-bg-color: $white;
-$colorpicker-initial-bg-color: $graphite03;
+$colorpicker-initial-bg-color: $color-default;
 $colorpicker-swatch-border-color: $graphite02;
 $colorpicker-checkmark-one-color: $graphite05;
 $colorpicker-checkmark-two-color: $white;
@@ -599,12 +599,12 @@ $datagrid-list-header-border-color: $graphite03;
 $datagrid-list-header-color: $graphite06;
 $datagrid-list-header-hover-color: $list-hover-color;
 $datagrid-list-row-hover-color: transparent;
-$datagrid-list-sort-icon-color: $graphite03;
+$datagrid-list-sort-icon-color: $color-default;
 $datagrid-list-sort-icon-hover-color: $graphite05;
 $datagrid-header-focus-bg-color: $datagrid-header-bg-color;
 $datagrid-header-focus-border-color: $white;
 $datagrid-list-header-checkbox-border-color: $graphite04;
-$datagrid-list-header-active-color: $graphite03;
+$datagrid-list-header-active-color: $color-default;
 
 $datagrid-filter-border-color: $slate04;
 $datagrid-filter-hover-border-color: $slate02;
@@ -654,16 +654,16 @@ $progress-border-color: $graphite04;
 $progress-bar-bg-color: $color-primary;
 
 //Chart Progress Bar
-$chart-progressbar-bg-color: $graphite03;
+$chart-progressbar-bg-color: $color-default;
 $chart-progressbar-bg-color-dark: $graphite04;
 $chart-progressbar-completed-fill: $emerald07;
 $chart-progressbar-target-fill: $graphite04;
 $chart-progressbar-primary-fill: $color-primary;
 $chart-progressbar-dark-fill: $graphite06;
-$chart-targeted-achievement-bg-color: $graphite03;
+$chart-targeted-achievement-bg-color: $color-default;
 
 //Timeline
-$timeline-indicator-color: $graphite03;
+$timeline-indicator-color: $color-default;
 $timeline-indicator-processing-color: $color-primary;
 $timeline-indicator-complete-color: $color-primary;
 $timeline-line-color: $graphite04;
@@ -671,7 +671,7 @@ $timeline-header-color: $color-primary;
 
 //Wizard
 $wizard-default-bg: $body-bg-color-primary;
-$wizard-bar-bg: $graphite03;
+$wizard-bar-bg: $color-default;
 $wizard-color: $graphite06;
 $wizard-disabled-color: $graphite04;
 $wizard-active-color: $color-primary;
@@ -707,7 +707,7 @@ $searchfield-context-text-color: $font-color;
 
 $searchfield-card-bg-color: $graphite01;
 $searchfield-card-border-color: $graphite02;
-$searchfield-card-icon-color: $graphite03;
+$searchfield-card-icon-color: $color-default;
 $searchfield-card-text-color: $font-color;
 
 $searchfield-header-bg-color: $slate08;

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -9,7 +9,7 @@
 
 // Form Background Color
 $body-bg-color:  $body-bg-color-primary;
-$header-bg-color: $azure07;
+$header-bg-color: $color-primary-alt;
 $subhead-bg-color: $azure08;
 $transparent: transparent;
 
@@ -383,7 +383,7 @@ $focus-color: #cbdce6;
 $focus-shadow: rgba(0, 0, 0, 0.3);
 
 $switch-checked-color: $color-primary;
-$switch-checked-hover-color: $azure07;
+$switch-checked-hover-color: $color-primary-alt;
 $switch-checked-bg-color: $azure03;
 $switch-unchecked-bar-color: $graphite04;
 $switch-unchecked-border-color: $graphite03;
@@ -451,7 +451,7 @@ $modal-btn-border-color: $graphite03;
 $modal-btn-hover-color: $graphite10;
 $modal-btn-primary-color: $color-primary;
 $modal-btn-primary-hover-color: $azure08;
-$modal-btn-primary-disabled-color: $azure07;
+$modal-btn-primary-disabled-color: $color-primary-alt;
 $modal-btn-disabled-color: $graphite06;
 $modal-btn-disabled-opacity: 0.5;
 $modal-color: $graphite06;
@@ -693,7 +693,7 @@ $searchfield-icon-color: $button-link-text-color;
 $searchfield-text-color: $button-link-text-color;
 $searchfield-lighter-bg-color: $graphite01;
 $searchfield-lighter-text-color: $graphite04;
-$searchfield-active-icon-color: $azure07;
+$searchfield-active-icon-color: $color-primary-alt;
 
 $searchfield-alt-bg-color: $white;
 $searchfield-alt-border-color: $graphite01;
@@ -764,14 +764,14 @@ $module-tabs-bg-color: $azure08;
 $module-tabs-x-border-color: $azure06;
 $module-tabs-y-border-color: $azure09;
 $module-tabs-inactive-bg-color: $azure08;
-$module-tabs-active-bg-color: $azure07;
+$module-tabs-active-bg-color: $color-primary-alt;
 $module-tabs-hover-bg-color: $azure10;
 $module-tabs-inactive-text-color: rgba($white, 0.85);
 $module-tabs-active-text-color: $white;
 $module-tabs-hover-text-color: $white;
 $module-tabs-disabled-bg-color: $azure06;
 $module-tabs-disabled-x-border-color: $azure04;
-$module-tabs-disabled-y-border-color: $azure07;
+$module-tabs-disabled-y-border-color: $color-primary-alt;
 $module-tabs-disabled-text-color: $azure04;
 
 // Composite Form Tabs

--- a/src/layouts/_layouts.scss
+++ b/src/layouts/_layouts.scss
@@ -773,8 +773,8 @@ body.no-scroll {
       &:focus,
       &.is-active {
         border-bottom: 0;
-        border-left: 3px solid $primary-color;
-        color: $primary-color;
+        border-left: 3px solid $color-primary;
+        color: $color-primary;
         outline: none;
       }
     }

--- a/src/themes/dark-theme.scss
+++ b/src/themes/dark-theme.scss
@@ -524,8 +524,8 @@ $datagrid-filter-color: $slate10;
 $datagrid-filter-hover-color: $slate10;
 $datagrid-filter-disabled-color: $slate04;
 $datagrid-filter-icon-color: $slate05;
-$datagrid-filter-focus-color: $azure07;
-$datagrid-filter-active-color: $azure07;
+$datagrid-filter-focus-color: $color-primary-alt;
+$datagrid-filter-active-color: $color-primary-alt;
 
 $datagrid-list-filter-border-color: $slate03;
 $datagrid-list-filter-hover-border-color: $white;
@@ -593,7 +593,7 @@ $searchfield-icon-color: $button-link-text-color;
 $searchfield-text-color: $button-link-text-color;
 $searchfield-lighter-bg-color: $slate08;
 $searchfield-lighter-text-color: $slate04;
-$searchfield-active-icon-color: $azure07;
+$searchfield-active-icon-color: $color-primary-alt;
 
 $searchfield-alt-bg-color: $slate07;
 $searchfield-alt-border-color: $slate08;

--- a/src/themes/dark-theme.scss
+++ b/src/themes/dark-theme.scss
@@ -67,10 +67,10 @@ $font-color-alert: $alert-red;
 
 //The hyperlink Style
 $hyperlink-color: $azure04;
-$hyperlink-focus-border-color: $azure06;
+$hyperlink-focus-border-color: $color-primary;
 $hyperlink-visited-color: $amethyst03;
 $hyperlink-disabled-color: $disabled-color;
-$hyperlink-hover-color: $azure06;
+$hyperlink-hover-color: $color-primary;
 
 // Rules
 $hr-top-color: $slate09;
@@ -100,7 +100,7 @@ $popover-alternate-table-header: $notification-alternate-table-header;
 //Progress
 $progress-bg-color: transparent;
 $progress-border-color: $slate04;
-$progress-bar-bg-color: $azure06;
+$progress-bar-bg-color: $color-primary;
 
 // Tooltips
 $tooltip-bg-color: $white;
@@ -132,9 +132,9 @@ $popupmenu-heading-color: $slate04;
 $popupmenu-bg-color: $slate07;
 $popupmenu-border-color: $slate05;
 $popupmenu-box-shadow: 0 2px 5px $drop-shadow-depth;
-$popupmenu-checked-color: $azure06;
+$popupmenu-checked-color: $color-primary;
 $popupmenu-hover-color: $slate06;
-$popupmenu-checked-color-inverse: $azure06;
+$popupmenu-checked-color-inverse: $color-primary;
 
 // Secondary With Border
 $secondary-border-btn-color:  $slate03;
@@ -533,8 +533,8 @@ $datagrid-list-filter-color: $white;
 $datagrid-list-filter-hover-color: $white;
 $datagrid-list-filter-icon-color: $slate03;
 $datagrid-list-filter-disabled-color: $slate06;
-$datagrid-list-filter-focus-color: $azure06;
-$datagrid-list-filter-active-color: $azure06;
+$datagrid-list-filter-focus-color: $color-primary;
+$datagrid-list-filter-active-color: $color-primary;
 
 $datagrid-rowgroup-header: $slate07;
 $datagrid-rowgroup-color: $font-color;

--- a/src/themes/dark-theme.scss
+++ b/src/themes/dark-theme.scss
@@ -42,7 +42,7 @@ $focus-box-shadow-spinbox-up: 0 -3px 3px 0 $focus-box-shadow-color,
   3px 0 3px 0 $focus-box-shadow-color;
 
 // Base Colors
-$primary-color: $color-primary;
+$color-primary: $color-primary;
 $inverse-color: #fff;
 
 //The hyperlink Style
@@ -61,7 +61,7 @@ $signin-title-color: $slate01;
 // New Text Colors
 $font-color-default: $white;
 $font-color-descriptive: $slate03;
-$font-color-hyperlink: $primary-color;
+$font-color-hyperlink: $color-primary;
 $font-color-muted: $slate04;
 $font-color-alert: $alert-red;
 
@@ -121,7 +121,7 @@ $badge-error-color: $pill-error-color;
 $badge-alert-color: $pill-alert-color;
 $badge-good-color: $pill-good-color;
 $badge-info-color: $pill-info-color;
-$badge-info-bg-color: $primary-color;
+$badge-info-bg-color: $color-primary;
 $badge-neutral-icon-color: $pill-neutral-icon-color;
 $badge-neutral-hover-icon-color: $pill-neutral-hover-icon-color;
 
@@ -146,7 +146,7 @@ $secondary-border-btn-ripple-color: $white;
 // Input Fields
 $input-color: $input-text-color;
 $input-disabled-color: $input-disabled-text-color;
-$input-focus-border-color: $primary-color;
+$input-focus-border-color: $color-primary;
 $input-placeholder-color: $input-placeholder-text-color;
 $input-readonly-color: $input-readonly-text-color;
 
@@ -156,8 +156,8 @@ $error-focus-box-shadow:  0 0 4px 2px rgba(222, 129, 129, 0.3);
 $error-icon-fill: $alert-red;
 $dirty-icon-fill: $alert-yellow;
 $confirm-icon-fill: $alert-green;
-$info-icon-fill: $primary-color;
-$selected-bg-color: rgba($primary-color, 0.3);
+$info-icon-fill: $color-primary;
+$selected-bg-color: rgba($color-primary, 0.3);
 
 // Autocomplete
 $autocomplete-light-text: $slate04;
@@ -167,8 +167,8 @@ $autocomplete-box-shadow-flipped: 0 -2px 5px 1px $focus-box-shadow-color;
 $trigger-icon-fill-color: $slate03;
 $trigger-icon-fill-light-color: $slate04;
 $trigger-hover-color: $white;
-$trigger-active-color: $primary-color;
-$trigger-focus-color: $primary-color;
+$trigger-active-color: $color-primary;
+$trigger-focus-color: $color-primary;
 $trigger-disabled-color: $slate04;
 
 //List View
@@ -188,8 +188,8 @@ $listview-toolbar-button-text-color: $slate03;
 $listview-toolbar-button-icon-color: $slate03;
 $listview-toolbar-button-text-hover-color: $white;
 $listview-toolbar-button-icon-hover-color: $white;
-$listview-toolbar-button-text-selected-color: $primary-color;
-$listview-toolbar-button-icon-selected-color: $primary-color;
+$listview-toolbar-button-text-selected-color: $color-primary;
+$listview-toolbar-button-icon-selected-color: $color-primary;
 $listview-full-width-bg-color: $slate08;
 $listview-full-width-hover-color: $slate06;
 
@@ -216,18 +216,18 @@ $formatter-toolbar-separator-color: $slate04;
 
 //Contextual Toolbar
 $contextual-toolbar-color: $inverse-color;
-$contextual-toolbar-bg-color: $primary-color;
+$contextual-toolbar-bg-color: $color-primary;
 $contextual-panel-seperator-bg-color: $slate03;
 
 // Drop down
-$dropdown-menu-border-color: $primary-color;
+$dropdown-menu-border-color: $color-primary;
 
 // Date Picker
 $datepicker-month-year-color: $inverse-color;
 $datepicker-alternate-month-color: $slate04;
 $datepicker-day-color: $slate03;
-$datepicker-focus-border-color: $primary-color;
-$datepicker-selected-bg-color: $primary-color;
+$datepicker-focus-border-color: $color-primary;
+$datepicker-selected-bg-color: $color-primary;
 $datepicker-selected-color: $inverse-color;
 $datepicker-today-color: $inverse-color;
 $datepicker-hover-bg-color: $slate06;
@@ -259,7 +259,7 @@ $fileupload-droparea-hover-color: $slate04;
 $fileupload-droparea-hover-bg-color: $azure09;
 $fileupload-droparea-bg-color: rgba($slate07, 0.5);
 $fileupload-droparea-hover-bg-color: $slate07;
-$fileupload-droparea-dd-hover-border-color: $primary-color;
+$fileupload-droparea-dd-hover-border-color: $color-primary;
 $fileupload-droparea-dd-hover-bg-color: rgba($slate10, 0.3);
 
 //Spinbox
@@ -307,12 +307,12 @@ $cardlist-header-color: $white;
 $cardlist-actions-color: $slate03;
 
 // Checkboxes
-$checkbox-color: $primary-color;
+$checkbox-color: $color-primary;
 $checkbox-disabled-font-color: $checkbox-disabled-text-color;
 $checkbox-disabled-select-bg-color: $checkbox-disabled-border-color;
 
 // Switch
-$switch-checked-color: $primary-color;
+$switch-checked-color: $color-primary;
 $switch-checked-bg-color: $azure03;
 $switch-unchecked-bg-color: $slate05;
 $switch-unchecked-bar-color: $slate03;
@@ -323,33 +323,33 @@ $switch-disabled-border-color: $slate06;
 $switch-disabled-bg-color: $slate07;
 $switch-disabled-bar-color: $slate06;
 $switch-disabled-label-color: $disabled-color;
-$switch-focus-box-shadow: 0 0 0 3px #3f505f, 0 0 0 4px $primary-color;
+$switch-focus-box-shadow: 0 0 0 3px #3f505f, 0 0 0 4px $color-primary;
 $switch-hover-box-shadow: 0 2px 5px $drop-shadow-depth;
 
 // Editor
 $editor-bg-color: transparent;
 $editor-border-color: $slate04;
 $editor-hover-border-color: $slate02;
-$editor-focus-border-color: $primary-color;
+$editor-focus-border-color: $color-primary;
 $editor-line-number-color: $slate04;
 $editor-color: $input-color;
 $editor-toolbar-bg-color: $slate06;
 $editor-middle-border-color: $slate04;
 $editor-btn-color: $slate03;
 $editor-btn-hover-color: $white;
-$editor-btn-active-color: $primary-color;
-$editor-btn-active-box-shadow: 0 0 0 2px transparent, 0 0 0 1px $primary-color, $focus-box-shadow;
+$editor-btn-active-color: $color-primary;
+$editor-btn-active-box-shadow: 0 0 0 2px transparent, 0 0 0 1px $color-primary, $focus-box-shadow;
 $editor-top-focus-box-shadow: -2px -2px 3px 0 rgba(141, 201, 230, 0.3);
 $editor-blockquote-color: $slate04;
 
 // Radio Buttons
 $radio-hover-border-color: $radio-border-hover-color;
-$radio-selected-color: $primary-color;
+$radio-selected-color: $color-primary;
 $radio-selected-bg-color: $radio-checked-bg-color;
 $radio-disabled-select-bg-color: $radio-disabled-checked-bg-color;
 
 //Pager
-$pager-text-color: $primary-color;
+$pager-text-color: $color-primary;
 $pager-selected-color: $font-color-extrahighcontrast;
 $pager-focus-border-color: $input-focus-border-color;
 $pager-hover-color: $font-color-extrahighcontrast;
@@ -357,7 +357,7 @@ $pager-disabled-color: $slate06;
 
 //Slider
 $slider-bg-color: $slate04;
-$slider-active-bg-color: $primary-color;
+$slider-active-bg-color: $color-primary;
 $slider-labels-color: $slate03;
 $slider-disabled-color: $slate06;
 $slider-disabled-active-bg-color: $slate03;
@@ -412,9 +412,9 @@ $accordion-inverse-text-color: $slate02;
 $accordion-inverse-text-hover-color: $white;
 $accordion-inverse-focus-state-color: $white;
 
-$accordion-focused-text-color: $primary-color;
-$accordion-focused-border-color: $primary-color;
-$accordion-selected-bg-color: $primary-color;
+$accordion-focused-text-color: $color-primary;
+$accordion-focused-border-color: $color-primary;
+$accordion-selected-bg-color: $color-primary;
 $accordion-selected-text-color: $white;
 
 $accordion-highcontrast-text-decoration: none;
@@ -442,11 +442,11 @@ $breadcrumb-disabled-color: $disabled-color;
 // Rating (Stars)
 $rating-bg-color: $amber04;
 $rating-border-color: $slate04;
-$rating-hover-color: $primary-color;
+$rating-hover-color: $color-primary;
 
 // Tabs
 $tab-text-color: $slate02;
-$tab-selected-color: $primary-color;
+$tab-selected-color: $color-primary;
 $tab-border-color: $slate07;
 $tab-hover-color: $font-color-extrahighcontrast;
 
@@ -500,12 +500,12 @@ $datagrid-row-selected-color-dark: #3e586c;
 $datagrid-row-hover-color: $slate06;
 $datagrid-row-icon-color: $slate03;
 
-$datagrid-header-focus-bg-color: $primary-color;
+$datagrid-header-focus-bg-color: $color-primary;
 $datagrid-alternate-bg-color: #414348;
 $datagrid-alternate-row-hover-color: $slate06;
 $datagrid-list-header-bg-color: $slate09;
 
-$datagrid-list-header-focus-border-color: $primary-color;
+$datagrid-list-header-focus-border-color: $color-primary;
 $datagrid-list-header-box-shadow: 0 0 4px 1px rgba(101, 104, 113, 0.4);
 $datagrid-list-header-border-color: $slate05;
 $datagrid-list-header-color: $slate03;
@@ -550,7 +550,7 @@ $tree-selected-color: $white;
 $tree-selected-bg-color: $slate06;
 $tree-isover-bg-color: $azure10;
 $tree-isover-border-color: $azure08;
-$tree-focus-border-color: $primary-color;
+$tree-focus-border-color: $color-primary;
 $tree-active-bg-color: #3e586c;
 $tree-icon-color: $slate03;
 $tree-link-color: $slate03;
@@ -563,25 +563,25 @@ $chart-progressbar-bg-color: $slate04;
 $chart-progressbar-bg-color-dark: $slate02;
 $chart-progressbar-completed-fill: $emerald08;
 $chart-progressbar-target-fill: $slate06;
-$chart-progressbar-primary-fill: $primary-color;
-$chart-progressbar-dark-fill: $primary-color;
+$chart-progressbar-primary-fill: $color-primary;
+$chart-progressbar-dark-fill: $color-primary;
 $chart-targeted-achievement-bg-color: $slate05;
 
 //Timeline
 $timeline-indicator-color: $slate03;
-$timeline-indicator-processing-color: $primary-color;
-$timeline-indicator-complete-color: $primary-color;
+$timeline-indicator-processing-color: $color-primary;
+$timeline-indicator-complete-color: $color-primary;
 $timeline-line-color: $slate04;
-$timeline-header-color: $primary-color;
+$timeline-header-color: $color-primary;
 
 //Themable Variables in config.scss
 $wizard-default-bg: $body-bg-color;
 $wizard-bar-bg: $slate04;
 $wizard-color: $slate03;
 $wizard-disabled-color: $slate04;
-$wizard-active-color: $primary-color;
+$wizard-active-color: $color-primary;
 $wizard-active-text-color: $azure04;
-$wizard-focus-box-shadow: 0 0 0 1px $primary-color;
+$wizard-focus-box-shadow: 0 0 0 1px $color-primary;
 
 //Themable Variables in config.scss
 $hierarchy-line-color: $slate04;
@@ -682,14 +682,14 @@ $splitter-box-shadow-color: rgba(54, 138, 192, 0.75);
 $step-chart-bg-color: $slate07;
 $step-chart-border-color: $slate05;
 $step-chart-inprogress-bg-color: $ruby02;
-$step-chart-completed-bg-color: $primary-color;
+$step-chart-completed-bg-color: $color-primary;
 $step-chart-totally-completed-bg-color: $alert-green;
 
 // Block Grid
 $blockgrid-selected-bg-color: $selected-bg-color;
 $blockgrid-selected-border-color: $button-default-focus-border-color;
 $blockgrid-hover-color: $listview-hover-bg-color;
-$blockgrid-focus-border-color: $primary-color;
+$blockgrid-focus-border-color: $color-primary;
 
 // Tree Map
 $treemap-title-bg-color: $slate03;
@@ -698,7 +698,7 @@ $treemap-title-color: $slate10;
 // Calendar
 $calendar-bg-color: $panel-bg-color;
 $calendar-line-color: $slate05;
-$calendar-selected-border-color: $primary-color;
+$calendar-selected-border-color: $color-primary;
 $calendar-selected-bg-color: $slate08;
 $calendar-hover-bg-color: $slate08;
 $calendar-disabled-bg-color: $slate08;

--- a/src/themes/high-contrast-theme.scss
+++ b/src/themes/high-contrast-theme.scss
@@ -96,11 +96,11 @@ $circlepager-active-focus-bg-color: $color-primary;
 $circlepager-active-focus-border-color: $color-primary;
 
 $circlepager-disable-bg-color: transparent;
-$circlepager-disable-border-color: $graphite04;
+$circlepager-disable-border-color: $color-default-alt;
 $circlepager-disable-hover-bg-color: transparent;
-$circlepager-disable-hover-border-color: $graphite04;
+$circlepager-disable-hover-border-color: $color-default-alt;
 $circlepager-disable-focus-bg-color: transparent;
-$circlepager-disable-focus-border-color: $graphite04;
+$circlepager-disable-focus-border-color: $color-default-alt;
 
 // Popovers
 $popover-bg-color: $graphite01;
@@ -146,7 +146,7 @@ $popupmenu-bg-color: $white;
 $popupmenu-border-color: $graphite06;
 $popupmenu-box-shadow: 0 2px 5px $drop-shadow-depth;
 $popupmenu-heading-color: $graphite07;
-$popupmenu-hover-color: $graphite04;
+$popupmenu-hover-color: $color-default-alt;
 $popupmenu-checked-color: $azure09;
 $popupmenu-checked-color-inverse: $color-primary;
 
@@ -188,19 +188,19 @@ $trigger-icon-fill-light-color: $graphite08;
 $trigger-hover-color: $graphite06;
 $trigger-active-color: $color-primary;
 $trigger-focus-color: $color-primary;
-$trigger-disabled-color: $graphite04;
+$trigger-disabled-color: $color-default-alt;
 
 //List View
 $listview-bg-color: $inverse-color;
 $listview-bg-color-alternate: $graphite02;
-$listview-hover-bg-color: $graphite04;
+$listview-hover-bg-color: $color-default-alt;
 $listview-border-color: $graphite06;
 $listview-color: $black;
 $listview-secondary-color: $graphite09;
 $listview-tertiary-color: $graphite07;
 $listview-disabled-color: $disabled-color;
 $listview-selected-text-color: $font-color-extrahighcontrast;
-$listview-header-bg-color: $graphite04;
+$listview-header-bg-color: $color-default-alt;
 $listview-header-color: $font-color-extrahighcontrast;
 $listview-subhead-color: $graphite06;
 
@@ -218,7 +218,7 @@ $listview-search-disabled-icon-color: $graphite06;
 
 // Listbuilder
 $listbuilder-bg-color: $input-bg-color;
-$listbuilder-bg-color-hover: $graphite04;
+$listbuilder-bg-color-hover: $color-default-alt;
 $listbuilder-bg-color-selected: $color-primary;
 $listbuilder-border-color: $input-border-color;
 $listbuilder-border-color-focus: $color-primary-alt;
@@ -260,18 +260,18 @@ $datepicker-focus-border-color: $color-primary-alt;
 $datepicker-selected-bg-color: $color-primary;
 $datepicker-selected-color: $inverse-color;
 $datepicker-today-color: $black;
-$datepicker-hover-bg-color: $graphite04;
-$datepicker-disabled-border-color: $graphite04;
+$datepicker-hover-bg-color: $color-default-alt;
+$datepicker-disabled-border-color: $color-default-alt;
 $datepicker-disabled-bg-color: $input-readonly-bg-color;
-$datepicker-disabled-color: $graphite04;
+$datepicker-disabled-color: $color-default-alt;
 
 .calendar-table .is-today {
   text-decoration: underline;
 }
 
 //Time Picker
-$timepicker-disabled-border-color: $graphite04;
-$timepicker-disabled-color: $graphite04;
+$timepicker-disabled-border-color: $color-default-alt;
+$timepicker-disabled-color: $color-default-alt;
 
 // Color Picker
 $colorpicker-initial-bg-color: $graphite06;
@@ -344,8 +344,8 @@ $switch-unchecked-border-color: $graphite06;
 $switch-unchecked-color: $slate05;
 $switch-unchecked-pressed-bg-color: $slate04;
 $switch-disabled-bg-color: $input-readonly-bg-color;
-$switch-disabled-border-color: $graphite04;
-$switch-disabled-bar-color: $graphite04;
+$switch-disabled-border-color: $color-default-alt;
+$switch-disabled-bar-color: $color-default-alt;
 $switch-disabled-label-color: $disabled-color;
 $switch-focus-box-shadow: 0 0 0 3px #3f505f, 0 0 0 4px $color-primary, 0 0 4px 6px rgba(41, 41, 41, 0.3);
 $switch-hover-box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
@@ -377,13 +377,13 @@ $pager-text-color: $color-primary;
 $pager-selected-color: $font-color-highcontrast;
 $pager-focus-border-color: $input-focus-border-color;
 $pager-hover-color: $font-color-extrahighcontrast;
-$pager-disabled-color: $graphite04;
+$pager-disabled-color: $color-default-alt;
 
 // Slider
 $slider-bg-color: $graphite06;
 $slider-active-bg-color: $color-primary;
 $slider-labels-color: $graphite09;
-$slider-disabled-color: $graphite04;
+$slider-disabled-color: $color-default-alt;
 $slider-disabled-active-bg-color: $graphite06;
 $slider-disabled-labels-color: $graphite05;
 $slider-disabled-handle-color: $graphite06;
@@ -414,7 +414,7 @@ $modal-secondary-color: $graphite09;
 $accordion-bg-color: $graphite01;
 $accordion-border-color: $graphite06;
 $accordion-toplevel-border-color: $slate04;
-$accordion-pane-bg-color: $graphite04;
+$accordion-pane-bg-color: $color-default-alt;
 $accordion-text-color: $graphite09;
 $accordion-text-active-color: $black;
 $accordion-icon-color: $graphite09;
@@ -422,11 +422,11 @@ $accordion-icon-hover-color: $black;
 $accordion-hover-border-color: $black;
 $accordion-hover-text-color: $graphite10;
 
-$accordion-panel-border-color: $graphite04;
+$accordion-panel-border-color: $color-default-alt;
 
 $accordion-alternate-bg-color: $white;
-$accordion-alternate-border-color: $graphite04;
-$accordion-alternate-pane-bg-color: $graphite04;
+$accordion-alternate-border-color: $color-default-alt;
+$accordion-alternate-pane-bg-color: $color-default-alt;
 
 $accordion-inverse-bg-color: $slate08;
 $accordion-inverse-pane-bg-color: $black;
@@ -476,14 +476,14 @@ $rating-hover-color: $color-primary;
 // Tabs
 $tab-text-color: $graphite10;
 $tab-selected-color: $azure09;
-$tab-border-color: $graphite04;
+$tab-border-color: $color-default-alt;
 $tab-hover-color: $font-color-extrahighcontrast;
 
 // Vertical Tabs
 $vertical-tab-text-color: $font-color-extrahighcontrast;
 $vertical-tab-text-hover-color: $font-color-extrahighcontrast;
 $vertical-tab-text-hover-decoration: underline;
-$vertical-tab-bg-hover-color: $graphite04;
+$vertical-tab-bg-hover-color: $color-default-alt;
 $vertical-tab-focus-border-color: $color-primary;
 $vertical-tab-active-text-color: $white;
 $vertical-tab-active-bg-color: $color-primary;
@@ -507,12 +507,12 @@ $datagrid-border-color: $graphite06;
 $datagrid-header-color: #fff;
 $datagrid-header-bg-color: $graphite08;
 $datagrid-nested-header-bg-color: $graphite06;
-$datagrid-nested-header-border-color: $graphite04;
+$datagrid-nested-header-border-color: $color-default-alt;
 $datagrid-header-border-color: $graphite06;
 $datagrid-header-hover-color: $graphite10;
 $datagrid-header-active-color: $graphite08;
 $datagrid-header-checkbox-border-color: $graphite05;
-$datagrid-sort-icon-color: $graphite04;
+$datagrid-sort-icon-color: $color-default-alt;
 $datagrid-sort-icon-sorted-color: $white;
 $datagrid-required-icon-color: $white;
 
@@ -525,20 +525,20 @@ $datagrid-cell-focus-box-shadow: 0 0 4px 1px rgba(80, 83, 90, 0.4);
 $datagrid-data-color: $font-color-extrahighcontrast;
 $datagrid-row-selected-color: #b3ccdb;
 $datagrid-row-selected-color-dark: #a2bbca;
-$datagrid-row-hover-color: $graphite04;
+$datagrid-row-hover-color: $color-default-alt;
 $datagrid-row-icon-color: $graphite09;
 
 $datagrid-alternate-bg-color: #bdbdbd;
-$datagrid-alternate-row-hover-color: $graphite04;
-$datagrid-list-header-bg-color: $graphite04;
+$datagrid-alternate-row-hover-color: $color-default-alt;
+$datagrid-list-header-bg-color: $color-default-alt;
 
 $datagrid-list-header-focus-border-color: $color-primary;
 $datagrid-list-header-box-shadow: 0 0 4px 1px rgba(80, 83, 90, 0.4);
 $datagrid-list-header-border-color: transparent;
 $datagrid-list-header-color: $graphite10;
-$datagrid-list-header-hover-color: $graphite04;
+$datagrid-list-header-hover-color: $color-default-alt;
 $datagrid-list-row-hover-color: transparent;
-$datagrid-list-sort-icon-color: $graphite04;
+$datagrid-list-sort-icon-color: $color-default-alt;
 $datagrid-list-sort-icon-hover-color: $graphite06;
 $datagrid-header-focus-bg-color: $graphite08;
 $datagrid-header-focus-border-color: $white;
@@ -574,7 +574,7 @@ $sr-masthead-item-color: $font-color-lowcontrast;
 
 // Tree
 $tree-selected-color: $black;
-$tree-selected-bg-color: $graphite04;
+$tree-selected-bg-color: $color-default-alt;
 $tree-focus-border-color: $color-primary-alt;
 $tree-active-bg-color: #8fa8b7;
 $tree-icon-color: $graphite09;
@@ -595,7 +595,7 @@ $chart-progressbar-completed-fill: #2f6b0a;
 $chart-progressbar-target-fill: $graphite05;
 $chart-progressbar-primary-fill: $color-primary;
 $chart-progressbar-dark-fill: $graphite08;
-$chart-targeted-achievement-bg-color: $graphite04;
+$chart-targeted-achievement-bg-color: $color-default-alt;
 
 //Timeline
 $timeline-indicator-color: $graphite05;
@@ -608,7 +608,7 @@ $timeline-header-color: $azure09;
 $wizard-default-bg: $body-bg-color;
 $wizard-bar-bg: $graphite06;
 $wizard-color: $graphite09;
-$wizard-disabled-color: $graphite04;
+$wizard-disabled-color: $color-default-alt;
 $wizard-active-color: $color-primary;
 $wizard-active-text-color: $color-primary;
 $wizard-focus-box-shadow: 0 0 0 1px $color-primary-alt;
@@ -632,7 +632,7 @@ $searchfield-context-bg: $graphite01;
 $searchfield-context-alt-bg: $white;
 $searchfield-context-border-color: $graphite03;
 $searchfield-context-box-shadow-color: $graphite03;
-$searchfield-context-icon-color: $graphite04;
+$searchfield-context-icon-color: $color-default-alt;
 $searchfield-context-text-color: $font-color;
 
 $searchfield-card-bg-color: $white;
@@ -668,7 +668,7 @@ $about-text-border-color: $graphite06;
 $about-text-hover-border-color: $black;
 
 // Header Tabs
-$header-tabcontainer-border-color: $graphite04;
+$header-tabcontainer-border-color: $color-default-alt;
 $header-tab-separator: rgba(255, 255, 255, 0.4);
 $header-tab-normal-color: $graphite01;
 $header-tab-hover-color: $inverse-color;
@@ -705,7 +705,7 @@ $composite-tabs-panel-bg-color: $white;
 
 // Splitter
 $splitter-grip-bg-color: $graphite09;
-$splitter-active-bg-color: $graphite04;
+$splitter-active-bg-color: $color-default-alt;
 $splitter-active-grip-bg-color: $black;
 $splitter-box-shadow-color: rgba(37, 120, 169, 0.75);
 
@@ -717,7 +717,7 @@ $step-chart-completed-bg-color: $color-primary;
 $step-chart-totally-completed-bg-color: #80ce4d;
 
 //Swaplist
-$swaplist-bg-color-hover: $graphite04;
+$swaplist-bg-color-hover: $color-default-alt;
 $swaplist-bg-color-selected: $color-primary;
 $swaplist-border-color-focus: $color-primary-alt;
 $swaplist-icon-color: $graphite05;

--- a/src/themes/high-contrast-theme.scss
+++ b/src/themes/high-contrast-theme.scss
@@ -262,7 +262,7 @@ $datepicker-selected-color: $inverse-color;
 $datepicker-today-color: $black;
 $datepicker-hover-bg-color: $graphite04;
 $datepicker-disabled-border-color: $graphite04;
-$datepicker-disabled-bg-color: $graphite02;
+$datepicker-disabled-bg-color: $input-readonly-bg-color;
 $datepicker-disabled-color: $graphite04;
 
 .calendar-table .is-today {
@@ -343,7 +343,7 @@ $switch-unchecked-bar-color: $graphite07;
 $switch-unchecked-border-color: $graphite06;
 $switch-unchecked-color: $slate05;
 $switch-unchecked-pressed-bg-color: $slate04;
-$switch-disabled-bg-color: $graphite02;
+$switch-disabled-bg-color: $input-readonly-bg-color;
 $switch-disabled-border-color: $graphite04;
 $switch-disabled-bar-color: $graphite04;
 $switch-disabled-label-color: $disabled-color;
@@ -518,7 +518,7 @@ $datagrid-required-icon-color: $white;
 
 $datagrid-cell-color: $font-color;
 $datagrid-cell-bg-color: $graphite01;
-$datagrid-cell-readonly-bg-color: $graphite02;
+$datagrid-cell-readonly-bg-color: $input-readonly-bg-color;
 $datagrid-cell-readonly-color: $font-color;
 $datagrid-cell-border-color: $graphite06;
 $datagrid-cell-focus-box-shadow: 0 0 4px 1px rgba(80, 83, 90, 0.4);
@@ -742,7 +742,7 @@ $calendar-line-color: $graphite09;
 $calendar-selected-border-color: $color-primary;
 $calendar-selected-bg-color: $graphite02;
 $calendar-hover-bg-color: $graphite01;
-$calendar-disabled-bg-color: $graphite02;
+$calendar-disabled-bg-color: $input-readonly-bg-color;
 $calendar-disabled-color: $graphite10;
 
 //================================================== //

--- a/src/themes/high-contrast-theme.scss
+++ b/src/themes/high-contrast-theme.scss
@@ -44,7 +44,6 @@ $focus-box-shadow-spinbox-up: 0 -3px 3px 0 $focus-box-shadow-color,
   3px 0 3px 0 $focus-box-shadow-color;
 
 // Base Colors
-$primary-color: $color-primary;
 $inverse-color: #fff;
 
 // Text Color
@@ -60,7 +59,7 @@ $signin-title-color: $slate10;
 // New Text Colors
 $font-color-default: $black;
 $font-color-descriptive: $graphite09;
-$font-color-hyperlink: $primary-color;
+$font-color-hyperlink: $color-primary;
 $font-color-muted: $graphite05;
 $font-color-alert: $alert-red;
 
@@ -89,12 +88,12 @@ $circlepager-hover-border-color: $black;
 $circlepager-focus-bg-color: $white;
 $circlepager-focus-border-color: $color-primary-alt;
 
-$circlepager-active-bg-color: $primary-color;
-$circlepager-active-border-color: $primary-color;
-$circlepager-active-hover-bg-color: $primary-color;
-$circlepager-active-hover-border-color: $primary-color;
-$circlepager-active-focus-bg-color: $primary-color;
-$circlepager-active-focus-border-color: $primary-color;
+$circlepager-active-bg-color: $color-primary;
+$circlepager-active-border-color: $color-primary;
+$circlepager-active-hover-bg-color: $color-primary;
+$circlepager-active-hover-border-color: $color-primary;
+$circlepager-active-focus-bg-color: $color-primary;
+$circlepager-active-focus-border-color: $color-primary;
 
 $circlepager-disable-bg-color: transparent;
 $circlepager-disable-border-color: $graphite04;
@@ -131,7 +130,7 @@ $badge-error-color: $pill-error-color;
 $badge-alert-color: $pill-alert-color;
 $badge-good-color: $pill-good-color;
 $badge-info-color: $pill-info-color;
-$badge-info-bg-color: $primary-color;
+$badge-info-bg-color: $color-primary;
 $badge-neutral-icon-color: $pill-neutral-icon-color;
 $badge-neutral-hover-icon-color: $pill-neutral-hover-icon-color;
 
@@ -172,12 +171,12 @@ $error-color: $alert-red;
 $error-icon-fill: $alert-red;
 $alert-color: #d66221;
 $confirm-color: $alert-green;
-$info-color: $primary-color;
+$info-color: $color-primary;
 $error-focus-box-shadow:  0 0 4px 2px rgba(222, 129, 129, 0.3);
 $dirty-icon-fill: $alert-yellow;
 $confirm-icon-fill: $alert-green;
 $info-icon-fill: $azure08;
-$selected-bg-color: rgba($color-primary-alt, .3);
+$selected-bg-color: rgba($color-primary-alt, 0.3);
 
 // Autocomplete
 $autocomplete-light-text: $graphite05;
@@ -187,8 +186,8 @@ $autocomplete-box-shadow-flipped: 0 -2px 5px 2px $focus-box-shadow-color;
 $trigger-icon-fill-color: $graphite09;
 $trigger-icon-fill-light-color: $graphite08;
 $trigger-hover-color: $graphite06;
-$trigger-active-color: $primary-color;
-$trigger-focus-color: $primary-color;
+$trigger-active-color: $color-primary;
+$trigger-focus-color: $color-primary;
 $trigger-disabled-color: $graphite04;
 
 //List View
@@ -207,10 +206,10 @@ $listview-subhead-color: $graphite06;
 
 $listview-toolbar-button-text-color: $button-link-text-color;
 $listview-toolbar-button-icon-color: $button-link-text-color;
-$listview-toolbar-button-text-hover-color: $primary-color;
-$listview-toolbar-button-icon-hover-color: $primary-color;
-$listview-toolbar-button-text-selected-color: $primary-color;
-$listview-toolbar-button-icon-selected-color: $primary-color;
+$listview-toolbar-button-text-hover-color: $color-primary;
+$listview-toolbar-button-icon-hover-color: $color-primary;
+$listview-toolbar-button-text-selected-color: $color-primary;
+$listview-toolbar-button-icon-selected-color: $color-primary;
 
 $listview-search-disabled-color: $black;
 $listview-search-disabled-opacity: 0.8;
@@ -220,7 +219,7 @@ $listview-search-disabled-icon-color: $graphite06;
 // Listbuilder
 $listbuilder-bg-color: $input-bg-color;
 $listbuilder-bg-color-hover: $graphite04;
-$listbuilder-bg-color-selected: $primary-color;
+$listbuilder-bg-color-selected: $color-primary;
 $listbuilder-border-color: $input-border-color;
 $listbuilder-border-color-focus: $color-primary-alt;
 $listbuilder-icon-color-hover: $font-color-highcontrast;
@@ -240,7 +239,7 @@ $fieldfilter-border-side-color: $input-border-color;
 $formatter-toolbar-separator-color: $graphite06;
 
 //Contextual Toolbar
-$contextual-toolbar-bg-color: $primary-color;
+$contextual-toolbar-bg-color: $color-primary;
 $contextual-toolbar-color: $inverse-color;
 $contextual-toolbar-button-color: rgba($inverse-color, 1);
 $contextual-toolbar-button-hover-color: rgba($inverse-color, 0.7);
@@ -248,8 +247,8 @@ $contextual-toolbar-button-disabled-color: rgba($inverse-color, 0.3);
 $contextual-panel-seperator-bg-color: $graphite06;
 
 // Drop down
-$dropdown-menu-border-color: $primary-color;
-$dropdown-selected-bg-color: $primary-color;
+$dropdown-menu-border-color: $color-primary;
+$dropdown-selected-bg-color: $color-primary;
 
 // Date Picker
 $datepicker-month-year-color: $black;
@@ -258,7 +257,7 @@ $datepicker-icon-active-color: $azure09;
 $datepicker-alternate-month-color: $graphite05;
 $datepicker-day-color: $black;
 $datepicker-focus-border-color: $color-primary-alt;
-$datepicker-selected-bg-color: $primary-color;
+$datepicker-selected-bg-color: $color-primary;
 $datepicker-selected-color: $inverse-color;
 $datepicker-today-color: $black;
 $datepicker-hover-bg-color: $graphite04;
@@ -296,7 +295,7 @@ $fileupload-cancel-hover-bg-color: darken($graphite05, 15%);
 $fileupload-droparea-bg-color: rgba($graphite01, 0.5);
 $fileupload-droparea-hover-bg-color: $graphite01;
 $fileupload-droparea-dd-hover-bg-color: rgba(200, 233, 244, 0.8);
-$fileupload-droparea-dd-hover-border-color: $primary-color;
+$fileupload-droparea-dd-hover-border-color: $color-primary;
 
 //Spinbox
 $spinbox-active-color: $font-color-extrahighcontrast;
@@ -306,7 +305,7 @@ $spinbox-button-color: #fff;
 //Skip Link
 $skip-link-border-color: $graphite06;
 $skip-link-bg-color: $graphite01;
-$skip-link-color: $primary-color;
+$skip-link-color: $color-primary;
 
 //Mast Head
 $masthead-bg-color: $slate10;
@@ -332,12 +331,12 @@ $cardlist-header-color: $black;
 $cardlist-actions-color: $graphite09;
 
 // Checkboxes
-$checkbox-color: $primary-color;
+$checkbox-color: $color-primary;
 $checkbox-disabled-font-color: $checkbox-disabled-text-color;
 $checkbox-disabled-select-bg-color: $checkbox-disabled-checked-bg-color;
 
 // Switch
-$switch-checked-color: $primary-color;
+$switch-checked-color: $color-primary;
 $switch-checked-bg-color: $color-primary;
 $switch-unchecked-bg-color: $white;
 $switch-unchecked-bar-color: $graphite07;
@@ -348,7 +347,7 @@ $switch-disabled-bg-color: $graphite02;
 $switch-disabled-border-color: $graphite04;
 $switch-disabled-bar-color: $graphite04;
 $switch-disabled-label-color: $disabled-color;
-$switch-focus-box-shadow: 0 0 0 3px #3f505f, 0 0 0 4px $primary-color, 0 0 4px 6px rgba(41, 41, 41, 0.3);
+$switch-focus-box-shadow: 0 0 0 3px #3f505f, 0 0 0 4px $color-primary, 0 0 4px 6px rgba(41, 41, 41, 0.3);
 $switch-hover-box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
 
 // Editor
@@ -362,19 +361,19 @@ $editor-toolbar-bg-color: $graphite02;
 $editor-middle-border-color: $graphite06;
 $editor-btn-color: $graphite09;
 $editor-btn-hover-color: $graphite05;
-$editor-btn-active-color: $primary-color;
-$editor-btn-active-box-shadow: 0 0 0 2px transparent, 0 0 0 1px $primary-color, $focus-box-shadow;
+$editor-btn-active-color: $color-primary;
+$editor-btn-active-box-shadow: 0 0 0 2px transparent, 0 0 0 1px $color-primary, $focus-box-shadow;
 $editor-top-focus-box-shadow: -2px -2px 3px 0 rgba(41, 41, 41, 0.3);
 $editor-blockquote-color: $graphite07;
 
 // Radio Buttons
 $radio-hover-border-color: $radio-border-hover-color;
-$radio-selected-color: $primary-color;
+$radio-selected-color: $color-primary;
 $radio-selected-bg-color: $radio-checked-bg-color;
 $radio-disabled-select-bg-color: $radio-disabled-checked-bg-color;
 
 // Pager
-$pager-text-color: $primary-color;
+$pager-text-color: $color-primary;
 $pager-selected-color: $font-color-highcontrast;
 $pager-focus-border-color: $input-focus-border-color;
 $pager-hover-color: $font-color-extrahighcontrast;
@@ -382,7 +381,7 @@ $pager-disabled-color: $graphite04;
 
 // Slider
 $slider-bg-color: $graphite06;
-$slider-active-bg-color: $primary-color;
+$slider-active-bg-color: $color-primary;
 $slider-labels-color: $graphite09;
 $slider-disabled-color: $graphite04;
 $slider-disabled-active-bg-color: $graphite06;
@@ -472,7 +471,7 @@ $breadcrumb-disabled-color: $disabled-color;
 // Rating (Stars)
 $rating-bg-color: $amber06;
 $rating-border-color: $graphite06;
-$rating-hover-color: $primary-color;
+$rating-hover-color: $color-primary;
 
 // Tabs
 $tab-text-color: $graphite10;
@@ -485,9 +484,9 @@ $vertical-tab-text-color: $font-color-extrahighcontrast;
 $vertical-tab-text-hover-color: $font-color-extrahighcontrast;
 $vertical-tab-text-hover-decoration: underline;
 $vertical-tab-bg-hover-color: $graphite04;
-$vertical-tab-focus-border-color: $primary-color;
+$vertical-tab-focus-border-color: $color-primary;
 $vertical-tab-active-text-color: $white;
-$vertical-tab-active-bg-color: $primary-color;
+$vertical-tab-active-bg-color: $color-primary;
 
 $vertical-tab-panel-bg-color: $panel-bg-color;
 $vertical-tab-sidebar-bg-color: $body-bg-color;
@@ -533,7 +532,7 @@ $datagrid-alternate-bg-color: #bdbdbd;
 $datagrid-alternate-row-hover-color: $graphite04;
 $datagrid-list-header-bg-color: $graphite04;
 
-$datagrid-list-header-focus-border-color: $primary-color;
+$datagrid-list-header-focus-border-color: $color-primary;
 $datagrid-list-header-box-shadow: 0 0 4px 1px rgba(80, 83, 90, 0.4);
 $datagrid-list-header-border-color: transparent;
 $datagrid-list-header-color: $graphite10;
@@ -594,14 +593,14 @@ $chart-progressbar-bg-color: #767676;
 $chart-progressbar-bg-color-dark: $graphite05;
 $chart-progressbar-completed-fill: #2f6b0a;
 $chart-progressbar-target-fill: $graphite05;
-$chart-progressbar-primary-fill: $primary-color;
+$chart-progressbar-primary-fill: $color-primary;
 $chart-progressbar-dark-fill: $graphite08;
 $chart-targeted-achievement-bg-color: $graphite04;
 
 //Timeline
 $timeline-indicator-color: $graphite05;
-$timeline-indicator-processing-color: $primary-color;
-$timeline-indicator-complete-color: $primary-color;
+$timeline-indicator-processing-color: $color-primary;
+$timeline-indicator-complete-color: $color-primary;
 $timeline-line-color: $graphite05;
 $timeline-header-color: $azure09;
 
@@ -610,8 +609,8 @@ $wizard-default-bg: $body-bg-color;
 $wizard-bar-bg: $graphite06;
 $wizard-color: $graphite09;
 $wizard-disabled-color: $graphite04;
-$wizard-active-color: $primary-color;
-$wizard-active-text-color: $primary-color;
+$wizard-active-color: $color-primary;
+$wizard-active-text-color: $color-primary;
 $wizard-focus-box-shadow: 0 0 0 1px $color-primary-alt;
 
 //Org Chart
@@ -692,13 +691,8 @@ $module-tabs-x-border-color: $azure05;
 $module-tabs-y-border-color: $azure10;
 $module-tabs-inactive-bg-color: $azure10;
 $module-tabs-active-bg-color: $color-primary-alt;
-<<<<<<< HEAD
 $module-tabs-hover-bg-color: $azure06;
 $module-tabs-inactive-text-color: rgba($white, 0.85);
-=======
-$module-tabs-hover-bg-color: $color-primary;
-$module-tabs-inactive-text-color: rgba($white, .85);
->>>>>>> Replacing azure06
 $module-tabs-active-text-color: $white;
 $module-tabs-hover-text-color: $white;
 $module-tabs-disabled-bg-color: $color-primary;
@@ -719,12 +713,12 @@ $splitter-box-shadow-color: rgba(37, 120, 169, 0.75);
 $step-chart-bg-color: $graphite02;
 $step-chart-border-color: $graphite01;
 $step-chart-inprogress-bg-color: $ruby02;
-$step-chart-completed-bg-color: $primary-color;
+$step-chart-completed-bg-color: $color-primary;
 $step-chart-totally-completed-bg-color: #80ce4d;
 
 //Swaplist
 $swaplist-bg-color-hover: $graphite04;
-$swaplist-bg-color-selected: $primary-color;
+$swaplist-bg-color-selected: $color-primary;
 $swaplist-border-color-focus: $color-primary-alt;
 $swaplist-icon-color: $graphite05;
 $swaplist-icon-color-hover: $font-color-highcontrast;
@@ -736,7 +730,7 @@ $swaplist-title-text-color: $black;
 $blockgrid-selected-bg-color: $selected-bg-color;
 $blockgrid-selected-border-color: $button-default-focus-border-color;
 $blockgrid-hover-color: $listview-hover-bg-color;
-$blockgrid-focus-border-color: $primary-color;
+$blockgrid-focus-border-color: $color-primary;
 
 // Tree Map
 $treemap-title-bg-color: $graphite08;
@@ -745,7 +739,7 @@ $treemap-title-color: $white;
 // Calendar
 $calendar-bg-color: $panel-bg-color;
 $calendar-line-color: $graphite09;
-$calendar-selected-border-color: $primary-color;
+$calendar-selected-border-color: $color-primary;
 $calendar-selected-bg-color: $graphite02;
 $calendar-hover-bg-color: $graphite01;
 $calendar-disabled-bg-color: $graphite02;

--- a/src/themes/high-contrast-theme.scss
+++ b/src/themes/high-contrast-theme.scss
@@ -69,7 +69,7 @@ $hyperlink-color: $azure09;
 $hyperlink-focus-border-color: $azure09;
 $hyperlink-visited-color: $amethyst10;
 $hyperlink-disabled-color: $disabled-color;
-$hyperlink-hover-color: $azure07;
+$hyperlink-hover-color: $color-primary-alt;
 
 // Alert Colors
 $alert-info: $azure09;
@@ -87,7 +87,7 @@ $circlepager-border-color: $graphite06;
 $circlepager-hover-bg-color: $white;
 $circlepager-hover-border-color: $black;
 $circlepager-focus-bg-color: $white;
-$circlepager-focus-border-color: $azure07;
+$circlepager-focus-border-color: $color-primary-alt;
 
 $circlepager-active-bg-color: $primary-color;
 $circlepager-active-border-color: $primary-color;
@@ -152,14 +152,14 @@ $popupmenu-checked-color: $azure09;
 $popupmenu-checked-color-inverse: $azure06;
 
 // Tertiary Buttons
-$tertiary-btn-ripple-color: $azure07;
+$tertiary-btn-ripple-color: $color-primary-alt;
 
 // Secondary with Border
 $secondary-border-btn-color:  $graphite09;
 $secondary-border-btn-border-color: $graphite09;
 $secondary-border-btn-hover-color:  $graphite10;
 $secondary-border-btn-hover-border-color: $graphite10;
-$secondary-border-btn-ripple-color: $azure07;
+$secondary-border-btn-ripple-color: $color-primary-alt;
 
 // Input Fields
 $input-color: $input-text-color;
@@ -177,7 +177,7 @@ $error-focus-box-shadow:  0 0 4px 2px rgba(222, 129, 129, 0.3);
 $dirty-icon-fill: $alert-yellow;
 $confirm-icon-fill: $alert-green;
 $info-icon-fill: $azure08;
-$selected-bg-color: rgba($azure07, 0.3);
+$selected-bg-color: rgba($color-primary-alt, .3);
 
 // Autocomplete
 $autocomplete-light-text: $graphite05;
@@ -222,7 +222,7 @@ $listbuilder-bg-color: $input-bg-color;
 $listbuilder-bg-color-hover: $graphite04;
 $listbuilder-bg-color-selected: $primary-color;
 $listbuilder-border-color: $input-border-color;
-$listbuilder-border-color-focus: $azure07;
+$listbuilder-border-color-focus: $color-primary-alt;
 $listbuilder-icon-color-hover: $font-color-highcontrast;
 $listbuilder-text-color: $black;
 $listbuilder-input-selection-bg-color: $azure10;
@@ -257,7 +257,7 @@ $datepicker-icon-active-color: $azure09;
 // $datepicker-alternate-month-color: rgba($graphite06, 0.5);
 $datepicker-alternate-month-color: $graphite05;
 $datepicker-day-color: $black;
-$datepicker-focus-border-color: $azure07;
+$datepicker-focus-border-color: $color-primary-alt;
 $datepicker-selected-bg-color: $primary-color;
 $datepicker-selected-color: $inverse-color;
 $datepicker-today-color: $black;
@@ -576,7 +576,7 @@ $sr-masthead-item-color: $font-color-lowcontrast;
 // Tree
 $tree-selected-color: $black;
 $tree-selected-bg-color: $graphite04;
-$tree-focus-border-color: $azure07;
+$tree-focus-border-color: $color-primary-alt;
 $tree-active-bg-color: #8fa8b7;
 $tree-icon-color: $graphite09;
 $tree-link-color: $graphite09;
@@ -612,7 +612,7 @@ $wizard-color: $graphite09;
 $wizard-disabled-color: $graphite04;
 $wizard-active-color: $primary-color;
 $wizard-active-text-color: $primary-color;
-$wizard-focus-box-shadow: 0 0 0 1px $azure07;
+$wizard-focus-box-shadow: 0 0 0 1px $color-primary-alt;
 
 //Org Chart
 $hierarchy-line-color: $graphite10;
@@ -691,14 +691,14 @@ $module-tabs-bg-color: $azure09;
 $module-tabs-x-border-color: $azure05;
 $module-tabs-y-border-color: $azure10;
 $module-tabs-inactive-bg-color: $azure10;
-$module-tabs-active-bg-color: $azure07;
+$module-tabs-active-bg-color: $color-primary-alt;
 $module-tabs-hover-bg-color: $azure06;
 $module-tabs-inactive-text-color: rgba($white, 0.85);
 $module-tabs-active-text-color: $white;
 $module-tabs-hover-text-color: $white;
 $module-tabs-disabled-bg-color: $azure06;
 $module-tabs-disabled-x-border-color: $azure04;
-$module-tabs-disabled-y-border-color: $azure07;
+$module-tabs-disabled-y-border-color: $color-primary-alt;
 $module-tabs-disabled-text-color: $azure04;
 
 // Composite Tabs
@@ -720,7 +720,7 @@ $step-chart-totally-completed-bg-color: #80ce4d;
 //Swaplist
 $swaplist-bg-color-hover: $graphite04;
 $swaplist-bg-color-selected: $primary-color;
-$swaplist-border-color-focus: $azure07;
+$swaplist-border-color-focus: $color-primary-alt;
 $swaplist-icon-color: $graphite05;
 $swaplist-icon-color-hover: $font-color-highcontrast;
 $swaplist-border-color-hover: $font-color-highcontrast;

--- a/src/themes/high-contrast-theme.scss
+++ b/src/themes/high-contrast-theme.scss
@@ -21,7 +21,7 @@ $header-button-color: rgba($white, 1);
 $header-button-focus-color: rgba($white, 1);
 $header-button-hover-color: rgba($white, 0.85);
 $header-button-disabled-color: rgba($white, 0.3);
-$header-primary-btn-background-color: $azure06;
+$header-primary-btn-background-color: $color-primary;
 $header-primary-btn-background-hover-color: $azure05;
 $header-disabled-color: $graphite05;
 $header-focus-box-shadow:  0 0 4px 3px rgba(255, 255, 255, 0.3);
@@ -149,7 +149,7 @@ $popupmenu-box-shadow: 0 2px 5px $drop-shadow-depth;
 $popupmenu-heading-color: $graphite07;
 $popupmenu-hover-color: $graphite04;
 $popupmenu-checked-color: $azure09;
-$popupmenu-checked-color-inverse: $azure06;
+$popupmenu-checked-color-inverse: $color-primary;
 
 // Tertiary Buttons
 $tertiary-btn-ripple-color: $color-primary-alt;
@@ -338,7 +338,7 @@ $checkbox-disabled-select-bg-color: $checkbox-disabled-checked-bg-color;
 
 // Switch
 $switch-checked-color: $primary-color;
-$switch-checked-bg-color: $azure06;
+$switch-checked-bg-color: $color-primary;
 $switch-unchecked-bg-color: $white;
 $switch-unchecked-bar-color: $graphite07;
 $switch-unchecked-border-color: $graphite06;
@@ -692,11 +692,16 @@ $module-tabs-x-border-color: $azure05;
 $module-tabs-y-border-color: $azure10;
 $module-tabs-inactive-bg-color: $azure10;
 $module-tabs-active-bg-color: $color-primary-alt;
+<<<<<<< HEAD
 $module-tabs-hover-bg-color: $azure06;
 $module-tabs-inactive-text-color: rgba($white, 0.85);
+=======
+$module-tabs-hover-bg-color: $color-primary;
+$module-tabs-inactive-text-color: rgba($white, .85);
+>>>>>>> Replacing azure06
 $module-tabs-active-text-color: $white;
 $module-tabs-hover-text-color: $white;
-$module-tabs-disabled-bg-color: $azure06;
+$module-tabs-disabled-bg-color: $color-primary;
 $module-tabs-disabled-x-border-color: $azure04;
 $module-tabs-disabled-y-border-color: $color-primary-alt;
 $module-tabs-disabled-text-color: $azure04;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
We want to slowly replace references to direct color variables from the color palette and use contextual token variables in their place.

_i.e_ Replace `color: $azure06` with `color: $color-primary`

**Related github/jira issue (required)**:
Closes #708 

**Steps necessary to review your pull request (required)**:
1. `npm start` to start the demo app
1. Verify
    - Colors look normal on the normal theme
    - Some colors change when switching themes ~, specifically the new Uplift theme~

_Edit: The themes aren't changing properly as there is a major structure/cascade issue on the tokens side. This can still be merged, but don't expect to see anything different on the Uplift theme when switching and the hc/dark themes will show some things different, but are also flawed._