### PR TITLE
787 - Fixed exportable true/false columns was not working with Datagrid

### DIFF
--- a/app/views/components/datagrid/example-export-from-button.html
+++ b/app/views/components/datagrid/example-export-from-button.html
@@ -18,11 +18,17 @@
         <span class="datagrid-result-count">(10 Results)</span>
       </div>
       <div class="buttonset">
-        <button type="button" class="btn" id="export">
+        <button type="button" class="btn" id="export-to-csv">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
             <use xlink:href="#icon-export-spreadsheet"></use>
           </svg>
-          <span>Export</span>
+          <span>Export To Csv</span>
+        </button>
+        <button type="button" class="btn" id="export-to-excel">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-export-spreadsheet"></use>
+          </svg>
+          <span>Export To Excel</span>
         </button>
       </div>
 
@@ -53,44 +59,49 @@
 <script>
   $('body').one('initialized', function () {
 
-    //Locale.set('en-US').done(function () {
-      var grid,
-        columns = [],
-        data = [];
+    var grid,
+      columns = [],
+      data = [];
 
-      // Some Sample Data
-      data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: '500', status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action', ex: 'ç ñ ÄËÏÖÜ äëïöü'});
-      data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: '2', price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold', ex:'àèìòù'});
-      data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: '120.99', status: null, orderDate: new Date(2014, 6, 3), action: 'Action', ex:'áéíóú'});
-      data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: '2345', status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action', ex:'ية (مصر'});
-      data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: '210.99', status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold', ex:'=HYPERLINK("http://www.google.com","Please Click For More Info")'});
-      data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: '120.99', status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
-      data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '123.99', status: 'OK', orderDate: null, action: 'On Hold'});
+    // Some Sample Data
+    data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: '500', status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action', ex: 'ç ñ ÄËÏÖÜ äëïöü'});
+    data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: '2', price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold', ex:'àèìòù'});
+    data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: '120.99', status: null, orderDate: new Date(2014, 6, 3), action: 'Action', ex:'áéíóú'});
+    data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: '2345', status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action', ex:'ية (مصر'});
+    data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: '210.99', status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold', ex:'=HYPERLINK("http://www.google.com","Please Click For More Info")'});
+    data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: '120.99', status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+    data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '123.99', status: 'OK', orderDate: null, action: 'On Hold'});
 
-      //Define Columns for the Grid.
-      columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Readonly});
-      columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink});
-      columns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity'});
-      columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity'});
-      columns.push({ id: 'price', name: 'Price', field: 'price', formatter: Formatters.Decimal});
-      columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
-      columns.push({ id: 'status', name: 'Status', field: 'status', formatter: Formatters.Text});
-      columns.push({ id: 'action', name: 'Action Item', field: 'action'});
-      columns.push({ id: 'ex', name: 'Extra', field: 'ex'});
+    // Define Columns for the Grid.
+    columns.push({ id: 'drilldown', name: '', field: '', resizable: false, formatter: Formatters.Drilldown, click: function(e, args) {
+      console.log(args);
+    }, align: 'center', sortable: false});
+    columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Readonly});
+    columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink});
+    columns.push({ id: 'activity', name: 'Activity', field: 'activity', formatter: Formatters.Hyperlink, exportable: false});
+    columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity'});
+    columns.push({ id: 'price', name: 'Price', field: 'price', formatter: Formatters.Decimal});
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy', exportable: false});
+    columns.push({ id: 'status', name: 'Status', field: 'status', formatter: Formatters.Text, exportable: true});
+    columns.push({ id: 'action', name: 'Action Item', field: 'action', exportable: false});
+    columns.push({ id: 'ex', name: 'Extra', field: 'ex', exportable: true});
 
-      //Init and get the api for the grid
-      grid = $('#datagrid').datagrid({
-        columns: columns,
-        columnReorder: true,
-        dataset: data,
-        toolbar: {personalize: true, results: true, exportToExcel: false}
-      }).on('columnchange', function (e, args) {
-        console.log('Changed', args.columns);
-      });
+    // Init and get the api for the grid
+    grid = $('#datagrid').datagrid({
+      columns: columns,
+      columnReorder: true,
+      dataset: data,
+      toolbar: {personalize: true, results: true, exportToExcel: false}
+    }).on('columnchange', function (e, args) {
+      console.log('Changed', args.columns);
+    });
 
