### PR TITLE
675 - Added more calendar features

### DIFF
--- a/app/data/event-types.json
+++ b/app/data/event-types.json
@@ -3,5 +3,5 @@
   { "id": "admin", "label": "Admin", "color": "amethyst", "checked": true, "click": null },
   { "id": "team", "label": "Team Event", "color": "azure", "checked": true, "click": null },
   { "id": "sick", "label": "Sick Time", "color": "amber", "checked": true, "click": null },
-  { "id": "comp", "label": "Company Holiday", "color": "ruby", "checked": true, "click": null, "disabled": true }
+  { "id": "comp", "label": "Company Holiday", "color": "graphite", "checked": true, "click": null, "disabled": true }
 ]

--- a/app/data/events.json
+++ b/app/data/events.json
@@ -3,7 +3,7 @@
     "id": "1",
     "subject": "Discretionary Time Off",
     "shortSubject": "DTO",
-    "comments": "",
+    "comments": "Short getaway",
     "location": "Us Office",
     "status": "Draft",
     "starts": "2018-08-22T09:00:00.000Z",
@@ -14,7 +14,7 @@
   {
     "id": "2",
     "subject": "Dentist",
-    "comments": "",
+    "comments": "Quick check-up",
     "location": "Us Office",
     "status": "Draft",
     "starts": "2018-08-22T14:00:00.000Z",
@@ -25,9 +25,8 @@
   {
     "id": "3",
     "subject": "Team Meeting",
-    "comments": "",
+    "comments": "Discuss fiscal year goals",
     "location": "Us Office",
-    "status": "",
     "starts": "2018-08-22T16:00:00.000Z",
     "ends": "2018-08-22T17:00:00.000Z",
     "type": "admin",
@@ -36,9 +35,8 @@
   {
     "id": "4",
     "subject": "Moving Offices",
-    "comments": "",
+    "comments": "Moving from floor 6 to 7",
     "location": "Us Office",
-    "status": "",
     "starts": "2018-08-22T16:00:00.000Z",
     "ends": "2018-08-22T17:00:00.000Z",
     "type": "admin",
@@ -47,9 +45,8 @@
   {
     "id": "5",
     "subject": "Scrum",
-    "comments": "",
+    "comments": "What are you working on? Any blockers?",
     "location": "Us Office",
-    "status": "",
     "starts": "2018-08-22T18:00:00.000Z",
     "ends": "2018-08-22T19:00:00.000Z",
     "type": "admin",
@@ -59,7 +56,7 @@
     "id": "6",
     "subject": "Discretionary Time Off",
     "shortSubject": "DTO",
-    "comments": "",
+    "comments": "Personal time",
     "location": "Canada Office",
     "status": "Approved",
     "starts": "2018-08-24T10:00:00.000Z",
@@ -70,9 +67,9 @@
   {
     "id": "7",
     "subject": "Team Event",
-    "comments": "",
+    "comments": "Bowling and BBQ",
     "location": "Manilla Office",
-    "status": "Submitted",
+    "status": "Approved",
     "starts": "2018-10-01T16:00:00.000Z",
     "ends": "2018-10-01T18:00:00.000Z",
     "type": "team",
@@ -81,12 +78,41 @@
   {
     "id": "8",
     "subject": "Labour Day",
-    "comments": "",
+    "comments": "US Holiday",
     "location": "USA",
-    "status": "Submitted",
-    "starts": "2018-09-03T00:00:00.000Z",
-    "ends": "2018-09-03T24:00:00.000Z",
+    "status": "Approved",
+    "starts": "2018-09-03T23:59:59.000Z",
+    "ends": "2018-09-03T23:59:59.000Z",
     "type": "comp",
+    "isAllDay": "true"
+  },
+  {
+    "id": "9",
+    "subject": "Autumn Foliage Trip",
+    "comments": "Annual Autumn Foliage Trip",
+    "status": "Pending",
+    "icon": "icon-clock",
+    "starts": "2018-10-22T09:00:00.000Z",
+    "ends": "2018-10-24T13:00:00.000Z",
+    "type": "dto",
+    "isAllDay": "true"
+  },
+  {
+    "id": "10",
+    "subject": "Birthday Off",
+    "comments": "Taking my birthday off",
+    "starts": "2018-10-12T09:00:00.000Z",
+    "ends": "2018-10-12T13:00:00.000Z",
+    "type": "dto",
+    "isAllDay": "true"
+  },
+  {
+    "id": "11",
+    "subject": "Mexico Trip",
+    "comments": "I week vacation in mexico",
+    "starts": "2018-11-01T23:59:59.000Z",
+    "ends": "2018-11-14T23:59:59.000Z",
+    "type": "dto",
     "isAllDay": "true"
   }
 ]

--- a/app/views/components/calendar/example-ajax-events.html
+++ b/app/views/components/calendar/example-ajax-events.html
@@ -1,0 +1,47 @@
+<div class="calendar" data-init="false">
+  <div class="calendar-events">
+    <div class="accordion" data-options="{'allowOnePane': false}">
+      <div class="accordion-header is-expanded">
+        <a href="#"><span>Legend</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="calendar-event-types accordion-content">
+        </div>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Upcoming Time off</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="calendar-event-upcoming accordion-content">
+          <p>Remix, optimize, "B2B, iterate?" Best-of-breed efficient beta-test; social cutting-edge: rich magnetic tagclouds front-end infomediaries viral authentic incentivize sexy extensible functionalities incentivize. Generate killer authentic grow vertical blogospheres, functionalities ecologies harness, "tag solutions synergies exploit data-driven B2C open-source e-markets optimize create, enhance convergence create." Out-of-the-box strategize best-of-breed back-end, deploy design markets metrics. Content web services enhance leading-edge Cluetrain, deliverables dot-com scalable. User-centric morph, back-end, synthesize mesh, frictionless, exploit next-generation tag portals, e-commerce channels; integrate; recontextualize distributed revolutionize innovative eyeballs.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="calendar-monthview">
+  </div>
+  <div class="calendar-event-details">
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    $('.calendar').on('monthrendered', function(e, args) {
+      console.log('Month Rendered');
+    }).calendar({
+      month: 7,
+      year: 2018,
+      onRenderMonth: function (ui, response) {
+        // Get both event types and events for the month (eventTypes can be passed initially)
+        const events = $.get('{{basepath}}api/events');
+        const eventTypes = $.get('{{basepath}}api/event-types');
+
+        $.when(events, eventTypes).done(function completed(events, eventTypes) {
+          setTimeout(function () {
+            response(events[0], eventTypes[0]);
+          }, 1000); //slow it down a bit more
+        });
+      }
+    });
+  });
+</script>

--- a/app/views/components/calendar/example-index.html
+++ b/app/views/components/calendar/example-index.html
@@ -42,7 +42,59 @@
   $('body').one('initialized', function () {
     $('.calendar').calendar({
       eventTypes: eventTypes,
-      events: events
+      events: events,
+      template: 'tmpl-readonly'
     });
   });
 </script>
+
+{{={{{ }}}=}}
+<script id="tmpl-readonly" type="text/html">
+  <div class="calendar-event-detail">
+    {{#event}}
+      <span class="calendar-event-header {{color}}">{{subject}}</span>
+      <div class="calendar-event-body">
+        <div class="field">
+          <span class="label">Status</span>
+          <span class="data">
+            {{status}}
+            {{#icon}}
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation" data-status="Pending"><use xlink:href="#{{icon}}"></use></svg>
+            {{/icon}}
+          </span>
+        </div>
+        <div class="field">
+          <span class="label">Date</span>
+          <span class="data">
+            {{startsLong}} to {{endsLong}}
+          </span>
+        </div>
+        <div class="field">
+          <span class="label">Event Type</span>
+          <span class="data">
+            {{typeLabel}}
+          </span>
+        </div>
+        <div class="field">
+          <span class="label">Comments</span>
+          <span class="data">
+            {{comments}}
+          </span>
+        </div>
+      </div>
+    {{/event}}
+  </div>
+</script>
+
+<!--
+"id": "1",
+"subject": "Discretionary Time Off",
+"shortSubject": "DTO",
+"comments": "",
+"location": "Us Office",
+"status": "Draft",
+"starts": "2018-08-22T09:00:00.000Z",
+"ends": "2018-08-22T13:00:00.000Z",
+"type": "dto",
+"isAllDay": "true"
+-->

--- a/app/views/components/calendar/example-specific-month.html
+++ b/app/views/components/calendar/example-specific-month.html
@@ -1,0 +1,102 @@
+<div class="calendar" data-init="false">
+  <div class="calendar-events">
+    <div class="accordion" data-options="{'allowOnePane': false}">
+      <div class="accordion-header is-expanded">
+        <a href="#"><span>Legend</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="calendar-event-types accordion-content">
+        </div>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Upcoming Time off</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="calendar-event-upcoming accordion-content">
+          <p>Remix, optimize, "B2B, iterate?" Best-of-breed efficient beta-test; social cutting-edge: rich magnetic tagclouds front-end infomediaries viral authentic incentivize sexy extensible functionalities incentivize. Generate killer authentic grow vertical blogospheres, functionalities ecologies harness, "tag solutions synergies exploit data-driven B2C open-source e-markets optimize create, enhance convergence create." Out-of-the-box strategize best-of-breed back-end, deploy design markets metrics. Content web services enhance leading-edge Cluetrain, deliverables dot-com scalable. User-centric morph, back-end, synthesize mesh, frictionless, exploit next-generation tag portals, e-commerce channels; integrate; recontextualize distributed revolutionize innovative eyeballs.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="calendar-monthview">
+
+  </div>
+  <div class="calendar-event-details">
+
+  </div>
+</div>
+
+<script>
+  // Get the Event Type and Events to show in the calendar
+  var eventTypes = [];
+  var events = [];
+
+  $.getJSON('{{basepath}}api/event-types', function(res) {
+    eventTypes = res;
+  });
+
+  $.getJSON('{{basepath}}api/events', function(res) {
+    events = res;
+  });
+
+  $('body').one('initialized', function () {
+    $('.calendar').calendar({
+      month: 9,
+      year: 2018,
+      eventTypes: eventTypes,
+      events: events,
+      template: 'tmpl-readonly'
+    });
+  });
+</script>
+
+{{={{{ }}}=}}
+<script id="tmpl-readonly" type="text/html">
+  <div class="calendar-event-detail">
+    {{#event}}
+      <span class="calendar-event-header {{color}}">{{subject}}</span>
+      <div class="calendar-event-body">
+        <div class="field">
+          <span class="label">Status</span>
+          <span class="data">
+            {{status}}
+            {{#icon}}
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation" data-status="Pending"><use xlink:href="#{{icon}}"></use></svg>
+            {{/icon}}
+          </span>
+        </div>
+        <div class="field">
+          <span class="label">Date</span>
+          <span class="data">
+            {{startsLong}} to {{endsLong}}
+          </span>
+        </div>
+        <div class="field">
+          <span class="label">Event Type</span>
+          <span class="data">
+            {{typeLabel}}
+          </span>
+        </div>
+        <div class="field">
+          <span class="label">Comments</span>
+          <span class="data">
+            {{comments}}
+          </span>
+        </div>
+      </div>
+    {{/event}}
+  </div>
+</script>
+
+<!--
+"id": "1",
+"subject": "Discretionary Time Off",
+"shortSubject": "DTO",
+"comments": "",
+"location": "Us Office",
+"status": "Draft",
+"starts": "2018-08-22T09:00:00.000Z",
+"ends": "2018-08-22T13:00:00.000Z",
+"type": "dto",
+"isAllDay": "true"
+-->

--- a/app/views/components/monthview/example-selectable-days.html
+++ b/app/views/components/monthview/example-selectable-days.html
@@ -1,0 +1,17 @@
+<div class="row">
+  <div class="twelve columns">
+    <div class="monthview" data-init="false">
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').on('initialized', function () {
+    $('.monthview').monthview({
+      selectable: true,
+      onSelected: function (node, args) {
+        console.log(args, 'selected')
+      }
+    });
+  });
+</script>

--- a/app/views/components/notification/example-index.html
+++ b/app/views/components/notification/example-index.html
@@ -1,0 +1,37 @@
+<script>
+  $('body').notification({
+    type: 'error',
+    message: 'DTO rejcted by your manager for Sept 30, 2018.',
+    link: '#',
+    linkText: 'Click to view'
+  });
+</script>
+
+<script>
+  $('body').notification({
+    type: 'info',
+    message: 'DTO rejcted by your manager for Sept 30, 2018.',
+    link: '#',
+    linkText: 'Click to view'
+  });
+</script>
+
+
+<script>
+  $('body').notification({
+    type: 'alert',
+    message: 'DTO rejcted by your manager for Sept 30, 2018.',
+    link: '#',
+    linkText: 'Click to view'
+  });
+</script>
+
+
+<script>
+  $('body').notification({
+    type: 'confirm',
+    message: 'DTO rejcted by your manager for Sept 30, 2018.',
+    link: '#',
+    linkText: 'Click to view'
+  });
+</script>

--- a/app/views/components/notification/example-no-link.html
+++ b/app/views/components/notification/example-no-link.html
@@ -1,0 +1,7 @@
+<script>
+  $('body').notification({
+    type: 'error',
+    message: 'DTO rejcted by your manager for Sept 30, 2018.',
+    linkText: ''
+  });
+</script>

--- a/app/views/components/tooltip/example-ajax-tooltip.html
+++ b/app/views/components/tooltip/example-ajax-tooltip.html
@@ -23,7 +23,7 @@
   }});
 
   //This Example uses properties set setup the functionality
- window.ajaxTooltip = function () {
+ window.ajaxTooltip = function (response) {
     //Ajax Call or async op
     setTimeout(function () {
       response('<strong>Tooltips Provide <br> Interesting Information</strong>');

--- a/scripts/controls.js
+++ b/scripts/controls.js
@@ -45,6 +45,7 @@ module.exports = [
   'components/listview/listview.js',
   'components/listbuilder/listbuilder.js',
   'components/monthview/monthview.js',
+  'components/notification/notification.js',
   'components/circlepager/circlepager.js',
   'components/pager/pager.js',
   'components/place/place.js', // behavior?

--- a/src/components/calendar/_calendar.scss
+++ b/src/components/calendar/_calendar.scss
@@ -77,7 +77,6 @@
 
   // A calendar event
   .calendar-event {
-    @include transition(opacity 1000ms cubic-bezier(0.17, 0.04, 0.03, 0.94));
     @include font-size(11);
 
     background-color: $azure02;
@@ -88,7 +87,6 @@
     display: block;
     height: 18px;
     margin: 0 2px 3px;
-    opacity: 1;
     width: calc(100% - 4px);
 
     //Event spanning

--- a/src/components/calendar/_calendar.scss
+++ b/src/components/calendar/_calendar.scss
@@ -77,6 +77,7 @@
 
   // A calendar event
   .calendar-event {
+    @include transition(opacity 1000ms cubic-bezier(0.17, 0.04, 0.03, 0.94));
     @include font-size(11);
 
     background-color: $azure02;
@@ -87,7 +88,47 @@
     display: block;
     height: 18px;
     margin: 0 2px 3px;
+    opacity: 1;
     width: calc(100% - 4px);
+
+    //Event spanning
+    &.event-day-start {
+      border-radius: 3px 0 0 3px;
+      padding-right: 4px;
+      width: calc(100% - 1px);
+    }
+
+    &.event-day-span {
+      border-left: 0 !important;
+      border-radius: 0;
+      margin: 0;
+      width: 100%;
+      z-index: 1;
+
+      .calendar-event-icon {
+        display: none;
+      }
+
+      .calendar-event-title {
+        display: none;
+      }
+    }
+
+    &.event-day-end {
+      border-left: 0 !important;
+      border-radius: 0 3px 3px 0;
+      margin-left: 0;
+      width: calc(100% - 2px);
+      z-index: 1;
+
+      .calendar-event-icon {
+        display: none;
+      }
+
+      .calendar-event-title {
+        display: none;
+      }
+    }
 
     .calendar-event-content {
       overflow: hidden;
@@ -95,6 +136,17 @@
       position: relative;
       text-overflow: ellipsis;
       white-space: nowrap;
+    }
+
+    .calendar-event-icon {
+      width: 20px;
+
+      .icon {
+        fill: $font-color;
+        height: 12px;
+        vertical-align: top;
+        width: 13px;
+      }
     }
 
     &.ruby {
@@ -143,6 +195,70 @@
     margin: 4px 10px;
     text-align: left;
     width: auto;
+  }
+}
+
+// Calendar Event Details section
+.calendar-event-detail {
+  background-color: $calendar-bg-color;
+  height: 100%;
+}
+
+.calendar-event-header {
+  @include font-size(18);
+
+  color: $white;
+  display: block;
+  height: 48px;
+  line-height: 48px;
+  overflow: hidden;
+  padding: 0 15px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &.ruby {
+    background-color: $ruby06;
+  }
+
+  &.amber {
+    background-color: $amber06;
+  }
+
+  &.emerald {
+    background-color: $emerald06;
+  }
+
+  &.azure {
+    background-color: $azure06;
+  }
+
+  &.turquoise {
+    background-color: $turquoise06;
+  }
+
+  &.amethyst {
+    background-color: $amethyst06;
+  }
+
+  &.slate {
+    background-color: $slate06;
+  }
+
+  &.graphite {
+    background-color: $graphite06;
+  }
+}
+
+.calendar-event-body {
+  margin: 20px;
+
+  .data {
+    @include font-size(12);
+  }
+
+  .icon {
+    margin-bottom: -3px;
+    margin-top: -2px;
   }
 }
 

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -2,6 +2,7 @@ import { utils } from '../../utils/utils';
 import { stringUtils } from '../../utils/string';
 import { MonthView } from '../monthview/monthview';
 import { Locale } from '../locale/locale';
+import { Tmpl } from '../tmpl/tmpl';
 
 // Settings and Options
 const COMPONENT_NAME = 'calendar';
@@ -11,7 +12,11 @@ const COMPONENT_NAME_DEFAULTS = {
     { id: 'example', label: 'Example', color: 'emerald07', checked: true, click: () => {} },
   ],
   events: [],
-  showViewChanger: true
+  month: null,
+  year: null,
+  showViewChanger: true,
+  onRenderMonth: null,
+  template: null
 };
 
 /**
@@ -21,7 +26,12 @@ const COMPONENT_NAME_DEFAULTS = {
  * @param {string} [settings] The settings element.
  * @param {array} [settings.eventTypes] An array of objects with data for the event types.
  * @param {array} [settings.events] An array of objects with data for the events.
- * @param {array} [settings.showViewChanger] If false the dropdown to change views will not be shown.
+ * @param {array} [settings.month] Initial month to show.
+ * @param {array} [settings.year] Initial year to show.
+ * @param {boolean} [settings.showViewChanger] If false the dropdown to change views will not be shown.
+ * @param {function} [settings.onRenderMonth] Fires when a month is rendered, allowing you to pass back events or event types to show.
+ * @param {function} [settings.onSelected] Fires when a month day is clicked. Allowing you to do something.
+ * @param {string} [settings.template] The ID of the template used for the events. This template will be used for editing events.
  */
 function Calendar(element, settings) {
   this.settings = utils.mergeSettings(element, settings, COMPONENT_NAME_DEFAULTS);
@@ -85,7 +95,13 @@ Calendar.prototype = {
    */
   renderMonthView() {
     this.monthViewContainer = document.querySelector('.calendar .calendar-monthview');
-    this.monthView = new MonthView(this.monthViewContainer, {});
+    this.monthView = new MonthView(this.monthViewContainer, {
+      month: this.settings.month,
+      year: this.settings.year,
+      onRenderMonth: this.settings.onRenderMonth,
+      onSelected: this.settings.onSelected,
+      selectable: true
+    });
     this.monthViewHeader = document.querySelector('.calendar .monthview-header');
     this.renderEvents();
     return this;
@@ -115,9 +131,59 @@ Calendar.prototype = {
   },
 
   /**
+   * Render or re-render the events details section, using on the readonly or default eventTemplate
+   * @param {string} eventId The event id
+   * @private
+   */
+  renderEventDetails(eventId) {
+    if (typeof Tmpl !== 'object' || !this.settings.template || !this.settings.events) {
+      return;
+    }
+
+    // Find the event data
+    const eventData = this.settings.events.filter(event => event.id === eventId);
+    if (!eventData) {
+      return;
+    }
+
+    this.eventTypeContainer = document.querySelector('.calendar-event-details');
+
+    // create a copy of the template
+    if (this.settings.template instanceof $) {
+      this.settings.template = `${this.settings.template.html()}`;
+    } else if (typeof this.settings.template === 'string') {
+      // If a string doesn't contain HTML elments,
+      // assume it's an element ID string and attempt to select with jQuery
+      if (!stringUtils.containsHTML(this.settings.template)) {
+        this.settings.template = $(`#${this.settings.template}`).html();
+      }
+    }
+
+    const event = eventData[0];
+    event.color = this.getEventTypeColor(event.type);
+    event.startsLong = Locale.formatDate(event.starts, { date: 'long' });
+    event.endsLong = Locale.formatDate(event.ends, { date: 'long' });
+    event.typeLabel = this.getEventTypeLabel(event.type);
+
+    const renderedTmpl = Tmpl.compile(this.settings.template, { event });
+    this.eventTypeContainer.innerHTML = renderedTmpl;
+  },
+
+  /**
+   * Clear all contents from the event details area.
+   * @private
+   */
+  clearEventDetails() {
+    this.eventTypeContainer = document.querySelector('.calendar-event-details');
+    if (this.eventTypeContainer) {
+      this.eventTypeContainer.innerHTML = '';
+    }
+  },
+
+  /**
    * Get the currently unchecked filter types
    * @returns {array} The active types.
-  * @private
+   * @private
    */
   filterEventTypes() {
     const checkboxes = this.eventTypeContainer.querySelectorAll('.checkbox');
@@ -134,11 +200,18 @@ Calendar.prototype = {
 
   /**
    * Render/ReRender the events attached to the settings.
+   * @param {boolean} isCallback Will be set to true when a callback occurs
    * @returns {object} The Calendar prototype, useful for chaining.
    */
-  renderEvents() {
+  renderEvents(isCallback) {
+    if (this.settings.onRenderMonth && !isCallback) {
+      this.callOnRenderMonth();
+      return this;
+    }
+
     const self = this;
     const filters = this.filterEventTypes();
+
     this.visibleEvents = [];
     this.removeAllEvents();
 
@@ -148,19 +221,44 @@ Calendar.prototype = {
         continue;
       }
 
+      // Check for events starting on this day , or only on this day.
       const startDate = new Date(event.starts);
       const startKey = stringUtils.padDate(
         startDate.getFullYear(),
         startDate.getMonth(),
-        startDate.getDate()
+        startDate.getDate(),
       );
-      const container = self.monthView.dayMap.filter(day => day.key === startKey);
 
-      if (container.length === 1) {
-        const color = self.getColorFromStyles(event.type);
-        self.appendEvent(container[0].elem[0], event, color);
+      // Check for events extending onto this day
+      const endDate = new Date(event.ends);
+      const endKey = stringUtils.padDate(
+        endDate.getFullYear(),
+        endDate.getMonth(),
+        endDate.getDate()
+      );
+
+      const days = self.monthView.dayMap.filter(day => day.key >= startKey && day.key <= endKey);
+
+      // Event is only on this day
+      if (days.length === 1) {
+        const color = self.getEventTypeColor(event.type);
+        self.appendEvent(days[0].elem[0], event, color, 'event-day-start-end');
+      }
+
+      // Event extends multiple days
+      if (days.length > 1) {
+        const color = self.getEventTypeColor(event.type);
+        for (let l = 0; l < days.length; l++) {
+          let cssClass = l === 0 ? 'event-day-start' : 'event-day-span';
+
+          if (days.length - 1 === l) {
+            cssClass = 'event-day-end';
+          }
+          self.appendEvent(days[l].elem[0], event, color, cssClass);
+        }
       }
     }
+
     return this;
   },
 
@@ -177,9 +275,10 @@ Calendar.prototype = {
    * @param {object} container The container to append to
    * @param {object} event The event data object.
    * @param {string} color The color to shade
+   * @param {string} type Type of event, can be event-day-start, event-day-start-end, event-day-span, event-day-end
    * @returns {object} The Calendar prototype, useful for chaining.
    */
-  appendEvent(container, event, color) {
+  appendEvent(container, event, color, type) {
     let node;
     const eventCnt = container.querySelectorAll('.calendar-event').length;
 
@@ -204,9 +303,32 @@ Calendar.prototype = {
     }
 
     node = document.createElement('a');
-    node.classList.add('calendar-event', color);
-    node.innerHTML = `<div class="calendar-event-content"><span class="calendar-event-title">${event.shortSubject || event.subject}</span></div>`;
+    node.classList.add('calendar-event', color, type);
+    node.setAttribute('data-id', event.id);
+
+    node.innerHTML = `<div class="calendar-event-content">
+      ${event.icon ? `<span class="calendar-event-icon"><svg class="icon" focusable="false" aria-hidden="true" role="presentation" data-status="${event.status}"><use xlink:href="#${event.icon}"></use></svg></span>` : ''}
+      <span class="calendar-event-title">${event.shortSubject || event.subject}</span>
+    </div>`;
     container.querySelector('.day-container').appendChild(node);
+
+    // Show the full text if cut off
+    if (!event.shortSubject) {
+      node.setAttribute('title', event.subject);
+      $(node).tooltip({
+        beforeShow: (response, ui) => {
+          const title = ui[0].querySelector('.calendar-event-title');
+          const icon = ui[0].querySelector('.calendar-event-icon');
+          const iconStatus = icon ? icon.querySelector('.icon').getAttribute('data-status') : '';
+
+          if (title.offsetWidth > ui[0].scrollWidth - (icon ? icon.offsetWidth : 0)) {
+            response(`${title.innerText}${iconStatus ? ` (${Locale.translate(iconStatus, false)})` : ''}`);
+            return;
+          }
+          response(false);
+        }
+      });
+    }
 
     this.visibleEvents.push({ id: event.id, type: event.type, elem: node });
     return this;
@@ -214,21 +336,40 @@ Calendar.prototype = {
 
   /**
    * Find the matching type and get the color.
-   * @param {object} type The type to find.
+   * @param {object} id The eventType id to find.
    * @param {object} event The event data object.
    * @returns {object} The Calendar prototype, useful for chaining.
    */
-  getColorFromStyles(type) {
+  getEventTypeColor(id) {
     let color = 'azure';
-    if (!type) {
+    if (!id) {
       return color;
     }
 
-    const eventInfo = this.settings.eventTypes.filter(eventType => eventType.id === type);
+    const eventInfo = this.settings.eventTypes.filter(eventType => eventType.id === id);
     if (eventInfo.length === 1) {
       color = eventInfo[0].color || 'azure';
     }
     return color;
+  },
+
+  /**
+   * Find the matching type and get the color.
+   * @param {object} id The eventType id to find.
+   * @param {object} event The event data object.
+   * @returns {object} The Calendar prototype, useful for chaining.
+   */
+  getEventTypeLabel(id) {
+    let type = '';
+    if (!id) {
+      return type;
+    }
+
+    const eventInfo = this.settings.eventTypes.filter(eventType => eventType.id === id);
+    if (eventInfo.length === 1) {
+      type = eventInfo[0].label;
+    }
+    return type;
   },
 
   /**
@@ -237,21 +378,53 @@ Calendar.prototype = {
    * @private
    */
   handleEvents() {
-    const self = this;
-
     this.element.on(`updated.${COMPONENT_NAME}`, () => {
-      self.updated();
+      this.updated();
     });
 
     this.element.on(`monthrendered.${COMPONENT_NAME}`, () => {
-      self.renderEvents();
+      this.renderEvents();
     });
 
     this.element.on(`change.${COMPONENT_NAME}`, '.checkbox', () => {
-      self.renderEvents();
+      this.renderEvents(true);
+    });
+
+    $(this.monthViewContainer).on(`selected.${COMPONENT_NAME}`, (e, args) => {
+      const dayEl = args.node;
+      const dayEvents = dayEl.querySelectorAll('.calendar-event');
+
+      if (!dayEvents || dayEvents.length === 0) {
+        this.clearEventDetails();
+        return;
+      }
+
+      for (let i = 0; i < dayEvents.length; i++) {
+        this.renderEventDetails(dayEvents[i].getAttribute('data-id'));
+      }
     });
 
     return this;
+  },
+
+  /**
+   * Handle updated settings and values.
+   * @private
+   */
+  callOnRenderMonth() {
+    const self = this;
+
+    function response(events, eventTypes) {
+      if (eventTypes && eventTypes.length > 0) {
+        self.settings.eventTypes = eventTypes;
+        self.renderEventTypes();
+      }
+      if (events && events.length > 0) {
+        self.settings.events = events;
+        self.renderEvents(true);
+      }
+    }
+    this.settings.onRenderMonth(this.element, response);
   },
 
   /**
@@ -272,7 +445,7 @@ Calendar.prototype = {
   teardown() {
     this.element.off(`updated.${COMPONENT_NAME}`);
     this.element.off(`monthrendered.${COMPONENT_NAME}`);
-    this.element.off(`click.${COMPONENT_NAME}`);
+    this.element.off(`change.${COMPONENT_NAME}`);
     return this;
   },
 

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -12,8 +12,8 @@ const COMPONENT_NAME_DEFAULTS = {
     { id: 'example', label: 'Example', color: 'emerald07', checked: true, click: () => {} },
   ],
   events: [],
-  month: null,
-  year: null,
+  month: new Date().getMonth(),
+  year: new Date().getFullYear(),
   showViewChanger: true,
   onRenderMonth: null,
   template: null
@@ -95,12 +95,13 @@ Calendar.prototype = {
    */
   renderMonthView() {
     this.monthViewContainer = document.querySelector('.calendar .calendar-monthview');
+
     this.monthView = new MonthView(this.monthViewContainer, {
-      month: this.settings.month,
-      year: this.settings.year,
       onRenderMonth: this.settings.onRenderMonth,
       onSelected: this.settings.onSelected,
-      selectable: true
+      selectable: true,
+      month: this.settings.month,
+      year: this.settings.year
     });
     this.monthViewHeader = document.querySelector('.calendar .monthview-header');
     this.renderEvents();
@@ -146,7 +147,7 @@ Calendar.prototype = {
       return;
     }
 
-    this.eventTypeContainer = document.querySelector('.calendar-event-details');
+    this.eventDetailsContainer = document.querySelector('.calendar-event-details');
 
     // create a copy of the template
     if (this.settings.template instanceof $) {
@@ -166,7 +167,7 @@ Calendar.prototype = {
     event.typeLabel = this.getEventTypeLabel(event.type);
 
     const renderedTmpl = Tmpl.compile(this.settings.template, { event });
-    this.eventTypeContainer.innerHTML = renderedTmpl;
+    this.eventDetailsContainer.innerHTML = renderedTmpl;
   },
 
   /**
@@ -174,9 +175,9 @@ Calendar.prototype = {
    * @private
    */
   clearEventDetails() {
-    this.eventTypeContainer = document.querySelector('.calendar-event-details');
-    if (this.eventTypeContainer) {
-      this.eventTypeContainer.innerHTML = '';
+    this.eventDetailsContainer = document.querySelector('.calendar-event-details');
+    if (this.eventDetailsContainer) {
+      this.eventDetailsContainer.innerHTML = '';
     }
   },
 
@@ -446,6 +447,8 @@ Calendar.prototype = {
     this.element.off(`updated.${COMPONENT_NAME}`);
     this.element.off(`monthrendered.${COMPONENT_NAME}`);
     this.element.off(`change.${COMPONENT_NAME}`);
+    $(this.monthViewContainer).off();
+
     return this;
   },
 
@@ -454,9 +457,15 @@ Calendar.prototype = {
    * @private
    */
   destroy() {
-    this.eventTypeContainer.innerHTML = '';
-    this.monthViewContainer.innerHTML = '';
-
+    if (this.eventTypeContainer) {
+      this.eventTypeContainer.innerHTML = '';
+    }
+    if (this.monthViewContainer) {
+      this.monthViewContainer.innerHTML = '';
+    }
+    if (this.eventDetailsContainer) {
+      this.eventDetailsContainer.innerHTML = '';
+    }
     this.teardown();
     $.removeData(this.element[0], COMPONENT_NAME);
   }

--- a/src/components/calendar/readme.md
+++ b/src/components/calendar/readme.md
@@ -8,14 +8,19 @@ demo:
     pages:
     - name: Loading events with Ajax
       slug: example-ajax-events
+    - name: Loading a specific month and year
+      slug: example-specific-month
 ---
 
-The setup for a calendar only involves creating a `div` with the class `datepicker`. In that div we add the three sections of the calendar. The first section calendar-events contains an accordion with a filter section and an upcomming events section (functionality to be added soon). The second section is a `div` with `calendar-monthview` this is where the monthview calendar will be rendered. The third section is `div` with `calendar-event-details` this is where the event details will be shown when you click on them.
+The setup for a calendar only involves creating a `div` with the class `calendar`. In that div we add the three sections of the calendar. The first section calendar-events contains an accordion with a filter section and an upcoming events section (functionality to be added soon). The second section is a `div` with `calendar-monthview` this is where the monthview calendar will be rendered. The third section is `div` with `calendar-event-details` this is where the event details will be shown when you click on them.
 
-The first pass of the calendar supports basic single day event rendering, filtering and changing months. We will next add better responsiveness, more views, better keyboard support, adding events and editing events.
+The first pass of the calendar added basic single day event rendering, filtering and changing months.
+The second pass of the calendar added events that span months, icon support, ajax support, selection and month change events, and a readonly details template.
+
+We will next add better responsiveness, better keyboard support, adding events and editing events.
 
 ```html
-<div class="calendar" data-init="false">
+<div class="calendar">
   <div class="calendar-events">
     <div class="accordion" data-options="{'allowOnePane': false}">
       <div class="accordion-header is-expanded">
@@ -60,6 +65,8 @@ The calendar runs off events, which are an array of objects. An example of an ev
 "isAllDay": "true"
 }
 ```
+
+The following fields are used.
 
 - id - a unique event id
 - subject - the event subject, which will be displayed on the calendar

--- a/src/components/calendar/readme.md
+++ b/src/components/calendar/readme.md
@@ -5,6 +5,9 @@ demo:
   embedded:
   - name: Full Page Calendar Example
     slug: example-index
+    pages:
+    - name: Loading events with Ajax
+      slug: example-ajax-events
 ---
 
 The setup for a calendar only involves creating a `div` with the class `datepicker`. In that div we add the three sections of the calendar. The first section calendar-events contains an accordion with a filter section and an upcomming events section (functionality to be added soon). The second section is a `div` with `calendar-monthview` this is where the monthview calendar will be rendered. The third section is `div` with `calendar-event-details` this is where the event details will be shown when you click on them.
@@ -38,6 +41,36 @@ The first pass of the calendar supports basic single day event rendering, filter
   </div>
 </div>
 ```
+
+## Event Data
+
+The calendar runs off events, which are an array of objects. An example of an event is..
+
+```JSON
+{
+"id": "1",
+"subject": "Discretionary Time Off",
+"shortSubject": "DTO",
+"comments": "",
+"location": "Us Office",
+"status": "Draft",
+"starts": "2018-08-22T09:00:00.000Z",
+"ends": "2018-10-22T13:00:00.000Z",
+"type": "dto",
+"isAllDay": "true"
+}
+```
+
+- id - a unique event id
+- subject - the event subject, which will be displayed on the calendar
+- shortSubject - if the subject is long, the shortSubject will be used to display on the calendar, the longer subject will show in the event details.
+- comments - any additional comments that will be shown in the event details
+- location - a location for the event that will be shown in the event details
+- status - a text status that will be shown in the event details (with optional icon on the calendar)
+- starts - the date/time when the event starts
+- starts - the date/time when the event ends
+- type - the eventType key, this must have a match in the eventTypes array
+- isAllDay - determines if the event is all day or not
 
 ## Accessibility
 

--- a/src/components/components.jquery.js
+++ b/src/components/components.jquery.js
@@ -45,6 +45,7 @@ import './message/message.jquery';
 import './modal/modal.jquery';
 import './monthview/monthview.jquery';
 import './multiselect/multiselect.jquery';
+import './notification/notification.jquery';
 import './pager/pager.jquery';
 import './progress/progress.jquery';
 import './popupmenu/popupmenu.jquery';

--- a/src/components/components.js
+++ b/src/components/components.js
@@ -34,6 +34,7 @@ export { ListView } from './listview/listview';
 export { MaskInput } from './mask/mask-input';
 export { Message } from './message/message';
 export { MultiSelect } from './multiselect/multiselect';
+export { Notification } from './notification/notification';
 export { Pager } from './pager/pager';
 export { Pie } from './pie/pie';
 export { PopupMenu } from './popupmenu/popupmenu';

--- a/src/components/locale/cultures/en-US.js
+++ b/src/components/locale/cultures/en-US.js
@@ -260,6 +260,7 @@ Soho.Locale.addCulture('en-US', {
     PasswordValidation: { id: 'PasswordValidation', value: '<strong>Password must</strong><br>Be at least 10 characters long<br>Have at least one upper case character<br>Have at least one lower case character<br>Contain one special character<br>Not contain your username<br>Can not be a Previously used password<br>', comment: 'Password validation requirements' },
     PasswordConfirmValidation: { id: 'PasswordConfirmValidation', value: 'Password must match', comment: 'Password Confirm validation' },
     Peak: { id: 'Peak', value: 'Peak', comment: 'the max or peak value in a chart' },
+    Pending: { id: 'Pending', value: 'Pending', comment: 'An event or task is pending' },
     PersonalizeColumns: { id: 'PersonalizeColumns', value: 'Personalize Columns', comment: 'Customize Columns in a Grid' },
     Plan: { id: 'Plan', value: 'Plan', comment: 'As in type of vacation plan' },
     Platform: { id: 'Platform', value: 'Platform', comment: 'The users operating system i.e. mac, windows' },

--- a/src/components/monthview/monthview.js
+++ b/src/components/monthview/monthview.js
@@ -400,7 +400,7 @@ MonthView.prototype = {
 
           if ((new Date(year, month, dayCnt))
             .setHours(tHours, tMinutes, tSeconds, 0) === elementDate
-              .setHours(tHours, tMinutes, tSeconds, 0)) { //eslint-disable-line
+            .setHours(tHours, tMinutes, tSeconds, 0)) {
             th.addClass(`is-selected${(s.range.useRange ? ' range' : '')}`).attr('aria-selected', 'true');
           }
         }

--- a/src/components/monthview/monthview.js
+++ b/src/components/monthview/monthview.js
@@ -37,7 +37,9 @@ const COMPONENT_NAME_DEFAULTS = {
     selectForward: false, // Only in forward direction
     selectBackward: false, // Only in backward direction
     includeDisabled: false // if true range will include disable dates in it
-  }
+  },
+  selectable: true,
+  onSelected: null
 };
 
 /**
@@ -85,6 +87,8 @@ const COMPONENT_NAME_DEFAULTS = {
  * @param {array} [settings.legend]  Legend Build up
  * for example `[{name: 'Public Holiday', color: '#76B051', dates: []},
  * {name: 'Weekends', color: '#EFA836', dayOfWeek: []}]`
+ * @param {boolean} [settings.selectable=false] If true the month days can be clicked to select
+ * @param {boolean} [settings.onSelected=false] Call back that fires when a month day is clicked.
  */
 function MonthView(element, settings) {
   this.settings = utils.mergeSettings(element, settings, COMPONENT_NAME_DEFAULTS);
@@ -376,11 +380,13 @@ MonthView.prototype = {
         self.setLegendColor(th, exYear, exMonth, exDay);
         self.dayMap.push({ key: stringUtils.padDate(exYear, exMonth, exDay), elem: th });
         th.addClass('alternate prev-month').html(`<span class="day-container"><span aria-hidden="true" class="day-text">${exDay}</span></span>`);
+        th.data('key', stringUtils.padDate(exYear, exMonth, exDay));
       }
 
       if (i >= leadDays && dayCnt <= thisMonthDays) {
         self.dayMap.push({ key: stringUtils.padDate(year, month, dayCnt), elem: th });
         th.html(`<span class="day-container"><span aria-hidden="true" class="day-text">${dayCnt}</span></span>`);
+        th.data('key', stringUtils.padDate(year, month, dayCnt));
 
         // Add Selected Class to Selected Date
         if (self.isIslamic) {
@@ -424,6 +430,7 @@ MonthView.prototype = {
         self.setLegendColor(th, exYear, exMonth, exDay);
 
         th.addClass('alternate next-month').html(`<span class="day-container"><span aria-hidden="true" class="day-text">${nextMonthDayCnt}</span></span>`);
+        th.data('key', stringUtils.padDate(exYear, exMonth, exDay));
         nextMonthDayCnt++;
       }
     });
@@ -821,6 +828,32 @@ MonthView.prototype = {
         self.showTodaysMonth();
       });
     }
+
+    // Allow dates to be selected
+    if (self.settings.selectable) {
+      self.element.addClass('is-selectable').off('click.monthview-day').on('click.monthview-day', 'td', (e) => {
+        const node = e.currentTarget;
+        const data = $(e.currentTarget).data();
+        const key = data.key;
+
+        const args = {
+          node,
+          key,
+          day: parseInt(key.substr(6, 2), 10),
+          month: parseInt(key.substr(4, 2), 10),
+          year: parseInt(key.substr(0, 4), 10)
+        };
+
+        self.element.trigger('selected', args);
+        if (self.settings.onSelected) {
+          self.settings.onSelected(node, args);
+        }
+
+        self.element.find('td.is-selected').removeClass('is-selected');
+        $(node).addClass('is-selected');
+      });
+    }
+
     return this;
   },
 
@@ -837,6 +870,10 @@ MonthView.prototype = {
     }
 
     this.showMonth(todayDate.getMonth(), todayDate.getFullYear());
+
+    if (this.settings.selectable) {
+      this.element.find('td.is-selected').trigger('click.monthview-day');
+    }
   },
 
   /**

--- a/src/components/notification/_notification.scss
+++ b/src/components/notification/_notification.scss
@@ -1,0 +1,88 @@
+// Notification
+//================================================== //
+
+.notification {
+  height: 0;
+  position: relative;
+  z-index: 1;
+
+  .notification-text {
+    @include font-size(14);
+
+    color: $font-color;
+    line-height: 40px;
+    margin-left: 25px;
+    position: relative;
+    width: auto;
+  }
+
+  .notification-link {
+    @include font-size(14);
+
+    color: $font-color;
+    font-weight: 300;
+    padding-left: 5px;
+    text-decoration: none;
+
+    &:hover {
+      color: $font-color-highcontrast;
+      text-decoration: underline;
+    }
+  }
+
+  .icon {
+    left: 15px;
+  }
+
+  .notification-close {
+    cursor: pointer;
+    float: right;
+    left: -30px;
+    position: relative;
+    top: 13px;
+
+    .icon {
+      color: $icon-fill;
+      height: 15px;
+      width: 15px;
+    }
+
+    &:hover .icon {
+      fill: $text-color;
+    }
+
+    &:active .icon {
+      fill: $font-color-extrahighcontrast;
+    }
+  }
+
+  &.error {
+    background-color: rgba(244, 188, 188, 0.2);
+  }
+
+  &.alert {
+    background-color: rgba(251, 233, 191, 0.4);
+  }
+
+  &.confirm {
+    background-color: rgba(213, 246, 192, 0.4);
+  }
+
+  &.info {
+    background-color: rgba(203, 235, 244, 0.2);
+  }
+}
+
+@include respond-to(phablet) {
+  .notification-link {
+    display: none;
+  }
+
+  .notification-text {
+    display: inline-block;
+    max-width: 77%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}

--- a/src/components/notification/notification.jquery.js
+++ b/src/components/notification/notification.jquery.js
@@ -1,0 +1,12 @@
+import { Notification, COMPONENT_NAME } from './notification';
+
+/**
+ * jQuery Component Wrapper for notification
+ * @param {object} [settings] incoming settings
+ * @returns {jQuery[]} elements being acted on
+ */
+$.fn.notification = function (settings) {
+  return this.each(function () {
+    $.data(this, COMPONENT_NAME, new Notification(this, settings));
+  });
+};

--- a/src/components/notification/notification.js
+++ b/src/components/notification/notification.js
@@ -17,11 +17,11 @@ const NOTIFICATION_DEFAULTS = {
  * @class Notification
  * @param {string} element The plugin element for the constuctor
  * @param {string} [settings] The settings element.
- * @param {string} [settings.message] The main text message to show in the alert.
- * @param {string} [settings.type] The message type, this influences the icon and color. Types: Error, Alert, Confirm, Positive
- * @param {string} [settings.parent] The settings element.
- * @param {string} [settings.link] The url to use for the link
- * @param {string} [settings.linkText] The text to show in the link.
+ * @param {string} [settings.message] The text message to show in the notification.
+ * @param {string} [settings.type] The message type, this influences the icon and color, possible types are 'error', 'alert', 'info' and 'confirm'
+ * @param {string} [settings.parent] The jQuery selector to find where to insert the message into (prepended). By default this will appear under the .header on the page.
+ * @param {string} [settings.link] The url to use for the hyperlink
+ * @param {string} [settings.linkText] The text to show in the hyperlink. Leave empty for no link.
  */
 function Notification(element, settings) {
   this.settings = utils.mergeSettings(element, settings, NOTIFICATION_DEFAULTS);
@@ -54,7 +54,7 @@ Notification.prototype = {
        <use xlink:href="#icon-${this.settings.type}"></use>
     </svg>
     <span class="notification-text">${this.settings.message}</span>
-    <a class="notification-link" href="${this.settings.link}">${this.settings.linkText}</a>
+    ${this.settings.linkText ? `<a class="notification-link" href="${this.settings.link}">${this.settings.linkText}</a>` : ''}
     <button type="text" class="notification-close"><svg class="icon" focusable="false" aria-hidden="true" role="presentation">
        <use xlink:href="#icon-close"></use>
     </svg><span class="audible">${Locale.translate('Close')}</span></button>`;

--- a/src/components/notification/notification.js
+++ b/src/components/notification/notification.js
@@ -1,0 +1,128 @@
+import { utils } from '../../utils/utils';
+import { Locale } from '../locale/locale';
+
+// Settings and Options
+const COMPONENT_NAME = 'notification';
+
+const NOTIFICATION_DEFAULTS = {
+  message: 'Hi! Im a notification message.',
+  type: 'alert',
+  parent: '.header',
+  link: '#',
+  linkText: 'Click here to view.'
+};
+
+/**
+ * Notification - Shows a slide in notifcation banner on the top of the page.
+ * @class Notification
+ * @param {string} element The plugin element for the constuctor
+ * @param {string} [settings] The settings element.
+ * @param {string} [settings.message] The main text message to show in the alert.
+ * @param {string} [settings.type] The message type, this influences the icon and color. Types: Error, Alert, Confirm, Positive
+ * @param {string} [settings.parent] The settings element.
+ * @param {string} [settings.link] The url to use for the link
+ * @param {string} [settings.linkText] The text to show in the link.
+ */
+function Notification(element, settings) {
+  this.settings = utils.mergeSettings(element, settings, NOTIFICATION_DEFAULTS);
+  this.element = $(element);
+  this.init();
+}
+
+// Plugin Methods
+Notification.prototype = {
+
+  /**
+   * Do initialization, build up and / or add events ect.
+   * @returns {object} The Notification prototype, useful for chaining.
+   */
+  init() {
+    return this
+      .build()
+      .handleEvents();
+  },
+
+  /**
+   * Add any needed markup to the component.
+   * @returns {object} The Component prototype, useful for chaining.
+   * @private
+   */
+  build() {
+    this.notificationEl = document.createElement('div');
+    this.notificationEl.classList.add('notification', this.settings.type);
+    this.notificationEl.innerHTML = `<svg class="icon icon-${this.settings.type}" focusable="false" aria-hidden="true" role="presentation">
+       <use xlink:href="#icon-${this.settings.type}"></use>
+    </svg>
+    <span class="notification-text">${this.settings.message}</span>
+    <a class="notification-link" href="${this.settings.link}">${this.settings.linkText}</a>
+    <button type="text" class="notification-close"><svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+       <use xlink:href="#icon-close"></use>
+    </svg><span class="audible">${Locale.translate('Close')}</span></button>`;
+
+    const parentEl = document.querySelector(this.settings.parent);
+
+    parentEl.parentNode.insertBefore(this.notificationEl, parentEl.nextSibling);
+    $(this.notificationEl).animateOpen({ distance: 40 });
+    return this;
+  },
+
+  /**
+   * Sets up event handlers for this component and its sub-elements.
+   * @returns {object} The Component prototype, useful for chaining.
+   * @private
+   */
+  handleEvents() {
+    const self = this;
+
+    this.element.off(`updated.${COMPONENT_NAME}`).on(`updated.${COMPONENT_NAME}`, () => {
+      self.updated();
+    });
+
+    $(this.notificationEl).off(`click.${COMPONENT_NAME}`).on(`click.${COMPONENT_NAME}`, '.notification-close', () => {
+      self.destroy();
+    });
+
+    return this;
+  },
+
+  /**
+   * Handle updated settings and values.
+   * @param {object} [settings] incoming settings
+   * @returns {object} [description]
+   */
+  updated(settings) {
+    if (settings) {
+      this.settings = utils.mergeSettings(this.element[0], settings, NOTIFICATION_DEFAULTS);
+    }
+
+    return this
+      .teardown()
+      .init();
+  },
+
+  /**
+   * Simple Teardown - remove events & rebuildable markup.
+   * @returns {object} The Component prototype, useful for chaining.
+   * @private
+   */
+  teardown() {
+    this.element.off(`updated.${COMPONENT_NAME}`);
+    this.element.off(`click.${COMPONENT_NAME}`, '.notification-close');
+    return this;
+  },
+
+  /**
+   * Teardown - Remove added markup and events.
+   * @private
+   */
+  destroy() {
+    if (this.notificationEl && this.notificationEl.parentNode) {
+      this.notificationEl.parentNode.removeChild(this.notificationEl);
+    }
+
+    this.teardown();
+    $.removeData(this.element[0], COMPONENT_NAME);
+  }
+};
+
+export { Notification, COMPONENT_NAME };

--- a/src/components/notification/readme.md
+++ b/src/components/notification/readme.md
@@ -1,16 +1,9 @@
 ---
-title: Pager
-description: This page describes Pager.
+title: Notification
+description: This page describes banner style notifications.
 demo:
   embedded:
-  - name: Paging a List (Ul)
-    slug: example-index
-  pages:
-  - name: Paging on the Listview Component
-    slug: example-paging
-  - name: Paging on the Datagrid Component
-    slug: example-paging
-  - name: Circle Pager Component
+  - name: Showing a notfication banner
     slug: example-index
 ---
 
@@ -18,40 +11,18 @@ demo:
 
 The auto initializer will search for `<ul>` elements with a `paginated` class and add a pager to them. You can add the option `data-options="{'pagesize': 10}"` to set the page size desired. For [listview](./listview) and [datagrid](./datagrid) components, this is built into those components.
 
-```html
-    <ul id="listview" class="paginated listview" data-options="{'pagesize': 10}">
-      <li>Item One</li>
-      <li>Item Two</li>
-      <li>Item Three</li>
-      <li>Item Four</li>
-      <li>Item Five</li>
-      <li>Item Six</li>
-      <li>Item Seven</li>
-      <li>Item Eight</li>
-      <li>Item Nine</li>
-      <li>Item Ten</li>
-      <li>Item Eleven</li>
-      <li>Item Twelve</li>
-      <li>Item Thirteen</li>
-      <li>Item Fourteen</li>
-      <li>Item Fifteen</li>
-      <li>Item Sixteen</li>
-      <li>Item Seventeen</li>
-      <li>Item Eighteen</li>
-      <li>Item Nineteen</li>
-      <li>Item Twenty</li>
-      <li>Item Twenty One</li>
-      <li>Item Twenty Two</li>
-      <li>Item Twenty Three</li>
-    </ul>
+```javascript
+  $('body').notification({
+    type: 'info',
+    message: 'DTO rejcted by your manager for Sept 30, 2018.',
+    link: '#',
+    linkText: 'Click to view'
+  });
 ```
 
 ## Accessibility
 
-- Since the buttons are arrows, we add an audible span with text like "next", "previous" so the user will know what these buttons are for
-- Icons have `role="presentation" aria-hidden="true" focusable="false"`
-- Selected page has `aria-selected = "true"`
-- Disabled pages (if exists) have `aria-disabled="true"`
+- TODO: We should add aria-alerts similar to the way toast works.
 
 ## Testability
 
@@ -59,5 +30,4 @@ The auto initializer will search for `<ul>` elements with a `paginated` class an
 
 ## Upgrading from 3.X
 
-- This did not exist as a standalone component
-- Datagrid paging has new options - [see datagrid docs]( ./datagrid)
+- This component is comparible to the inforSlideInDialog in 3.X

--- a/src/components/notification/readme.md
+++ b/src/components/notification/readme.md
@@ -1,0 +1,63 @@
+---
+title: Pager
+description: This page describes Pager.
+demo:
+  embedded:
+  - name: Paging a List (Ul)
+    slug: example-index
+  pages:
+  - name: Paging on the Listview Component
+    slug: example-paging
+  - name: Paging on the Datagrid Component
+    slug: example-paging
+  - name: Circle Pager Component
+    slug: example-index
+---
+
+## Code Example
+
+The auto initializer will search for `<ul>` elements with a `paginated` class and add a pager to them. You can add the option `data-options="{'pagesize': 10}"` to set the page size desired. For [listview](./listview) and [datagrid](./datagrid) components, this is built into those components.
+
+```html
+    <ul id="listview" class="paginated listview" data-options="{'pagesize': 10}">
+      <li>Item One</li>
+      <li>Item Two</li>
+      <li>Item Three</li>
+      <li>Item Four</li>
+      <li>Item Five</li>
+      <li>Item Six</li>
+      <li>Item Seven</li>
+      <li>Item Eight</li>
+      <li>Item Nine</li>
+      <li>Item Ten</li>
+      <li>Item Eleven</li>
+      <li>Item Twelve</li>
+      <li>Item Thirteen</li>
+      <li>Item Fourteen</li>
+      <li>Item Fifteen</li>
+      <li>Item Sixteen</li>
+      <li>Item Seventeen</li>
+      <li>Item Eighteen</li>
+      <li>Item Nineteen</li>
+      <li>Item Twenty</li>
+      <li>Item Twenty One</li>
+      <li>Item Twenty Two</li>
+      <li>Item Twenty Three</li>
+    </ul>
+```
+
+## Accessibility
+
+- Since the buttons are arrows, we add an audible span with text like "next", "previous" so the user will know what these buttons are for
+- Icons have `role="presentation" aria-hidden="true" focusable="false"`
+- Selected page has `aria-selected = "true"`
+- Disabled pages (if exists) have `aria-disabled="true"`
+
+## Testability
+
+- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+
+## Upgrading from 3.X
+
+- This did not exist as a standalone component
+- Datagrid paging has new options - [see datagrid docs]( ./datagrid)

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -517,15 +517,19 @@ Tooltip.prototype = {
 
     if (this.settings.beforeShow && !ajaxReturn) {
       const response = function (content) {
+        if (typeof content === 'boolean' && !content) {
+          return;
+        }
+        self.content = content;
         self.show({ content }, true);
       };
 
       if (typeof this.settings.beforeShow === 'string') {
-        window[this.settings.beforeShow](response);
+        window[this.settings.beforeShow](response, this.element);
         return;
       }
 
-      this.settings.beforeShow(response);
+      this.settings.beforeShow(response, this.element);
       return;
     }
 

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -1874,7 +1874,7 @@ Tree.prototype = {
                 startFolderNode: a.closest('ul').prev('a'),
                 startWidth: a.outerWidth()
               };
-    
+
               self.element.triggerHandler('dragstart', self.sortable);
               e.preventDefault();
               e.stopImmediatePropagation();

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -796,7 +796,7 @@ $calendar-bg-color: $panel-bg-color;
 $calendar-line-color: $graphite02;
 $calendar-selected-border-color: $color-primary;
 $calendar-selected-bg-color: $graphite01;
-$calendar-hover-bg-color: $graphite01;
+$calendar-hover-bg-color: rgba(240, 240, 240, 0.5);
 $calendar-disabled-bg-color: $graphite01;
 $calendar-disabled-color: $color-default-contrast;
 

--- a/src/core/_controls.scss
+++ b/src/core/_controls.scss
@@ -24,6 +24,7 @@
 @import '../components/dropdown/dropdown';
 @import '../components/modal/modal';
 @import '../components/monthview/monthview';
+@import '../components/notification/notification';
 @import '../components/slider/slider';
 @import '../components/popupmenu/popupmenu';
 @import '../components/tooltip/tooltip';

--- a/src/themes/dark-theme.scss
+++ b/src/themes/dark-theme.scss
@@ -704,7 +704,7 @@ $calendar-bg-color: $panel-bg-color;
 $calendar-line-color: $slate05;
 $calendar-selected-border-color: $color-primary;
 $calendar-selected-bg-color: $slate08;
-$calendar-hover-bg-color: $slate08;
+$calendar-hover-bg-color: rgba(49, 50, 54, 0.5);
 $calendar-disabled-bg-color: $slate08;
 $calendar-disabled-color: $slate04;
 

--- a/src/themes/high-contrast-theme.scss
+++ b/src/themes/high-contrast-theme.scss
@@ -741,7 +741,7 @@ $calendar-bg-color: $panel-bg-color;
 $calendar-line-color: $graphite09;
 $calendar-selected-border-color: $color-primary;
 $calendar-selected-bg-color: $graphite02;
-$calendar-hover-bg-color: $graphite01;
+$calendar-hover-bg-color: rgba(240, 240, 240, 0.75);
 $calendar-disabled-bg-color: $input-readonly-bg-color;
 $calendar-disabled-color: $graphite10;
 

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -99,7 +99,7 @@ stringUtils.textWidth = function capitalize(text, fontsize = 14) {
  * @returns {void}
  */
 stringUtils.padDate = function padDate(year, month, day) {
-  return `0${day}`.slice(-2) + `0${month + 1}`.slice(-2) + year;
+  return year + `0${month + 1}`.slice(-2) + `0${day}`.slice(-2);
 };
 
 /**

--- a/test/components/calendar/calendar.e2e-spec.js
+++ b/test/components/calendar/calendar.e2e-spec.js
@@ -91,3 +91,51 @@ describe('Calendar ajax loading tests', () => {
     expect(await element.all(by.css('.calendar-event')).count()).toEqual(2);
   });
 });
+
+describe('Calendar specific month tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/calendar/example-specific-month');
+    const dateField = await element(by.id('monthview-datepicker-field'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dateField), config.waitsFor);
+  });
+
+  it('Should render correctly', async () => {
+    expect(await element.all(by.css('.monthview-table td')).count()).toEqual(42);
+    await utils.checkForErrors();
+
+    const testDate = new Date();
+    await testDate.setDate(1);
+    await testDate.setMonth(9);
+
+    expect(await element(by.id('monthview-datepicker-field')).getAttribute('value')).toEqual(testDate.toLocaleDateString('en-US', { month: 'long', year: 'numeric' }));
+  });
+
+  it('should display a tooltip when hovering an event', async () => {
+    await browser.actions()
+      .mouseMove(await element.all(by.css('.calendar-event.emerald.event-day-start')).first())
+      .perform();
+
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('tooltip'))), config.waitsFor);
+
+    expect(await element(by.id('tooltip')).getText()).toEqual('Autumn Foliage Trip (Pending)');
+  });
+
+  it('should render icons on events', async () => {
+    expect(await element.all(by.css('.calendar-event.emerald.event-day-start .icon')).count()).toEqual(1);
+  });
+
+  it('should allow event to span days', async () => {
+    expect(await element.all(by.css('.calendar-event.emerald.event-day-start')).count()).toEqual(2);
+    expect(await element.all(by.css('.calendar-event.emerald.event-day-span')).count()).toEqual(9);
+    expect(await element.all(by.css('.calendar-event.emerald.event-day-end')).count()).toEqual(2);
+  });
+
+  it('should show events on click', async () => {
+    await element.all(by.cssContainingText('.monthview-table td', '1')).first().click();
+
+    expect(await element(by.css('.calendar-event-header')).getText()).toEqual('Team Event');
+    expect(await element(by.css('.calendar-event-body')).getText()).toBeTruthy();
+  });
+});

--- a/test/components/calendar/calendar.e2e-spec.js
+++ b/test/components/calendar/calendar.e2e-spec.js
@@ -1,5 +1,6 @@
 const { browserStackErrorReporter } = requireHelper('browserstack-error-reporter');
 const utils = requireHelper('e2e-utils');
+const config = requireHelper('e2e-config');
 requireHelper('rejection');
 
 jasmine.getEnv().addReporter(browserStackErrorReporter);
@@ -47,5 +48,46 @@ describe('Calendar index tests', () => {
     expect(await element(by.id('monthview-datepicker-field')).getAttribute('value')).toEqual(testDate.toLocaleDateString('en-US', { month: 'long', year: 'numeric' }));
 
     expect(await prevButton.getText()).toEqual('Previous Month');
+  });
+});
+
+describe('Calendar ajax loading tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/calendar/example-ajax-events');
+    const dateField = await element(by.id('monthview-datepicker-field'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dateField), config.waitsFor);
+  });
+
+  it('Should render without error', async () => {
+    expect(await element.all(by.css('.monthview-table td')).count()).toEqual(42);
+    await utils.checkForErrors();
+
+    const testDate = new Date();
+    await testDate.setDate(1);
+    await testDate.setMonth(7);
+
+    expect(await element(by.id('monthview-datepicker-field')).getAttribute('value')).toEqual(testDate.toLocaleDateString('en-US', { month: 'long', year: 'numeric' }));
+  });
+
+  it('Should render ajax loaded dates for august 2018', async () => {
+    const eventMore = await element(by.css('.calendar-event-more'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(eventMore), config.waitsFor);
+
+    expect(await element.all(by.css('.calendar-event-more')).count()).toEqual(1);
+    expect(await element.all(by.css('.calendar-event')).count()).toEqual(4);
+  });
+
+  it('Should render ajax loaded dates for october 2018', async () => {
+    const eventMore = await element(by.css('.monthview-header .next'));
+    await eventMore.click();
+
+    const event = await element(by.css('.calendar-event.graphite'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(event), config.waitsFor);
+
+    expect(await element.all(by.css('.calendar-event-more')).count()).toEqual(0);
+    expect(await element.all(by.css('.calendar-event')).count()).toEqual(2);
   });
 });

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -435,7 +435,7 @@ describe('Datagrid paging multiselect tests', () => {
 
     expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(2);
 
-    element(by.css('.pager-next')).click();
+    await element(by.css('.pager-next')).click();
 
     await browser.driver
       .wait(protractor.ExpectedConditions.elementToBeClickable(await element(by.css('.pager-prev'))), config.waitsFor);
@@ -470,7 +470,7 @@ describe('Datagrid paging client side multiselect tests', () => {
 
     expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(2);
 
-    element(by.css('.pager-next')).click();
+    await element(by.css('.pager-next')).click();
 
     await browser.driver
       .wait(protractor.ExpectedConditions.elementToBeClickable(await element(by.css('.pager-prev'))), config.waitsFor);

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -56,7 +56,7 @@ describe('Datepicker example-index tests', () => {
   });
 
   if (!utils.isBS()) {
-    it('Should be able to select with arrows and enter', async () => { //eslint-disable-line
+    it('Should be able to select with arrows and enter', async () => {
       const datepickerEl = await element(by.id('date-field-normal'));
       let focusTD = await element(by.css('#monthview-popup td.is-selected'));
       await datepickerEl.sendKeys(protractor.Key.ARROW_DOWN);

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -180,7 +180,7 @@ describe('Dropdown example-index tests', () => {
       expect(await element(by.css('div[aria-controls="dropdown-list"]'))).not.toContain('is-open');
     });
 
-    it('Should not allow the escape key to re-open a closed menu', async () => { //eslint-disable-line
+    it('Should not allow the escape key to re-open a closed menu', async () => {
       const dropdownEl = await element(by.css('div[aria-controls="dropdown-list"]'));
 
       await browser.driver

--- a/test/components/monthview/monthview-events.func-spec.js
+++ b/test/components/monthview/monthview-events.func-spec.js
@@ -1,0 +1,69 @@
+import { MonthView } from '../../../src/components/monthview/monthview';
+import { Locale } from '../../../src/components/locale/locale';
+
+const datepickerHTML = require('../../../app/views/components/monthview/example-index.html');
+const svg = require('../../../src/components/icons/svg.html');
+
+let monthviewEl;
+let svgEl;
+let monthviewAPI;
+
+describe('Monthview API', () => {
+  beforeEach(() => {
+    monthviewEl = null;
+    svgEl = null;
+    monthviewAPI = null;
+    document.body.insertAdjacentHTML('afterbegin', svg);
+    document.body.insertAdjacentHTML('afterbegin', datepickerHTML);
+    monthviewEl = document.body.querySelector('.monthview');
+    svgEl = document.body.querySelector('.svg-icons');
+
+    Locale.addCulture('ar-SA', Soho.Locale.cultures['ar-SA']); //eslint-disable-line
+    Locale.addCulture('en-US', Soho.Locale.cultures['en-US']); //eslint-disable-line
+    Locale.addCulture('ja-JP', Soho.Locale.cultures['ja-JP']); //eslint-disable-line
+    Locale.addCulture('sv-SE', Soho.Locale.cultures['sv-SE']); //eslint-disable-line
+    Locale.addCulture('en-GB', Soho.Locale.cultures['en-GB']); //eslint-disable-line
+    Locale.addCulture('de-DE', Soho.Locale.cultures['de-DE']); //eslint-disable-line
+    Locale.set('en-US');
+    Soho.Locale.set('en-US'); //eslint-disable-line
+
+    monthviewAPI = new MonthView(monthviewEl, {
+      month: 8,
+      year: 2018,
+      activeDate: new Date(2018, 8, 10)
+    });
+  });
+
+  afterEach(() => {
+    monthviewAPI.destroy();
+    monthviewEl.parentNode.removeChild(monthviewEl);
+    svgEl.parentNode.removeChild(svgEl);
+
+    const rowEl = document.body.querySelector('.row');
+    rowEl.parentNode.removeChild(rowEl);
+  });
+
+  it('triggers a `monthrendered` event when the month is rendered', (done) => {
+    const spyEvent = spyOnEvent($(monthviewEl), 'monthrendered');
+    monthviewAPI.showMonth(7, 2018);
+
+    expect(spyEvent).toHaveBeenTriggered();
+    done();
+  });
+
+  it('triggers a `selected` event when the day is selected', (done) => {
+    monthviewAPI.destroy();
+    monthviewAPI = new MonthView(monthviewEl, {
+      month: 8,
+      year: 2018,
+      activeDate: new Date(2018, 8, 10),
+      selctable: true
+    });
+
+    const spyEvent = spyOnEvent($(monthviewEl), 'selected');
+    monthviewEl.querySelector('tr:nth-child(2) td:nth-child(1)').click();
+
+    expect(spyEvent).toHaveBeenTriggered();
+    done();
+  });
+});

--- a/test/components/tooltip/tooltip.e2e-spec.js
+++ b/test/components/tooltip/tooltip.e2e-spec.js
@@ -6,7 +6,24 @@ requireHelper('rejection');
 
 jasmine.getEnv().addReporter(browserStackErrorReporter);
 
-describe('Tooltips on icons', () => {
+describe('Tooltips index page tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/tooltip/example-index');
+  });
+
+  it('should display when hovering the icon', async () => {
+    await browser.actions()
+      .mouseMove(await element(by.id('tooltip-btn')))
+      .perform();
+
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('tooltip'))), config.waitsFor);
+
+    expect(await element(by.id('tooltip')).getText()).toEqual('Tooltips Provide Additional Information');
+  });
+});
+
+describe('Tooltips on icon tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/icons/example-tooltips');
   });
@@ -15,13 +32,14 @@ describe('Tooltips on icons', () => {
     await utils.checkForErrors();
   });
 
-  it('should display when hovering the icon', async () => {
+  it('should display a tooltip when hovering a button', async () => {
     await browser.actions()
       .mouseMove(await element(by.id('standalone-delete-icon')))
       .perform();
 
-    await browser.driver.sleep(config.sleep);
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('tooltip'))), config.waitsFor);
 
-    expect(await element(by.css('.tooltip')).getText()).toEqual('Send to Trashcan');
+    expect(await element(by.id('tooltip')).getText()).toEqual('Send to Trashcan');
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Added more features to calendar for Sept sprint specifically:

- ajax load events for a month
- events for changing months
- tooltip on ellipsis of event name
- status (fx.. pending) on the event
- a notification banner
- allow calendar items to span multiple dates
- selecting events (with an event when selecting a day)
- show readonly events details on a template - when days are clicked

**Related github/jira issue (required)**:
Fixes #675 (with a remaining issue to be added)

**Steps necessary to review your pull request (required)**:

- ajax load events for a month
http://localhost:4000/components/calendar/example-ajax-events.html
After a moment, and after changing each page the events will be loaded on an ajax call

- events for changing months
Covered by unit tests (renderedmonth)

- tooltip on ellipsis of event name
http://localhost:4000/components/calendar/example-index.html
go to oct
resize page so ellipsis is shown on events
hover the events

- status (fx.. pending) on the event
http://localhost:4000/components/calendar/example-index.html
go to oct
resize page so ellipsis is shown on events
hover the event with an icon (note that an icon is shown)
click that day (note that the icon is shown in the day details)

- a notification banner
http://localhost:4000/components/notification/example-index.html
page should render
clicking x will dismiss (this will be used on calendar examples later)

- allow calendar items to span multiple dates
http://localhost:4000/components/calendar/example-index.html
go to oct (or nov)
notice events spanning more than one day

- selecting events (with an event when selecting a day)
http://localhost:4000/components/monthview/example-selectable-days.html
click any day to select
click today to select today again
also covered by unit tests but evident when clicking a day that it shows

- show readonly events details on a template - when days are clicked
http://localhost:4000/components/calendar/example-index.html
any month (aug - nov)
click days with events
events should be shown (multiple in a day not yet supported)