### PR TITLE
NG-147, 374 - Fixed hidden column and group headers alignment with Datagrid

### DIFF
--- a/app/views/components/datagrid/example-grouped-headers.html
+++ b/app/views/components/datagrid/example-grouped-headers.html
@@ -37,7 +37,7 @@
       $('#datagrid').datagrid({
         columns: columns,
 
-        // Numeric Column Span Groups (3 + 1 + 5 === 9)
+        // Numeric Column Span Groups (3 + 1 + 2 + 3 === 9)
         columnGroups: [
           { colspan: 3, id: 'group1', name: 'Column Group One' },
           { colspan: 1, id: 'group2', name: 'Column Group Two' },

--- a/app/views/components/datagrid/example-grouped-headers.html
+++ b/app/views/components/datagrid/example-grouped-headers.html
@@ -22,7 +22,8 @@
       data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: '120.99', status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
       data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '123.99', status: 'OK', orderDate: null, action: 'On Hold'});
 
-      //Define Columns for the Grid.
+      // Define Columns for the Grid.
+      columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
       columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Readonly});
       columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', filterType: 'text', formatter: Formatters.Text});
       columns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', filterType: 'text'});
@@ -32,15 +33,23 @@
       columns.push({ id: 'status', name: 'Status', field: 'status', formatter: Formatters.Text});
       columns.push({ id: 'action', name: 'Action Item', field: 'action'});
 
-      //Init and get the api for the grid
+      // Init and get the api for the grid
       $('#datagrid').datagrid({
         columns: columns,
-        columnGroups: [{colspan: 3, id: 'group1', name: 'Column Group One'}, {colspan: 4, id: 'group2', name: 'Column Group Two'}], //Numeric Column Span Groups
+
+        // Numeric Column Span Groups (3 + 1 + 5 === 9)
+        columnGroups: [
+          { colspan: 3, id: 'group1', name: 'Column Group One' },
+          { colspan: 1, id: 'group2', name: 'Column Group Two' },
+          { colspan: 2, id: 'group3', name: 'Column Group Three' },
+          { colspan: 3, id: 'group4', name: 'Column Group four' }
+        ],
         dataset: data,
         columnReorder: true,
         saveColumns: false,
         filterable: true,
-        toolbar: {title: 'Groups', actions: true, personalize: true, results: true, resetLayout: true}
+        selectable: 'multiple',
+        toolbar: { title: 'Groups', actions: true, personalize: true, results: true, resetLayout: true }
       });
 
  });

