### PR TITLE
786 - Initial fix for dropdown height

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1804,7 +1804,7 @@ Dropdown.prototype = {
       // Set the <UL> height to 100% of the `.dropdown-list` minus the size of the search input
       const ulHeight = parseInt(window.getComputedStyle(self.listUl[0]).height, 10);
       const listHeight = parseInt(window.getComputedStyle(self.list[0]).height, 10);
-      const searchInputHeight = 34;
+      const searchInputHeight = 24;
       if (ulHeight + searchInputHeight > listHeight) {
         self.listUl[0].style.height = `${listHeight - searchInputHeight}px`;
       }

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1804,7 +1804,8 @@ Dropdown.prototype = {
       // Set the <UL> height to 100% of the `.dropdown-list` minus the size of the search input
       const ulHeight = parseInt(window.getComputedStyle(self.listUl[0]).height, 10);
       const listHeight = parseInt(window.getComputedStyle(self.list[0]).height, 10);
-      const searchInputHeight = 24;
+      const searchInputHeight = $(this).hasClass('dropdown-short') ? 24 : 34;
+
       if (ulHeight + searchInputHeight > listHeight) {
         self.listUl[0].style.height = `${listHeight - searchInputHeight}px`;
       }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

My initial fix is to change the value of `searchInputHeight` from `34` to `24` in dropdown.js.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/786

**Steps necessary to review your pull request (required)**:

- Run http://localhost:4000/components/dropdown/test-extra-padding-short-fields.html
- Expand the dropdown
- There should be no scrollbar. 

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
