### PR TITLE
886 - Added fix for completion chart alignment issue

### DIFF
--- a/src/components/charts/_charts.scss
+++ b/src/components/charts/_charts.scss
@@ -69,6 +69,10 @@
 
   &.completion-chart {
     margin: 30px;
+
+    @media only screen and (min-width: $breakpoint-phone-to-tablet) and (max-width: $breakpoint-tablet-to-desktop) {
+      margin: 30px 5px;
+    }
   }
 
   // Right aligned Legend

--- a/src/components/completion-chart/_completion-chart.scss
+++ b/src/components/completion-chart/_completion-chart.scss
@@ -10,6 +10,7 @@
 
   &.chart-completion {
     margin-bottom: 25px;
+    margin-top: 5px;
 
     .completed {
       background-color: $turquoise06;
@@ -188,6 +189,7 @@
   .target {
     background-color: $chart-progressbar-target-fill;
     height: 10px;
+    margin-top: 8px;
     position: relative;
     transition: width 0.5s ease 0s;
     width: 60%;
@@ -316,7 +318,6 @@
 
 }
 
-// TODO - Fix this.
 .completion-chart {
   .remaining,
   .info {

--- a/src/components/completion-chart/completion-chart.js
+++ b/src/components/completion-chart/completion-chart.js
@@ -42,7 +42,7 @@ CompletionChart.prototype = {
   /**
    * Do initialization, build up and / or add events ect.
    * @private
-   * @returns {object} The bullet chart prototype for chaining.
+   * @returns {object} The completion chart prototype for chaining.
    */
   init() {
     // Do initialization. Build or Events ect
@@ -332,8 +332,8 @@ CompletionChart.prototype = {
 
       html.label = `<b class="label name">${name}</b>
       <b class="label info ${bColor} colored">
-      <span class="value ${bColor}" style="color: ${styleColor};">${styleValue}</span>
-      <span class="text ${bColor}" style="color: ${styleColor};">${infoText}</span>
+      <span class="value ${bColor}" ${styleColor ? `style="color:${styleColor}` : ''}">${styleValue}</span>
+      <span class="text ${bColor}" ${styleColor ? `style="color:${styleColor}` : ''}">${infoText}</span>
       </b>`;
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Removing some margin when in tablet view. It seems that the issue occurs on that viewport.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/886

**Steps necessary to review your pull request (required)**:

- Run http://localhost:4000/components/completion-chart/example-colors.html
- Try to resize or change the viewport of the browser.
- `#880e0e` and `alert-yellow` completion bar should now be aligned properly

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
