### PR TITLE
Disabled opening of popup menu when element is disabled

### DIFF
--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -734,6 +734,12 @@ PopupMenu.prototype = {
     }
 
     function doOpen(e) {
+      if (self.element.hasClass('is-disabled')) {
+        e.stopPropagation();
+        e.preventDefault();
+        return;
+      }
+
       const rightClick = self.settings.trigger === 'rightClick';
 
       e.stopPropagation();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Disabled popup menu when containing tab is disabled
- http://localhost:4000/components/tabs/example-enable-disable.html

**Related github/jira issue (required)**:
Closes #736 

**Steps necessary to review your pull request (required)**:
- Click "Disable Entire Tabs Control" button to disable tab control
- Click on disabled "Dropdown" tab menu
- Popup menu should not be displayed since tab menu is disabled 
