### PR TITLE
936 - resetForm function not allowing errors to appear after [v4.11.x]

### DIFF
--- a/app/views/components/validation/test-resetform.html
+++ b/app/views/components/validation/test-resetform.html
@@ -1,0 +1,41 @@
+<form>
+
+  <div class="row">
+    <div class="twelve columns">
+
+      <h2 class="fieldset-title">Form Reset Test</h2>
+
+       <div class="field">
+        <label class="required" for="email-address-ok">Email Address <span class="audible">Required</span></label>
+        <input type="text" id="email-address-ok" name="email-address-ok" data-validate="required email" value="someone@someplace.com"/>
+      </div>
+
+      <div class="field">
+        <label class="required" for="credit-card">Credit Card <span class="audible">Required</span></label>
+        <input type="text" id="credit-card" name="credit-card" data-validate="required" value="xxxx-xxxx-xxxx-xxxx"/>
+      </div>
+
+      <div class="field">
+        <label class="required" for="credit-code">Code <span class="audible">Required</span></label>
+        <input type="text" id="credit-code" class="input-sm" name="credit-code" data-validate="required" value="10" data-mask-mode="number"/>
+      </div>
+
+      <button type="button" id="reset" class="btn-secondary">Reset Form</button>
+    </div>
+  </div>
+
+</form>
+
+<script>
+  $('form').on('valid', function (e, args) {
+    console.log('valid event', e, args);
+  });
+
+  $('form').on('error', function (e, args) {
+    console.log('error event', e, args);
+  });
+
+  $('#reset').on('click', function (e, args) {
+    $('body').resetForm();
+  });
+</script>

--- a/src/components/validation/validator.js
+++ b/src/components/validation/validator.js
@@ -1037,6 +1037,11 @@ Validator.prototype = {
     if (form.is('form')) {
       form[0].reset();
     }
+
+    const validationTypes = $.fn.validation.ValidationTypes;
+    Object.keys(validationTypes).forEach((validationType) => {
+      formFields.removeData(`${validationType}message`);
+    });
   },
 
   /**

--- a/test/components/validation/validation.e2e-spec.js
+++ b/test/components/validation/validation.e2e-spec.js
@@ -474,3 +474,34 @@ describe('Validation input tests', () => {
     expect(await element.all(by.css('.icon-error')).count()).toEqual(1);
   });
 });
+
+describe('Validation resetForm tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/validation/test-resetform');
+  });
+
+  it('Should be able reset form', async () => {
+    const emailEl = await element(by.id('email-address-ok'));
+    await emailEl.clear();
+    await emailEl.sendKeys(protractor.Key.TAB);
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('.icon-error'))), config.waitsFor);
+
+    expect(await element(by.css('.message-text')).getText()).toBe('Required');
+    expect(await element(by.css('.icon-error')).isPresent()).toBe(true);
+    expect(await emailEl.getAttribute('class')).toContain('error');
+
+    await element(by.id('reset')).click();
+
+    expect(await element(by.css('.icon-error')).isPresent()).toBe(false);
+
+    await emailEl.clear();
+    await emailEl.sendKeys(protractor.Key.TAB);
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('.icon-error'))), config.waitsFor);
+
+    expect(await element(by.css('.message-text')).getText()).toBe('Required');
+    expect(await element(by.css('.icon-error')).isPresent()).toBe(true);
+    expect(await emailEl.getAttribute('class')).toContain('error');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Reset form was resetting the form, but after that no errors will ever appear again. Added a test for this case as well.

**Related github/jira issue (required)**:
Closes #936

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/validation/test-resetform.html
- clear email field and tab out and an error should show
- click reset form button and error will reset
- clear email field and tab out again  error will show (before it did not)
