### PR TITLE
Tweak the order of some sass imports for correct theming

### DIFF
--- a/app/src/docs.scss
+++ b/app/src/docs.scss
@@ -1,6 +1,12 @@
 // Docs Site Styling
 // Compiles down to what used to be `site.css`
-//==================================================//
+//================================================== //
+
+// Enterprise color palette
+@import '../../src/components/colors/colorpalette';
+
+// ids-identity token vars
+@import '../../node_modules/ids-identity/dist/tokens/web/theme-soho';
 
 // Soho Core/Helpers
 @import '../../src/core/config';

--- a/app/src/index.scss
+++ b/app/src/index.scss
@@ -4,7 +4,13 @@
 // This stylesheet assumes that it's being loaded alongside
 // a SoHo Xi Theme, and therefore doesn't pull in any of those
 // styles.
-//==================================================//
+//================================================== //
+
+// Enterprise color palette
+@import '../../src/components/colors/colorpalette';
+
+// ids-identity token vars
+@import '../../node_modules/ids-identity/dist/tokens/web/theme-soho';
 
 // Soho Core/Helpers
 @import '../../src/core/config';

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "handlebars-registrar": "^1.5.2",
     "html-loader": "^0.5.5",
     "ids-css": "^1.3.0",
-    "ids-identity": "1.3.1",
+    "ids-identity": "1.3.2",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jasmine-core": "^3.2.1",
     "jasmine-jquery": "^2.1.1",

