### PR TITLE
418 - Added keyword filterMode for autocomplete component

### DIFF
--- a/app/views/components/autocomplete/example-keyword.html
+++ b/app/views/components/autocomplete/example-keyword.html
@@ -1,0 +1,14 @@
+<div class="row">
+  <div class="twelve columns">
+    <div class="field">
+      <label for="autocomplete-default">States</label>
+      <input type="text" autocomplete="off" class='autocomplete' data-options='{source: "{{basepath}}api/states?term=", filterMode: "keyword"}' placeholder="Type to Search" id="autocomplete-default">
+    </div>
+  </div>
+</div>
+
+<script id="test-scripts">
+  $('#autocomplete-default').on('selected', function (e, args) {
+    console.log(args.parent().attr('data-value'));
+  });
+</script>

--- a/src/components/listfilter/listfilter.js
+++ b/src/components/listfilter/listfilter.js
@@ -144,6 +144,17 @@ ListFilter.prototype = {
         }
       }
 
+      if (self.settings.filterMode === 'keyword') {
+        const keywords = term.split(' ');
+        for (let i = 0; i < keywords.length; i++) {
+          const keyword = keywords[i];
+          if (text.toLowerCase().indexOf(keyword) >= 0) {
+            match = true;
+            break;
+          }
+        }
+      }
+
       // assume filtered server side
       if (self.settings.filterMode === null) {
         match = true;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Added keyword filterMode for autocomplete component
- http://localhost:4000/components/autocomplete/example-keyword.html

**Related github/jira issue (required)**:
Closes #418 

**Steps necessary to review your pull request (required)**:
- Type in "al ca wy" or any keyword with space in between
- Autocomplete should be able to filter out data using those keywords
