### PR TITLE
793 - Fix ctrlkey onkeydown and add test page

### DIFF
--- a/app/views/components/dropdown/test-onkeydown-ctrlkey.html
+++ b/app/views/components/dropdown/test-onkeydown-ctrlkey.html
@@ -1,0 +1,51 @@
+<div class="row">
+  <div class="twelve columns">
+    <p id="pressed-key"></p>
+    <div class="field">
+      <label for="towns-optgroup" class="label">Towns</label>
+      <select id="towns-optgroup" name="towns-optgroup" class="dropdown">
+        <optgroup label="Burlington County">
+          <option>Bordentown</option>
+          <option>Burlington Township</option>
+          <option selected>Cinnaminson</option>
+          <option>Delran</option>
+          <option>Evesham</option>
+          <option>Moorestown</option>
+          <option>Mount Laurel</option>
+          <option>Palmyra</option>
+        </optgroup>
+        <optgroup label="Camden County">
+          <option>Brooklawn</option>
+          <option>Camden</option>
+          <option>Cherry Hill</option>
+          <option>Erial</option>
+          <option>Haddonfield</option>
+          <option>Pennsauken</option>
+          <option>Pine Hill</option>
+          <option>Sicklerville</option>
+        </optgroup>
+        <optgroup label="Gloucester County">
+          <option>Cross Keys</option>
+          <option>Deptford</option>
+          <option>Glassboro</option>
+          <option>Mullica Hill</option>
+          <option>Turnersville</option>
+          <option>Washington Township</option>
+          <option>Woodbury Heights</option>
+        </optgroup>
+      </select>
+    </div>
+  </div>
+  <script>
+    $(function() {
+      $('body').on('keydown', function(e) {
+        $('p#pressed-key').text('key pressed! which=' + e.which);
+        console.log(e);
+        //try not to allow it to navigate away or something
+        if (e.ctrlKey) {
+          return false;
+        }
+      })
+    })
+  </script>
+</div>

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -895,7 +895,14 @@ Dropdown.prototype = {
     }
 
     if (e.ctrlKey) {
-      return false;
+      if (this.settings.onKeyDown) {
+        const ret = this.settings.onKeyDown(e);
+        if (ret === false) {
+          e.stopPropagation();
+          e.preventDefault();
+          return false;
+        }
+      }
     }
 
     return true;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes an issue where the `ctrlKey` keydown event was not firing. This was a purposeful non-event as there was as preexisting issue that pressing `ctrlKey` + `someOtherKey` fired an event in dropdown search for `someOtherKey`. Now, the `ctrlKey` is caught in callback `onKeyDown` and event is fired, allowing custom code implementation inside the `ctrlKey` keypress.

Test page markup came directly from client. No alterations made in an effort to demonstrate the fix with content they provide.

**Related github/jira issue (required)**:
Closes #793 .

**Steps necessary to review your pull request (required)**:
- Pull branch
- `npm start`
- Browse to http://localhost:4000/components/dropdown/test-onkeydown-ctrlkey.html
- Verify `ctrlKey` event fires when focused on dropdown search
