### PR TITLE
752 - add tests for new Tree methods

### DIFF
--- a/test/components/tree/tree.e2e-spec.js
+++ b/test/components/tree/tree.e2e-spec.js
@@ -217,3 +217,27 @@ describe('Tree select-multiple tests', () => {
     expect(await element.all(by.css('.tree li.folder')).get(0).all(by.css('a[role="treeitem"].is-disabled')).count()).toBe(1);
   });
 });
+
+describe('Tree disable all nodes test', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/tree/example-disable');
+  });
+
+  it('Should not detect any non-disabled tree nodes', async () => {
+    const count = await element.all(by.css('.tree li a[role="treeitem"]')).count();
+
+    await element(by.id('disable')).click();
+    expect(await element.all(by.css('.tree li a[role="treeitem"].is-disabled')).count()).toBe(count);
+  });
+});
+
+describe('Tree enable all nodes test', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/tree/example-enable');
+  });
+
+  it('Should not detect any disabled tree nodes', async () => {
+    await element(by.id('enable')).click();
+    expect(await element.all(by.css('.tree li a[role="treeitem"].is-disabled')).count()).toBe(0);
+  });
+});

--- a/test/components/tree/tree.func-spec.js
+++ b/test/components/tree/tree.func-spec.js
@@ -585,4 +585,19 @@ describe('Tree Methods', () => {
     expect(icon).toEqual('#icon-tree-node');
     expect(children.length).toEqual(1);
   });
+
+  it('Should not detect any non-disabled tree nodes', () => {
+    const count = treeEl.querySelectorAll('li a[role="treeitem"]').length;
+    treeObj.disable();
+    const countDisabled = treeEl.querySelectorAll('li a[role="treeitem"].is-disabled').length;
+
+    expect(countDisabled).toEqual(count);
+  });
+
+  it('Should not detect any disabled tree nodes', () => {
+    treeObj.enable();
+    const countDisabled = treeEl.querySelectorAll('li a[role="treeitem"].is-disabled').length;
+
+    expect(countDisabled).toEqual(0);
+  });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Creates tests for disable(), enable() methods on Tree.

**Related github/jira issue (required)**:
Closes #752 .

**Steps necessary to review your pull request (required)**:
- Pull branch `752-add-tree-tests`
- `npm run start` (`npm i` first if need to compile node_modules)
- `npm run test` to run all tests
  - can `npm run functional:local` for just functional tests
  - can `env PROTRACTOR_SPECS='components/tree/tree.e2e-spec.js' npm run e2e:ci` for just end-to-end tests on Tree.
- Ensure new tests pass
- For extra credit, comment on robustness of tests and suggest any improvements
