### PR TITLE
718 - Fixed data was not sync with sorting Tree

### DIFF
--- a/app/views/components/tree/test-sortable-update-dataset.html
+++ b/app/views/components/tree/test-sortable-update-dataset.html
@@ -1,0 +1,42 @@
+<div class="row top-padding">
+  <div class="twelve columns">
+
+    <ul role="tree" id="addnode-tree" aria-label="Asset Types" class="tree" data-init="false">
+      <li class="is-open">
+        <a href="#" id="public">Public Folders</a>
+      </li>
+    </ul>
+
+  </div>
+</div>
+
+<script>
+
+  var elem = $('#addnode-tree').tree({
+    sortable: true
+  });
+
+  //Add at Root
+  var api = elem.data('tree');
+
+  api.addNode({text: 'New Item 1', id: 'new1', exta: "some-data1"});
+  api.addNode({text: 'New Item 2', id: 'new2', exta: "some-data2", "children": [{
+    "id": "node3", extastuff: "some-data3",
+    "text": "Node 2.1"
+  }, {
+    "id": "node4",
+    "text": "Node 2.2",
+    "children": [{
+      "id": "node5",
+      "text": " Node 2.2.1",
+      "icon": "icon-tree-chart",
+      "testdata": "some-test-data",
+      "children": [{
+        "id": "node6",
+        "text": "Node 2.2.1.1",
+        "icon": "icon-tree-chart"
+      }]
+    }]
+  }]});
+
+</script>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Dataset was not syncing when drag-drop/sorting tree nodes

**Related github/jira issue (required)**:
Closes #718

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/tree/test-sortable-update-dataset.html
- Open above link
- Open developer tools
- Run in console `$('#addnode-tree').data('tree').settings.dataset`
- Result object data should be as:
```
-Public Folder
-New Item 1
-New Item 2
  -Node 2.1
  -Node 2.2
    -Node 2.2.1
      -Node 2.2.1.1
```
- Drag "New Item 2" and drop "Public Folders"
- Drag "New Item 2" and drop at same level "Public Folder"
- Drag "New Item 2" and drop "New Item 1"
- Drag "New Item 2" and drop at same level "Public Folder"
- Run again in console `$('#addnode-tree').data('tree').settings.dataset`
- See result object data order does not matter make sure no duplicate nodes