### PR TITLE
791 - Added fixes for save filter

### DIFF
--- a/app/views/components/datagrid/test-save-settings.html
+++ b/app/views/components/datagrid/test-save-settings.html
@@ -71,27 +71,23 @@
     columns.push({ id: 'status', name: 'Status', align: 'left', field: 'status', formatter: Formatters.Alert, filterType: 'select', editorOptions: {clearable: true}, options: statuses, ranges: [{'value':'Confirmed', 'classes': 'confirm', text: 'Confirmed'}, {'value':'Error', 'classes': 'error', text: 'Error'}]});
     columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy', filterType: 'date'});
 
-    //Get some data via ajax
-    //var url = '{{basepath}}api/compressors?pageNum=1&pageSize=1000';
-
-    //$.getJSON(url, function(res) {
-        //Init and get the api for the grid
-        grid = $('#datagrid').datagrid({
-          columns: columns,
-          columnReorder: true,
-          dataset: data,
-          paging: true,
-          pagesize: 10,
-          pagesizes: [5, 10, 15],
-          filterable: true,
-          saveUserSettings: {columns: true,
-             rowHeight: true,
-             sortOrder: true,
-             pagesize: true,
-             activePage: true,
-             filter: true},
-          toolbar: {personalize: true, filterRow: true, results: true, resetLayout: true}
-        });
-
+    //Init and get the api for the grid
+    grid = $('#datagrid').datagrid({
+      columns: columns,
+      columnReorder: true,
+      dataset: data,
+      paging: true,
+      pagesize: 10,
+      pagesizes: [5, 10, 15],
+      filterable: true,
+      saveUserSettings: {columns: true,
+         rowHeight: true,
+         sortOrder: true,
+         pagesize: true,
+         activePage: true,
+         filter: true},
+      toolbar: {personalize: true, filterRow: true, results: true, resetLayout: true}
     });
+
+  });
 </script>

--- a/app/views/components/datagrid/test-save-settings.html
+++ b/app/views/components/datagrid/test-save-settings.html
@@ -50,13 +50,17 @@
       data = [];
 
     // Some Sample Data
-    data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: '500', status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action', ex: 'ç ñ ÄËÏÖÜ äëïöü'});
-    data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: '2', price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold', ex:'àèìòù'});
-    data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: '120.99', status: null, orderDate: new Date(2014, 6, 3), action: 'Action', ex:'áéíóú'});
-    data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: '2345', status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action', ex:'ية (مصر'});
-    data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: '210.99', status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold', ex:''});
-    data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: '120.99', status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
-    data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '123.99', status: 'OK', orderDate: null, action: 'On Hold'});
+    data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: '500', status: 'Confirmed', orderDate: new Date(2014, 12, 8), action: 'Action', ex: 'ç ñ ÄËÏÖÜ äëïöü'});
+    data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: '2', price: 210.99, status: 'Confirmed', orderDate: new Date(2015, 7, 3), action: 'On Hold', ex:'àèìòù'});
+    data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: '120.99', status: 'Error', orderDate: new Date(2014, 6, 3), action: 'Action', ex:'áéíóú'});
+    data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: '2345', status: 'Error', orderDate: new Date(2015, 3, 3), action: 'Action', ex:'ية (مصر'});
+    data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: '210.99', status: 'Error', orderDate: new Date(2015, 5, 5), action: 'On Hold', ex:''});
+    data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: '120.99', status: 'Confirmed', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+    data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '123.99', status: 'Confirmed', orderDate: null, action: 'On Hold'});
+
+    var statuses = [{id: '', value: '', label:'&nbsp;'},
+                      {id:'Confirmed', value:'Confirmed', label:'Confirmed'},
+                      {id:'Error', value:'Error', label:'Error'}];
 
     //Define Columns for the Grid.
     columns.push({ id: 'id', name: 'Id', field: 'id', formatter: Formatters.Text, filterType: 'text'});
@@ -64,17 +68,18 @@
     columns.push({ id: 'activity', name: 'Activity', field: 'activity', filterType: 'text'});
     columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', filterType: 'integer'});
     columns.push({ id: 'price', name: 'Price', field: 'price', formatter: Formatters.Decimal, filterType: 'decimal'});
+    columns.push({ id: 'status', name: 'Status', align: 'left', field: 'status', formatter: Formatters.Alert, filterType: 'select', editorOptions: {clearable: true}, options: statuses, ranges: [{'value':'Confirmed', 'classes': 'confirm', text: 'Confirmed'}, {'value':'Error', 'classes': 'error', text: 'Error'}]});
     columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy', filterType: 'date'});
 
     //Get some data via ajax
-    var url = '{{basepath}}api/compressors?pageNum=1&pageSize=1000';
+    //var url = '{{basepath}}api/compressors?pageNum=1&pageSize=1000';
 
-    $.getJSON(url, function(res) {
+    //$.getJSON(url, function(res) {
         //Init and get the api for the grid
         grid = $('#datagrid').datagrid({
           columns: columns,
           columnReorder: true,
-          dataset: res.data,
+          dataset: data,
           paging: true,
           pagesize: 10,
           pagesizes: [5, 10, 15],
@@ -89,5 +94,4 @@
         });
 
     });
- });
 </script>

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1848,9 +1848,13 @@ Datagrid.prototype = {
 
       input.val(conditions[i].value);
 
-      if (input.is('select') && conditions[i].value instanceof Array) {
-        for (let j = 0; j < conditions[i].value.length; j++) {
-          input.find(`option[value="${conditions[i].value[j]}"]`).prop('selected', true);
+      if (input.is('select')) {
+        if (conditions[i].value instanceof Array) {
+          for (let j = 0; j < conditions[i].value.length; j++) {
+            input.find(`option[value="${conditions[i].value[j]}"]`).prop('selected', true);
+          }
+        } else {
+          input.find(`option[value="${conditions[i].value}"]`).prop('selected', true);
         }
         input.trigger('updated');
       }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

It doesn't return an array or object, instead, it returns a scalar value. There's a condition that if there's an array, that's the only time that it will execute the selected property.

```
if (input.is('select')) {
        if (conditions[i].value instanceof Array) {
          for (let j = 0; j < conditions[i].value.length; j++) {
            input.find(`option[value="${conditions[i].value[j]}"]`).prop('selected', true);
          }
        } else {
          input.find(`option[value="${conditions[i].value}"]`).prop('selected', true);
        }
        input.trigger('updated');
      }
```

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/791

**Steps necessary to review your pull request (required)**:

- Run http://localhost:4000/components/datagrid/test-save-settings.html
- Add some filter in header
- Reload the page
- Filter should still display after reloading

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
