### PR TITLE
788 - Fixed actionable mode was not working with Datagrid

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7467,7 +7467,7 @@ Datagrid.prototype = {
 
   setNextActiveCell(e) {
     const self = this;
-    if (e.type === 'keydown' && !self.settings.actionableMode) {
+    if (e.type === 'keydown') {
       if (this.settings.actionableMode) {
         setTimeout(() => {
           const evt = $.Event('keydown.datagrid');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
In actionable mode after editing cell and pressing enter key should move to down row in same column cell, but this feature was not working so this PR will fix this actionable mode issue.

**Related github/jira issue (required)**:
Closes #788

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-editable-actionable-mode.html
- Open above link
- Click on an editable cell
- Type something like 'xyz' 
- Press enter key (should move to down row in same column cell)