### PR TITLE
778 - Added fix for datagrid search special characters

### DIFF
--- a/app/views/components/datagrid/example-keyword-search.html
+++ b/app/views/components/datagrid/example-keyword-search.html
@@ -23,9 +23,9 @@
       data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: '210.99', percent: 0.10, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
       data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: '120.99', percent: 0.10, status: 'OK', orderDate:new Date(2017, 5, 5), action: 'On Hold'});
       data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '123.99', percent: 0.10, status: 'OK', orderDate: null, action: 'On Hold'});
-      data.push({ id: 7, productId: 2642207, productName: 'Mac & Cheese', activity:  'Mac & Cheese', quantity: 20, price: '13.99', percent: 0.10, status: 'OK', orderDate: null, action: 'On Hold'});
-      data.push({ id: 8, productId: 2642208, productName: '100 % fave', activity:  '100 % fave', quantity: 10, price: '123.99', percent: 0.10, status: 'OK', orderDate: null, action: 'On Hold'});
-      data.push({ id: 9, productId: 2642209, productName: 'Test # item', activity:  'Test # item', quantity: 40, price: '1223.99', percent: 0.20, status: 'OK', orderDate: null, action: 'On Hold'});
+      data.push({ id: 7, productId: 2642207, productName: 'Compressor & Compressor', activity:  'Fix & Test', quantity: 20, price: '13.99', percent: 0.10, status: 'OK', orderDate: null, action: 'On Hold'});
+      data.push({ id: 8, productId: 2642208, productName: '100% Compressor', activity:  'Evaluate', quantity: 10, price: '123.99', percent: 0.10, status: 'OK', orderDate: null, action: 'On Hold'});
+      data.push({ id: 9, productId: 2642209, productName: 'Compress #4', activity:  'Test', quantity: 40, price: '1223.99', percent: 0.20, status: 'OK', orderDate: null, action: 'On Hold'});
 
       //Define Columns for the Grid.
       columns.push({ id: 'productId', name: 'Id', field: 'productId', reorderable: true, formatter: Formatters.Text, width: 100});

--- a/app/views/components/datagrid/example-keyword-search.html
+++ b/app/views/components/datagrid/example-keyword-search.html
@@ -23,6 +23,9 @@
       data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: '210.99', percent: 0.10, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
       data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: '120.99', percent: 0.10, status: 'OK', orderDate:new Date(2017, 5, 5), action: 'On Hold'});
       data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '123.99', percent: 0.10, status: 'OK', orderDate: null, action: 'On Hold'});
+      data.push({ id: 7, productId: 2642207, productName: 'Mac & Cheese', activity:  'Mac & Cheese', quantity: 20, price: '13.99', percent: 0.10, status: 'OK', orderDate: null, action: 'On Hold'});
+      data.push({ id: 8, productId: 2642208, productName: '100 % fave', activity:  '100 % fave', quantity: 10, price: '123.99', percent: 0.10, status: 'OK', orderDate: null, action: 'On Hold'});
+      data.push({ id: 9, productId: 2642209, productName: 'Test # item', activity:  'Test # item', quantity: 40, price: '1223.99', percent: 0.20, status: 'OK', orderDate: null, action: 'On Hold'});
 
       //Define Columns for the Grid.
       columns.push({ id: 'productId', name: 'Id', field: 'productId', reorderable: true, formatter: Formatters.Text, width: 100});

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5275,7 +5275,8 @@ Datagrid.prototype = {
         value = value.toLowerCase();
 
         // Strip any html markup that might be in the formatted value
-        value = value.replace(/(<([^>]+)>)|(&lt;([^>]+)&gt;)/ig, '');
+        //value = value.replace(/(<([^>]+)>)|(&lt;([^>]+)&gt;)/ig, '');
+        value = value.replace(/(<([^>]+)>)|(amp;)|(&lt;([^>]+)&gt;)/ig, '');
 
         return value.indexOf(filterExpr.value) > -1;
       };

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5275,7 +5275,6 @@ Datagrid.prototype = {
         value = value.toLowerCase();
 
         // Strip any html markup that might be in the formatted value
-        //value = value.replace(/(<([^>]+)>)|(&lt;([^>]+)&gt;)/ig, '');
         value = value.replace(/(<([^>]+)>)|(amp;)|(&lt;([^>]+)&gt;)/ig, '');
 
         return value.indexOf(filterExpr.value) > -1;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adding formatted value for ampersand.

```
value = value.replace(/(<([^>]+)>)|(amp;)|(&lt;([^>]+)&gt;)/ig, '');
```

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/778

**Steps necessary to review your pull request (required)**:

- Run http://localhost:4000/components/datagrid/example-keyword-search.html
- Click on search icon
- Type "&" (with trailing space)
- There should be a results and highlighted.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
