### PR TITLE
832 - Added examples and fixes to placeholders on dropdowns

### DIFF
--- a/app/views/components/dropdown/example-placeholder.html
+++ b/app/views/components/dropdown/example-placeholder.html
@@ -1,0 +1,61 @@
+<div class="row">
+  <div class="twelve columns">
+    <div class="field">
+      <label for="states" class="label">States</label>
+      <select id="states" name="states" class="dropdown" placeholder="Select a State">
+        <option value="blank">&nbsp;</option>
+        <option value="AL">Alabama</option>
+        <option value="AK">Alaska</option>
+        <option value="AZ">Arizona</option>
+        <option value="AR">Arkansas</option>
+        <option value="CA">California</option>
+        <option value="CO">Colorado</option>
+        <option value="CT">Connecticut</option>
+        <option value="DE">Delaware</option>
+        <option value="DC">District Of Columbia</option>
+        <option value="FL">Florida</option>
+        <option value="GA">Georgia</option>
+        <option value="HI">Hawaii</option>
+        <option value="ID">Idaho</option>
+        <option value="IL">Illinois</option>
+        <option value="IN">Indiana</option>
+        <option value="IA">Iowa</option>
+        <option value="KS">Kansas</option>
+        <option value="KY">Kentucky</option>
+        <option value="LA">Louisiana</option>
+        <option value="ME">Maine</option>
+        <option value="MD">Maryland</option>
+        <option value="MA">Massachusetts</option>
+        <option value="MI">Michigan</option>
+        <option value="MN">Minnesota</option>
+        <option value="MS">Mississippi</option>
+        <option value="MO">Missouri</option>
+        <option value="MT">Montana</option>
+        <option value="NE">Nebraska</option>
+        <option value="NV">Nevada</option>
+        <option value="NH">New Hampshire</option>
+        <option value="NJ">New Jersey</option>
+        <option value="NM">New Mexico</option>
+        <option value="NY">New York</option>
+        <option value="NC">North Carolina</option>
+        <option value="ND">North Dakota</option>
+        <option value="OH">Ohio</option>
+        <option value="OK">Oklahoma</option>
+        <option value="OR">Oregon</option>
+        <option value="PA">Pennsylvania</option>
+        <option value="RI">Rhode Island</option>
+        <option value="SC">South Carolina</option>
+        <option value="SD">South Dakota</option>
+        <option value="TN">Tennessee</option>
+        <option value="TX">Texas</option>
+        <option value="UT">Utah</option>
+        <option value="VT">Vermont</option>
+        <option value="VA">Virginia</option>
+        <option value="WA">Washington</option>
+        <option value="WV">West Virginia</option>
+        <option value="WI">Wisconsin</option>
+        <option value="WY">Wyoming</option>
+      </select>
+    </div>
+  </div>
+</div>

--- a/app/views/components/multiselect/example-placeholder.html
+++ b/app/views/components/multiselect/example-placeholder.html
@@ -1,0 +1,60 @@
+<div class="row">
+  <div class="twelve columns">
+    <div class="field">
+      <label for="states-multi" class="label">States</label>
+      <select multiple="true" id="states-multi" name="states-multi" class="multiselect" placeholder="Select a State">
+        <option value="AL">Alabama</option>
+        <option value="AK">Alaska</option>
+        <option value="AZ">Arizona</option>
+        <option value="AR">Arkansas</option>
+        <option value="CA">California</option>
+        <option value="CO">Colorado</option>
+        <option value="CT">Connecticut</option>
+        <option value="DE">Delaware</option>
+        <option value="DC">District Of Columbia</option>
+        <option value="FL">Florida</option>
+        <option value="GA">Georgia</option>
+        <option value="HI">Hawaii</option>
+        <option value="ID">Idaho</option>
+        <option value="IL">Illinois</option>
+        <option value="IN">Indiana</option>
+        <option value="IA">Iowa</option>
+        <option value="KS">Kansas</option>
+        <option value="KY">Kentucky</option>
+        <option value="LA">Louisiana</option>
+        <option value="ME">Maine</option>
+        <option value="MD">Maryland</option>
+        <option value="MA">Massachusetts</option>
+        <option value="MI">Michigan</option>
+        <option value="MN">Minnesota</option>
+        <option value="MS">Mississippi</option>
+        <option value="MO">Missouri</option>
+        <option value="MT">Montana</option>
+        <option value="NE">Nebraska</option>
+        <option value="NV">Nevada</option>
+        <option value="NH">New Hampshire</option>
+        <option value="NJ">New Jersey</option>
+        <option value="NM">New Mexico</option>
+        <option value="NY">New York</option>
+        <option value="NC">North Carolina</option>
+        <option value="ND">North Dakota</option>
+        <option value="OH">Ohio</option>
+        <option value="OK">Oklahoma</option>
+        <option value="OR">Oregon</option>
+        <option value="PA">Pennsylvania</option>
+        <option value="RI">Rhode Island</option>
+        <option value="SC">South Carolina</option>
+        <option value="SD">South Dakota</option>
+        <option value="TN">Tennessee</option>
+        <option value="TX">Texas</option>
+        <option value="UT">Utah</option>
+        <option value="VT">Vermont</option>
+        <option value="VA">Virginia</option>
+        <option value="WA">Washington</option>
+        <option value="WV">West Virginia</option>
+        <option value="WI">Wisconsin</option>
+        <option value="WY">Wyoming</option>
+      </select>
+    </div>
+  </div>
+</div>

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -102,6 +102,12 @@ div.multiselect {
     text-overflow: ellipsis;
     vertical-align: top;
     width: inhert;
+
+    &:empty::before {
+      color: $input-placeholder-color;
+      content: attr(data-placeholder-text);
+      -webkit-text-fill-color: $input-placeholder-color;
+    }
   }
 
   > .listoption-icon {

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -867,9 +867,9 @@ Dropdown.prototype = {
       this.pseudoElem.next('svg').hide();
     }
 
+    // set placeholder text on pseudoElem span element
     if (this.element.attr('placeholder')) {
-      this.pseudoElem.attr('placeholder', this.element.attr('placeholder'));
-      this.element.removeAttr('placeholder');
+      this.pseudoElem.find('span').attr('data-placeholder-text', this.element.attr('placeholder'));
     }
   },
 

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -418,3 +418,13 @@ describe('Dropdown typeahead-reloading tests', () => {
     });
   }
 });
+
+describe('Dropdown placeholder tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/dropdown/example-placeholder');
+  });
+
+  it('Show a placeholder', async () => {
+    expect(await element(by.css('[data-placeholder-text]')).isDisplayed()).toBeTruthy();
+  });
+});

--- a/test/components/multiselect/multiselect.e2e-spec.js
+++ b/test/components/multiselect/multiselect.e2e-spec.js
@@ -311,3 +311,13 @@ describe('Multiselect typeahead-reloading tests', () => {
     });
   }
 });
+
+describe('Multiselect placeholder tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/multiselect/example-placeholder');
+  });
+
+  it('Show a placeholder', async () => {
+    expect(await element(by.css('[data-placeholder-text]')).isDisplayed()).toBeTruthy();
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Allows a user to view placeholder text in the multiselect dropdown when no options are selected. Also added an example for dropdown

**Related github/jira issue (required)**:
Closes #832 

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/dropdown/example-placeholder.html
and
http://localhost:4000/components/multiselect/example-placeholder.html

Placeholder will show if nothing is selected, note that the dropdown has a blank item in it to reset the placeholder.

Thanks @picitelli !