### PR TITLE
Fix for calendar layout issue

### DIFF
--- a/src/layouts/_layouts.scss
+++ b/src/layouts/_layouts.scss
@@ -805,8 +805,6 @@ body.no-scroll {
 
 // Banner Detail Pattern
 .page-container {
-  @include font-size(16);
-
   .banner-detail {
     min-height: 100%;
     position: relative;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

http://localhost:4000/components/calendar/example-index.html
- had a layout issue when selecting a day, the event details would flow to the bottom

**Related github/jira issue (required)**:
Fixes #675 (more)

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/calendar/example-index.html
- click a day with an event
- details should show on the right

@EdwardCoyle can you follow up on the layout issues that you were addressing where you added this?
https://github.com/infor-design/enterprise/blame/9b817555ddfee31739d758105c1212a1ae62dafb/src/layouts/_layouts.scss#L808
Im not sure what issue you saw. Perhaps add the font size to the real element
