### PR TITLE
937 - Fix datepicker error [v4.11.x]

### DIFF
--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -1481,7 +1481,8 @@ DatePicker.prototype = {
       self.setValue(Locale.parseDate(self.element.val().trim(), self.pattern, false));
     }
 
-    if (s.range.useRange && s.range.first.date && !s.range.second.date) {
+    if (s.range.useRange && s.range.first && s.range.first.date
+      && s.range.second && !s.range.second.date) {
       this.setRangeToElem(this.currentDate, true);
     }
   },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Clear was giving an error on range picker. This fixes it.

**Related github/jira issue (required)**:
Closes #937 

(Before was an error, now its fixed). 

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datepicker/example-range.html
- on the "Range - No Initial value" field
- open picker
- hit cancel 
- check other pickers for "fun"
