### PR TITLE
Restore missing demo styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dist"
   ],
   "scripts": {
-    "start": "npm run build  && node app/server.js",
+    "start": "npm run build && npm run quickstart",
     "quickstart": "npx grunt demo && node app/server.js",
     "quickstart:livereload": "npx grunt demo && node app/server.js --livereload",
     "build": "npx grunt",

--- a/src/core/_controls.scss
+++ b/src/core/_controls.scss
@@ -72,6 +72,7 @@
 @import '../components/datagrid/datagrid';
 @import '../components/editor/editor';
 @import '../components/monthview/monthview';
+@import '../components/notification/notification';
 
 // Charts ====/
 @import '../components/charts/charts'; // Base


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
http://localhost:4000/components/notification/example-index.html was missing styles, added back a merged out _notifcation.scss

Also demo.css was giving a 404 on the demo server on any page. fx http://localhost:4000/components/notification/example-index.html

**Related github/jira issue (required)**:
Fixes #675

**Steps necessary to review your pull request (required)**:
- run npm run start
- check notifcations page
- check console for errors.
