### PR TITLE
703 - Add message modal status icon and color options

### DIFF
--- a/app/views/components/message/example-index.html
+++ b/app/views/components/message/example-index.html
@@ -2,6 +2,8 @@
   <div class="twelve columns">
 
     <button class="btn-secondary" type="button" id="show-application-error">Error Example</button><br><br>
+    <button class="btn-secondary" type="button" id="show-application-warning">Warning Example</button><br><br>
+    <button class="btn-secondary" type="button" id="show-application-success">Success Example</button><br><br>
     <button class="btn-secondary" type="button" id="show-fileupload-confirmation">Complete Example</button><br><br>
     <button class="btn-secondary" type="button" id="show-delete-confirmation">Confirmation Example</button>
 
@@ -15,13 +17,53 @@
     $('#show-application-error').on('click', function() {
       $('body').message({
         title: '<span>Application Error</span>',
-        isError: true,
+        status: 'error',
         returnFocus: $(this),
         message: 'This application has experienced a system error due to the lack of internet access. Please restart the application in order to proceed.',
         buttons: [{
             text: 'Restart Now',
             click: function() {
               console.log('Restart Now');
+              $(this).data('modal').close();
+            },
+            isDefault: true
+        }]
+      });
+    });
+
+    $('#show-application-warning').on('click', function() {
+      $('body').message({
+        title: '<span>Application Warning</span>',
+        status: 'warning',
+        returnFocus: $(this),
+        message: 'This application has experienced a security warning. Please acknowledge the warning to proceed or cancel to abort.',
+        buttons: [{
+            text: 'Acknowledge',
+            click: function() {
+              console.log('Acknowledge');
+              $(this).data('modal').close();
+            },
+            isDefault: true
+          }, {
+            text: 'Cancel',
+            click: function() {
+              console.log('Cancel');
+              $(this).data('modal').close();
+            }
+        }]
+      });
+    });
+
+    $('#show-application-success').on('click', function() {
+      $('body').message({
+        title: '<span>Application Success</span>',
+        status: 'success',
+        returnFocus: $(this),
+        message: 'Success! You\'ve done the thing!',
+        buttons: [{
+            text: 'Confirm',
+            click: function() {
+              console.log('Confirm');
               $(this).data('modal').close();
             },
             isDefault: true

--- a/app/views/components/message/example-index.html
+++ b/app/views/components/message/example-index.html
@@ -2,8 +2,8 @@
   <div class="twelve columns">
 
     <button class="btn-secondary" type="button" id="show-application-error">Error Example</button><br><br>
-    <button class="btn-secondary" type="button" id="show-application-warning">Warning Example</button><br><br>
-    <button class="btn-secondary" type="button" id="show-application-success">Success Example</button><br><br>
+    <button class="btn-secondary" type="button" id="show-application-alert">Alert Example</button><br><br>
+    <button class="btn-secondary" type="button" id="show-application-confirm">Confirm Example</button><br><br>
     <button class="btn-secondary" type="button" id="show-fileupload-confirmation">Complete Example</button><br><br>
     <button class="btn-secondary" type="button" id="show-delete-confirmation">Confirmation Example</button>
 
@@ -31,12 +31,12 @@
       });
     });
 
-    $('#show-application-warning').on('click', function() {
+    $('#show-application-alert').on('click', function() {
       $('body').message({
-        title: '<span>Application Warning</span>',
-        status: 'warning',
+        title: '<span>Application Alert</span>',
+        status: 'alert',
         returnFocus: $(this),
-        message: 'This application has experienced a security warning. Please acknowledge the warning to proceed or cancel to abort.',
+        message: 'This application has experienced a security alert. Please acknowledge the alert to proceed or cancel to abort.',
         buttons: [{
             text: 'Acknowledge',
             click: function() {
@@ -54,10 +54,10 @@
       });
     });
 
-    $('#show-application-success').on('click', function() {
+    $('#show-application-confirm').on('click', function() {
       $('body').message({
-        title: '<span>Application Success</span>',
-        status: 'success',
+        title: '<span>Application Confirm</span>',
+        status: 'confirm',
         returnFocus: $(this),
         message: 'Success! You\'ve done the thing!',
         buttons: [{

--- a/src/components/message/message.js
+++ b/src/components/message/message.js
@@ -110,12 +110,12 @@ Message.prototype = {
 
     if (this.settings.status === 'error') {
       this.title.addClass('has-status is-error').prepend($.createIconElement('error'));
-    } else if (this.settings.status === 'warning') {
-      this.title.addClass('has-status is-warning').prepend($.createIconElement('alert'));
-    } else if (this.settings.status === 'success') {
-      this.title.addClass('has-status is-success').prepend($.createIconElement('confirm'));
+    } else if (this.settings.status === 'alert') {
+      this.title.addClass('has-status is-alert').prepend($.createIconElement('alert'));
+    } else if (this.settings.status === 'confirm') {
+      this.title.addClass('has-status is-confirm').prepend($.createIconElement('confirm'));
     } else {
-      this.title.removeClass('has-status', 'is-error', 'is-warning', 'is-success').find('svg').remove();
+      this.title.removeClass('has-status is-error is-alert is-confirm').find('svg').remove();
     }
   },
 

--- a/src/components/message/message.js
+++ b/src/components/message/message.js
@@ -14,7 +14,7 @@ const COMPONENT_NAME = 'message';
  * @param {object} element The component element.
  * @param {object} [settings] The component settings.
  * @param {string} [settings.title='Message Title']  Title text or content shown in the message
- * @param {boolean} [settings.isError=false]  If true, will show title styled as an error with an error icon
+ * @param {string} [settings.status=null]  Pass a status to style icon and title color ('error', 'warning', 'success')
  * @param {string} [settings.message='Message Summary']  The message content or text
  * @param {number} [settings.width='auto']  Pass a specific with or defaults to auto
  * @param {object} [settings.buttons=null]  Array of buttons to add to the message (see modal examples as well)
@@ -23,7 +23,7 @@ const COMPONENT_NAME = 'message';
  */
 const MESSAGE_DEFAULTS = {
   title: 'Message Title',
-  isError: false,
+  status: '',
   message: 'Message Summary',
   width: 'auto',
   buttons: null,
@@ -108,10 +108,14 @@ Message.prototype = {
       }
     });
 
-    if (this.settings.isError) {
-      this.title.addClass('is-error').prepend($.createIconElement('error'));
+    if (this.settings.status === 'error') {
+      this.title.addClass('has-status is-error').prepend($.createIconElement('error'));
+    } else if (this.settings.status === 'warning') {
+      this.title.addClass('has-status is-warning').prepend($.createIconElement('alert'));
+    } else if (this.settings.status === 'success') {
+      this.title.addClass('has-status is-success').prepend($.createIconElement('confirm'));
     } else {
-      this.title.removeClass('is-error').find('svg').remove();
+      this.title.removeClass('has-status', 'is-error', 'is-warning', 'is-success').find('svg').remove();
     }
   },
 

--- a/src/components/message/message.js
+++ b/src/components/message/message.js
@@ -14,7 +14,7 @@ const COMPONENT_NAME = 'message';
  * @param {object} element The component element.
  * @param {object} [settings] The component settings.
  * @param {string} [settings.title='Message Title']  Title text or content shown in the message
- * @param {string} [settings.status=null]  Pass a status to style icon and title color ('error', 'warning', 'success')
+ * @param {string} [settings.status='']  Pass a status to style icon and title color ('error', 'alert', 'confirm')
  * @param {string} [settings.message='Message Summary']  The message content or text
  * @param {number} [settings.width='auto']  Pass a specific with or defaults to auto
  * @param {object} [settings.buttons=null]  Array of buttons to add to the message (see modal examples as well)

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -246,7 +246,6 @@
     }
 
     &.has-status {
-
       .icon {
         left: -6px;
         margin-left: 5px;

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -245,15 +245,37 @@
       outline: none;
     }
 
+    &.has-status {
+
+      .icon {
+        left: -6px;
+        margin-left: 5px;
+        margin-right: 4px;
+        top: auto;
+      }
+    }
+
     &.is-error {
       color: $error-color;
 
       .icon {
         fill: $error-color;
-        left: -6px;
-        margin-left: 5px;
-        margin-right: 4px;
-        top: auto;
+      }
+    }
+
+    &.is-warning {
+      color: $alert-color;
+
+      .icon {
+        fill: $alert-color;
+      }
+    }
+
+    &.is-success {
+      color: $confirm-color;
+
+      .icon {
+        fill: $confirm-color;
       }
     }
   }
@@ -449,7 +471,7 @@ html[dir='rtl'] {
       padding-left: 20px;
       text-align: right;
 
-      &.is-error {
+      &.has-status {
         svg {
           left: auto;
           margin-left: 10px;

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -250,7 +250,7 @@
         left: -6px;
         margin-left: 5px;
         margin-right: 4px;
-        top: auto;
+        top: -2px;
       }
     }
 
@@ -262,7 +262,7 @@
       }
     }
 
-    &.is-warning {
+    &.is-alert {
       color: $alert-color;
 
       .icon {
@@ -270,7 +270,7 @@
       }
     }
 
-    &.is-success {
+    &.is-confirm {
       color: $confirm-color;
 
       .icon {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Creates a setting that allows the choice of a status for a message modal and styles accordingly. Some mild refactoring occurred during this PR to reduce overhead and promote semantic class naming.

**Related github/jira issue (required)**:
Closes #703 .

**Steps necessary to review your pull request (required)**:
- Pull branch
- Run app
- Browse to http://localhost:4000/components/message/example-index
- Click Error, Warning, and Success buttons and ensure new styling is in effect and appropriate. Styling is appearance of SVG of appropriate color and color of `modal-title`