--- a/scripts/configs/sass.js
+++ b/scripts/configs/sass.js
@@ -8,7 +8,6 @@ module.exports = {
         sourceMap: true
       },
       files: {
-        'app/dist/css/demo.css': 'app/src/index.scss',
         'dist/css/light-theme.css': 'src/themes/light-theme.scss',
         'dist/css/dark-theme.css': 'src/themes/dark-theme.scss',
         'dist/css/high-contrast-theme.css': 'src/themes/high-contrast-theme.scss',

--- a/src/components/busyindicator/_busyindicator.scss
+++ b/src/components/busyindicator/_busyindicator.scss
@@ -78,7 +78,7 @@ $busy-indicator-check-color: $inverse-color;
   @include opacity(0.75);
   @include transition(opacity 500ms);
 
-  background-color: $body-bg-color;
+  background-color: $body-bg-color-primary;
   position: absolute;
   visibility: visible;
 

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -163,7 +163,7 @@ button {
     border: 1px solid transparent;
 
     &:not(.hide-focus) {
-      box-shadow: 0 0 0 2px $body-bg-color, 0 0 0 3px $button-primary-bg-color, $focus-box-shadow;
+      box-shadow: 0 0 0 2px $body-bg-color-primary, 0 0 0 3px $button-primary-bg-color, $focus-box-shadow;
     }
 
     &:active {
@@ -293,7 +293,7 @@ a.btn-close {
     border: 1px solid transparent;
 
     &:not(.hide-focus) {
-      box-shadow: 0 0 0 2px $body-bg-color, 0 0 0 3px $button-default-focus-border-color, $focus-box-shadow;
+      box-shadow: 0 0 0 2px $body-bg-color-primary, 0 0 0 3px $button-default-focus-border-color, $focus-box-shadow;
     }
 
     &:active {
@@ -773,7 +773,7 @@ html[lang^='fr-'] {
   }
 
   &:focus {
-    box-shadow: 0 0 0 1px $body-bg-color, 0 0 0 2px $color-primary, $focus-box-shadow;
+    box-shadow: 0 0 0 1px $body-bg-color-primary, 0 0 0 2px $color-primary, $focus-box-shadow;
   }
 
   &:disabled {

--- a/src/components/calendar/_calendar.scss
+++ b/src/components/calendar/_calendar.scss
@@ -63,7 +63,7 @@
 
   // The details section
   .calendar-event-details {
-    background-color: $body-bg-color;
+    background-color: $body-bg-color-primary;
     border-left: 1px solid $calendar-line-color;
     display: inline-block;
     height: 100%;

--- a/src/components/cards/_cards.scss
+++ b/src/components/cards/_cards.scss
@@ -244,7 +244,7 @@
 
     &.card-group-action,
     &.widget-group-action {
-      background-color: $body-bg-color;
+      background-color: $body-bg-color-primary;
       border: 1px solid transparent;
       border-bottom-color: $listview-border-color;
     }
@@ -278,7 +278,7 @@
   }
 
   &.alternate {
-    background-color: $body-bg-color;
+    background-color: $body-bg-color-primary;
   }
 
 }

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -27,13 +27,13 @@
 }
 
 @mixin checkbox-checked-before-style {
-  background-color: $checkbox-color;
-  border-color: $checkbox-color;
+  background-color: $checkbox-checked-bg-color;
+  border-color: $checkbox-checked-bg-color;
 }
 
 @mixin checkbox-checked-disabled-before-style {
-  background-color: $checkbox-disabled-select-bg-color;
-  border-color: $checkbox-disabled-select-bg-color;
+  background-color: $checkbox-disabled-checked-bg-color;
+  border-color: $checkbox-disabled-checked-bg-color;
 }
 
 @mixin checkbox-checked-after-style {
@@ -153,7 +153,7 @@ label.inline .checkbox:disabled ~ .label-text,
 input.checkbox:disabled + label,
 input.checkbox:disabled + input[type='hidden'] + label,
 span.checkbox > input:disabled + label {
-  color: $checkbox-disabled-font-color;
+  color: $checkbox-disabled-text-color;
   cursor: default;
 }
 

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1184,7 +1184,7 @@ $datagrid-short-row-height: 23px;
       height: $datagrid-row-height + 7;
 
       td {
-        background-color: $body-bg-color;
+        background-color: $body-bg-color-primary;
       }
     }
 
@@ -2030,7 +2030,7 @@ $datagrid-short-row-height: 23px;
       }
 
       &.is-checked::before {
-        border: 1px solid $checkbox-color;
+        border: 1px solid $checkbox-border-color;
       }
     }
 

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -219,7 +219,7 @@ div.multiselect {
 
   // Enables certain mobile-specific settings
   &.mobile {
-    background-color: $body-bg-color;
+    background-color: $body-bg-color-primary;
   }
 
   &.is-ontop {
@@ -517,7 +517,7 @@ div.multiselect {
 }
 
 .dropdown-search {
-  background-color: $body-bg-color;
+  background-color: $body-bg-color-primary;
   border: 0;
   border-bottom: 1px solid $dropdown-menu-separator-border-color;
   border-radius: 0;

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -291,7 +291,7 @@ $subheader-height: 60px;
     }
 
     &:not(.hide-focus) {
-      box-shadow: 0 0 0 1px $body-bg-color, 0 0 0 2px $button-default-focus-border-color, $focus-box-shadow;
+      box-shadow: 0 0 0 1px $body-bg-color-primary, 0 0 0 2px $button-default-focus-border-color, $focus-box-shadow;
     }
   }
 }

--- a/src/components/hierarchy/_hierarchy.scss
+++ b/src/components/hierarchy/_hierarchy.scss
@@ -175,7 +175,7 @@ $hierarchy-line-width: 1.34px; //Fixes zoom somewhat
 
     // Remove the last node if its expandable
     .chart:not(.has-single-child) > .sub-level > li.branch-expanded:last-child::after {
-      background-color: $body-bg-color;
+      background-color: $body-bg-color-primary;
       content: '';
       height: 100%;
       left: 13px;

--- a/src/components/listview/_listview.scss
+++ b/src/components/listview/_listview.scss
@@ -610,7 +610,7 @@
 // Search Toolbar on Listview
 .listview-search {
   .searchfield-wrapper {
-    background-color: $body-bg-color;
+    background-color: $body-bg-color-primary;
     height: 36px;
     margin-bottom: 0;
     width: 100%;

--- a/src/components/processindicator/_processindicator.scss
+++ b/src/components/processindicator/_processindicator.scss
@@ -94,7 +94,7 @@ $indicator-current-size: ($indicator-size * 1.6);
 
 // Indicator icons
 .indicator {
-  background-color: $body-bg-color;
+  background-color: $body-bg-color-primary;
   border: 2px solid $indicator-blank;
   border-radius: ($indicator-size / 2);
   display: inline-block;

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -48,7 +48,7 @@
 .radio:hover + label::before {
   @include css3(transition, border-color 300ms ease);
 
-  border-color: $radio-hover-border-color;
+  border-color: $radio-border-hover-color;
 }
 
 .inline .radio ~ .label-text,
@@ -65,8 +65,8 @@
 
 .inline .radio ~ .label-text::after,
 .radio + label::after {
-  background-color: $radio-selected-bg-color;
-  border: 2px solid $radio-selected-bg-color;
+  background-color: $radio-checked-bg-color;
+  border: 2px solid $radio-checked-bg-color;
   border-radius: 50%;
   content: '';
   height: 4px;
@@ -83,8 +83,8 @@
 
 .inline .radio:checked ~ .label-text::before,
 .radio:checked + label::before {
-  background-color: $radio-selected-color;
-  border: 1px solid $radio-selected-color;
+  background-color: $radio-checked-color;
+  border: 1px solid $radio-checked-color;
 }
 
 // checked mark aspect changes
@@ -119,8 +119,8 @@
 
 .inline .radio:disabled:checked ~ .label-text::before,
 .radio:disabled:checked + label::after {
-  background-color: $radio-disabled-select-bg-color;
-  border: 2px solid $radio-disabled-select-bg-color;
+  background-color: $radio-disabled-checked-bg-color;
+  border: 2px solid $radio-disabled-checked-bg-color;
 }
 
 .inline .radio:disabled ~ .label-text,

--- a/src/components/switch/_switch.scss
+++ b/src/components/switch/_switch.scss
@@ -88,8 +88,8 @@
   //Checked Styling - Toggle Handle
   input:checked ~ .label-text::after,
   input:checked ~ label::after {
-    background: $switch-checked-color;
-    border-color: $switch-checked-color;
+    background: $radio-checked-color;
+    border-color: $radio-checked-color;
     left: 15px;
   }
 
@@ -106,7 +106,7 @@
   input:not(:disabled):checked:focus ~ .label-text::after,
   input:not(:disabled):checked:active ~ label::after,
   input:not(:disabled):checked:focus ~ label::after {
-    background-color: $switch-checked-color;
+    background-color: $radio-checked-color;
   }
 
   input:not(:disabled):checked:hover ~ .label-text::after,

--- a/src/components/tabs/_tabs-horizontal.scss
+++ b/src/components/tabs/_tabs-horizontal.scss
@@ -7,8 +7,8 @@ $horizontal-tabs-height: 40px;
   &::after {
     background-image: linear-gradient(
       to right,
-      rgba($body-bg-color, 0),
-      rgba($body-bg-color, 1)
+      rgba($body-bg-color-primary, 0),
+      rgba($body-bg-color-primary, 1)
     );
     height: ($horizontal-tabs-height - 1px);
   }
@@ -20,8 +20,8 @@ $horizontal-tabs-height: 40px;
   &::before {
     background-image: linear-gradient(
       to right,
-      rgba($body-bg-color, 1),
-      rgba($body-bg-color, 0)
+      rgba($body-bg-color-primary, 1),
+      rgba($body-bg-color-primary, 0)
     );
     height: ($horizontal-tabs-height - 1px);
   }
@@ -177,16 +177,16 @@ html[dir='rtl'] {
     &::before {
       background-image: linear-gradient(
         to left,
-        rgba($body-bg-color, 1),
-        rgba($body-bg-color, 0)
+        rgba($body-bg-color-primary, 1),
+        rgba($body-bg-color-primary, 0)
       );
     }
 
     &::after {
       background-image: linear-gradient(
         to left,
-        rgba($body-bg-color, 0),
-        rgba($body-bg-color, 1)
+        rgba($body-bg-color-primary, 0),
+        rgba($body-bg-color-primary, 1)
       );
     }
 

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -162,7 +162,7 @@
   }
 
   &.alternate {
-    background-color: $body-bg-color;
+    background-color: $body-bg-color-primary;
     min-height: 100%;
   }
 

--- a/src/components/typography/_typography.scss
+++ b/src/components/typography/_typography.scss
@@ -20,7 +20,7 @@ html {
   font-size: 62.5%;
 
   body {
-    background-color: $body-bg-color;
+    background-color: $body-bg-color-primary;
     color: $font-color-default;
     font-family: $font-regular;
     font-size: 1rem;

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -43,7 +43,6 @@ $focus-box-shadow-spinbox-up: 0 -3px 3px 0 $focus-box-shadow-color,
   3px 0 3px 0 $focus-box-shadow-color;
 
 // Base Colors
-$color-primary: $color-primary;
 $inverse-color: $button-primary-text-color;
 
 // Text Color

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -1,12 +1,6 @@
 // Variables
 //================================================== //
 
-// IDS-identity vars
-@import '../../node_modules/ids-identity/dist/tokens/web/theme-soho.sass';
-
-// Local vars
-@import '../components/colors/colorpalette';
-
 // Form Background Color
 $header-bg-color: $color-primary-alt;
 $subhead-bg-color: $azure08;

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -8,7 +8,6 @@
 @import '../components/colors/colorpalette';
 
 // Form Background Color
-$body-bg-color:  $body-bg-color-primary;
 $header-bg-color: $color-primary-alt;
 $subhead-bg-color: $azure08;
 $transparent: transparent;
@@ -374,15 +373,13 @@ $cardlist-actions-color: $text-color;
 $cardlist-text-color: $font-color;
 
 // Checkboxes
-$checkbox-color: $color-primary;
-$checkbox-disabled-font-color: $checkbox-disabled-text-color;
-$checkbox-disabled-select-bg-color: $checkbox-disabled-checked-bg-color;
+$checkbox-disabled-text-color: $checkbox-disabled-text-color;
+$checkbox-disabled-checked-bg-color: $checkbox-disabled-checked-bg-color;
 
 // Switch
 $focus-color: #cbdce6;
 $focus-shadow: rgba(0, 0, 0, 0.3);
 
-$switch-checked-color: $color-primary;
 $switch-checked-hover-color: $color-primary-alt;
 $switch-checked-bg-color: $azure03;
 $switch-unchecked-bar-color: $color-default-alt;
@@ -412,12 +409,6 @@ $editor-btn-active-color: $color-primary;
 $editor-btn-active-box-shadow: 0 0 0 2px transparent, 0 0 0 1px $color-primary, $focus-box-shadow;
 $editor-top-focus-box-shadow: -2px -2px 3px 0 rgba(54, 138, 192, 0.3);
 $editor-blockquote-color: $graphite06;
-
-// Radio Buttons
-$radio-hover-border-color: $radio-border-hover-color;
-$radio-selected-color: $radio-checked-color;
-$radio-selected-bg-color: $radio-checked-bg-color;
-$radio-disabled-select-bg-color: $radio-disabled-checked-bg-color;
 
 //Pager
 $pager-text-color: $color-primary;

--- a/src/layouts/_layouts.scss
+++ b/src/layouts/_layouts.scss
@@ -95,7 +95,7 @@ body.no-scroll {
   }
 
   > .sidebar {
-    background-color: $body-bg-color;
+    background-color: $body-bg-color-primary;
     border-right: 1px solid $panel-border-color;
     height: 100%;
     width: calc(25%);
@@ -105,7 +105,7 @@ body.no-scroll {
     }
 
     .listview {
-      background-color: $body-bg-color;
+      background-color: $body-bg-color-primary;
 
       &.paginated {
         height: calc(100% - 38px);
@@ -251,7 +251,7 @@ body.no-scroll {
   }
 
   .sidebar {
-    background-color: $body-bg-color;
+    background-color: $body-bg-color-primary;
     width: 20%;
   }
 
@@ -752,7 +752,7 @@ body.no-scroll {
   }
 
   .hero {
-    background-color: $body-bg-color;
+    background-color: $body-bg-color-primary;
     border-bottom: 1px solid $graphite02;
     height: 350px;
   }
@@ -821,7 +821,7 @@ body.no-scroll {
   }
 
   .detail {
-    background-color: $body-bg-color;
+    background-color: $body-bg-color-primary;
     height: auto;
 
     .tab-container.alternate {
@@ -861,7 +861,7 @@ body.no-scroll {
 }
 
 .header-section {
-  background-color: $body-bg-color;
+  background-color: $body-bg-color-primary;
   border-bottom: 1px solid $panel-border-color;
 }
 
@@ -894,7 +894,7 @@ body.no-scroll {
 .sticky-footer {
   @include font-size(12);
 
-  background-color: $body-bg-color;
+  background-color: $body-bg-color-primary;
   bottom: 0;
   left: 50%;
   max-width: 1280px;

--- a/src/patterns/_card-deck.scss
+++ b/src/patterns/_card-deck.scss
@@ -2,7 +2,7 @@
 //================================================== //
 
 .card-deck {
-  background-color: $body-bg-color;
+  background-color: $body-bg-color-primary;
   padding-top: 20px;
 
   //Remove grid padding on last row

--- a/src/patterns/_header-detail.scss
+++ b/src/patterns/_header-detail.scss
@@ -19,7 +19,7 @@
   }
 
   .detail {
-    background-color: $body-bg-color;
+    background-color: $body-bg-color-primary;
     border-top: 1px solid $panel-border-color;
     height: 50%;
   }

--- a/src/patterns/_master-detail.scss
+++ b/src/patterns/_master-detail.scss
@@ -10,7 +10,7 @@
   }
 
   .detail {
-    background-color: $body-bg-color;
+    background-color: $body-bg-color-primary;
     border-top: 1px solid $panel-border-color;
     height: auto;
     padding: 30px;

--- a/src/patterns/list-detail/_list-detail.scss
+++ b/src/patterns/list-detail/_list-detail.scss
@@ -17,7 +17,7 @@
     height: 100%;
 
     &.alternate {
-      background-color: $body-bg-color;
+      background-color: $body-bg-color-primary;
     }
 
     .main-content {

--- a/src/themes/dark-theme.scss
+++ b/src/themes/dark-theme.scss
@@ -6,14 +6,14 @@
 @import '../core/mixins';
 @import '../core/config';
 
-// IDS-identity vars
-@import '../../node_modules/ids-identity/dist/tokens/web/theme-soho-dark.sass';
+// IDS-identity token variables
+@import '../../node_modules/ids-identity/dist/tokens/web/theme-soho-dark';
 
-//Override Config
+// Override Config
 //================================================== //
 
 // Form Background Color
-$body-bg-color:  $slate08;
+$body-bg-color-primary:  $slate08;
 $header-bg-color: $slate09;
 $subhead-bg-color: $slate06;
 $header-border-color: $slate10;
@@ -161,7 +161,7 @@ $selected-bg-color: rgba($color-primary, 0.3);
 
 // Autocomplete
 $autocomplete-light-text: $slate04;
-$autocomplete-active-bg-color: $body-bg-color;
+$autocomplete-active-bg-color: $body-bg-color-primary;
 $autocomplete-box-shadow: 0 2px 5px 1px $focus-box-shadow-color;
 $autocomplete-box-shadow-flipped: 0 -2px 5px 1px $focus-box-shadow-color;
 $trigger-icon-fill-color: $slate03;
@@ -265,7 +265,7 @@ $fileupload-droparea-dd-hover-bg-color: rgba($slate10, 0.3);
 //Spinbox
 $spinbox-active-color: $font-color-extrahighcontrast;
 $spinbox-bg-color: $slate06;
-$spinbox-button-color: $body-bg-color;
+$spinbox-button-color: $body-bg-color-primary;
 
 //Skip Link
 $skip-link-border-color: $slate05;
@@ -307,12 +307,11 @@ $cardlist-header-color: $white;
 $cardlist-actions-color: $slate03;
 
 // Checkboxes
-$checkbox-color: $color-primary;
-$checkbox-disabled-font-color: $checkbox-disabled-text-color;
-$checkbox-disabled-select-bg-color: $checkbox-disabled-border-color;
+$checkbox-disabled-text-color: $checkbox-disabled-text-color;
+$checkbox-disabled-checked-bg-color: $checkbox-disabled-border-color;
 
 // Switch
-$switch-checked-color: $color-primary;
+$radio-checked-color: $color-primary;
 $switch-checked-bg-color: $azure03;
 $switch-unchecked-bg-color: $slate05;
 $switch-unchecked-bar-color: $slate03;
@@ -343,10 +342,10 @@ $editor-top-focus-box-shadow: -2px -2px 3px 0 rgba(141, 201, 230, 0.3);
 $editor-blockquote-color: $slate04;
 
 // Radio Buttons
-$radio-hover-border-color: $radio-border-hover-color;
-$radio-selected-color: $color-primary;
-$radio-selected-bg-color: $radio-checked-bg-color;
-$radio-disabled-select-bg-color: $radio-disabled-checked-bg-color;
+$radio-border-hover-color: $radio-border-hover-color;
+$radio-checked-color: $color-primary;
+$radio-checked-bg-color: $radio-checked-bg-color;
+$radio-disabled-checked-bg-color: $radio-disabled-checked-bg-color;
 
 //Pager
 $pager-text-color: $color-primary;
@@ -575,7 +574,7 @@ $timeline-line-color: $slate04;
 $timeline-header-color: $color-primary;
 
 //Themable Variables in config.scss
-$wizard-default-bg: $body-bg-color;
+$wizard-default-bg: $body-bg-color-primary;
 $wizard-bar-bg: $slate04;
 $wizard-color: $slate03;
 $wizard-disabled-color: $slate04;

--- a/src/themes/dark-theme.scss
+++ b/src/themes/dark-theme.scss
@@ -50,7 +50,7 @@ $focus-box-shadow-spinbox-up: 0 -3px 3px 0 $focus-box-shadow-color,
 $color-primary: $color-primary;
 $inverse-color: #fff;
 
-//The hyperlink Style
+// The hyperlink Style
 $hyperlink-color: $azure04;
 
 // Text Color
@@ -70,7 +70,7 @@ $font-color-hyperlink: $color-primary;
 $font-color-muted: $slate04;
 $font-color-alert: $alert-red;
 
-//The hyperlink Style
+// The hyperlink Style
 $hyperlink-color: $azure04;
 $hyperlink-focus-border-color: $color-primary;
 $hyperlink-visited-color: $amethyst03;
@@ -102,7 +102,7 @@ $popover-alternate-arrow-color: $notification-alternate-arrow-color;
 $popover-alternate-title-bg-color: $notification-alternate-title-bg-color;
 $popover-alternate-table-header: $notification-alternate-table-header;
 
-//Progress
+// Progress
 $progress-bg-color: transparent;
 $progress-border-color: $slate04;
 $progress-bar-bg-color: $color-primary;
@@ -155,7 +155,7 @@ $input-focus-border-color: $color-primary;
 $input-placeholder-color: $input-placeholder-text-color;
 $input-readonly-color: $input-readonly-text-color;
 
-//States
+// States
 $error-color: $alert-red;
 $error-focus-box-shadow:  0 0 4px 2px rgba(222, 129, 129, 0.3);
 $error-icon-fill: $alert-red;
@@ -176,7 +176,7 @@ $trigger-active-color: $color-primary;
 $trigger-focus-color: $color-primary;
 $trigger-disabled-color: $slate04;
 
-//List View
+// List View
 $listview-bg-color: $slate07;
 $listview-bg-color-alternate: $slate08;
 $listview-hover-bg-color: $slate06;
@@ -219,7 +219,7 @@ $toolbar-separator-color: $slate05;
 // Formatter Toolbar
 $formatter-toolbar-separator-color: $slate04;
 
-//Contextual Toolbar
+// Contextual Toolbar
 $contextual-toolbar-color: $inverse-color;
 $contextual-toolbar-bg-color: $color-primary;
 $contextual-panel-seperator-bg-color: $slate03;
@@ -241,7 +241,7 @@ $datepicker-disabled-border-color: $slate05;
 $datepicker-disabled-bg-color: rgba($slate06, 0.5);
 $datepicker-disabled-color: $slate04;
 
-//Time Picker
+// Time Picker
 $timepicker-disabled-icon-color: $slate05;
 $timepicker-disabled-border-color: $slate05;
 $timepicker-disabled-color: $slate04;
@@ -267,17 +267,17 @@ $fileupload-droparea-hover-bg-color: $slate07;
 $fileupload-droparea-dd-hover-border-color: $color-primary;
 $fileupload-droparea-dd-hover-bg-color: rgba($slate10, 0.3);
 
-//Spinbox
+// Spinbox
 $spinbox-active-color: $font-color-extrahighcontrast;
 $spinbox-bg-color: $slate06;
 $spinbox-button-color: $body-bg-color-primary;
 
-//Skip Link
+// Skip Link
 $skip-link-border-color: $slate05;
 $skip-link-bg-color: $slate07;
 $skip-link-color: $azure04;
 
-//Swaplist
+// Swaplist
 $swaplist-bg-color-hover: $slate06;
 $swaplist-border-color-card: $slate05;
 $swaplist-icon-color: $slate03;
@@ -288,7 +288,7 @@ $swaplist-border-color-hover: $white;
 $swaplist-title-text-color: $white;
 $swaplist-text-color: $white;
 
-//Mast Head
+// Mast Head
 $masthead-bg-color: $header-bg-color;
 $masthead-border-color: $slate08;
 
@@ -296,7 +296,7 @@ $masthead-border-color: $slate08;
 $icon-color: $slate03;
 $icon-empty-bg-color: $font-color-lowcontrast;
 
-//Field Set
+// Field Set
 $fieldset-border-top-color: $slate06;
 $fieldset-border-bottom-color: transparent;
 $fieldset-title-color: $font-color-highcontrast;
@@ -352,14 +352,14 @@ $radio-checked-color: $color-primary;
 $radio-checked-bg-color: $radio-checked-bg-color;
 $radio-disabled-checked-bg-color: $radio-disabled-checked-bg-color;
 
-//Pager
+// Pager
 $pager-text-color: $color-primary;
 $pager-selected-color: $font-color-extrahighcontrast;
 $pager-focus-border-color: $input-focus-border-color;
 $pager-hover-color: $font-color-extrahighcontrast;
 $pager-disabled-color: $slate06;
 
-//Slider
+// Slider
 $slider-bg-color: $slate04;
 $slider-active-bg-color: $color-primary;
 $slider-labels-color: $slate03;
@@ -375,7 +375,7 @@ $slider-readonly-handle-color: $graphite07;
 $slider-readonly-range-color: $graphite07;
 $slider-hover-shadow: 0 2px 5px 0 rgba($black, 0.4);
 
-//Modal
+// Modal
 $modal-bg-color: $slate07;
 $modal-border-color: $slate05;
 $modal-box-shadow: 0 2px 5px $drop-shadow-depth;
@@ -438,7 +438,7 @@ $contextual-panel-bg: $slate06;
 $contextual-panel-border-color: $slate05;
 $contextual-panel-color: $slate02;
 
-//BreadCrumb
+// BreadCrumb
 $breadcrumb-color: $slate03;
 $breadcrumb-hover-color: $slate03;
 $breadcrumb-disabled-color: $disabled-color;
@@ -466,12 +466,12 @@ $vertical-tab-panel-bg-color: $slate08;
 $vertical-tab-sidebar-bg-color: $slate07;
 $vertical-tab-sidebar-border-color: $slate05;
 
-//Multi-tabs
+// Multi-tabs
 $mutlitabs-section-border-color: $slate07;
 $mutlitabs-section-alt-bg-color: $black;
 $mutlitabs-section-alt-border-color: $slate09;
 
-//Charts
+// Charts
 $chart-line-color: $slate04;
 $chart-line-color-axis: $slate03;
 $chart-font-color: $slate01;
@@ -542,7 +542,7 @@ $datagrid-list-filter-active-color: $color-primary;
 
 $datagrid-rowgroup-header: $slate07;
 $datagrid-rowgroup-color: $font-color;
-$datagrid-empty-bg-color: #414247; //$datagrid-cell-bg-color
+$datagrid-empty-bg-color: #414247; // $datagrid-cell-bg-color
 
 // Search Results
 $sr-masthead-text-color: $font-color;
@@ -562,7 +562,7 @@ $tree-disabled-color: $slate05;
 $tree-hover-color: $white;
 $tree-hover-icon-color: $white;
 
-//Chart Progress Bar
+// Chart Progress Bar
 $chart-progressbar-bg-color: $slate04;
 $chart-progressbar-bg-color-dark: $slate02;
 $chart-progressbar-completed-fill: $emerald08;
@@ -571,14 +571,14 @@ $chart-progressbar-primary-fill: $color-primary;
 $chart-progressbar-dark-fill: $color-primary;
 $chart-targeted-achievement-bg-color: $slate05;
 
-//Timeline
+// Timeline
 $timeline-indicator-color: $slate03;
 $timeline-indicator-processing-color: $color-primary;
 $timeline-indicator-complete-color: $color-primary;
 $timeline-line-color: $slate04;
 $timeline-header-color: $color-primary;
 
-//Themable Variables in config.scss
+// Themable Variables in config.scss
 $wizard-default-bg: $body-bg-color-primary;
 $wizard-bar-bg: $slate04;
 $wizard-color: $slate03;
@@ -587,7 +587,7 @@ $wizard-active-color: $color-primary;
 $wizard-active-text-color: $azure04;
 $wizard-focus-box-shadow: 0 0 0 1px $color-primary;
 
-//Themable Variables in config.scss
+// Themable Variables in config.scss
 $hierarchy-line-color: $slate04;
 
 // Searchfield Colors
@@ -620,21 +620,21 @@ $searchfield-header-text-color: $white;
 $searchfield-header-placeholder-text-color: $slate04;
 $searchfield-header-icon-color: $header-button-color;
 
-//Image Border Color
+// Image Border Color
 $image-border-color: $slate04;
 $image-background-color: $slate04;
 
-//Toast
+// Toast
 $toast-bg-color: $notification-bg-color;
 $toast-border-color: $notification-border-color;
 $toast-header-color: $notification-header-color;
 $toast-text-color: $notification-text-color;
-$toast-shadow: none; //0 0 5px rgba(255, 255, 255, .2);
+$toast-shadow: none; // 0 0 5px rgba(255, 255, 255, .2);
 
-//Builder Pattern
+// Builder Pattern
 $builder-header-bg-color: $slate08;
 
-//About
+// About
 $about-header-color: $white;
 $about-text-color: $white;
 $about-text-border-color: $slate05;
@@ -708,7 +708,7 @@ $calendar-hover-bg-color: $slate08;
 $calendar-disabled-bg-color: $slate08;
 $calendar-disabled-color: $slate04;
 
-//Multi Select
+// Multi Select
 .dropdown-list.multiple li:hover:not(.group-label)::before {
   border: 1px solid $slate04;
 }

--- a/src/themes/dark-theme.scss
+++ b/src/themes/dark-theme.scss
@@ -4,10 +4,15 @@
 // Standard CSS reset
 @import '../core/reset';
 @import '../core/mixins';
-@import '../core/config';
 
-// IDS-identity token variables
+// Enterprise color palette
+@import '../components/colors/colorpalette';
+
+// ids-identity token vars
 @import '../../node_modules/ids-identity/dist/tokens/web/theme-soho-dark';
+
+// Local vars
+@import '../core/config';
 
 // Override Config
 //================================================== //

--- a/src/themes/high-contrast-theme.scss
+++ b/src/themes/high-contrast-theme.scss
@@ -7,13 +7,13 @@
 @import '../core/config';
 
 // IDS-identity vars
-@import '../../node_modules/ids-identity/dist/tokens/web/theme-soho-high-contrast.sass';
+@import '../../node_modules/ids-identity/dist/tokens/web/theme-soho-high-contrast';
 
 //Override Config
 //================================================== //
 
 // Form Background Color
-$body-bg-color:  $graphite03;
+$body-bg-color-primary:  $graphite03;
 $header-bg-color: $azure09;
 $subhead-bg-color: $azure08;
 $header-border-color: $slate10;
@@ -180,7 +180,7 @@ $selected-bg-color: rgba($color-primary-alt, 0.3);
 
 // Autocomplete
 $autocomplete-light-text: $graphite05;
-$autocomplete-active-bg-color: $body-bg-color;
+$autocomplete-active-bg-color: $body-bg-color-primary;
 $autocomplete-box-shadow: 0 2px 5px 2px $focus-box-shadow-color;
 $autocomplete-box-shadow-flipped: 0 -2px 5px 2px $focus-box-shadow-color;
 $trigger-icon-fill-color: $graphite09;
@@ -330,13 +330,8 @@ $cardlist-border-color: $graphite06;
 $cardlist-header-color: $black;
 $cardlist-actions-color: $graphite09;
 
-// Checkboxes
-$checkbox-color: $color-primary;
-$checkbox-disabled-font-color: $checkbox-disabled-text-color;
-$checkbox-disabled-select-bg-color: $checkbox-disabled-checked-bg-color;
-
 // Switch
-$switch-checked-color: $color-primary;
+$radio-checked-color: $color-primary;
 $switch-checked-bg-color: $color-primary;
 $switch-unchecked-bg-color: $white;
 $switch-unchecked-bar-color: $graphite07;
@@ -367,10 +362,10 @@ $editor-top-focus-box-shadow: -2px -2px 3px 0 rgba(41, 41, 41, 0.3);
 $editor-blockquote-color: $graphite07;
 
 // Radio Buttons
-$radio-hover-border-color: $radio-border-hover-color;
-$radio-selected-color: $color-primary;
-$radio-selected-bg-color: $radio-checked-bg-color;
-$radio-disabled-select-bg-color: $radio-disabled-checked-bg-color;
+$radio-border-hover-color: $radio-border-hover-color;
+$radio-checked-color: $color-primary;
+$radio-checked-bg-color: $radio-checked-bg-color;
+$radio-disabled-checked-bg-color: $radio-disabled-checked-bg-color;
 
 // Pager
 $pager-text-color: $color-primary;
@@ -489,7 +484,7 @@ $vertical-tab-active-text-color: $white;
 $vertical-tab-active-bg-color: $color-primary;
 
 $vertical-tab-panel-bg-color: $panel-bg-color;
-$vertical-tab-sidebar-bg-color: $body-bg-color;
+$vertical-tab-sidebar-bg-color: $body-bg-color-primary;
 $vertical-tab-sidebar-border-color: $graphite06;
 
 //Multi-tabs
@@ -605,7 +600,7 @@ $timeline-line-color: $graphite05;
 $timeline-header-color: $azure09;
 
 //Wizard
-$wizard-default-bg: $body-bg-color;
+$wizard-default-bg: $body-bg-color-primary;
 $wizard-bar-bg: $graphite06;
 $wizard-color: $graphite09;
 $wizard-disabled-color: $color-default-alt;

--- a/src/themes/high-contrast-theme.scss
+++ b/src/themes/high-contrast-theme.scss
@@ -4,12 +4,17 @@
 // Standard CSS reset
 @import '../core/reset';
 @import '../core/mixins';
-@import '../core/config';
 
-// IDS-identity vars
+// Enterprise colors
+@import '../components/colors/colorpalette';
+
+// ids-identity token vars
 @import '../../node_modules/ids-identity/dist/tokens/web/theme-soho-high-contrast';
 
-//Override Config
+// Local vars
+@import '../core/config';
+
+// Override Config
 //================================================== //
 
 // Form Background Color

--- a/src/themes/light-theme.scss
+++ b/src/themes/light-theme.scss
@@ -4,6 +4,14 @@
 // Standard CSS reset
 @import '../core/reset';
 @import '../core/mixins';
+
+// Enterprise color palette
+@import '../components/colors/colorpalette';
+
+// ids-identity token vars
+@import '../../node_modules/ids-identity/dist/tokens/web/theme-soho';
+
+// Local vars
 @import '../core/config';
 
 // Core Controls

--- a/src/themes/uplift-theme.scss
+++ b/src/themes/uplift-theme.scss
@@ -4,10 +4,15 @@
 // Standard CSS reset stuff here
 @import '../core/reset';
 @import '../core/mixins';
-@import '../core/config';
 
-// IDS-identity token variables
+// Enterprise colors
+@import '../components/colors/colorpalette';
+
+// ids-identity token vars
 @import '../../node_modules/ids-identity/dist/tokens/web/theme-uplift';
+
+// Local vars
+@import '../core/config';
 
 // Core Controls
 @import '../core/controls';

--- a/src/themes/uplift-theme.scss
+++ b/src/themes/uplift-theme.scss
@@ -6,8 +6,8 @@
 @import '../core/mixins';
 @import '../core/config';
 
-// IDS-identity vars
-@import '../../node_modules/ids-identity/dist/tokens/web/theme-uplift.sass';
+// IDS-identity token variables
+@import '../../node_modules/ids-identity/dist/tokens/web/theme-uplift';
 
 // Core Controls
 @import '../core/controls';


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Moved sass imports up one level from config, to their corresponding themes for proper sass/token/color cascade and overriding
- upgraded to use ids-identity@1.3.2
- refactored some existing vars into tokens

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise/issues/785

**Steps necessary to review your pull request (required)**:
1. `npm i`
1. `npm run build`
1. <http://localhost:4000>
    - View the regular theme
    - Compare it to the other themes. The most dramatic Uplift theme change will be the primary color to a deeper blue. (screenshots are on the ticket)