### PR TITLE
746 - Added fix for unique id editor

### DIFF
--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -823,7 +823,7 @@ Editor.prototype = {
             self.createLink($(`[name="em-url-${self.id}"]`, this));
           }
         } else {
-          self.insertImage($('#image').val());
+          self.insertImage($(`#image-${self.id}`).val());
         }
       });
 
@@ -909,8 +909,8 @@ Editor.prototype = {
         </div>
         <div class="modal-body">
           <div class="field">
-            <label for="image">${Locale.translate('Url')}</label>
-            <input id="image" name="image" type="text" value="${this.settings.image.url}">
+            <label for="image-${this.id}">${Locale.translate('Url')}</label>
+            <input id="image-${this.id}" name="image-${this.id}" type="text" value="${this.settings.image.url}">
           </div>
           <div class="modal-buttonset">
             <button type="button" class="btn-modal btn-cancel">


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Append a dynamic id in the input field and in bind modals.

line(912)
```
<label for="image-${this.id}">${Locale.translate('Url')}</label>
    <input id="image-${this.id}" name="image-${this.id}" type="text" value="${this.settings.image.url}">
```

line(826)
```
self.insertImage($(`#image-${self.id}`).val());
```

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/746

**Steps necessary to review your pull request (required)**:

- Run http://localhost:4000/components/editor/example-index.html
- Click on the Insert Image button
- Inspect the input field and observe that the id is "image".
- There should be a unique id in the input field not just "image"

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
