### PR TITLE
870 - Fixed more veracode scan errors

### DIFF
--- a/app/views/components/editor/test-paste-as-plain-text.html
+++ b/app/views/components/editor/test-paste-as-plain-text.html
@@ -3,7 +3,7 @@
   <div class="twelve columns">
     <div class="field">
       <label class="label" for="title">Title</label>
-      <input type="text" id="title" value="The Page Title">
+      <input type="text" id="title" value="The Page Title"/>
     </div>
 
     <div class="field">

--- a/app/views/components/field-options/example-no-init.html
+++ b/app/views/components/field-options/example-no-init.html
@@ -361,9 +361,6 @@
         fullWidth: true
       }
     }
-  }).on('change', function (e, args) {
-    console.log(args[0]);
-  })
-  .fieldoptions();
+  }).fieldoptions();
 
 </script>

--- a/app/views/components/lookup/example-index.html
+++ b/app/views/components/lookup/example-index.html
@@ -64,10 +64,6 @@
           fullWidth: true
         }
       }
-    }).on('change', function (e, args) {
-      if (args) {
-        console.log(args[0]);
-      }
     });
 
 </script>

--- a/src/components/charts/_charts.scss
+++ b/src/components/charts/_charts.scss
@@ -170,6 +170,9 @@
     }
   }
 
+  &.line .swatch-caption b {
+    display: inline-block;
+  }
 }
 
 .chart-tooltip-total {

--- a/src/components/charts/charts.js
+++ b/src/components/charts/charts.js
@@ -1,5 +1,7 @@
 import { Environment as env } from '../../utils/environment';
 import { utils } from '../../utils/utils';
+import { xssUtils } from '../../utils/xss';
+import { DOM } from '../../utils/dom';
 
 const charts = {};
 
@@ -15,7 +17,7 @@ charts.isIEEdge = env.browser.name === 'edge';
  * @returns {object} Object with the height and width.
  */
 charts.tooltipSize = function tooltipSize(content) {
-  this.tooltip.find('.tooltip-content').html(content);
+  DOM.html(this.tooltip.find('.tooltip-content'), content, '*');
   return { height: this.tooltip.outerHeight(), width: this.tooltip.outerWidth() };
 };
 
@@ -230,7 +232,7 @@ charts.showTooltip = function (x, y, content, arrow) {
 
   this.tooltip[0].style.left = `${x}px`;
   this.tooltip[0].style.top = `${y}px`;
-  this.tooltip.find('.tooltip-content').html(content);
+  DOM.html(this.tooltip.find('.tooltip-content'), content, '*');
 
   this.tooltip.removeClass('bottom top left right').addClass(arrow);
   this.tooltip.removeClass('is-hidden');
@@ -311,7 +313,7 @@ charts.addLegend = function (series, chartType, settings, container) {
     if (chartType === 'scatterplot') {
       color = $('<span class="chart-legend-color"></span>');
     }
-    const textBlock = $(`<span class="chart-legend-item-text">${series[i].name}</span>`);
+    const textBlock = $(`<span class="chart-legend-item-text">${xssUtils.stripTags(series[i].name)}</span>`);
 
     if (series[i].pattern) {
       color.append(`<svg width="12" height="12"><rect height="12" width="12" mask="url(#${series[i].pattern})"/></svg>`);

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -8,6 +8,7 @@ import * as debug from '../../utils/debug';
 import { utils } from '../../utils/utils';
 import { Locale } from '../locale/locale';
 import { xssUtils } from '../../utils/xss';
+import { DOM } from '../../utils/dom';
 
 const COMPONENT_NAME = 'editor';
 
@@ -1469,6 +1470,7 @@ Editor.prototype = {
 
             // Working with list
             // Start with "<li"
+            let pasteHtml = '';
             if (/(^(\s+?)?<li)/ig.test(html)) {
               // Pasted data starts and ends with "li" tag
               if (/((\s+?)?<\/li>(\s+?)?$)/ig.test(html)) { // ends with "</li>"
@@ -1476,11 +1478,11 @@ Editor.prototype = {
                 if (!thisNode.is('li')) {
                   html = `<ul>${html}</ul>`;
                 }
-                thisNode.replaceWith(html);
+                pasteHtml = html;
               } else if (thisNode.is('li')) {
                 // Missing at the end "</li>" tag
                 // Pasting on "li" node
-                thisNode.replaceWith(`${html}</li>`);
+                pasteHtml = `${html}</li>`;
               } else {
                 // Not pasting on "li" node
 
@@ -1488,9 +1490,9 @@ Editor.prototype = {
                 str = (html.match(/<\/ul|<\/ol/gi) || []);
                 // Pasted data contains "ul or ol" tags
                 if (str.length) {
-                  thisNode.replaceWith(html);
+                  pasteHtml = html;
                 } else {
-                  thisNode.replaceWith(`${html}</li></ul>`);
+                  pasteHtml = `${html}</li></ul>`;
                 }
               }
             } else if (/((\s+?)?<\/li>(\s+?)?$)/ig.test(html)) {
@@ -1498,7 +1500,7 @@ Editor.prototype = {
 
               // Pasting on "li" node
               if (thisNode.is('li')) {
-                thisNode.replaceWith(`<li>${html}`);
+                pasteHtml = `<li>${html}`;
               } else {
                 str = (html.match(/<ul|<ol/gi) || []);
                 // Pasted data contains "ul or ol" tags
@@ -1507,8 +1509,12 @@ Editor.prototype = {
                 } else {
                   html = `<ul>${html}</ul>`;
                 }
-                thisNode.replaceWith(html);
+                pasteHtml = html;
               }
+            }
+
+            if (pasteHtml) {
+              DOM.html(thisNode, pasteHtml, '*');
             }
 
             // Default case

--- a/src/components/lookup/_lookup.scss
+++ b/src/components/lookup/_lookup.scss
@@ -107,7 +107,11 @@
     padding: 0;
 
     .buttonset {
-      width: calc(100%);
+      width: 100%;
+    }
+
+    &.do-resize .buttonset {
+      width: 100%;
     }
 
     &.has-more-button .buttonset {


### PR DESCRIPTION
**Reason for changes**:

Mitigated errors reported in charts.js and editor.js
Fixed 2 css problems noted when testing

**Related github/jira issue (required)**:
Closes #870 

**Steps necessary to review your pull request (required)**:

- run kitchen sink http://localhost:4000/kitchen-sink
- open lookup (notice that search should expand across modal)
- hover charts tooltips (should still work and fixed a layout issue in scatter chart)
- paste html in the editor (IE specifically) - should still work
