### PR TITLE
753 - Fix for Failing Tabs Tests

### DIFF
--- a/test/components/tabs/tabs.e2e-spec.js
+++ b/test/components/tabs/tabs.e2e-spec.js
@@ -482,7 +482,7 @@ describe('Tabs ajax as href tests', () => {
 
     await element.all(by.id('example-tab-two')).click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.visibilityOf(element(by.css('#ajaxified-tabs-tab-2.is-visible'))), config.waitsFor);
+      .wait(protractor.ExpectedConditions.visibilityOf(element(by.css('#ajaxified-tabs-tab-2[aria-selected="true"]'))), config.waitsFor);
     await browser.driver.sleep(config.waitsFor);
 
     await utils.checkForErrors();

--- a/test/components/tabs/tabs.e2e-spec.js
+++ b/test/components/tabs/tabs.e2e-spec.js
@@ -481,11 +481,6 @@ describe('Tabs ajax as href tests', () => {
     expect(await element(by.id('ajaxified-tabs-tab-1')).getAttribute('innerHTML')).not.toBe('');
 
     await element.all(by.id('example-tab-two')).click();
-    await browser.driver
-      .wait(protractor.ExpectedConditions.visibilityOf(element(by.css('#ajaxified-tabs-tab-2[aria-selected="true"]'))), config.waitsFor);
-    await browser.driver.sleep(config.waitsFor);
-
-    await utils.checkForErrors();
 
     expect(await element(by.id('ajaxified-tabs-tab-2')).getAttribute('innerHTML')).not.toBe('');
   });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Tabs tests were failing in #855 and various other PRs, so we're trying to fix it in this one by removing possibly extraneous `browser.wait()` and `utils.checkForErrors()` calls.

**Related github/jira issue (required)**:
#753 (fixing tests) and #855 (originally reported)

**Steps necessary to review your pull request (required)**:
See if this branch passes the automated Travis checks.  Also, if you've got the docker-based Travis debug image installed and operating, pull this branch and run the Tabs e2e tests.  There should be no failures.
