### PR TITLE
Enabled filtering of child rows

### DIFF
--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -366,15 +366,15 @@ const formatters = {
 
   // Tree Expand / Collapse Button and Paddings
   Tree(row, cell, value, col, item, api) {
-    const isOpen = item.expanded;
-    const depth = api.settings.treeDepth[row] ? api.settings.treeDepth[row].depth : 0;
+    const isOpen = item ? item.expanded : true;
+    const depth = item && item.depth ? item.depth : 0;
     const button = `<button type="button" class="btn-icon datagrid-expand-btn${(isOpen ? ' is-expanded' : '')}" tabindex="-1"${(depth ? ` style="margin-left: ${(depth ? `${(30 * (depth - 1))}px` : '')}"` : '')}>
       <span class="icon plus-minus ${(isOpen ? ' active' : '')}"></span>
       <span class="audible">${Locale.translate('ExpandCollapse')}</span>
       </button>${(value ? `<span> ${value}</span>` : '')}`;
     const node = `<span class="datagrid-tree-node"${(depth ? ` style="margin-left: ${(depth ? `${(30 * (depth - 1))}px` : '')}"` : '')}> ${value}</span>`;
 
-    return (item[col.children ? col.children : 'children'] ? button : node);
+    return (item && item[col.children ? col.children : 'children'] ? button : node);
   },
 
   // Badge / Tags and Visual Indictors

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -365,7 +365,7 @@ const formatters = {
   },
 
   // Tree Expand / Collapse Button and Paddings
-  Tree(row, cell, value, col, item, api) {
+  Tree(row, cell, value, col, item) {
     const isOpen = item ? item.expanded : true;
     const depth = item && item.depth ? item.depth : 0;
     const button = `<button type="button" class="btn-icon datagrid-expand-btn${(isOpen ? ' is-expanded' : '')}" tabindex="-1"${(depth ? ` style="margin-left: ${(depth ? `${(30 * (depth - 1))}px` : '')}"` : '')}>

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -2833,9 +2833,8 @@ Datagrid.prototype = {
     let rowHtml = '';
     let d = self.settings.treeDepth ? self.settings.treeDepth[dataRowIdx] : 0;
     let depth = null;
-    let d2;
     let j = 0;
-    let isHidden;
+    let isHidden = false;
     let skipColumns;
 
     if (!rowData) {
@@ -2852,13 +2851,19 @@ Datagrid.prototype = {
         const treeDepthItem = self.settings.treeDepth[i];
 
         if (rowData.id === treeDepthItem.node.id) {
-          d2 = treeDepthItem;
-
-          if (d !== d2.depth && d > d2.depth) {
-            d = d2.depth;
-            depth = d;
-            isHidden = !d2.node.expanded;
+          let parentNode = null;
+          for (let ii = i; ii >= 0; ii--) {
+            if (self.settings.treeDepth[ii].node.depth < treeDepthItem.node.depth) {
+              parentNode = self.settings.treeDepth[ii];
+              break;
+            }
           }
+
+          if (parentNode && parentNode.node.expanded !== undefined && !parentNode.node.expanded) {
+            isHidden = true;
+          }
+
+          depth = treeDepthItem.depth;
 
           break;
         }

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1701,7 +1701,7 @@ Datagrid.prototype = {
             isMatch = !(rowValueStr.indexOf(conditionValue) === 0 && rowValueStr !== '');
             break;
           case 'is-empty':
-            isMatch = (rowValue === '');
+            isMatch = (rowValueStr === '');
             break;
           case 'is-not-empty':
             isMatch = (rowValue !== '');

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1540,7 +1540,9 @@ Datagrid.prototype = {
 
       for (let i = 0; i < conditions.length; i++) {
         const columnDef = self.columnById(conditions[i].columnId)[0];
-        let rowValue = rowData ? rowData[columnDef.field] : self.fieldValue(rowData, columnDef.field);
+
+        let rowValue = rowData ? rowData[columnDef.field] :
+          self.fieldValue(rowData, columnDef.field);
         let rowValueStr = (rowValue === null || rowValue === undefined) ? '' : rowValue.toString().toLowerCase();
         let conditionValue = conditions[i].value.toString().toLowerCase();
         let rangeData = null;
@@ -2845,19 +2847,21 @@ Datagrid.prototype = {
     depth = d;
 
     // Setup if this row will be hidden or not
-    for (let i = 0; i < self.settings.treeDepth.length; i++) {
-      const treeDepthItem = self.settings.treeDepth[i];
+    if (self.settings.treeDepth && self.settings.treeDepth.length) {
+      for (let i = 0; i < self.settings.treeDepth.length; i++) {
+        const treeDepthItem = self.settings.treeDepth[i];
 
-      if (rowData.id === treeDepthItem.node.id) {
-        d2 = treeDepthItem;
+        if (rowData.id === treeDepthItem.node.id) {
+          d2 = treeDepthItem;
 
-        if (d !== d2.depth && d > d2.depth) {
-          d = d2.depth;
-          depth = d;
-          isHidden = !d2.node.expanded;
+          if (d !== d2.depth && d > d2.depth) {
+            d = d2.depth;
+            depth = d;
+            isHidden = !d2.node.expanded;
+          }
+
+          break;
         }
-
-        break;
       }
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Updated applyFilter function to enable filtering of datagrid rows using tree child elements
- http://localhost:4000/components/datagrid/test-tree-filter.html

**Related github/jira issue (required)**:
- Closes #437 

**Steps necessary to review your pull request (required)**:
- Click on searchfield under "Task" column header
- Test keywords "quotes", "contact" or other keywords that can be found on child nodes
- Rows should be filtered accordingly