### PR TITLE
849 - Added fix for special characters search highlighting

### DIFF
--- a/app/views/components/datagrid/example-keyword-search.html
+++ b/app/views/components/datagrid/example-keyword-search.html
@@ -26,6 +26,7 @@
       data.push({ id: 7, productId: 2642207, productName: 'Compressor & Compressor', activity:  'Fix & Test', quantity: 20, price: '13.99', percent: 0.10, status: 'OK', orderDate: null, action: 'On Hold'});
       data.push({ id: 8, productId: 2642208, productName: '100% Compressor', activity:  'Evaluate', quantity: 10, price: '123.99', percent: 0.10, status: 'OK', orderDate: null, action: 'On Hold'});
       data.push({ id: 9, productId: 2642209, productName: 'Compress #4', activity:  'Test', quantity: 40, price: '1223.99', percent: 0.20, status: 'OK', orderDate: null, action: 'On Hold'});
+      data.push({ id: 10, productId: 2642210, productName: 'Mac & Cheese', activity:  'Mac & Cheese', quantity: 410, price: '12223.99', percent: 0.40, status: 'OK', orderDate: null, action: 'Action'});
 
       //Define Columns for the Grid.
       columns.push({ id: 'productId', name: 'Id', field: 'productId', reorderable: true, formatter: Formatters.Text, width: 100});

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1564,7 +1564,7 @@ Datagrid.prototype = {
           rowValue = self.formatValue(fmt, i, id, rowValue, columnDef, rowData, self);
 
           // Strip any html markup that might be in the formatters
-          const rex = /(<([^>]+)>)|(&lt;([^>]+)&gt;)/ig;
+          const rex = /(<([^>]+)>)|(amp;)|(&lt;([^>]+)&gt;)/ig;
           rowValue = rowValue.replace(rex, '').trim().toLowerCase();
 
           rowValueStr = (rowValue === null || rowValue === undefined) ? '' : rowValue.toString().toLowerCase();
@@ -5344,7 +5344,7 @@ Datagrid.prototype = {
         if (cellText.indexOf(term) > -1 && isSearchExpandableRow) {
           found = true;
           cell.find('*').each(function () {
-            if (this.innerHTML === this.textContent) {
+            if (this.innerHTML.replace('&amp;', '&') === this.textContent) {
               const contents = this.textContent;
               const node = $(this);
               const exp = new RegExp(`(${term})`, 'i');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The innerHTML produces `&amp;` instead of `&`. I just replace the value of it when searching.

```
if (this.innerHTML.replace('&amp;', '&') === this.textContent)
```

I also added the `amp;` in the regEx.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/849

Relates https://github.com/infor-design/enterprise/pull/828

**Steps necessary to review your pull request (required)**:

- Run http://localhost:4000/components/datagrid/example-keyword-search.html 
- Type words with special characters like &, #, %
- Searching words with those characters should be highlighted.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
