### PR TITLE
Fixed "NAN" in deploy docs script

### DIFF
--- a/scripts/deploy-documentation.js
+++ b/scripts/deploy-documentation.js
@@ -489,7 +489,7 @@ function removeTrailingSlash(uri) {
  * Console.log statistics from the build
  */
 function statsConclusion() {
-  logTaskEnd('deploy');
+  logTaskEnd(`deploying ${packageJson.version}`);
   // did not use multiline string for formatting reasons
   let str = '';
   str += `\nComponents ${chalk.green('converted')}:  ${componentStats.numConverted}/${componentStats.total}`;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Seeing `NAN` as a time value for elapsed time in the documentation deploy script. The fix was using the proper key in the stopwatch object.

**Related github/jira issue (required)**:
n/a

**Steps necessary to review your pull request (required)**:
1. `npm run documentation -- --test-mode --dry-run`
    - Make sure all elapsed seconds (purple in terminal) are numbers (including "0") and not "NAN"