### PR TITLE
Improve Flex Toolbar functional tests

### DIFF
--- a/test/components/tabs/tabs-api.func-spec.js
+++ b/test/components/tabs/tabs-api.func-spec.js
@@ -15,22 +15,25 @@ describe('Tabs API', () => {
     tabsPanelEl = null;
     svgEl = null;
     tabsObj = null;
+
     document.body.insertAdjacentHTML('afterbegin', svg);
     document.body.insertAdjacentHTML('afterbegin', tabsHTML);
+
     tabsEl = document.body.querySelector('.tab-container');
     rowEl = document.body.querySelector('.row');
     tabsPanelEl = document.body.querySelector('.tab-panel-container');
     svgEl = document.body.querySelector('.svg-icons');
     tabsEl.classList.add('no-init');
+
     tabsObj = new Tabs(tabsEl);
   });
 
   afterEach(() => {
     tabsObj.destroy();
-    tabsEl.parentNode.removeChild(tabsEl);
-    rowEl.parentNode.removeChild(rowEl);
     tabsPanelEl.parentNode.removeChild(tabsPanelEl);
+    tabsEl.parentNode.removeChild(tabsEl);
     svgEl.parentNode.removeChild(svgEl);
+    rowEl.parentNode.removeChild(rowEl);
   });
 
   it('Should be defined on jQuery object', () => {

--- a/test/components/toolbar-flex/toolbar-flex-api.func-spec.js
+++ b/test/components/toolbar-flex/toolbar-flex-api.func-spec.js
@@ -29,6 +29,11 @@ describe('Flex Toolbar', () => {
     toolbarAPI.destroy();
     rowEl.parentNode.removeChild(rowEl);
     svgEl.parentNode.removeChild(svgEl);
+
+    const popupmenuEl = document.body.querySelector('.popupmenu');
+    if (popupmenuEl) {
+      popupmenuEl.parentNode.removeChild(popupmenuEl);
+    }
   });
 
   it('Should be invoked', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Trying to fix some [test failures](https://travis-ci.com/infor-design/enterprise/jobs/148821759#L2315) that cropped up during the nightly build of EP over the weekend. 

The test failures in question are not e2e tests like the one's we've been fixing in #753.  They are functional tests that randomly failed.  After some discussion with @tmcconechy, we decided to attempt to fix this failure by removing references to extra elements on the page, which can unexpectedly cause test failures in some cases.  The Flex Toolbar tests require a Popupmenu on the page, so some extra cleanup code has been added to remove extraneous Popupmenus.

**Related github/jira issue (required)**:
n/a

**Steps necessary to review your pull request (required)**:
Pull this branch and run the entire functional test suite with `npm run functional:ci` (errors will only happen if the test suites are allowed to run in an asynchronous order). If possible, run the tests against the TravisCI Docker environment.
