### PR TITLE
Update component readme files for ids website

### DIFF
--- a/docs/templates/documentationjs/theme-ids-website/section._
+++ b/docs/templates/documentationjs/theme-ids-website/section._
@@ -41,7 +41,7 @@
   <% if (section.since) { %><div>Since: <%- section.since %></div><% }%>
 
   <% if (section.params.length) { %>
-    <table>
+    <table class="jsdoc-parameters">
       <caption class="jsdoc-section--heading">Parameters</caption>
       <colgroup>
         <col width='30%' />

--- a/docs/templates/hbs/page.hbs
+++ b/docs/templates/hbs/page.hbs
@@ -24,6 +24,15 @@
   <main class="ids-container">
     <h1>{{component.title}}</h1>
     <p>{{component.description}}</p>
+    <h2>Embedded Links (iframes on ids)</h2>
+    <ul>
+      {{#each component.demo.embedded}}
+        <li>
+          <a href="../components/{{../component.slug}}/{{slug}}">{{name}}</a>
+        </li>
+      {{/each}}
+    </ul>
+    <h2>External links</h2>
     <ul>
       {{#each component.demo.pages}}
         <li>

--- a/src/components/about/readme.md
+++ b/src/components/about/readme.md
@@ -2,9 +2,10 @@
 title: About
 description: This page describes About.
 demo:
-  pages:
+  embedded:
   - name: Default About Example
     slug: example-index
+  pages:
   - name: Close Event Demo
     slug: test-close-event
 ---

--- a/src/components/accordion/readme.md
+++ b/src/components/accordion/readme.md
@@ -2,9 +2,10 @@
 title: Accordion
 description: This page describes Accordion.
 demo:
-  pages:
+  embedded:
   - name: Basic Accordion
     slug: example-index
+  pages:
   - name: Accordion Panels
     slug: example-accordion-panels
 ---

--- a/src/components/alerts/readme.md
+++ b/src/components/alerts/readme.md
@@ -2,9 +2,10 @@
 title: Alerts
 description: This page describes Alerts.
 demo:
-  pages:
+  embedded:
   - name: Alerts (Icons)
     slug: example-index
+  pages:
   - name: Alerts (Badges)
     slug: example-index
 ---

--- a/src/components/applicationmenu/readme.md
+++ b/src/components/applicationmenu/readme.md
@@ -2,9 +2,10 @@
 title: Application Menu
 description: This page describes Application Menu.
 demo:
-  pages:
+  embedded:
   - name: Default About Example
     slug: example-index
+  pages:
   - name: Different Header Types Event Demo
     slug: example-different-header-types
   - name: As Shown on the Soho Site

--- a/src/components/area/readme.md
+++ b/src/components/area/readme.md
@@ -2,9 +2,10 @@
 title: Area
 description: This page describes Area.
 demo:
-  pages:
+  embedded:
   - name: Main Example
     slug: example-index
+  pages:
   - name: Make the Tooltip Formatted (Currency)
     slug: example-formatter
   - name: Set animation speed

--- a/src/components/arrange/readme.md
+++ b/src/components/arrange/readme.md
@@ -2,7 +2,7 @@
 title: Arrange
 description: This page describes Arrange.
 demo:
-  pages:
+  embedded:
   - name: Main Example
     slug: example-index
 ---

--- a/src/components/autocomplete/readme.md
+++ b/src/components/autocomplete/readme.md
@@ -2,9 +2,10 @@
 title: Autocomplete
 description: This page describes Autocomplete.
 demo:
-  pages:
+  embedded:
   - name: Default Autocomplete
     slug: example-index
+  pages:
   - name: Ajax Autocomplete
     slug: example-ajax
   - name: Ajax as a Function Autocomplete

--- a/src/components/badges/readme.md
+++ b/src/components/badges/readme.md
@@ -2,9 +2,10 @@
 title: Badges
 description: This page describes Badges.
 demo:
-  pages:
+  embedded:
   - name: Default Badge Example
     slug: example-index
+  pages:
   - name: Additional Badges
     slug: example-additional-badges
 ---

--- a/src/components/bar-grouped/readme.md
+++ b/src/components/bar-grouped/readme.md
@@ -2,9 +2,10 @@
 title: Bar Chart (Grouped)
 description: This page describes Bar Chart (Grouped).
 demo:
-  pages:
+  embedded:
   - name: Standard Grouped Bar Chart
     slug: example-index
+  pages:
   - name: Example showing defaulting a selected value
     slug: example-selected
   - name: Example showing with negative values

--- a/src/components/bar-stacked/readme.md
+++ b/src/components/bar-stacked/readme.md
@@ -2,9 +2,10 @@
 title: Bar Chart (Stacked)
 description: This page describes Bar Chart (Stacked).
 demo:
-  pages:
+  embedded:
   - name: Standard Stacked Bar Chart
     slug: example-index
+  pages:
   - name: 100% Stacked Bar Chart
     slug: example-stacked-100
   - name: Colors

--- a/src/components/bar/readme.md
+++ b/src/components/bar/readme.md
@@ -2,9 +2,10 @@
 title: Bar Chart
 description: This page describes Bar Chart.
 demo:
-  pages:
+  embedded:
   - name: Standard Bar Chart
     slug: example-index
+  pages:
   - name: Example with More Elements and Longer Text
     slug: example-alignment
   - name: Example showing how to set Colors

--- a/src/components/blockgrid/readme.md
+++ b/src/components/blockgrid/readme.md
@@ -2,9 +2,10 @@
 title: Blockgrid
 description: This page describes Blockgrid.
 demo:
-  pages:
+  embedded:
   - name: Blockgrid with images
     slug: example-index
+  pages:
   - name: Blockgrid with image and text
     slug: example-text
   - name: Blockgrid with single selection

--- a/src/components/breadcrumb/readme.md
+++ b/src/components/breadcrumb/readme.md
@@ -2,9 +2,10 @@
 title: Breadcrumb
 description: This page describes Breadcrumb.
 demo:
-  pages:
+  embedded:
   - name: Default Breadcrumb Example
     slug: example-index
+  pages:
   - name: Breadcrumb with current item a link
     slug: example-current-as-link
 ---

--- a/src/components/breakpoints/readme.md
+++ b/src/components/breakpoints/readme.md
@@ -2,7 +2,7 @@
 title: Favorites
 description: This page describes Favorites.
 demo:
-  pages:
+  embedded:
   - name: Breakpoint Event Change Detection
     slug: example-change-detection
 ---

--- a/src/components/bubble/readme.md
+++ b/src/components/bubble/readme.md
@@ -2,9 +2,10 @@
 title: Bubble Chart
 description: This page describes Bubble Chart.
 demo:
-  pages:
+  embedded:
   - name: Standard Bubble Chart
     slug: example-index
+  pages:
   - name: Defaulting a selected bubble
     slug: example-selected
   - name: Set animation speed

--- a/src/components/bullet/readme.md
+++ b/src/components/bullet/readme.md
@@ -2,9 +2,10 @@
 title: Bullet Chart
 description: This page describes Bullet Chart.
 demo:
-  pages:
+  embedded:
   - name: Standard Bullet Chart
     slug: example-index
+  pages:
   - name: Shows Grouping a Series of Related Bullet Charts
     slug: example-data-group
   - name: Shows a Bullet Chart with Positive and Negative Values

--- a/src/components/busyindicator/readme.md
+++ b/src/components/busyindicator/readme.md
@@ -2,9 +2,10 @@
 title: Busy Indicator
 description: This page describes Busy Indicator.
 demo:
-  pages:
+  embedded:
   - name: Busy Form Example
     slug: example-index
+  pages:
   - name: Busy Input Elements
     slug: example-inputs
   - name: Non Blocking Busy Indicator

--- a/src/components/button/readme.md
+++ b/src/components/button/readme.md
@@ -2,9 +2,10 @@
 title: Button
 description: This page describes Button.
 demo:
-  pages:
+  embedded:
   - name: Form Buttons
     slug: example-index
+  pages:
   - name: 100% Width Button
     slug: example-100-percent
   - name: Button on an `<a>` tag

--- a/src/components/calendar/readme.md
+++ b/src/components/calendar/readme.md
@@ -2,7 +2,7 @@
 title: Calendar
 description: This page describes Calendar.
 demo:
-  pages:
+  embedded:
   - name: Full Page Calendar Example
     slug: example-index
 ---

--- a/src/components/cards/readme.md
+++ b/src/components/cards/readme.md
@@ -2,9 +2,10 @@
 title: Cards
 description: This page describes Cards.
 demo:
-  pages:
+  embedded:
   - name: Simple Card Example
     slug: example-index
+  pages:
   - name: Expandable Card
     slug: example-expandable
   - name: Full Page Width Cards

--- a/src/components/charts/readme.md
+++ b/src/components/charts/readme.md
@@ -2,7 +2,7 @@
 title: Charts
 description: This page describes Charts.
 demo:
-  pages:
+  embedded:
   - name: Using Patterns on Chart Colors
     slug: example-chart-patterns
   - name: How to Hide / Show a Chart

--- a/src/components/checkboxes/readme.md
+++ b/src/components/checkboxes/readme.md
@@ -2,9 +2,10 @@
 title: Checkboxes
 description: This page describes Checkboxes.
 demo:
-  pages:
+  embedded:
   - name: Default Checkbox Example
     slug: example-index
+  pages:
   - name: Checkbox Groups
     slug: example-checkbox-groups
   - name: Horizontal Checkbox Group

--- a/src/components/circlepager/readme.md
+++ b/src/components/circlepager/readme.md
@@ -2,9 +2,10 @@
 title: Circle Pager
 description: This page describes Circle Pager.
 demo:
-  pages:
+  embedded:
   - name: Default Circle Pager Example
     slug: example-index
+  pages:
   - name: Circle Pager on a Form
     slug: example-form
   - name: Circle Pager with more than one item per slide

--- a/src/components/colorpicker/readme.md
+++ b/src/components/colorpicker/readme.md
@@ -2,9 +2,10 @@
 title: Color Picker
 description: This page describes Color Picker.
 demo:
-  pages:
+  embedded:
   - name: Color Picker Example
     slug: example-index
+  pages:
   - name: Showing Custom Colors
     slug: example-custom-labels
   - name: Showing Label on Select

--- a/src/components/colors/readme.md
+++ b/src/components/colors/readme.md
@@ -2,9 +2,10 @@
 title: Color Palette
 description:
 demo:
-  pages:
+  embedded:
   - name: Full Color Palette
     slug: example-index
+  pages:
   - name: Color Variables (Badges)
     slug: example-color-vars
 ---

--- a/src/components/column-grouped/readme.md
+++ b/src/components/column-grouped/readme.md
@@ -2,9 +2,10 @@
 title: Column Chart (Grouped)
 description: This page describes Column Chart (Grouped).
 demo:
-  pages:
+  embedded:
   - name: Standard Grouped Column Chart
     slug: example-index
+  pages:
   - name: Default a Selected Group
     slug: example-selected
   - name: Handle negative values

--- a/src/components/column-stacked/readme.md
+++ b/src/components/column-stacked/readme.md
@@ -2,9 +2,10 @@
 title: Column Chart (Stacked)
 description: This page describes Column Chart (Stacked).
 demo:
-  pages:
+  embedded:
   - name: Standard Stacked Column Chart
     slug: example-index
+  pages:
   - name: Defaulting Selected Stacks
     slug: example-selected
   - name: Single Column Chart

--- a/src/components/column/readme.md
+++ b/src/components/column/readme.md
@@ -2,9 +2,10 @@
 title: Column Chart
 description: This page describes Column Chart.
 demo:
-  pages:
+  embedded:
   - name: Standard Column Chart
     slug: example-index
+  pages:
   - name: Column Chart with Legend
     slug: example-legend
   - name: Balance Widget

--- a/src/components/completion-chart/readme.md
+++ b/src/components/completion-chart/readme.md
@@ -2,9 +2,10 @@
 title: Completion Chart
 description: This page describes Completion Chart.
 demo:
-  pages:
+  embedded:
   - name: Standard Completion Chart Example
     slug: example-index
+  pages:
   - name: All Completion Chart Examples
     slug: example-variations
   - name: Range of Colors for Completion Chart

--- a/src/components/compositeform/readme.md
+++ b/src/components/compositeform/readme.md
@@ -2,9 +2,10 @@
 title: Composite Form Pattern
 description: This page describes Composite Form Pattern.
 demo:
-  pages:
+  embedded:
   - name: Default Composite Form Example
     slug: example-index
+  pages:
   - name: Composite Form With No Summary Area
     slug: example-no-summary
 ---

--- a/src/components/contextmenu/readme.md
+++ b/src/components/contextmenu/readme.md
@@ -2,7 +2,7 @@
 title: Context Menu
 description: This page describes Context Menu .
 demo:
-  pages:
+  embedded:
   - name: Context Menu on an Input
     slug: example-index
 ---

--- a/src/components/contextualactionpanel/readme.md
+++ b/src/components/contextualactionpanel/readme.md
@@ -2,9 +2,10 @@
 title: Contextual Action Panel
 description: This page describes Contextual Action Panel.
 demo:
-  pages:
+  embedded:
   - name: Default CAP Example
     slug: example-index
+  pages:
   - name: CAP using jQuery Object for Content
     slug: example-jquery
   - name: CAP using Inline Markup for Content

--- a/src/components/counts/readme.md
+++ b/src/components/counts/readme.md
@@ -2,7 +2,7 @@
 title: Counts
 description: This page describes Counts.
 demo:
-  pages:
+  embedded:
   - name: Counts - Of an Instance
     slug: example-instance-count
   - name: Counts - Of an Object

--- a/src/components/datagrid/readme.md
+++ b/src/components/datagrid/readme.md
@@ -2,9 +2,10 @@
 title: Datagrid
 description: This page describes Datagrid .
 demo:
-  pages:
+  embedded:
   - name: Simple Datagrid Example
     slug: example-index
+  pages:
   - name: Alternate Row Shading
     slug: example-alternate-row-shading.html
   - name: Drilldown Formatter

--- a/src/components/datepicker/readme.md
+++ b/src/components/datepicker/readme.md
@@ -2,9 +2,10 @@
 title: Datepicker
 description: This page describes Datepicker.
 demo:
-  pages:
+  embedded:
   - name: Simple Date Picker Example
     slug: example-index
+  pages:
   - name: Anniversary Format (Month, Year)
     slug: example-anniversay-format
   - name: Date Picker With Legend

--- a/src/components/donut/readme.md
+++ b/src/components/donut/readme.md
@@ -2,9 +2,10 @@
 title: Donut Chart
 description: This page describes Donut Chart.
 demo:
-  pages:
+  embedded:
   - name: Standard Donut Chart
     slug: example-index
+  pages:
   - name: Showing Slices as Alerts
     slug: example-alerts
   - name: With a Right Click Menu

--- a/src/components/drag/readme.md
+++ b/src/components/drag/readme.md
@@ -2,7 +2,7 @@
 title: Drag Behavior
 description: This page describes Drag Behavior.
 demo:
-  pages:
+  embedded:
   - name: Basic Drag Examples
     slug: example-index
 ---

--- a/src/components/dropdown/readme.md
+++ b/src/components/dropdown/readme.md
@@ -2,9 +2,10 @@
 title: Dropdown
 description: This page describes Dropdown.
 demo:
-  pages:
+  embedded:
   - name: Default Dropdown Example
     slug: example-index
+  pages:
   - name: Clearable Dropdown
     slug: example-clearable
   - name: Updating the Contents

--- a/src/components/editor/readme.md
+++ b/src/components/editor/readme.md
@@ -2,9 +2,10 @@
 title: Editor (Rich Text)
 description: This page describes Editor (Rich Text).
 demo:
-  pages:
+  embedded:
   - name: Default Rich Text Editor Example
     slug: example-index
+  pages:
   - name: Customize Buttons
     slug: example-customize-buttons
   - name: Back Color Button (Experimental - Limited Browser Support)

--- a/src/components/emptymessage/readme.md
+++ b/src/components/emptymessage/readme.md
@@ -2,9 +2,10 @@
 title: Empty Message
 description: This page describes Empty Message .
 demo:
-  pages:
+  embedded:
   - name: Simple Empty Message
     slug: example-index
+  pages:
   - name: Widget Examples
     slug: example-widgets
 ---

--- a/src/components/expandablearea/readme.md
+++ b/src/components/expandablearea/readme.md
@@ -2,9 +2,10 @@
 title: Expandable Area
 description: This page describes Expandable Area .
 demo:
-  pages:
+  embedded:
   - name: Default Expandable Area Example
     slug: example-index
+  pages:
   - name: Custom Link Text Demo
     slug: example-custom-text
 ---

--- a/src/components/favorites/readme.md
+++ b/src/components/favorites/readme.md
@@ -2,7 +2,7 @@
 title: Favorites
 description: This page describes Favorites.
 demo:
-  pages:
+  embedded:
   - name: Default Favorites Example
     slug: example-index
 ---

--- a/src/components/field-filter/readme.md
+++ b/src/components/field-filter/readme.md
@@ -2,9 +2,10 @@
 title: Field Filter
 description: This page describes Field Filter.
 demo:
-  pages:
+  embedded:
   - name: Default Field Filter Example
     slug: example-index
+  pages:
   - name: Filter Example with Datepicker
     slug: example-datepicker
 ---

--- a/src/components/field-options/readme.md
+++ b/src/components/field-options/readme.md
@@ -2,9 +2,10 @@
 title: Field Options
 description: This page describes Field Options.
 demo:
-  pages:
+  embedded:
   - name: Default Field Options Example
     slug: example-index
+  pages:
   - name: Fieldset Example
     slug: example-fieldset
 ---

--- a/src/components/fieldset/readme.md
+++ b/src/components/fieldset/readme.md
@@ -2,9 +2,10 @@
 title: Field Set
 description: This page describes Field Set.
 demo:
-  pages:
+  embedded:
   - name: Default Fieldset Example
     slug: example-index
+  pages:
   - name: 50/50 Fieldset Example
     slug: example-50-50
   - name: Example Showing Input Fields

--- a/src/components/fileupload-advanced/readme.md
+++ b/src/components/fileupload-advanced/readme.md
@@ -2,9 +2,10 @@
 title: File Upload Advanced
 description: This page describes File Upload Advanced.i
 demo:
-  pages:
+  embedded:
   - name: Advanced File Upload Example
     slug: example-index
+  pages:
   - name: Default File Upload Example
     slug: example-index
 ---

--- a/src/components/fileupload/readme.md
+++ b/src/components/fileupload/readme.md
@@ -2,9 +2,10 @@
 title: File Upload
 description: This page describes File Upload.
 demo:
-  pages:
+  embedded:
   - name: Default File Upload Example
     slug: example-index
+  pages:
   - name: Advanced File Upload Example
     slug: example-index
   - name: Limit File Types

--- a/src/components/form/readme.md
+++ b/src/components/form/readme.md
@@ -2,9 +2,10 @@
 title: Form Functionality
 description: The forms plugins are a set of form related utilities and functionality contained in `forms.js`. This page outlines the functionality contained in that plugin and shows some from related examples for layout from other areas.
 demo:
-  pages:
+  embedded:
   - name: Form Inputs in the Responsive Grid
     slug: example-inputs
+  pages:
   - name: Form Inputs in the Responsive Simplified Grid
     slug: example-inputs-simple
   - name: Form Layouts

--- a/src/components/grid/readme.md
+++ b/src/components/grid/readme.md
@@ -2,9 +2,10 @@
 title: Grid
 description: This page describes Grid.
 demo:
-  pages:
+  embedded:
   - name: 12 Column Responsive Grid
     slug: example-index
+  pages:
   - name: Simplified Responsive Grid
     slug: example-simplified
   - name: Inputs in the Responsive Grid

--- a/src/components/header/readme.md
+++ b/src/components/header/readme.md
@@ -2,9 +2,10 @@
 title: Header
 description: This page describes Header.
 demo:
-  pages:
+  embedded:
   - name: Default Header Example
     slug: example-index
+  pages:
   - name: Disabled Buttons On Header
     slug: example-disabled-buttons
   - name: Eyebrow Style (Emphasis on the ID)

--- a/src/components/hierarchy/readme.md
+++ b/src/components/hierarchy/readme.md
@@ -2,9 +2,10 @@
 title: Hierarchy
 description: This page describes Hierarchy.
 demo:
-  pages:
+  embedded:
   - name: Org Chart Example
     slug: example-index
+  pages:
   - name: Lazy Loading Example
     slug: example-lazy-load
   - name: Example Paging

--- a/src/components/homepage/readme.md
+++ b/src/components/homepage/readme.md
@@ -2,9 +2,10 @@
 title: HomePage
 description: This page describes HomePage.
 demo:
-  pages:
+  embedded:
   - name: Example of Empty HomePage Layout
     slug: example-index
+  pages:
   - name: Example of HomePage filled with Sample Data
     slug: example-filled
   - name: 4 Column Layout

--- a/src/components/hyperlinks/readme.md
+++ b/src/components/hyperlinks/readme.md
@@ -2,7 +2,7 @@
 title: Hyperlinks
 description: This page describes Hyperlinks.
 demo:
-  pages:
+  embedded:
   - name: Default Hyperlink Example
     slug: example-index
 ---

--- a/src/components/icons/readme.md
+++ b/src/components/icons/readme.md
@@ -2,17 +2,14 @@
 title: Icons
 description:
 demo:
-  pages:
+  embedded:
   - name: Basic Icons
     slug: example-index
+  pages:
   - name: Extended Icon Set
     slug: example-extended
-  - name: Alert Icons
-    slug: example-index
   - name: Tree Folder Icons
     slug: example-tree
-  - name: Tree Icons
-    slug: example-index
   - name: Empty Widget Icons
     slug: example-empty-widgets
   - name: Grid Filter Drop Down Menu Icons

--- a/src/components/images/readme.md
+++ b/src/components/images/readme.md
@@ -2,9 +2,10 @@
 title: Images
 description: This page describes Images.
 demo:
-  pages:
+  embedded:
   - name: Image Sizes and Placeholders
     slug: example-index
+  pages:
   - name: A Pattern showing a toolbar over a list of Images
     slug: example-image-list
   - name: People Photos and initials

--- a/src/components/input/readme.md
+++ b/src/components/input/readme.md
@@ -2,9 +2,10 @@
 title: Text Input
 description: This page describes Text Input.
 demo:
-  pages:
+  embedded:
   - name: Text Input Examples
     slug: example-index
+  pages:
   - name: Inputs with Action Menus
     slug: example-actions
   - name: Inputs with Info message under

--- a/src/components/line/readme.md
+++ b/src/components/line/readme.md
@@ -2,9 +2,10 @@
 title: Line
 description: This page describes Line.
 demo:
-  pages:
+  embedded:
   - name: Standard Line Chart
     slug: example-index
+  pages:
   - name: Labels on Axis
     slug: example-axis-labels
   - name: Ticks Adjustment (Less ticks than data points)

--- a/src/components/listbuilder/readme.md
+++ b/src/components/listbuilder/readme.md
@@ -2,7 +2,7 @@
 title: ListBuilder
 description: This page describes ListBuilder.
 demo:
-  pages:
+  embedded:
   - name: Default List Builder Example
     slug: example-index
 ---

--- a/src/components/listview/readme.md
+++ b/src/components/listview/readme.md
@@ -5,9 +5,10 @@ system:
   category: blocks
   name: data-list
 demo:
-  pages:
+  embedded:
   - name: Default Listview Example
     slug: example-index
+  pages:
   - name: Alternate Row Colors
     slug: example-alternate-row-color
   - name: Multiple Selection

--- a/src/components/lookup/readme.md
+++ b/src/components/lookup/readme.md
@@ -2,9 +2,10 @@
 title: Lookup
 description: This page describes Lookup.
 demo:
-  pages:
+  embedded:
   - name: Default Lookup
     slug: example-index
+  pages:
   - name: Multiselect Lookup
     slug: example-multiselect
   - name: Lookup with Paging

--- a/src/components/mask/readme.md
+++ b/src/components/mask/readme.md
@@ -2,9 +2,10 @@
 title: Mask
 description: This page describes Mask.
 demo:
-  pages:
+  embedded:
   - name: Main Example
     slug: example-index
+  pages:
   - name: Common Mask Patterns
     slug: example-common-patterns
   - name: Fields with Symbols

--- a/src/components/masthead/readme.md
+++ b/src/components/masthead/readme.md
@@ -2,7 +2,7 @@
 title: Masthead
 description: This page describes Masthead.
 demo:
-  pages:
+  embedded:
   - name: Default Masthead Example
     slug: example-index
 ---

--- a/src/components/menubutton/readme.md
+++ b/src/components/menubutton/readme.md
@@ -2,9 +2,10 @@
 title: MenuButton Component
 description: This page describes MenuButton Component .
 demo:
-  pages:
+  embedded:
   - name: Simple Menu Button
     slug: example-index
+  pages:
   - name: Menu Button Events
     slug: example-events
   - name: Submenus

--- a/src/components/message/readme.md
+++ b/src/components/message/readme.md
@@ -2,7 +2,7 @@
 title: Message
 description: This page describes Message.
 demo:
-  pages:
+  embedded:
   - name: Message Examples
     slug: example-index
 ---

--- a/src/components/modal/readme.md
+++ b/src/components/modal/readme.md
@@ -2,9 +2,10 @@
 title: Modal
 description: This page describes Modal.
 demo:
-  pages:
+  embedded:
   - name: Modal Example
     slug: example-index
+  pages:
   - name: Modal Event Handlers
     slug: example-events
   - name: Supplying Full Modal content

--- a/src/components/monthview/readme.md
+++ b/src/components/monthview/readme.md
@@ -2,9 +2,10 @@
 title: MonthView
 description: This page describes MonthView.
 demo:
-  pages:
+  embedded:
   - name: Full Page MonthView Example
     slug: example-index
+  pages:
   - name: Disabling Weeks/Days
     slug: example-disable-weeks
   - name: Restricting Month Selection

--- a/src/components/multiselect/readme.md
+++ b/src/components/multiselect/readme.md
@@ -2,9 +2,10 @@
 title: Multi-Select
 description:
 demo:
-  pages:
+  embedded:
   - name: Multiselect
     slug: example-index
+  pages:
   - name: Clear All
     slug: example-clear-all
   - name: Ajax

--- a/src/components/pager/readme.md
+++ b/src/components/pager/readme.md
@@ -2,9 +2,10 @@
 title: Pager
 description: This page describes Pager.
 demo:
-  pages:
+  embedded:
   - name: Paging a List (Ul)
     slug: example-index
+  pages:
   - name: Paging on the Listview Component
     slug: example-paging
   - name: Paging on the Datagrid Component

--- a/src/components/personalize/readme.md
+++ b/src/components/personalize/readme.md
@@ -2,9 +2,10 @@
 title: Personalize
 description: This page describes Personalize.
 demo:
-  pages:
+  embedded:
   - name: Themes Example
     slug: example-index?colors=800000
+  pages:
   - name: Property Page
     slug: example-settings-page
 ---

--- a/src/components/pie/readme.md
+++ b/src/components/pie/readme.md
@@ -2,9 +2,10 @@
 title: Pie Chart
 description: This page describes Pie Chart.
 demo:
-  pages:
+  embedded:
   - name: Standard Pie Chart
     slug: example-index
+  pages:
   - name: HCM Example
     slug: example-hcm
   - name: Tooltips

--- a/src/components/place/readme.md
+++ b/src/components/place/readme.md
@@ -2,7 +2,7 @@
 title: Place
 description: This page describes Place.
 demo:
-  pages:
+  embedded:
   - name: Place by Coordinate
     slug: test-coordinates
   - name: Place by Relative Parent

--- a/src/components/popover/readme.md
+++ b/src/components/popover/readme.md
@@ -2,9 +2,10 @@
 title: Popover Component
 description: This page describes Popover Component .
 demo:
-  pages:
+  embedded:
   - name: Common Configuration
     slug: example-index
+  pages:
   - name: Simple Popover Content
     slug: example-simple
   - name: Complex Form Layout Inside Popover

--- a/src/components/popupmenu/readme.md
+++ b/src/components/popupmenu/readme.md
@@ -2,7 +2,7 @@
 title: Popupmenu Component
 description: This page describes Popupmenu Component .
 demo:
-  pages:
+  embedded:
   - name: Popupmenu as a Menu Button
     slug: example-menubutton
   - name: Popupmenu with multiselect

--- a/src/components/positive-negative/readme.md
+++ b/src/components/positive-negative/readme.md
@@ -2,9 +2,10 @@
 title: Positive-Negative Chart
 description: This page describes Positive-Negative Chart.
 demo:
-  pages:
+  embedded:
   - name: Standard Positive/Negative Chart
     slug: example-index
+  pages:
   - name: Example showing color patterns
     slug: example-patterns
   - name: Set animation speed

--- a/src/components/processindicator/readme.md
+++ b/src/components/processindicator/readme.md
@@ -2,7 +2,7 @@
 title: Process Indicator
 description: This page describes Process Indicator .
 demo:
-  pages:
+  embedded:
   - name: Main Process Indicator Example
     slug: example-index
 ---

--- a/src/components/progress/readme.md
+++ b/src/components/progress/readme.md
@@ -2,7 +2,7 @@
 title: Progress Indicator
 description: This page describes Progress Indicator.
 demo:
-  pages:
+  embedded:
   - name: Default Progress Indicator Example
     slug: example-index
 ---

--- a/src/components/radar/readme.md
+++ b/src/components/radar/readme.md
@@ -2,7 +2,7 @@
 title: Radar Chart
 description: This page describes Radar Chart.
 demo:
-  pages:
+  embedded:
   - name: Standard Radar Chart
     slug: example-index
 ---

--- a/src/components/radios/readme.md
+++ b/src/components/radios/readme.md
@@ -2,9 +2,10 @@
 title: Radio Buttons
 description: This page describes Radio Buttons.
 demo:
-  pages:
+  embedded:
   - name: Radio Button Example
     slug: example-index
+  pages:
   - name: Horizontal Radio Button Example
     slug: example-horizontal
   - name: Dirty Flag

--- a/src/components/rating/readme.md
+++ b/src/components/rating/readme.md
@@ -2,9 +2,10 @@
 title: Rating
 description: This page describes Rating.
 demo:
-  pages:
+  embedded:
   - name: Rating Example
     slug: example-index
+  pages:
   - name: Readonly Example
     slug: example-readonly
   - name: Rounding Decimals Up Example

--- a/src/components/scatterplot/readme.md
+++ b/src/components/scatterplot/readme.md
@@ -2,9 +2,10 @@
 title: Scatter Plot Chart
 description: This page describes Scatter Plot Chart.
 demo:
-  pages:
+  embedded:
   - name: Standard Scatter Plot Chart
     slug: example-index
+  pages:
   - name: Defaulting a selected plot item
     slug: example-selected
   - name: Set animation speed

--- a/src/components/searchfield/readme.md
+++ b/src/components/searchfield/readme.md
@@ -2,9 +2,10 @@
 title: Searchfield
 description: This page describes Searchfield.
 demo:
-  pages:
+  embedded:
   - name: Common Configuration
     slug: example-index.html
+  pages:
   - name: Context Search Style
     slug: example-context-search-style.html
   - name: Different Template

--- a/src/components/signin/readme.md
+++ b/src/components/signin/readme.md
@@ -2,9 +2,10 @@
 title: Signin Component
 description: This page describes Signin Component .
 demo:
-  pages:
+  embedded:
   - name: Main Example
     slug: example-index
+  pages:
   - name: Remember Me Example
     slug: example-remember-me
   - name: Customer Designed Sign in Page

--- a/src/components/skiplink/readme.md
+++ b/src/components/skiplink/readme.md
@@ -2,7 +2,7 @@
 title: Skiplink Component
 description: This page describes Skiplink Component .
 demo:
-  pages:
+  embedded:
   - name: Main Example
     slug: example-index
 ---

--- a/src/components/slider/readme.md
+++ b/src/components/slider/readme.md
@@ -2,9 +2,10 @@
 title: Slider Component
 description: This page describes Slider Component.
 demo:
-  pages:
+  embedded:
   - name: Main Example
     slug: example-index
+  pages:
   - name: Range Example (Two Handles)
     slug: example-range
   - name: Steps

--- a/src/components/sparkline/readme.md
+++ b/src/components/sparkline/readme.md
@@ -2,9 +2,10 @@
 title: Sparklines
 description: This page describes Sparklines.
 demo:
-  pages:
+  embedded:
   - name: Standard Sparkline Chart
     slug: example-index
+  pages:
   - name: Example showing Get Selected value
     slug: example-get-selected
   - name: Example showing Set Selected value

--- a/src/components/spinbox/readme.md
+++ b/src/components/spinbox/readme.md
@@ -2,9 +2,10 @@
 title: Spinbox Component
 description: This page describes Spinbox Component .
 demo:
-  pages:
+  embedded:
   - name: Main
     slug: example-index
+  pages:
   - name: Configured with Range Limits
     slug: example-range-limits
   - name: Configured with Step Intervals of 3

--- a/src/components/splitter/readme.md
+++ b/src/components/splitter/readme.md
@@ -2,9 +2,10 @@
 title: Splitter Component
 description: This page describes Splitter Component .
 demo:
-  pages:
+  embedded:
   - name: Main Example
     slug: example-index
+  pages:
   - name: Splitter Element in Left Pane
     slug: example-splitter-left
   - name: Events

--- a/src/components/stepchart/readme.md
+++ b/src/components/stepchart/readme.md
@@ -2,9 +2,10 @@
 title: Step Chart
 description: This page describes Step Chart.
 demo:
-  pages:
+  embedded:
   - name: Standard Step Chart
     slug: example-index
+  pages:
   - name: Custom Colors
     slug: example-colors
 ---

--- a/src/components/swaplist/readme.md
+++ b/src/components/swaplist/readme.md
@@ -2,9 +2,10 @@
 title: Swaplist Component
 description: This page describes Swaplist Component .
 demo:
-  pages:
+  embedded:
   - name: Main Swaplist Example
     slug: example-index.html
+  pages:
   - name: Swaplist with Selected Items
     slug: example-selected.html
   - name: Swaplist with Filter/Search

--- a/src/components/switch/readme.md
+++ b/src/components/switch/readme.md
@@ -2,9 +2,10 @@
 title: Switch Component
 description: This page describes Switch Component .
 demo:
-  pages:
+  embedded:
   - name: Main Switch Example
     slug: example-index
+  pages:
   - name: Alternate Alignment
     slug: example-alignment
   - name: Two Column Layout

--- a/src/components/tabs-header/readme.md
+++ b/src/components/tabs-header/readme.md
@@ -2,9 +2,10 @@
 title: Header Tabs
 description: This page describes Header Tabs .
 demo:
-  pages:
+  embedded:
   - name: Common Configuration
     slug: example-index
+  pages:
   - name: Alternate Styling
     slug: example-alternate
   - name: Add Tab Button

--- a/src/components/tabs-module/readme.md
+++ b/src/components/tabs-module/readme.md
@@ -2,9 +2,10 @@
 title: Module Tabs
 description: This page describes Module Tabs .
 demo:
-  pages:
+  embedded:
   - name: Common Configuration
     slug: example-index
+  pages:
   - name: Showing Tooltips when Tabs are too short
     slug: example-cutoff-tooltips
   - name: Add Tab Button

--- a/src/components/tabs-multi/readme.md
+++ b/src/components/tabs-multi/readme.md
@@ -2,9 +2,10 @@
 title: Tabs-multi
 description: This page describes Tabs-multi.
 demo:
-  pages:
+  embedded:
   - name: Default tabs-multi example
     slug: example-index
+  pages:
   - name: test masthead
     slug: test-masthead
   - name: test side by side

--- a/src/components/tabs-vertical/readme.md
+++ b/src/components/tabs-vertical/readme.md
@@ -2,9 +2,10 @@
 title: Vertical Tabs
 description: This page describes Vertical Tabs .
 demo:
-  pages:
+  embedded:
   - name: Independent Column Scrolling
     slug: example-independent-scrolling
+  pages:
   - name: Vertical Tabs as outbound links
     slug: example-outbound-links-page1
   - name: Responsive Setting (changes to header tabs)

--- a/src/components/tabs/readme.md
+++ b/src/components/tabs/readme.md
@@ -2,9 +2,10 @@
 title: Tabs Component
 description: This page describes Tabs Component .
 demo:
-  pages:
+  embedded:
   - name: Common Configuration
     slug: example-index
+  pages:
   - name: Tabs With Counts
     slug: example-counts
   - name: Dismissible Tabs

--- a/src/components/tag/readme.md
+++ b/src/components/tag/readme.md
@@ -2,7 +2,7 @@
 title: Tag Component
 description: This page describes Tag Component .
 demo:
-  pages:
+  embedded:
   - name: Common Tag Examples
     slug: example-index
 ---

--- a/src/components/targeted-achievement/readme.md
+++ b/src/components/targeted-achievement/readme.md
@@ -2,9 +2,10 @@
 title: Targeted Achievement Chart
 description: This page describes Targeted Achievement Chart.
 demo:
-  pages:
+  embedded:
   - name: Main Target to Achievement Example (shows 3 examples)
     slug: example-index
+  pages:
   - name: Showing Percentage Text
     slug: example-percent-text
   - name: Used on a Datagrid

--- a/src/components/textarea/readme.md
+++ b/src/components/textarea/readme.md
@@ -2,7 +2,7 @@
 title: Textarea Component
 description: This page describes Textarea Component.
 demo:
-  pages:
+  embedded:
   - name: Main Examples
     slug: example-index
 ---

--- a/src/components/timeline/readme.md
+++ b/src/components/timeline/readme.md
@@ -2,7 +2,7 @@
 title: Timeline Component
 description: This page describes Timeline Component .
 demo:
-  pages:
+  embedded:
   - name: Main Example
     slug: example-index
 ---

--- a/src/components/timepicker/readme.md
+++ b/src/components/timepicker/readme.md
@@ -2,9 +2,10 @@
 title: Timepicker Component
 description: This page describes Timepicker Component .
 demo:
-  pages:
+  embedded:
   - name: Default Example
     slug: example-index
+  pages:
   - name: 24-Hour (Military) Time
     slug: example-24-hour
   - name: Rounded Minute Intervals

--- a/src/components/toast/readme.md
+++ b/src/components/toast/readme.md
@@ -2,9 +2,10 @@
 title: Toast Component
 description: This page describes Toast Component .
 demo:
-  pages:
+  embedded:
   - name: Common Configuration
     slug: example-index
+  pages:
   - name: Demo of all Positions
     slug: example-positions
 ---

--- a/src/components/toolbar/readme.md
+++ b/src/components/toolbar/readme.md
@@ -2,9 +2,10 @@
 title: Toolbar
 description: This page describes Toolbar.
 demo:
-  pages:
+  embedded:
   - name: Common Configuration
     slug: example-index
+  pages:
   - name: Title + All Icon Buttons
     slug: example-all-icon-buttons
   - name: Title + All Text-Only Buttons

--- a/src/components/toolbarsearchfield/readme.md
+++ b/src/components/toolbarsearchfield/readme.md
@@ -2,9 +2,10 @@
 title: Toolbar Searchfield
 description: This page describes Toolbar Searchfield .
 demo:
-  pages:
+  embedded:
   - name: Common Configuration
     slug: example-index.html
+  pages:
   - name: Alternate In-Page Style
     slug: example-alternate-style.html
   - name: "`collapsibleOnMobile` Setting Demo"

--- a/src/components/tooltip/readme.md
+++ b/src/components/tooltip/readme.md
@@ -2,9 +2,10 @@
 title: Tooltip Component
 description: This page describes Tooltip Component .
 demo:
-  pages:
+  embedded:
   - name: Default Tooltip Example
     slug: example-index
+  pages:
   - name: Tooltip with an Icon
     slug: example-icon-in-tooltip
   - name: Functioning URL inside of a Tooltip

--- a/src/components/trackdirty/readme.md
+++ b/src/components/trackdirty/readme.md
@@ -2,7 +2,7 @@
 title: Trackdirty
 description: This page describes Trackdirty.
 demo:
-  pages:
+  embedded:
   - name: Main Example
     slug: example-index
 ---

--- a/src/components/tree/readme.md
+++ b/src/components/tree/readme.md
@@ -2,9 +2,10 @@
 title: Tree Component
 description: This page describes Tree Component .
 demo:
-  pages:
+  embedded:
   - name: Common Configuration
     slug: example-index
+  pages:
   - name: Add Node
     slug: example-add-node
   - name: Ajax

--- a/src/components/treemap/readme.md
+++ b/src/components/treemap/readme.md
@@ -2,9 +2,10 @@
 title: Treemap
 description: This page describes treemap.
 demo:
-  pages:
+  embedded:
   - name: Treemap Main Example
     slug: example-index
+  pages:
   - name: Treemap Nesting Example
     slug: example-nested
 ---

--- a/src/components/typography/readme.md
+++ b/src/components/typography/readme.md
@@ -2,9 +2,9 @@
 title: Typography
 description: This page describes Typography .
 demo:
-  pages:
-    - name: Main Example Page
-      slug: example-index
+  embedded:
+  - name: Main Example Page
+    slug: example-index
 ---
 
 ## Font family

--- a/src/components/validation/readme.md
+++ b/src/components/validation/readme.md
@@ -2,9 +2,10 @@
 title: Validation
 description: This page describes Validation.
 demo:
-  pages:
+  embedded:
   - name: Main Validation Examples
     slug: example-index
+  pages:
   - name: Multiple Validation Errors on a Field
     slug: example-multiple-errors
   - name: Legacy Short Fields

--- a/src/components/visibility/readme.md
+++ b/src/components/visibility/readme.md
@@ -2,9 +2,10 @@
 title: Visibility CSS Classes
 description: This page describes Visibility CSS Classes.
 demo:
-  pages:
+  embedded:
   - name: All Examples
     slug: example-index
+  pages:
   - name: Multiple classes at once
     slug: example-multiple-visibility-classes
 ---

--- a/src/components/wizard/readme.md
+++ b/src/components/wizard/readme.md
@@ -2,9 +2,10 @@
 title: Wizard Component
 description: This page describes Wizard Component .
 demo:
-  pages:
+  embedded:
   - name: Common Configuration
     slug: example-index
+  pages:
   - name: Disabled Tick Clicks
     slug: example-in-page
   - name: Programmatic Tick Selection

--- a/src/patterns/stepprocess/stepprocess.md
+++ b/src/patterns/stepprocess/stepprocess.md
@@ -2,9 +2,10 @@
 title: Step Process Component
 description: This page describes Step Process Component .
 demo:
-  pages:
+  embedded:
   - name: Main Example
     slug: example-index
+  pages:
   - name: Markup-driven Example
     slug: example-markup
 ---


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Display some inline examples for the components on the IDS website.
- Fixed tiny bug in documentation script
- Updated templates associated with docs/md files accordingly

**Related github/jira issue (required)**:
https://github.com/infor-design/website/issues/560

**Steps necessary to review your pull request (required)**:
1. I've already deployed this documentation to staging as `4.11.0-dev`.
1. Once [this pull request](https://github.com/infor-design/website/pull/655) is merged and on staging, you should be able to view some of the examples inline (iframe) per component.
- https://staging.design.infor.com/code/ids-enterprise/latest/accordion
- https://staging.design.infor.com/code/ids-enterprise/latest/button
- https://staging.design.infor.com/code/ids-enterprise/latest/icons

**Screenshot**
<img width="400" alt="screen shot 2018-09-18 at 2 42 15 pm" src="https://user-images.githubusercontent.com/742319/45709087-1abae080-bb51-11e8-8018-daa676c3e96c.png">
