### PR TITLE
856 - Modified the banner generator used on compiled files to match on JS/SCSS [v4.11.x]

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -12,20 +12,9 @@ module.exports = function (grunt) {
   const compress = require('./scripts/configs/compress.js');
   const meta = require('./scripts/configs/meta.js');
   const clean = require('./scripts/configs/clean.js');
-  const dependencyBuilder = require('./scripts/dependencybuilder.js');
-  const strBanner = require('./scripts/strbanner.js');
-  const controls = require('./scripts/controls.js');
   const run = require('./scripts/configs/run.js');
 
-  let selectedControls = dependencyBuilder(grunt);
-  let bannerText = '/**\n* IDS Enterprise Components v<%= pkg.version %>\n* Date: <%= grunt.template.today("dd/mm/yyyy h:MM:ss TT") %>\n* Revision: <%= meta.revision %>\n* <%= meta.copyright %>\n*/\n';
-
-  if (selectedControls) {
-    const bannerList = strBanner(selectedControls);
-    bannerText = `/**\n* IDS Enterprise Components v<%= pkg.version %>\n* ${bannerList}\n* Date: <%= grunt.template.today("dd/mm/yyyy h:MM:ss TT") %>\n* Revision: <%= meta.revision %>\n* <%= meta.copyright %>\n*/ \n`;
-  } else {
-    selectedControls = controls;
-  }
+  const bannerText = require('./scripts/generate-bundle-banner');
 
   const config = {
     pkg: grunt.file.readJSON('package.json'),

--- a/scripts/generate-bundle-banner.js
+++ b/scripts/generate-bundle-banner.js
@@ -3,38 +3,66 @@
 const fs = require('fs');
 const path = require('path');
 const moment = require('moment');
-const cp = require('child_process');
+const childProcess = require('child_process');
 const pjson = require('../package.json');
 const args = require('yargs').argv;
 
-let commitHash = '';
-let isCustom = '';
-let componentsArgs;
-let componentsList = '';
+const projectName = 'IDS Enterprise Components';
+const commitHash = childProcess.execSync('git rev-parse HEAD') || '';
 
-if (args.customBuild) {
-  isCustom = ' (custom)';
-}
-if (args.components) {
-  componentsArgs = args.components.split(',');
-
-  componentsList += 'Custom bundle containing the following components:\n';
-  componentsArgs.forEach((comp) => {
-    componentsList += `- ${comp}\n`;
-  });
-  componentsList += '\n';
+function prependLines(str, prepender) {
+  prepender = prepender || '';
+  const strArr = str.split('\n');
+  // eslint-disable-next-line
+  for (let x in strArr) {
+    strArr[x] = `${prepender}${strArr[x].trim()}`;
+  }
+  return strArr.join('\n');
 }
 
-const license = fs.readFileSync(path.join(__dirname, '..', 'LICENSE'), ['utf-8']);
+/**
+ * Generate the IDS Bundle Banner
+ * @param {boolean} useComments if true, prepends comment syntax around the banner lines
+ * @returns {string} containing the bundle banner
+ */
+function render(useComments) {
+  const startComment = useComments ? '/** ' : '';
+  const comment = useComments ? ' *  ' : '';
+  const endComment = useComments ? ' */ ' : '';
+  const date = `Date: ${moment().format('DD/MM/YYYY, h:mm:ss a')}`;
+  const revision = `Revision: ${commitHash}`.trim();
+  let isCustom = '';
+  let componentsArgs;
+  let componentsList = '';
 
-commitHash = cp.execSync('git rev-parse HEAD');
+  // Grabs a list of included components (optional)
+  if (args.components) {
+    isCustom = ' (custom)';
+    componentsArgs = args.components.split(',');
 
-const version2 = `Soho XI Controls v${pjson.version}${isCustom}`;
-const date = `Date: ${moment().format('DD/MM/YYYY, h:mm:ss a')}`;
-const revision = `Revision: ${commitHash}`;
+    componentsList += 'Custom bundle containing the following components:';
+    componentsArgs.forEach((comp) => {
+      componentsList += `\n${comment} - ${comp}`;
+    });
+    componentsList += `\n${comment}`;
+  }
 
-module.exports = `${version2}\n${
-  date}\n${
-  revision}\n${
-  componentsList}${
-  license}\n`;
+  // Project Name and Version Headline
+  const headline = `${projectName} - v${pjson.version}${isCustom}`;
+
+  // Prepend comments to each line of the license
+  let license = fs.readFileSync(path.join(__dirname, '..', 'LICENSE'), 'utf8');
+  license = prependLines(license, comment);
+
+  return `${startComment}\n${
+    comment}${headline}\n${
+    comment}${date}\n${
+    comment}${revision}\n${
+    comment}\n${
+    comment}${componentsList}\n${
+    license}\n${
+    endComment}`;
+}
+
+// default export is just the string (backwards compat)
+module.exports = render(true);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR addresses several issues with the comment banner used on generated CSS and JS files:

- Previously the banner didn't match between JS and CSS files.  
- The one being used in CSS was hardcoded against an old license, and wasn't having the date/revision properly applied.  It was also still calling the project "SoHo Xi"
- no way to pass a list of custom components to the banner
- no way to mark a `(custom)` identifier after the IDS version.

**Related github/jira issue (required)**:
Closes #856 

**Steps necessary to review your pull request (required)**:
pull this branch and run:

```sh
npm run build:custom -- --components=button,input,popupmenu
```

1. Ensure the following files both have a generated bundle banner:
  - `dist/css/dark-theme.css`
  - `dist/css/dark-theme.min.css`
  - `dist/css/high-contrast-theme.css`
  - `dist/css/high-contrast-theme.min.css`
  - `dist/css/light-theme.css`
  - `dist/css/light-theme.min.css`
  - `dist/js/sohoxi.js`
  - `dist/js/sohoxi.min.js`
2. Ensure the banner contains the following:
  - the project "IDS Enterprise Components" (not "SoHo Xi")
  - a correct date/time
  - a Git commit hash
  - a list of the three components included
  - the apache license
