### PR TITLE
656 - Added fix for dropdown closing when scrolling

### DIFF
--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -818,11 +818,13 @@ div.dropdown-xs,
       top: 11px;
     }
   }
+
   div.dropdown,
   div.multiselect {
     > .listoption-icon {
       top: 9px;
     }
+
     + .icon {
       top: 4px;
     }
@@ -836,6 +838,7 @@ div.dropdown-xs,
     > .listoption-icon {
       top: 9px;
     }
+
     + .icon {
       top: 4px;
     }

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1529,10 +1529,11 @@ Dropdown.prototype = {
       this.list.find(`.dropdown-option[data-val="${this.previousActiveDescendant.replace(/"/g, '/quot/')}"]`) :
       this.list.find('.is-selected');
     const self = this;
-    let touchPrevented = false;
     const threshold = 10;
     let isEmpty = true;
     let pos;
+
+    this.touchPrevented = false;
 
     if (current.length > 0) {
       isEmpty = true;
@@ -1657,6 +1658,10 @@ Dropdown.prototype = {
     self.list
       .removeClass('dropdown-tall')
       .on('touchend.list click.list', 'li', function (e) {
+        if (self.touchPrevented) {
+          return;
+        }
+
         const itemSelected = self.selectListItem($(this));
         e.preventDefault();
         if (!itemSelected) {
@@ -1686,7 +1691,7 @@ Dropdown.prototype = {
     // Ignores Scrolling on Mobile, and will not close the list if accessing an item within the list
     function scrollDocument(e) {
       const focus = $('*:focus'); // dont close on timepicker arrow down and up
-      if (touchPrevented || isDropdownElement($(e.target)) || focus.is('.timepicker')) {
+      if (self.touchPrevented || isDropdownElement($(e.target)) || focus.is('.timepicker')) {
         return;
       }
       self.closeList('cancel');
@@ -1697,10 +1702,10 @@ Dropdown.prototype = {
 
     function clickDocument(e) {
       const target = $(e.target);
-      if (touchPrevented || (isDropdownElement(target) && !target.is('.icon'))) {
+      if (self.touchPrevented || (isDropdownElement(target) && !target.is('.icon'))) {
         e.preventDefault();
 
-        touchPrevented = false;
+        self.touchPrevented = false;
         return;
       }
 
@@ -1708,7 +1713,7 @@ Dropdown.prototype = {
     }
 
     function touchStartCallback(e) {
-      touchPrevented = false;
+      self.touchPrevented = false;
 
       pos = {
         x: e.originalEvent.touches[0].pageX,
@@ -1723,18 +1728,17 @@ Dropdown.prototype = {
 
         if ((newPos.x >= pos.x + threshold) || (newPos.x <= pos.x - threshold) ||
             (newPos.y >= pos.y + threshold) || (newPos.y <= pos.y - threshold)) {
-          touchPrevented = true;
+          self.touchPrevented = true;
         }
       });
-
-      e.stopPropagation();
     }
 
     function touchEndCallback(e) {  //eslint-disable-line
       $(document).off('touchmove.dropdown');
       e.preventDefault();
 
-      if (touchPrevented) {
+      if (self.touchPrevented) {
+        e.stopPropagation();
         return false;
       }
 

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1723,6 +1723,8 @@ Dropdown.prototype = {
           touchPrevented = true;
         }
       });
+
+      e.stopPropagation();
     }
 
     function touchEndCallback(e) {  //eslint-disable-line

--- a/src/components/trackdirty/trackdirty.js
+++ b/src/components/trackdirty/trackdirty.js
@@ -75,7 +75,6 @@ Trackdirty.prototype = {
       pos.left += el.scrollLeft;
       pos.top += el.scrollTop;
     });
-    
     return { left: pos.left, top: pos.top };
   },
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Possible issue in mobile bubbling the touchStartCallback function.

Tried to debug in safari web inspector (while my phone is connected) and it seems that the function is working but after this function is done, it started to close the dropdown while scrolling.

Added a `e.stopPropagation()` at the end of the line.

**Related github/jira issue (required)**:
 
Closes https://github.com/infor-design/enterprise/issues/656

**Steps necessary to review your pull request (required)**:

 This is only reproducible in:

- http://master-enterprise.demo.design.infor.com/components/dropdown/example-index.html 
- Open in any mobile browser

This is my assumption solution. Let me know your thoughts.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