--- a/app/views/components/datagrid/test-update-grouped-headers.html
+++ b/app/views/components/datagrid/test-update-grouped-headers.html
@@ -61,7 +61,7 @@
       //Init and get the api for the grid
       grid = $('#datagrid').datagrid({
         columns: columns,
-        columnGroups: [{colspan: 3, id: 'group1', name: 'Column Group One'}, {colspan: 4, id: 'group2', name: 'Column Group Two'}], //Numeric Column Span Groups
+        columnGroups: [{colspan: 4, id: 'group1', name: 'Column Group One'}, {colspan: 4, id: 'group2', name: 'Column Group Two'}], //Numeric Column Span Groups
         dataset: data,
         saveColumns: false
       }).data('datagrid');

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -748,7 +748,7 @@ Datagrid.prototype = {
   * @param {number} idx The index of the column group
   * @param {boolean} show Did we show or hide the col.
   */
-  updateColumnGroup(idx, show) {
+  updateColumnGroup() {
     const colGroups = this.settings.columnGroups;
     if (!this.originalColGroups) {
       this.originalColGroups = JSON.parse(JSON.stringify(colGroups));
@@ -769,128 +769,124 @@ Datagrid.prototype = {
       return;
     }
 
-    let cnt = 0;
-    let lastSpanIdx = -1;
-    let skipNext = 0;
-
-    // Update the data object
-    for (let i = 0; i < colGroups.length; i++) {
-      if (skipNext > 0) {
-        if (idx === i && !show) {
-          colGroups[lastSpanIdx].colspan -= 1;
-          this.settings.columns[i].isSpanned = true;
-        }
-        skipNext -= 1;
-      }
-
-      if (idx === cnt || idx === 1 && i === 1) {
-        if (colGroups[i].colspan === 1 && !show) {
-          colGroups[i].hidden = true;
-        }
-
-        if (colGroups[i].colspan > 1 && !show) {
-          this.settings.columns[i].isSpanned = true;
-          colGroups[i].colspan -= 1;
-        }
-
-        // have to re-render here
-        if (this.settings.columns[i].isSpanned && show) {
-          this.settings.columnGroups = JSON.parse(JSON.stringify(this.originalColGroups));
-          this.render();
-        }
-
-        if (colGroups[i].colspan === 1 && show) {
-          delete colGroups[i].hidden;
-        }
-
-        if (colGroups[i].colspan > 1 && show) {
-          colGroups[i].colspan += 1;
-        }
-      }
-      cnt += colGroups[i].colspan;
-
-      if (colGroups[i].colspan > 1) {
-        lastSpanIdx = i;
-        skipNext = colGroups[i].colspan - 1;
-      }
-    }
-
     // Update the dom
     if (!this.colGroups) {
       return;
     }
 
-    const headGroups = this.colGroups.find('th').toArray();
-    cnt = 0;
-    lastSpanIdx = 0;
-    skipNext = 0;
-    for (let i = 0; i < headGroups.length; i++) {
-      const elem = headGroups[i];
-      const colspan = parseInt(elem.getAttribute('colspan'), 10);
-      cnt += colspan;
+    const headGroups = [].slice.call(this.colGroups[0].querySelectorAll('th'));
+    const columns = this.settings.columns;
+    const columnsLen = columns.length;
+    const visibleColumnsLen = this.visibleColumns().length;
+    const groups = colGroups.map(group => parseInt(group.colspan, 10));
+    const getGroupsTotal = () => groups.reduce((a, b) => a + b, 0);
+    const getDiff = () => {
+      const groupsTotal = getGroupsTotal();
+      return groupsTotal > columnsLen ? groupsTotal - columnsLen : columnsLen - groupsTotal;
+    };
 
-      if (skipNext > 0) {
-        if (idx === i && !show) {
-          headGroups[lastSpanIdx].setAttribute('colspan', headGroups[lastSpanIdx].getAttribute('colspan') - 1);
+    const groupsTotal = getGroupsTotal();
+    let diff;
+    if (groupsTotal > columnsLen) {
+      let move = true;
+      for (let i = groups.length - 1; i >= 0 && move; i--) {
+        diff = getDiff();
+        if (groups[i] >= diff) {
+          groups[i] -= diff;
+          move = false;
+        } else {
+          groups[i] = 0;
         }
-        skipNext -= 1;
-      }
-
-      if (idx === cnt - colspan || idx === 1 && i === 1) {
-        if (colspan === 1 && !show) {
-          elem.classList.add('hidden');
-        }
-
-        if (colspan > 1 && !show) {
-          elem.setAttribute('colspan', colspan - 1);
-        }
-
-        if (colspan === 1 && show) {
-          elem.classList.remove('hidden');
-        }
-
-        if (colspan > 1 && show) {
-          elem.setAttribute('colspan', colspan + 1);
-        }
-      }
-
-      if (colspan > 1) {
-        lastSpanIdx = i;
-        skipNext = colspan - 1;
       }
     }
 
-    this.hideShowColumnGroups(show);
+    let i = 0;
+    let total = 0;
+    groups.forEach((groupColspan, k) => {
+      let colspan = groupColspan;
+      for (let l = i + groupColspan; i < l; i++) {
+        if (i < columnsLen && columns[i].hidden) {
+          colspan--;
+        }
+      }
+
+      if (colspan > 0) {
+        total += colspan;
+      }
+
+      const groupHeaderEl = headGroups[k];
+      groupHeaderEl.setAttribute('colspan', colspan > 0 ? colspan : 1);
+
+      if ((colGroups[k].hidden || colspan < 1)) {
+        groupHeaderEl.classList.add('hidden');
+      } else {
+        groupHeaderEl.classList.remove('hidden');
+      }
+    });
+
+    if (total < visibleColumnsLen) {
+      const groupHeaderEl = headGroups[headGroups.length - 1];
+      diff = visibleColumnsLen - total;
+      groupHeaderEl.setAttribute('colspan', diff > 0 ? diff : 1);
+    }
   },
 
   /**
-   * Test if the group header should be closed and close / open it.
-   * @private
-   * @param {boolean} show Hide and show the column group if it should be.
-   */
-  hideShowColumnGroups(show) {
-    if (!this.colGroups) {
+  * Update group headers after column reorder/dragged.
+  * @private
+  * @param {number} indexFrom The column index dragged from.
+  * @param {number} indexTo The column index dragged to.
+  * @returns {void}
+  */
+  updateGroupHeadersAfterColumnReorder(indexFrom, indexTo) {
+    const colGroups = this.settings.columnGroups;
+    if (!colGroups) {
       return;
     }
 
-    const headGroups = this.colGroups.find('th').toArray();
-    const allEmpty = $(headGroups).filter(':not(.hidden)').text() === '';
+    if (!this.originalColGroups) {
+      this.originalColGroups = JSON.parse(JSON.stringify(colGroups));
+    }
 
-    let cnt = 0;
-    for (let i = 0; i < headGroups.length; i++) {
-      const elem = headGroups[i];
-      const colspan = parseInt(elem.getAttribute('colspan'), 10);
-      cnt += colspan;
+    const headGroups = [].slice.call(this.colGroups[0].querySelectorAll('th'));
+    const colspans = { fromGroup: null, toGroup: null, index: 0, groupIndex: 0 };
 
-      // Find up to the index
-      if (i === headGroups.length - 1 && headGroups.length === cnt && !show && allEmpty) {
-        this.colGroups.addClass('hidden');
-        this.element.removeClass('has-group-headers');
+    headGroups.forEach((group) => {
+      const colspan = parseInt(group.getAttribute('colspan'), 10);
+      const end = colspans.index + (colspan > -1 ? colspan : 0);
+
+      for (; colspans.index < end; colspans.index++) {
+        if (colspans.index === indexFrom) {
+          colspans.fromGroup = group;
+          colspans.fromColspan = colspan;
+          colspans.fromGroupIndex = colspans.groupIndex;
+        } else if (colspans.index === indexTo) {
+          colspans.toGroup = group;
+          colspans.toColspan = colspan;
+          colspans.toGroupIndex = colspans.groupIndex;
+        }
       }
+      colGroups[colspans.groupIndex].colspan = colspan;
+      colspans.groupIndex++;
+    });
 
-      if (i === headGroups.length - 1 && headGroups.length === cnt && show && !allEmpty) {
-        this.colGroups.removeClass('hidden');
-        this.element.addClass('has-group-headers');
+    let newColspan;
+    if (colspans.fromGroup !== null) {
+      newColspan = colspans.fromColspan > 1 ? colspans.fromColspan - 1 : 0;
+      if (newColspan > 0) {
+        colspans.fromGroup.setAttribute('colspan', newColspan);
+        colGroups[colspans.fromGroupIndex].colspan = newColspan;
+      } else {
+        colGroups.splice(colspans.fromGroupIndex, 1);
+      }
+    }
+    if (colspans.toGroup !== null) {
+      newColspan = colspans.toColspan + 1;
+      if (newColspan > 0) {
+        colspans.toGroup.setAttribute('colspan', newColspan);
+        colGroups[colspans.toGroupIndex].colspan = newColspan;
+      } else {
+        colGroups.splice(colspans.toGroupIndex, 1);
       }
     }
   },
@@ -928,20 +924,56 @@ Datagrid.prototype = {
     if (colGroups) {
       this.element.addClass('has-group-headers');
 
-      let total = 0;
+      const columns = this.settings.columns;
+      const columnsLen = columns.length;
+      const visibleColumnsLen = this.visibleColumns().length;
+      const groups = colGroups.map(group => parseInt(group.colspan, 10));
+      const getGroupsTotal = () => groups.reduce((a, b) => a + b, 0);
+      const getDiff = () => {
+        const groupsTotal = getGroupsTotal();
+        return groupsTotal > columnsLen ? groupsTotal - columnsLen : columnsLen - groupsTotal;
+      };
 
       headerRow += '<tr role="row" class="datagrid-header-groups">';
 
-      for (let k = 0; k < colGroups.length; k++) {
-        const hiddenStr = colGroups[k].hidden || this.settings.columns[k].hidden ? 'class="hidden"' : '';
-        total += parseInt(colGroups[k].colspan, 10);
-        uniqueId = self.uniqueId(`-header-group-${k}`);
-
-        headerRow += `<th ${hiddenStr}colspan="${colGroups[k].colspan}" id="${uniqueId}"><div class="datagrid-column-wrapper "><span class="datagrid-header-text">${colGroups[k].name}</span></div></th>`;
+      const groupsTotal = getGroupsTotal();
+      let diff;
+      if (groupsTotal > columnsLen) {
+        let move = true;
+        for (let i = groups.length - 1; i >= 0 && move; i--) {
+          diff = getDiff();
+          if (groups[i] >= diff) {
+            groups[i] -= diff;
+            move = false;
+          } else {
+            groups[i] = 0;
+          }
+        }
       }
 
-      if (total < this.visibleColumns().length) {
-        headerRow += `<th colspan="${this.visibleColumns().length - total}"></th>`;
+      let i = 0;
+      let total = 0;
+      groups.forEach((groupColspan, k) => {
+        let colspan = groupColspan;
+        for (let l = i + groupColspan; i < l; i++) {
+          if (i < columnsLen && columns[i].hidden) {
+            colspan--;
+          }
+        }
+        const hiddenStr = colGroups[k].hidden || colspan < 1 ? ' class="hidden"' : '';
+        const colspanStr = ` colspan="${colspan > 0 ? colspan : 1}"`;
+        uniqueId = self.uniqueId(`-header-group-${k}`);
+        if (colspan > 0) {
+          total += colspan;
+        }
+
+        headerRow += `<th${hiddenStr}${colspanStr} id="${uniqueId}"><div class="datagrid-column-wrapper"><span class="datagrid-header-text">${colGroups[k].name}</span></div></th>`;
+      });
+
+      if (total < visibleColumnsLen) {
+        diff = visibleColumnsLen - total;
+        const colspanStr = ` colspan="${diff > 0 ? diff : 1}"`;
+        headerRow += `<th${colspanStr}></th>`;
       }
       headerRow += '</tr><tr>';
     } else {
@@ -1009,7 +1041,6 @@ Datagrid.prototype = {
 
     if (colGroups && self.headerRow) {
       self.colGroups = self.headerRow.find('.datagrid-header-groups');
-      self.hideShowColumnGroups();
     }
 
     self.syncHeaderCheckbox(this.settings.dataset);
@@ -1923,14 +1954,51 @@ Datagrid.prototype = {
   },
 
   /**
+  * Get extra top position for current target in header
+  * @private
+  * @returns {number} the extra top position of the rows depending on rowHeight setting.
+  */
+  getExtraTop() {
+    const s = this.settings;
+    const topPositions = {
+      default: { short: 0, medium: 0, normal: 0 },
+      filterable: { short: 0, medium: 0, normal: 0 },
+      group: { short: -25, medium: -30, normal: -39 },
+      groupFilterable: { short: -29, medium: -30, normal: -41 }
+    };
+    let extraTop = 0;
+    if (s.columnGroups) {
+      extraTop = s.filterable ?
+        topPositions.groupFilterable[s.rowHeight] : topPositions.group[s.rowHeight];
+    } else {
+      extraTop = s.filterable ?
+        topPositions.filterable[s.rowHeight] : topPositions.default[s.rowHeight];
+    }
+    return extraTop;
+  },
+
+  /**
   * Get height for current target in header
   * @private
   * @returns {number} the height of the rows depending on rowHeight setting.
   */
   getTargetHeight() {
-    const h = this.settings.filterable ?
-      { short: 48, medium: 51, normal: 56 } : { short: 20, medium: 28, normal: 35 };
-    return h[this.settings.rowHeight];
+    const s = this.settings;
+    const heights = {
+      default: { short: 20, medium: 28, normal: 35 },
+      filterable: { short: 48, medium: 51, normal: 56 },
+      group: { short: 46, medium: 56, normal: 74 },
+      groupFilterable: { short: 78, medium: 84, normal: 99 }
+    };
+    let height = 0;
+    if (s.columnGroups) {
+      height = s.filterable ?
+        heights.groupFilterable[s.rowHeight] : heights.group[s.rowHeight];
+    } else {
+      height = s.filterable ?
+        heights.filterable[s.rowHeight] : heights.default[s.rowHeight];
+    }
+    return height;
   },
 
   /**
@@ -1957,6 +2025,7 @@ Datagrid.prototype = {
       let clone = null;
       let headerPos = null;
       let offPos = null;
+      let extraTopPos = 0;
       const handle = $(this);
       const header = handle.parent();
 
@@ -1976,6 +2045,7 @@ Datagrid.prototype = {
 
             self.setDraggableColumnTargets();
 
+            extraTopPos = self.getExtraTop();
             headerPos = header.position();
             offPos = { top: (pos.top - headerPos.top), left: (pos.left - headerPos.left) };
 
@@ -2009,7 +2079,7 @@ Datagrid.prototype = {
                   showTarget.addClass('is-over');
                   rect = target.el[0].getBoundingClientRect();
                   showTarget[0].style.left = `${parseInt(rect.left, 10)}px`;
-                  showTarget[0].style.top = `${parseInt(rect.top, 10) + 1}px`;
+                  showTarget[0].style.top = `${(parseInt(rect.top, 10) + 1) + extraTopPos}px`;
                 }
               }
             }
@@ -2051,6 +2121,7 @@ Datagrid.prototype = {
                 indexFrom = tempArray[self.draggableStatus.startIndex] || 0;
                 indexTo = tempArray[self.draggableStatus.endIndex] || 0;
 
+                self.updateGroupHeadersAfterColumnReorder(indexFrom, indexTo);
                 self.arrayIndexMove(self.settings.columns, indexFrom, indexTo);
                 self.updateColumns(self.settings.columns);
               }
@@ -2096,7 +2167,7 @@ Datagrid.prototype = {
         dropArea: {
           x1: pos.left - extra,
           x2: pos.left + target.outerWidth() + extra,
-          y1: pos.top - extra,
+          y1: (pos.top - extra) + self.getExtraTop(),
           y2: pos.top + target.outerHeight() + extra
         }
       });
@@ -3424,7 +3495,7 @@ Datagrid.prototype = {
   * @returns {void}
   */
   calculateRowspan(value, row, col) {
-    let cnt = 0;
+    let total = 0;
     let min = null;
 
     if (!col.rowspan) {
@@ -3433,17 +3504,14 @@ Datagrid.prototype = {
 
     for (let i = 0; i < this.settings.dataset.length; i++) {
       if (value === this.settings.dataset[i][col.field]) {
-        cnt++;
+        total++;
         if (min === null) {
           min = i;
         }
       }
     }
 
-    if (row === min) {
-      return ` rowspan ="${cnt}"`;
-    }
-    return '';
+    return row === min ? ` rowspan ="${total}"` : '';
   },
 
   /**
@@ -3925,8 +3993,9 @@ Datagrid.prototype = {
     }
 
     if (this.originalColumns) {
-      this.updateColumns(this.originalColumns);
-      this.originalColumns = this.columnsFromString(JSON.stringify(this.settings.columns));
+      const columnGroups = this.settings.columnGroups && this.originalColGroups ?
+        this.originalColGroups : null;
+      this.updateColumns(this.originalColumns, columnGroups);
     }
   },
 
@@ -3947,7 +4016,7 @@ Datagrid.prototype = {
     this.headerColGroup.find('col').eq(idx).addClass('is-hidden');
 
     // Shrink or remove colgroups
-    this.updateColumnGroup(idx, false);
+    this.updateColumnGroup();
 
     if (this.bodyColGroup) {
       this.bodyColGroup.find('col').eq(idx).addClass('is-hidden');
@@ -4006,7 +4075,7 @@ Datagrid.prototype = {
     }
 
     // Shrink or add colgroups
-    this.updateColumnGroup(idx, true);
+    this.updateColumnGroup();
 
     // Handle colSpans if present on the column
     if (this.hasColSpans) {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -848,46 +848,23 @@ Datagrid.prototype = {
       this.originalColGroups = JSON.parse(JSON.stringify(colGroups));
     }
 
-    const headGroups = [].slice.call(this.colGroups[0].querySelectorAll('th'));
-    const colspans = { fromGroup: null, toGroup: null, index: 0, groupIndex: 0 };
+    const groups = colGroups.map(group => parseInt(group.colspan, 10));
+    const changed = { from: null, to: null, total: 0 };
 
-    headGroups.forEach((group) => {
-      const colspan = parseInt(group.getAttribute('colspan'), 10);
-      const end = colspans.index + (colspan > -1 ? colspan : 0);
+    groups.forEach((colspan, i) => {
+      changed.total += colspan;
 
-      for (; colspans.index < end; colspans.index++) {
-        if (colspans.index === indexFrom) {
-          colspans.fromGroup = group;
-          colspans.fromColspan = colspan;
-          colspans.fromGroupIndex = colspans.groupIndex;
-        } else if (colspans.index === indexTo) {
-          colspans.toGroup = group;
-          colspans.toColspan = colspan;
-          colspans.toGroupIndex = colspans.groupIndex;
-        }
+      if (changed.total > indexFrom && changed.from === null) {
+        changed.from = i;
       }
-      colGroups[colspans.groupIndex].colspan = colspan;
-      colspans.groupIndex++;
+      if (changed.total > indexTo && changed.to === null) {
+        changed.to = i;
+      }
     });
 
-    let newColspan;
-    if (colspans.fromGroup !== null) {
-      newColspan = colspans.fromColspan > 1 ? colspans.fromColspan - 1 : 0;
-      if (newColspan > 0) {
-        colspans.fromGroup.setAttribute('colspan', newColspan);
-        colGroups[colspans.fromGroupIndex].colspan = newColspan;
-      } else {
-        colGroups.splice(colspans.fromGroupIndex, 1);
-      }
-    }
-    if (colspans.toGroup !== null) {
-      newColspan = colspans.toColspan + 1;
-      if (newColspan > 0) {
-        colspans.toGroup.setAttribute('colspan', newColspan);
-        colGroups[colspans.toGroupIndex].colspan = newColspan;
-      } else {
-        colGroups.splice(colspans.toGroupIndex, 1);
-      }
+    if (changed.from !== changed.to) {
+      colGroups[changed.from].colspan -= 1;
+      colGroups[changed.to].colspan += 1;
     }
   },
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
When some columns hidden by default at render time or by updating later header group colspan was not aligning because it was calculating wrong value.

Group headers were not updating when columns reorder. While dragging column for reorder the drop target indicator arrows were not aligning with each case row height and filterable headers.

This PR should fix all those alignment issue and correct colspan value.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#147
Closes #374 (formerly) https://jira.infor.com/browse/SOHO-8151

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/example-grouped-headers.html
- Open above link
- Click on grid toolbar button "..." three dots from opened menu
- Click "Personalize Columns"
- Click checkboxes to show/hide columns
- Click button "Close"
- See should group header should update accordingly
- Try reorder columns by drag-drop headers
- See drop target indicator arrows should align
- See should group header should update accordingly