### PR TITLE
860 - Added fix for $ sign highlighting

### DIFF
--- a/app/views/components/datagrid/example-keyword-search.html
+++ b/app/views/components/datagrid/example-keyword-search.html
@@ -26,7 +26,7 @@
       data.push({ id: 7, productId: 2642207, productName: 'Compressor & Compressor', activity:  'Fix & Test', quantity: 20, price: '13.99', percent: 0.10, status: 'OK', orderDate: null, action: 'On Hold'});
       data.push({ id: 8, productId: 2642208, productName: '100% Compressor', activity:  'Evaluate', quantity: 10, price: '123.99', percent: 0.10, status: 'OK', orderDate: null, action: 'On Hold'});
       data.push({ id: 9, productId: 2642209, productName: 'Compress #4', activity:  'Test', quantity: 40, price: '1223.99', percent: 0.20, status: 'OK', orderDate: null, action: 'On Hold'});
-      data.push({ id: 10, productId: 2642210, productName: 'Mac & Cheese', activity:  'Mac & Cheese', quantity: 410, price: '12223.99', percent: 0.40, status: 'OK', orderDate: null, action: 'Action'});
+      data.push({ id: 10, productId: 2642210, productName: '$200 Mac & Cheese', activity:  '$200 Mac & Cheese', quantity: 410, price: '12223.99', percent: 0.40, status: 'OK', orderDate: null, action: 'Action'});
 
       //Define Columns for the Grid.
       columns.push({ id: 'productId', name: 'Id', field: 'productId', reorderable: true, formatter: Formatters.Text, width: 100});

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5397,10 +5397,10 @@ Datagrid.prototype = {
         if (cellText.indexOf(term) > -1 && isSearchExpandableRow) {
           found = true;
           cell.find('*').each(function () {
-            if (this.innerHTML.replace('&amp;', '&') === this.textContent) {
+            if (xssUtils.unescapeHTML(this.innerHTML) === this.textContent) {
               const contents = this.textContent;
               const node = $(this);
-              const exp = new RegExp(`(${term})`, 'i');
+              const exp = new RegExp(`(${stringUtils.escapeRegExp(term)})`, 'gi');
 
               node.addClass('search-mode').html(contents.replace(exp, '<i>$1</i>'));
             }

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -126,7 +126,7 @@ stringUtils.textWidth = function textWidth(text, padding, font) {
  * @returns {string} string after escaping.
  */
 stringUtils.escapeRegExp = function escapeRegExp(s) {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); //$& whole matched string
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& whole matched string
 };
 
 export { stringUtils }; //eslint-disable-line

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -119,4 +119,14 @@ stringUtils.textWidth = function textWidth(text, padding, font) {
   return Math.round(metrics.width + (padding || 0));
 };
 
+/**
+ * Escape  user input to be treated as literal string with regular expressions
+ * @private
+ * @param {string} s string to process.
+ * @returns {string} string after escaping.
+ */
+stringUtils.escapeRegExp = function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); //$& whole matched string
+};
+
 export { stringUtils }; //eslint-disable-line


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Creating an escape regEx for `highlightingSearchRow()`

In string.js
```
stringUtils.escapeRegExp = function escapeRegExp(s) {
  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); //$& whole matched string
};
```

Then use it in the `highlightingSearchRow()`

```
 const exp = new RegExp(`(${stringUtils.escapeRegExp(term)})`, 'gi');
```

I also used the xssUtils.unescapeHTML for the special characters.

```
if (xssUtils.unescapeHTML(this.innerHTML) === this.textContent) {
```

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/860

**Steps necessary to review your pull request (required)**:

- Run http://localhost:4000/components/datagrid/example-keyword-search.html
- Search for $
- $ should highlighted

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
