### PR TITLE
172 datagrid scrollbars

### DIFF
--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -89,7 +89,7 @@ $datagrid-short-row-height: 23px;
   }
 
   &.has-toolbar.paginated {
-    height: calc(100% - 103px);
+    height: calc(100% - 90px);
   }
 
   //Adjust borders and IE adjustment for vertical scrollbars

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -100,7 +100,7 @@ $datagrid-short-row-height: 23px;
     }
   }
 
-  &.has-toolbar.has-filterable-columns {
+  &.has-filterable-columns {
     .datagrid-body {
       height: calc(100% - 60px);
     }

--- a/src/layouts/_scrollable-flex.scss
+++ b/src/layouts/_scrollable-flex.scss
@@ -104,6 +104,10 @@
 
   .datagrid-container {
     height: 100%;
+
+    &.paginated {
+      height: calc(100% - 40px);
+    }
   }
 
   // Support for list-detail-popup-search-no-split-header


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Some rules are missing for different grid layout combinations, so the pager or the scrollbar was cut off.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#172

**Steps necessary to review your pull request (required)**:
- review the scroll bars on http://localhost:4000/components/datagrid/test-fixed-header-filter.html
- test on IE...