### PR TITLE
726 - Fix modal closing when enter key pressed

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -601,12 +601,7 @@ Modal.prototype = {
       if (e.which === 13 && this.isOnTop() &&
           !target.closest('form').find(':submit').length &&
           this.element.find('.btn-modal-primary:enabled').length) {
-        e.stopPropagation();
-        e.preventDefault();
-
-        if ((!target.hasClass('fileupload') && !$(target).is(':input')) || target.hasClass('colorpicker')) {
-          this.element.find('.btn-modal-primary:enabled').trigger('click');
-        }
+        return;
       }
     });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Cancels submit when Enter is pressed in a modal form element.

**Related github/jira issue (required)**:
closes #726 

**Steps necessary to review your pull request (required)**:
* Go to http://localhost:4000/components/editor/test-modal.html
* Type test content in the editor
* Press Enter key

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
