### PR TITLE
739 - Added fix to bar chart tooltips, Fixed Failing Month Tests

### DIFF
--- a/src/components/bar/bar.js
+++ b/src/components/bar/bar.js
@@ -450,7 +450,7 @@ Bar.prototype = {
             for (j = 0, l = data.length; j < l; j++) {
               hexColor = charts.chartColor(j, 'bar', legendMap[j]);
               content += `<div class="swatch-row">
-                    <div class="swatch-color"}${setPattern(legendMap[j].pattern, hexColor)}</div>
+                    <div class="swatch-color">${setPattern(legendMap[j].pattern, hexColor)}</div>
                   <span>${data[j].name}</span><b>${format(data[j].value)}</b>
                 </div>`;
             }

--- a/src/components/monthview/monthview.js
+++ b/src/components/monthview/monthview.js
@@ -279,7 +279,8 @@ MonthView.prototype = {
 
     if (this.isIslamic) {
       if (!this.settings.activeDateIslamic) {
-        this.todayDateIslamic = this.conversions.fromGregorian(new Date());
+        const gregorianDate = new Date();
+        this.todayDateIslamic = this.conversions.fromGregorian(gregorianDate);
         this.settings.activeDateIslamic = [];
         this.settings.activeDateIslamic[0] = this.todayDateIslamic[0];
         this.settings.activeDateIslamic[1] = this.todayDateIslamic[1];
@@ -287,8 +288,7 @@ MonthView.prototype = {
         year = this.settings.activeDateIslamic[0];
         month = this.settings.activeDateIslamic[1];
       }
-
-      elementDate = this.settings.activeDateIslamic;
+      elementDate = this.conversions.fromGregorian(now);
     }
 
     if (year.toString().length < 4) {

--- a/test/components/datepicker/datepicker-api.func-spec.js
+++ b/test/components/datepicker/datepicker-api.func-spec.js
@@ -126,7 +126,7 @@ describe('DatePicker API', () => {
 
     const converted = datepickerAPI.conversions.fromGregorian(testDate);
 
-    expect(datepickerEl.value).toEqual(`${converted[0]}/${converted[1] + 1}/${converted[2].toString().length === 1 ? `0${converted[2]}` : converted[2]}`);
+    expect(datepickerEl.value).toEqual(`${converted[0]}/${(`${converted[1] + 1}`).padStart(2, '0')}/${(`${converted[2]}`).padStart(2, '0')}`);
   });
 
   it('Should set internal format', () => {

--- a/test/components/monthview/monthview-api.func-spec.js
+++ b/test/components/monthview/monthview-api.func-spec.js
@@ -74,10 +74,10 @@ describe('Monthview API', () => {
     Soho.Locale.set('ar-SA'); //eslint-disable-line
     monthviewAPI.showMonth(7, 2018);
 
-    expect(document.getElementById('monthview-datepicker-field').value).toEqual('ذو الحجة 1439');
+    expect(document.getElementById('monthview-datepicker-field').value).toEqual('محرم 1440');
     expect(document.body.querySelector('thead tr th:first-child').textContent.trim()).toEqual('السبت');
-    expect(document.body.querySelector('tbody tr:first-child td:first-child').textContent.trim()).toEqual('29');
-    expect(document.body.querySelector('tbody tr:first-child td:last-child').textContent.trim()).toEqual('6');
+    expect(document.body.querySelector('tbody tr:first-child td:first-child').textContent.trim()).toEqual('28');
+    expect(document.body.querySelector('tbody tr:first-child td:last-child').textContent.trim()).toEqual('4');
   });
 
   it('Should render disabled days', () => {
@@ -128,7 +128,7 @@ describe('Monthview API', () => {
     Soho.Locale.set('ar-SA'); //eslint-disable-line
     monthviewAPI.showMonth(7, 2018);
 
-    expect(document.getElementById('monthview-datepicker-field').value).toEqual('ذو الحجة 1439');
+    expect(document.getElementById('monthview-datepicker-field').value).toEqual('محرم 1440');
 
     Locale.set('de-DE');
     Soho.Locale.set('de-DE'); //eslint-disable-line


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Made a fix for faulty markup on tooltips that caused them to render badly on bar charts. In order to pass tests going forward had to fix the failing monthview tests.

Explanation is today is a new year in arabic calendar. So basically the month changed going forward since the calendar shows todays date. This isnt really reflected in the test either so bumped the year so the tests pass going forward.

**Related github/jira issue (required)**:
Closes #739 

**Steps necessary to review your pull request (required)**:
- test any of the examples on the ticket such as http://localhost:4000/components/bar-grouped/example-animation.html by hovering the bar set
- Tooltip now ok.
- Let tests run
