### PR TITLE
762 - Added fix for lookup color text

### DIFF
--- a/src/components/lookup/_lookup.scss
+++ b/src/components/lookup/_lookup.scss
@@ -28,6 +28,7 @@
       background-color: $input-bg-color;
       border: 1px solid $input-border-color;
       color: $input-color;
+      -webkit-text-fill-color: $input-color;
 
       &:not([disabled]) + .trigger {
         cursor: pointer;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adding `-webkit-text-fill-color` and set it as the same variable/value of color property.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/762

**Steps necessary to review your pull request (required)**:

- Run http://localhost:4000/components/lookup/example-editable-strict.html
- Click on the lookup icon. The "Lookup that can only be edited by selection in modal" window will appear
- Select 2142201, 2241202, 2342203 and click the "Apply"
- In the "Lookup that can only be edited by selection in modal" The color of the text should now appearing in black.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
