### PR TITLE
659 - Dropdown mobile validation

### DIFF
--- a/src/components/validation/validator.js
+++ b/src/components/validation/validator.js
@@ -6,6 +6,7 @@ import { Validation } from './validation';
 // jQuery Components
 import '../icons/icons.jquery';
 import '../toast/toast.jquery';
+import { Environment } from '../../utils/environment';
 
 // Component Name
 const COMPONENT_NAME = 'Validator';
@@ -208,6 +209,13 @@ Validator.prototype = {
         const thisField = $(this);
         let tooltip = thisField.data('tooltip');
         const dropdownApi = thisField.data('dropdown');
+
+        if (Environment.features.touch) {
+          dropdownApi.pseudoElem.focus();
+          setTimeout(() => {
+            dropdownApi.pseudoElem.blur();
+          }, 100);
+        }
 
         if (dropdownApi && dropdownApi.wrapper) {
           tooltip = dropdownApi.wrapper


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Possible solution for validation not firing on mobile. 
On `listclosed.validate` checks for touch device, adds `.focus()` then `.blur()` after `100ms`

**Related github/jira issue (required)**:
closes #659 

**Steps necessary to review your pull request (required)**:
* go to http://localhost:4000/components/dropdown/example-validation.html
* open dev tools and select ios device or use xcode ios simulator 
* select empty from the dropdown.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
