### PR TITLE
751 - Add preserve and restore methods for tree

### DIFF
--- a/app/views/components/tree/example-preserve-restore.html
+++ b/app/views/components/tree/example-preserve-restore.html
@@ -7,7 +7,7 @@
         <li>
             <a id="home" href="#">Home</a>
         </li>
-        <li><a id="about-us" href="#">About Us</a></li>
+        <li><a id="about-us" href="#" class="is-disabled" aria-disabled="true">About Us</a></li>
         <li class="is-open mycustom">
             <a id="public-folders" href="#">Public Folders</a>
             <ul class="is-open root">
@@ -18,7 +18,7 @@
                       <a href="#">Leadership</a>
                     </li>
                     <li>
-                      <a id="history" href="#" class="is-disabled hide-focus" disabled>History</a>
+                      <a id="history" href="#" class="is-disabled" aria-disabled="true">History</a>
                     </li>
                     <li>
                       <a id="careers-last" href="#">Careers last</a>
@@ -30,13 +30,13 @@
             </ul>
         </li>
         <li>
-            <a id="icons" href="#">Icons</a>
+            <a id="icons" href="#" class="is-disabled" aria-disabled="true">Icons</a>
             <ul class="root">
               <li>
                 <a id="audio" href="#" class="icon-tree-audio">Audio</a>
               </li>
               <li>
-                <a id="avi" href="#" class="icon-tree-avi">Avi</a>
+                <a id="avi" href="#" class="icon-tree-avi is-disabled" aria-disabled="true">Avi</a>
               </li>
               <li>
                 <a id="bmp" href="#" class="icon-tree-bmp">Bmp</a>
@@ -147,16 +147,25 @@
       <div class="row">
         <div class="six columns">
 
-          <h2>Tree Component: Disable nodes</h2>
+          <h2>Tree Component: Preserve nodes</h2>
 
-          <p>The button below this paragraph disables all nodes in the Tree Component.</p>
+          <p>The buttons below this paragraph respectively preserve or restore all nodes in the Tree Component. Preserve must be clicked prior to Restore if Restore is to operate correctly.</p>
 
           <div class="field">
-            <button type="button" id="disable" class="btn-secondary">
+            <button type="button" id="preserve" class="btn-secondary">
               <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
                 <use xlink:href="#icon-alert"></use>
               </svg>
-              <span>Disable Tree Component</span>
+              <span>Preserve</span>
+            </button>
+          </div>
+
+          <div class="field">
+            <button type="button" id="restore" class="btn-secondary">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use xlink:href="#icon-alert"></use>
+              </svg>
+              <span>Restore</span>
             </button>
           </div>
 
@@ -171,17 +180,16 @@
 
 <script>
 
-  // button click direct call to method
-  // $('#disable').on('click', () => {
-  //   $('#tree').disable();
-  // });
-
   const tree = $('#tree').tree().data('tree');
+  const preserveBtn = document.getElementById('preserve');
+  const restoreBtn = document.getElementById('restore');
 
