### PR TITLE
898 - Closed popup menu when clicking on other tree nodes

### DIFF
--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -849,6 +849,12 @@ Tree.prototype = {
         }
         e.stopPropagation();
       }
+
+      if (self.popupEl && self.popupEl.data('popupmenu')) {
+        self.popupEl.data('popupmenu').close();
+        self.popupEl = null;
+      }
+
       return false; // Prevent Click from Going to Top
     });
 
@@ -1833,7 +1839,7 @@ Tree.prototype = {
     this.element.off('contextmenu.tree').on('contextmenu.tree', 'a', function (e) {
       const node = $(this);
       e.preventDefault();
-      $(e.currentTarget).popupmenu({ menuId, eventObj: e, trigger: 'immediate', attachToBody: true }).off('selected').on('selected', (event, args) => {
+      self.popupEl = $(e.currentTarget).popupmenu({ menuId, eventObj: e, trigger: 'immediate', attachToBody: true }).off('selected').on('selected', (event, args) => {
         /**
         * Fires when the an attached context menu item is selected.
         *


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Closed popup menu when clicking on other tree nodes
- http://localhost:4000/components/tree/example-context-menu.html#

**Related github/jira issue (required)**:
Closes #898 

**Steps necessary to review your pull request (required)**:
- Right-click on the Node Two to open the contextmenu
- Click on the Node One or on the child nodes of Node Two
- Contextmenu should now close
