### PR TITLE
Fixes #832 - Adding placeholder text to pseudoElem SPAN and displaying it as placeholder when no options are selected

### DIFF
--- a/app/views/components/multiselect/example-placeholder.html
+++ b/app/views/components/multiselect/example-placeholder.html
@@ -1,0 +1,62 @@
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="field">
+      <label for="states-multi" class="label">States</label>
+      <select multiple id="states-multi" name="states-multi" class="multiselect" placeholder="Select a State">
+        <option value="AL">Alabama</option>
+        <option value="AK">Alaska</option>
+        <option value="AZ">Arizona</option>
+        <option value="AR">Arkansas</option>
+        <option value="CA">California</option>
+        <option value="CO">Colorado</option>
+        <option value="CT">Connecticut</option>
+        <option value="DE">Delaware</option>
+        <option value="DC">District Of Columbia</option>
+        <option value="FL">Florida</option>
+        <option value="GA">Georgia</option>
+        <option value="HI">Hawaii</option>
+        <option value="ID">Idaho</option>
+        <option value="IL">Illinois</option>
+        <option value="IN">Indiana</option>
+        <option value="IA">Iowa</option>
+        <option value="KS">Kansas</option>
+        <option value="KY">Kentucky</option>
+        <option value="LA">Louisiana</option>
+        <option value="ME">Maine</option>
+        <option value="MD">Maryland</option>
+        <option value="MA">Massachusetts</option>
+        <option value="MI">Michigan</option>
+        <option value="MN">Minnesota</option>
+        <option value="MS">Mississippi</option>
+        <option value="MO">Missouri</option>
+        <option value="MT">Montana</option>
+        <option value="NE">Nebraska</option>
+        <option value="NV">Nevada</option>
+        <option value="NH">New Hampshire</option>
+        <option value="NJ">New Jersey</option>
+        <option value="NM">New Mexico</option>
+        <option value="NY">New York</option>
+        <option value="NC">North Carolina</option>
+        <option value="ND">North Dakota</option>
+        <option value="OH">Ohio</option>
+        <option value="OK">Oklahoma</option>
+        <option value="OR">Oregon</option>
+        <option value="PA">Pennsylvania</option>
+        <option value="RI">Rhode Island</option>
+        <option value="SC">South Carolina</option>
+        <option value="SD">South Dakota</option>
+        <option value="TN">Tennessee</option>
+        <option value="TX">Texas</option>
+        <option value="UT">Utah</option>
+        <option value="VT">Vermont</option>
+        <option value="VA">Virginia</option>
+        <option value="WA">Washington</option>
+        <option value="WV">West Virginia</option>
+        <option value="WI">Wisconsin</option>
+        <option value="WY">Wyoming</option>
+      </select>
+    </div>
+
+  </div>
+</div>

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -102,6 +102,11 @@ div.multiselect {
     text-overflow: ellipsis;
     vertical-align: top;
     width: inhert;
+
+    &:empty:before {
+      content:attr(data-placeholder-text);
+    }
+
   }
 
   > .listoption-icon {

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -868,8 +868,8 @@ Dropdown.prototype = {
     }
 
     if (this.element.attr('placeholder')) {
-      this.pseudoElem.attr('placeholder', this.element.attr('placeholder'));
-      this.element.removeAttr('placeholder');
+      // set placeholder text on pseudoElem SPAN el
+      this.pseudoElem.find('span').attr('data-placeholder-text', this.element.attr('placeholder'));
     }
   },
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Allows a user to view placeholder text in the multiselect dropdown when no options are selected.

**Related github/jira issue (required)**:
Fixes #832 

**Steps necessary to review your pull request (required)**:
1. Build latest version of controls
2. Go to multiselect control, add placeholder text to the SELECT element
3. Test on control when no options are selected, and placeholder text will appear within the pseudoElem SPAN

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