-  // method call on tree api
-  $('#disable').on('click', () => {
-    tree.disable();
+  preserveBtn.addEventListener('click', () => {
+    tree.preserveEnablementState();
   });
 
+  restoreBtn.addEventListener('click', () => {
+    tree.restoreEnablementState();
+  });
 
 </script>

--- a/src/components/tree/readme.md
+++ b/src/components/tree/readme.md
@@ -33,6 +33,8 @@ demo:
     slug: example-update-node
   - name: Disable Tree
     slug: example-disable
+  - name: Preserve and Restore Tree
+    slug: example-preserve-restore
 ---
 
 ## Testability

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -2164,9 +2164,9 @@ Tree.prototype = {
 
     nodes.forEach((node) => {
       if ((node.classList.contains('is-disabled')) || (node.getAttribute('aria-disabled') === true)) {
-        enablementStates.push({nodeId: node.id, state: 'disabled'});
+        enablementStates.push({ nodeId: node.id, state: 'disabled' });
       } else {
-        enablementStates.push({nodeId: node.id, state: 'enabled'});
+        enablementStates.push({ nodeId: node.id, state: 'enabled' });
       }
     });
 

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -2163,7 +2163,7 @@ Tree.prototype = {
     const enablementStates = [];
 
     nodes.forEach((node) => {
-      if ( ( node.classList.contains('is-disabled') ) || ( node.getAttribute('aria-disabled') === true ) ) {
+      if ((node.classList.contains('is-disabled')) || (node.getAttribute('aria-disabled') === true)) {
         enablementStates.push({nodeId: node.id, state: 'disabled'});
       } else {
         enablementStates.push({nodeId: node.id, state: 'enabled'});
@@ -2181,11 +2181,11 @@ Tree.prototype = {
     const nodes = this.element[0].querySelectorAll('a');
 
     // check to prevent error if preserveEnablementState() has not been invoked
-    if ( !(this.settings.originalEnablementState === null) ) {
+    if (!(this.settings.originalEnablementState === null)) {
       nodes.forEach((node) => {
         this.settings.originalEnablementState.forEach((origNode) => {
-          if ( origNode.nodeId === node.id ) {
-            if ( origNode.state === 'disabled' ) {
+          if (origNode.nodeId === node.id) {
+            if (origNode.state === 'disabled') {
               node.classList.add('is-disabled');
               node.setAttribute('aria-disabled', 'true');
             } else {

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -20,7 +20,8 @@ const TREE_DEFAULTS = {
   sortable: false, // Allow nodes to be sortable
   onBeforeSelect: null,
   onExpand: null,
-  onCollapse: null
+  onCollapse: null,
+  originalEnablementState: null
 };
 
 /**
@@ -2151,6 +2152,50 @@ Tree.prototype = {
       node.classList.add('is-disabled');
       node.setAttribute('aria-disabled', 'true');
     });
+  },
+
+  /**
+   * Preserves all nodes' enablement states in the Tree component
+   * @returns {void}
+   */
+  preserveEnablementState() {
+    const nodes = this.element[0].querySelectorAll('a');
+    const enablementStates = [];
+
+    nodes.forEach((node) => {
+      if ( ( node.classList.contains('is-disabled') ) || ( node.getAttribute('aria-disabled') === true ) ) {
+        enablementStates.push({nodeId: node.id, state: 'disabled'});
+      } else {
+        enablementStates.push({nodeId: node.id, state: 'enabled'});
+      }
+    });
+
+    this.settings.originalEnablementState = enablementStates;
+  },
+
+  /**
+   * Restores all nodes' original enablement states in the Tree component
+   * @returns {void}
+   */
+  restoreEnablementState() {
+    const nodes = this.element[0].querySelectorAll('a');
+
+    // check to prevent error if preserveEnablementState() has not been invoked
+    if ( !(this.settings.originalEnablementState === null) ) {
+      nodes.forEach((node) => {
+        this.settings.originalEnablementState.forEach((origNode) => {
+          if ( origNode.nodeId === node.id ) {
+            if ( origNode.state === 'disabled' ) {
+              node.classList.add('is-disabled');
+              node.setAttribute('aria-disabled', 'true');
+            } else {
+              node.classList.remove('is-disabled');
+              node.removeAttribute('aria-disabled');
+            }
+          }
+        });
+      });
+    }
   }
 
 };


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Need a method to preserve the original state of nodes in terms of enablement (disabled or enabled) and then restore the nodes to that original state once preserved.

**Related github/jira issue (required)**:
Closes #751 .

**Steps necessary to review your pull request (required)**:
- Pull branch and run app.
- Go to http://localhost:4000/components/tree/example-preserve-restore.html
- Click Preserve button. Note which nodes are disabled or enabled.
- Open developer tools console.
  - Remove class `is-disabled` and/or `aria-disabled="true"` from any given node(s). Add  class `is-disabled` and/or `aria-disabled="true"`to any given node(s).
- Click Restore button. Note that nodes return to original state when you clicked Preserve button.