-      $('#export').on('click', function () {
-        grid.data('datagrid').exportToExcel('myExport');
-      });
+    $('#export-to-csv').on('click', function () {
+      grid.data('datagrid').exportToCsv('myExport');
+    });
+    $('#export-to-excel').on('click', function () {
+      grid.data('datagrid').exportToExcel('myExport');
+    });
 
- });
+  });
 </script>

--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -6,100 +6,107 @@ import { Editors } from '../components/datagrid/datagrid.editors';
 const excel = {};
 
 /**
-* Export the grid contents to csv
-* @param {string} fileName The desired export filename in the download.
-* @param {string} customDs An optional customized version of the data to use.
-* @param {string} self The grid api to use (if customDs is not used)
-*/
-excel.exportToCsv = function (fileName, customDs, self) {
-  const name = fileName || self.element.attr('id') || 'Export';
-  fileName = `${name}.csv`;
-
-  let csvData = null;
-  const cleanExtra = function (table) {
-    $('tr, th, td, div, span', table).each(function () {
-      const el = this;
-      const elm = $(this);
-
-      if (elm.is('.is-hidden, .datagrid-expandable-row')) {
-        elm.remove();
+ * Clean all extra stuff
+ * @private
+ * @param {string} customDs An optional customized version of the data to use.
+ * @param {string} self The grid api to use (if customDs is not used)
+ * @returns {object} an table element cleaned extra stuff
+ */
+excel.cleanExtra = function (customDs, self) {
+  const clean = function (table) {
+    const removeNode = (node) => {
+      if (node.parentNode) {
+        node.parentNode.removeChild(node);
+      }
+    };
+    const nonExportables = [];
+    const elements = [].slice.call(table[0].querySelectorAll('tr, th, td, div, span'));
+    elements.forEach((el) => {
+      if (el.classList.contains('is-hidden') || el.classList.contains('datagrid-expandable-row')) {
+        removeNode(el);
         return;
       }
 
-      $('.is-hidden, .is-draggable-target, .handle, .sort-indicator, .datagrid-filter-wrapper', el).remove();
+      // THEAD
+      const attrId = el.getAttribute('id');
+      const attrExportable = el.getAttribute('data-exportable');
+      if (attrExportable && attrExportable === 'no' && typeof attrId !== 'undefined') {
+        nonExportables.push(parseInt(attrId.charAt(attrId.length - 1), 10) + 1);
+        removeNode(el);
+        return;
+      }
+
+      // TBODY
+      const attrAriaColindex = el.getAttribute('aria-colindex');
+      if (el.tagName.toLowerCase() !== 'th' && typeof attrAriaColindex !== 'undefined') {
+        if (nonExportables.indexOf(parseInt(attrAriaColindex, 10)) !== -1) {
+          removeNode(el);
+          return;
+        }
+      }
+
+      const innerElements = [].slice.call(table[0].querySelectorAll('.is-hidden, .is-draggable-target, .handle, .sort-indicator, .datagrid-filter-wrapper'));
+      innerElements.forEach(innerEl => removeNode(innerEl));
+
       while (el.attributes.length > 0) {
         el.removeAttribute(el.attributes[0].name);
       }
 
       // White Hat Security Violation. Remove Excel formulas
       // Excel Formulas Start with =SOMETHING
-      const text = elm.text();
+      const text = el.textContent;
       if (text.substr(0, 1) === '=' && text.substr(1, 1) !== '') {
-        elm.text(`'${text}`);
+        el.textContent = `'${text}'`;
       }
     });
     return table;
   };
 
-  const formatCsv = function (table) {
-    const csv = [];
-    const rows = table.find('tr');
-    let row;
-    let cols;
-    let content;
-
-    // CHECK EXPORTABLE
-    const nonExportables = [];
-    if (self) {
-      $.each($('th', self.headerRow).not('.is-hidden'), (index, item) => {
-        if ($(item)[0].getAttribute('data-exportable') && $(item)[0].getAttribute('data-exportable') === 'no') {
-          nonExportables.push(index);
-        }
-      });
-    }
-
-    for (let i = 0, l = rows.length; i < l; i++) {
-      row = [];
-      cols = $(rows[i]).find('td, th');
-      for (let i2 = 0; i2 < cols.length; i2++) {
-        if (nonExportables.indexOf(i2) <= -1) {
-          content = cols[i2].innerText.replace(/"/g, '""');
-
-          // Exporting data with trailing negative signs moved in front
-          if (self && self.settings.exportConvertNegative) {
-            content = content.replace(/^(.+)(-$)/, '$2$1');
-          }
-          row.push(content);
-        }
-      }
-      csv.push(row.join('","'));
-    }
-    return `"${csv.join('"\n"')}"`;
-  };
   let table = [];
   if (!self && customDs) {
-    table = this.datasetToHtml(customDs);
+    table = excel.datasetToHtml(customDs);
   } else {
-    table = this.appendRows(self.settings.dataset, self.table.clone(), self);
+    table = excel.appendRows(self.settings.dataset, self.table[0].cloneNode(true), self);
   }
 
-  if (!customDs && !table.find('thead').length) {
-    self.headerRow.clone().insertBefore(table.find('tbody'));
+  if (!customDs && !table[0].querySelector('thead')) {
+    const tbody = table[0].querySelector('tbody');
+    tbody.parentNode.insertBefore(self.headerRow[0].cloneNode(true), tbody);
   }
 
-  table = cleanExtra(table);
-  csvData = formatCsv(table);
+  table = clean(table);
+
+  // Exporting data with trailing negative signs moved in front
+  if (self && self.settings.exportConvertNegative) {
+    const cells = [].slice.call(table[0].querySelectorAll('td'));
+    cells.forEach((td) => {
+      td.textContent = td.textContent.replace(/^(.+)(-$)/, '$2$1');
+    });
+  }
+  return table;
+};
+
+/**
+ * Save file to download `.xls or .csv`.
+ * @private
+ * @param {string} content The content for the file in the download.
+ * @param {string} fileName The desired export filename in the download.
+ * @returns {void}
+ */
+excel.save = function (content, fileName) {
+  const ext = (fileName.match(/\.([^.]*?)(?=\?|#|$)/) || [])[1];
+  const isTypeExcel = typeof ext === 'string' && /\b(xlsx|xls)\b/g.test(ext);
 
   if (env.browser.name === 'ie' || env.browser.name === 'edge') {
     if (window.navigator.msSaveBlob) {
-      const blob = new Blob([csvData], {
+      const blob = new Blob([content], {
         type: 'application/csv;charset=utf-8;'
       });
       navigator.msSaveBlob(blob, fileName);
     }
   } else if (window.URL.createObjectURL) { // createObjectURL api allows downloading larger files
-    const blob = new Blob([csvData], {
-      type: 'application/csv;charset=utf-8;'
+    const blob = new Blob([content], {
+      type: `application/${isTypeExcel ? 'vnd.ms-excel' : 'csv'};charset=utf-8;`
     });
     const objectUrl = URL.createObjectURL(blob);
     const link = document.createElement('a');
@@ -111,7 +118,7 @@ excel.exportToCsv = function (fileName, customDs, self) {
     URL.revokeObjectURL(objectUrl);
   } else {
     const link = document.createElement('a');
-    link.href = this.base64(csvData);
+    link.href = this.base64(content);
     link.download = fileName;
     document.body.appendChild(link);
     link.click();
@@ -150,168 +157,35 @@ excel.datasetToHtml = function (dataset) {
 * @returns {object} The table with rows appended.
 */
 excel.appendRows = function (dataset, table, self) {
-  let tableHtml;
-  const body = table.find('tbody').empty();
+  const isjQuery = obj => (obj && (obj instanceof jQuery || obj.constructor.prototype.jquery));
+  const tableJq = isjQuery(table) ? table : $(table);
+  table = tableJq[0];
 
-  for (let i = 0; i < dataset.length; i++) {
-    if (!dataset[i].isFiltered) {
-      tableHtml += self.rowHtml(dataset[i], i, i);
+  let tableHtml = '';
+  const body = table.querySelector('tbody');
+  body.innerHTML = '';
+
+  dataset.forEach((d, i) => {
+    if (!d.isFiltered) {
+      tableHtml += self.rowHtml(d, i, i);
     }
-  }
+  });
 
-  body.append(tableHtml);
-  return table;
+  body.insertAdjacentHTML('beforeend', tableHtml);
+  return tableJq;
 };
 
 /**
-* Convert a excel string to base64 format for download.
-* @private
-* @param {string} s The string containing the document.
-* @returns {string} The excel doc as a base64 string.
-*/
+ * Convert a excel string to base64 format for download.
+ * @private
+ * @param {string} s The string containing the document.
+ * @returns {string} The excel doc as a base64 string.
+ */
 excel.base64 = function (s) {
   if (window.btoa) {
     return `data:application/vnd.ms-excel;base64,${window.btoa(unescape(encodeURIComponent(s)))}`;
   }
   return `data:application/vnd.ms-excel;,${unescape(encodeURIComponent(s))}`;
-};
-
-/**
-* Export the grid contents to xls format. This may give a warning when opening the file.
-* exportToCsv may be prefered.
-* @param {string} fileName The desired export filename in the download.
-* @param {string} worksheetName A name to give the excel worksheet tab.
-* @param {string} customDs An optional customized version of the data to use.
-* @param {object} self The grid api if customDS is not used
-*/
-excel.exportToExcel = function (fileName, worksheetName, customDs, self) {
-  const template = '' +
-    '<html xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel" xmlns="http://www.w3.org/TR/REC-html40">' +
-      '<head>' +
-        '<!--[if gte mso 9]>' +
-          '<xml>' +
-            '<x:ExcelWorkbook>' +
-              '<x:ExcelWorksheets>' +
-                '<x:ExcelWorksheet>' +
-                  '<x:Name>{worksheet}</x:Name>' +
-                  '<x:WorksheetOptions>' +
-                    '<x:Panes></x:Panes>' +
-                    '<x:DisplayGridlines></x:DisplayGridlines>' +
-                  '</x:WorksheetOptions>' +
-                '</x:ExcelWorksheet>' +
-              '</x:ExcelWorksheets>' +
-            '</x:ExcelWorkbook>' +
-          '</xml>' +
-        '<![endif]-->' +
-        '<meta http-equiv="content-type" content="text/plain; charset=UTF-8"/>' +
-      '</head>' +
-      '<body>' +
-        '<table border="1px solid #999999">{table}</table>' +
-      '</body>' +
-    '</html>';
-
-  const cleanExtra = function (table) {
-    const nonExportables = [];
-    $('tr, th, td, div, span', table).each(function () {
-      const el = this;
-      const elm = $(this);
-
-      if (elm.is('.is-hidden, .datagrid-expandable-row')) {
-        elm.remove();
-        return;
-      }
-
-      // THEAD
-      if (el.getAttribute('data-exportable') && el.getAttribute('data-exportable') === 'no') {
-        const id = parseInt(el.getAttribute('id').substr(el.getAttribute('id').length - 1), 10) - 1;
-        nonExportables.push(id);
-        elm.remove();
-        return;
-      }
-
-      // TBODY
-      if (el.cellIndex) {
-        if (nonExportables.length > 0 && nonExportables.indexOf(el.cellIndex) !== -1) {
-          elm.remove();
-          return;
-        }
-      }
-
-      $('.is-hidden, .is-draggable-target, .handle, .sort-indicator, .datagrid-filter-wrapper', el).remove();
-      while (el.attributes.length > 0) {
-        el.removeAttribute(el.attributes[0].name);
-      }
-
-      // White Hat Security Violation. Remove Excel formulas
-      // Excel Formulas Start with =SOMETHING
-      const text = elm.text();
-      if (text.substr(0, 1) === '=' && text.substr(1, 1) !== '') {
-        elm.text(`'${text}'`);
-      }
-    });
-    return table;
-  };
-
-  const format = function (s, c) {
-    return s.replace(/{(\w+)}/g, (m, p) => c[p]);
-  };
-
-  let table = [];
-  if (!self && customDs) {
-    table = this.datasetToHtml(customDs);
-  } else {
-    table = this.appendRows(self.settings.dataset, self.table.clone(), self);
-  }
-
-  if (!customDs && !table.find('thead').length) {
-    self.headerRow.clone().insertBefore(table.find('tbody'));
-  }
-
-  table = cleanExtra(table);
-
-  // Exporting data with trailing negative signs moved in front
-  if (self && self.settings.exportConvertNegative) {
-    table.find('td').each(function () {
-      const td = $(this);
-      const content = td.text();
-
-      td.text(content.replace(/^(.+)(-$)/, '$2$1'));
-    });
-  }
-
-  const ctx = { worksheet: (worksheetName || 'Worksheet'), table: table.html() };
-
-  fileName = `${fileName ||
-    self.element.closest('.datagrid-container').attr('id') ||
-    'datagrid'}.xls`;
-
-  if (env.browser.name === 'ie' || env.browser.name === 'edge') {
-    if (window.navigator.msSaveBlob) {
-      const blob = new Blob([format(template, ctx)], {
-        type: 'application/csv;charset=utf-8;'
-      });
-      navigator.msSaveBlob(blob, fileName);
-    }
-  } else if (window.URL.createObjectURL) { // createObjectURL api allows downloading larger files
-    const blob = new Blob([format(template, ctx)], {
-      type: 'application/vnd.ms-excel;charset=utf-8;'
-    });
-    const objectUrl = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = objectUrl;
-    link.download = fileName;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(objectUrl);
-  } else {
-    const link = document.createElement('a');
-    link.href = this.base64(format(template, ctx));
-    link.download = fileName;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  }
 };
 
 /**
@@ -380,6 +254,78 @@ excel.copyToDataSet = function (pastedData, rowCount, colIndex, dataSet, self) {
   self.renderRows();
   self.syncSelectedUI();
   self.pagerRefresh('bottom');
+};
+
+/**
+ * Export the grid contents to xls format. This may give a warning when opening the file.
+ * exportToCsv may be prefered.
+ * @param {string} fileName The desired export filename in the download.
+ * @param {string} worksheetName A name to give the excel worksheet tab.
+ * @param {string} customDs An optional customized version of the data to use.
+ * @param {object} self The grid api if customDS is not used
+ * @returns {void}
+ */
+excel.exportToExcel = function (fileName, worksheetName, customDs, self) {
+  const template = '' +
+    '<html xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel" xmlns="http://www.w3.org/TR/REC-html40">' +
+      '<head>' +
+        '<!--[if gte mso 9]>' +
+          '<xml>' +
+            '<x:ExcelWorkbook>' +
+              '<x:ExcelWorksheets>' +
+                '<x:ExcelWorksheet>' +
+                  '<x:Name>{worksheet}</x:Name>' +
+                  '<x:WorksheetOptions>' +
+                    '<x:Panes></x:Panes>' +
+                    '<x:DisplayGridlines></x:DisplayGridlines>' +
+                  '</x:WorksheetOptions>' +
+                '</x:ExcelWorksheet>' +
+              '</x:ExcelWorksheets>' +
+            '</x:ExcelWorkbook>' +
+          '</xml>' +
+        '<![endif]-->' +
+        '<meta http-equiv="content-type" content="text/plain; charset=UTF-8"/>' +
+      '</head>' +
+      '<body>' +
+        '<table border="1px solid #999999">{table}</table>' +
+      '</body>' +
+    '</html>';
+
+  const formatExcel = function (s, c) {
+    return s.replace(/{(\w+)}/g, (m, p) => c[p]);
+  };
+
+  const table = excel.cleanExtra(customDs, self);
+  const ctx = { worksheet: (worksheetName || 'Worksheet'), table: table[0].innerHTML };
+
+  fileName = `${fileName || self.element[0].id || 'Export'}.xls`;
+  excel.save(formatExcel(template, ctx), fileName);
+};
+
+/**
+ * Export the grid contents to csv
+ * @param {string} fileName The desired export filename in the download.
+ * @param {string} customDs An optional customized version of the data to use.
+ * @param {string} self The grid api to use (if customDs is not used)
+ * @returns {void}
+ */
+excel.exportToCsv = function (fileName, customDs, self) {
+  const formatCsv = function (table) {
+    const csv = [];
+    const rows = [].slice.call(table[0].querySelectorAll('tr'));
+    rows.forEach((row) => {
+      const rowContent = [];
+      const cols = [].slice.call(row.querySelectorAll('td, th'));
+      cols.forEach(col => rowContent.push(col.textContent.replace(/\r?\n|\r/g, '').replace(/"/g, '""').trim()));
+      csv.push(rowContent.join('","'));
+    });
+    return `"${csv.join('"\n"')}"`;
+  };
+
+  const table = excel.cleanExtra(customDs, self);
+
+  fileName = `${fileName || self.element[0].id || 'Export'}.csv`;
+  excel.save(formatCsv(table), fileName);
 };
 
 export { excel };


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Exportable true/false columns was not working. It should work as all columns with `exportable: true` (or without exportable key with column node in user data) should be exported. All columns with `exportable: false` should be excluded. Their should be no missing data in between columns.

**Related github/jira issue (required)**:
Closes #787

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/example-export-from-button.html
- Open above link
- Click on "Export To Csv"
- Click on "Export To Excel"
- Go to downloaded location
- Should be two files downloaded "myExport.xls" and "myExport.csv"
- Open "myExport.xls" it might show warning about file format and extension don't match
- Click to open it anyway
- See exportable columns only in file
- Now open "myExport.csv" with any text-editor (ie. Atom)
- See exportable columns only in file and no missing data in between (ie. first column drilldown)