### PR TITLE
949 - lookup issues [v4.11.x]

### DIFF
--- a/app/views/components/lookup/test-custom-matching.html
+++ b/app/views/components/lookup/test-custom-matching.html
@@ -51,7 +51,7 @@
           return row.productId + '|' + row.productName;
         },
         match: function (value, row, field, grid) {
-          return ((row.productId + '|' + row.productName) !== value);
+          return ((row.productId + '|' + row.productName) === value);
         },
         options: {
           columns: columns,

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5546,7 +5546,7 @@ Datagrid.prototype = {
           const actualIdx = self.actualPagingRowIndex(idx);
           this._selectedRows.push({
             idx: actualIdx,
-            rowData,
+            data: rowData,
             elem: self.dataRowNode(actualIdx),
             group: s.dataset[gData.group]
           });
@@ -7943,6 +7943,54 @@ Datagrid.prototype = {
 
     if (!this.settings.disableClientSort) {
       this.settings.dataset.sort(sort);
+    }
+
+    // Resync the _selectedRows array
+    if (this.settings.selectable) {
+      this.syncDatasetWithSelectedRows();
+    }
+  },
+
+  /**
+  * Sync the dataset._selected elements with the _selectedRows array
+  * @private
+  */
+  syncDatasetWithSelectedRows() {
+    this._selectedRows = [];
+    const s = this.settings;
+    const dataset = s.treeGrid ? s.treeDepth : s.dataset;
+    let idx = -1;
+
+    for (let i = 0, data; i < dataset.length; i++) {
+      if (s.groupable) {
+        for (let k = 0; k < dataset[i].values.length; k++) {
+          idx++;
+          data = dataset[i].values[k];
+          if (this.isNodeSelected(data)) {
+            this._selectedRows.push({
+              idx,
+              data,
+              elem: this.dataRowNode(idx),
+              group: dataset[i],
+              page: this.pager ? this.pager.activePage : 1,
+              pagingIdx: idx,
+              pagesize: this.settings.pagesize
+            });
+          }
+        }
+      } else {
+        data = s.treeGrid ? dataset[i].node : dataset[i];
+        if (this.isNodeSelected(data)) {
+          this._selectedRows.push({
+            idx: i,
+            data,
+            elem: this.visualRowNode(i),
+            pagesize: this.settings.pagesize,
+            page: this.pager ? this.pager.activePage : 1,
+            pagingIdx: idx
+          });
+        }
+      }
     }
   },
 

--- a/src/components/lookup/lookup.js
+++ b/src/components/lookup/lookup.js
@@ -284,8 +284,12 @@ Lookup.prototype = {
 
     self.createModal();
     self.element.trigger('open', [self.modal, self.grid]);
-
     self.modal.element.find('.btn-actions').removeClass('is-selected');
+
+    // Set tabindex on first row
+    if (self.grid) {
+      self.grid.cellNode(0, 0, true).attr('tabindex', '0');
+    }
 
     // Fix: IE-11 more button was not showing
     const thisMoreBtn = self.modal.element.find('.toolbar .more > .btn-actions');
@@ -618,7 +622,8 @@ Lookup.prototype = {
         }
       }
 
-      if (data[i][field].toString() === value.toString()) {
+      if (typeof this.settings.match !== 'function' &&
+        data[i][field].toString() === value.toString()) {
         isMatch = true;
       }
 
@@ -654,6 +659,12 @@ Lookup.prototype = {
       }
 
       value += (i !== 0 ? this.settings.delimiter : '') + currValue;
+
+      // Clear _selected tag
+      const idx = this.selectedRows[i].idx;
+      if (this.settings.options.dataset) {
+        delete this.settings.options.dataset[idx]._selected;
+      }
     }
 
     /**

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -118,6 +118,27 @@ describe('Datagrid multiselect tests', () => {
 
     expect(await element.all(by.css('.datagrid-row')).count()).toEqual(5);
   });
+
+  it('Should work with sort', async () => {
+    await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(2)')).click();
+    await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(2) td:nth-child(2)')).click();
+
+    expect(await element(by.css('.selection-count')).getText()).toEqual('2 Selected');
+    expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(2);
+
+    await element(by.css('#datagrid .datagrid-header th:nth-child(2)')).click();
+    await element(by.css('#datagrid .datagrid-header th:nth-child(2)')).click();
+
+    await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(2)')).click();
+
+    expect(await element(by.css('.selection-count')).getText()).toEqual('3 Selected');
+    expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(3);
+
+    await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(6) td:nth-child(2)')).click();
+
+    expect(await element(by.css('.selection-count')).getText()).toEqual('2 Selected');
+    expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(2);
+  });
 });
 
 describe('Datagrid page size selector tests', () => {
@@ -172,6 +193,26 @@ describe('Datagrid single select tests', () => {
 
     expect(await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(1)')).getAttribute('class')).not.toMatch('is-selected');
     expect(await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(2)')).getAttribute('class')).not.toMatch('is-selected');
+  });
+
+  it('Should work with sort', async () => {
+    await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1)')).click();
+
+    expect(await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(1)')).getAttribute('class')).toMatch('is-selected');
+    expect(await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(2)')).getAttribute('class')).not.toMatch('is-selected');
+    expect(await element(by.css('#datagrid .datagrid-row.is-selected td:nth-child(1) span')).getText()).toEqual('2142201');
+
+    // Sort
+    await element(by.css('#datagrid .datagrid-header th:nth-child(4)')).click();
+    await element(by.css('#datagrid .datagrid-header th:nth-child(4)')).click();
+
+    expect(await element(by.css('#datagrid .datagrid-row.is-selected td:nth-child(1) span')).getText()).toEqual('2142201');
+
+    await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1)')).click();
+
+    expect(await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(1)')).getAttribute('class')).toMatch('is-selected');
+    expect(await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(2)')).getAttribute('class')).not.toMatch('is-selected');
+    expect(await element(by.css('#datagrid .datagrid-row.is-selected td:nth-child(1) span')).getText()).toEqual('2642205');
   });
 });
 

--- a/test/components/lookup/lookup.e2e-spec.js
+++ b/test/components/lookup/lookup.e2e-spec.js
@@ -57,7 +57,7 @@ describe('Lookup', () => {
     const lookupEl = await element(by.id('product-lookup'));
     await element.all(by.className('trigger')).first().click();
 
-    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('lookup-datagrid'))), config.waitsFor);
+    await browser.driver.wait(protractor.ExpectedConditions.visibilityOf(element(by.id('lookup-datagrid'))), config.waitsFor);
     await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1)')).click();
 
     expect(await lookupEl.getAttribute('value')).toEqual('2142201');
@@ -66,7 +66,7 @@ describe('Lookup', () => {
     await browser.driver.sleep(301);
     await element.all(by.className('trigger')).first().click();
 
-    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('lookup-datagrid'))), config.waitsFor);
+    await browser.driver.wait(protractor.ExpectedConditions.visibilityOf(element(by.id('lookup-datagrid'))), config.waitsFor);
     await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(2) td:nth-child(1)')).click();
 
     expect(await lookupEl.getAttribute('value')).toEqual('2241202');
@@ -95,7 +95,7 @@ describe('Lookup', () => {
 
     await element.all(by.className('trigger')).first().click();
 
-    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('lookup-datagrid'))), config.waitsFor);
+    await browser.driver.wait(protractor.ExpectedConditions.visibilityOf(element(by.id('lookup-datagrid'))), config.waitsFor);
     await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1)')).click();
 
     expect(await lookupEl.getAttribute('value')).toEqual('2142201');
@@ -307,7 +307,7 @@ describe('Lookup custom matching tests', () => {
 
     await buttonEl.click();
 
-    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('lookup-datagrid'))), config.waitsFor);
+    await browser.driver.wait(protractor.ExpectedConditions.visibilityOf(element(by.id('lookup-datagrid'))), config.waitsFor);
     await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1)')).click();
 
     await browser.driver.wait(protractor.ExpectedConditions.invisibilityOf(element(by.css('.overlay'))), config.waitsFor);
@@ -316,7 +316,7 @@ describe('Lookup custom matching tests', () => {
     expect(await lookupEl.getAttribute('value')).toEqual('2142201|Compressor');
     await buttonEl.click();
 
-    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('lookup-datagrid'))), config.waitsFor);
+    await browser.driver.wait(protractor.ExpectedConditions.visibilityOf(element(by.id('lookup-datagrid'))), config.waitsFor);
     await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(3) td:nth-child(1)')).click();
 
     expect(await lookupEl.getAttribute('value')).toEqual('2342203|Compressor');
@@ -332,10 +332,10 @@ describe('Lookup modal tests', () => {
     const buttonEl = await element.all(by.className('btn-secondary')).first();
     await buttonEl.click();
 
-    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('modal-1-text'))), config.waitsFor);
+    await browser.driver.wait(protractor.ExpectedConditions.visibilityOf(element(by.id('modal-1-text'))), config.waitsFor);
     await element(by.css('#modal-1-text .trigger')).click();
 
-    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('lookup-datagrid'))), config.waitsFor);
+    await browser.driver.wait(protractor.ExpectedConditions.visibilityOf(element(by.id('lookup-datagrid'))), config.waitsFor);
     await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1)')).click();
 
     const lookupEl = await element(by.id('product-lookup'));
@@ -345,7 +345,7 @@ describe('Lookup modal tests', () => {
     expect(await lookupEl.getAttribute('value')).toEqual('2142201|Compressor');
     await element(by.css('#modal-1-text .trigger')).click();
 
-    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('lookup-datagrid'))), config.waitsFor);
+    await browser.driver.wait(protractor.ExpectedConditions.visibilityOf(element(by.id('lookup-datagrid'))), config.waitsFor);
     await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(2) td:nth-child(1)')).click();
     await browser.driver.sleep(301);
 

--- a/test/components/lookup/lookup.e2e-spec.js
+++ b/test/components/lookup/lookup.e2e-spec.js
@@ -79,12 +79,12 @@ describe('Lookup', () => {
     await browser.driver.wait(protractor.ExpectedConditions.visibilityOf(element(by.id('lookup-datagrid'))), config.waitsFor);
     await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1)')).click();
 
-    await browser.driver.sleep(301);
+    await browser.driver.sleep(1000);
 
     expect(await lookupEl.getAttribute('value')).toEqual('2142201');
 
     await browser.driver.wait(protractor.ExpectedConditions.invisibilityOf(element(by.css('.overlay'))), config.waitsFor);
-    await browser.driver.sleep(301);
+    await browser.driver.sleep(1000);
     await element.all(by.id('product-lookup')).clear();
     await element.all(by.id('product-lookup')).sendKeys(protractor.Key.TAB);
 

--- a/test/components/lookup/lookup.e2e-spec.js
+++ b/test/components/lookup/lookup.e2e-spec.js
@@ -79,6 +79,8 @@ describe('Lookup', () => {
     await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('lookup-datagrid'))), config.waitsFor);
     await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1)')).click();
 
+    await browser.driver.sleep(301);
+
     expect(await lookupEl.getAttribute('value')).toEqual('2142201');
 
     await browser.driver.wait(protractor.ExpectedConditions.invisibilityOf(element(by.css('.overlay'))), config.waitsFor);

--- a/test/components/lookup/lookup.e2e-spec.js
+++ b/test/components/lookup/lookup.e2e-spec.js
@@ -74,17 +74,9 @@ describe('Lookup', () => {
 
   it('should be able to validate', async () => {
     const lookupEl = await element(by.id('product-lookup'));
-    await element.all(by.className('trigger')).first().click();
-
-    await browser.driver.wait(protractor.ExpectedConditions.visibilityOf(element(by.id('lookup-datagrid'))), config.waitsFor);
-    await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1)')).click();
-
-    await browser.driver.sleep(1000);
-
-    expect(await lookupEl.getAttribute('value')).toEqual('2142201');
 
     await browser.driver.wait(protractor.ExpectedConditions.invisibilityOf(element(by.css('.overlay'))), config.waitsFor);
-    await browser.driver.sleep(1000);
+    await browser.driver.sleep(301);
     await element.all(by.id('product-lookup')).clear();
     await element.all(by.id('product-lookup')).sendKeys(protractor.Key.TAB);
 

--- a/test/components/lookup/lookup.e2e-spec.js
+++ b/test/components/lookup/lookup.e2e-spec.js
@@ -72,7 +72,7 @@ describe('Lookup', () => {
     expect(await lookupEl.getAttribute('value')).toEqual('2241202');
   });
 
-  fit('should be able to validate', async () => { //eslint-disable-line
+  it('should be able to validate', async () => {
     const lookupEl = await element(by.id('product-lookup'));
     await element.all(by.className('trigger')).first().click();
 

--- a/test/components/lookup/lookup.e2e-spec.js
+++ b/test/components/lookup/lookup.e2e-spec.js
@@ -52,6 +52,52 @@ describe('Lookup', () => {
 
     expect(await lookupEl.getAttribute('value')).toEqual('2142201');
   });
+
+  it('should be able to reselect', async () => {
+    const lookupEl = await element(by.id('product-lookup'));
+    await element.all(by.className('trigger')).first().click();
+
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('lookup-datagrid'))), config.waitsFor);
+    await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1)')).click();
+
+    expect(await lookupEl.getAttribute('value')).toEqual('2142201');
+
+    await browser.driver.wait(protractor.ExpectedConditions.invisibilityOf(element(by.css('.overlay'))), config.waitsFor);
+    await browser.driver.sleep(301);
+    await element.all(by.className('trigger')).first().click();
+
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('lookup-datagrid'))), config.waitsFor);
+    await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(2) td:nth-child(1)')).click();
+
+    expect(await lookupEl.getAttribute('value')).toEqual('2241202');
+  });
+
+  it('should be able to validate', async () => {
+    const lookupEl = await element(by.id('product-lookup'));
+    await element.all(by.className('trigger')).first().click();
+
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('lookup-datagrid'))), config.waitsFor);
+    await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1)')).click();
+
+    expect(await lookupEl.getAttribute('value')).toEqual('2142201');
+
+    await browser.driver.wait(protractor.ExpectedConditions.invisibilityOf(element(by.css('.overlay'))), config.waitsFor);
+    await browser.driver.sleep(301);
+    await element.all(by.id('product-lookup')).clear();
+    await element.all(by.id('product-lookup')).sendKeys(protractor.Key.TAB);
+
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.css('.message-text'))), config.waitsFor);
+
+    expect(await element(by.css('.message-text')).getText()).toBe('Required');
+    expect(await element(by.css('.icon-error')).isPresent()).toBe(true);
+
+    await element.all(by.className('trigger')).first().click();
+
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('lookup-datagrid'))), config.waitsFor);
+    await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1)')).click();
+
+    expect(await lookupEl.getAttribute('value')).toEqual('2142201');
+  });
 });
 
 describe('Lookup (editable)', () => {
@@ -245,5 +291,62 @@ describe('Lookup multiselect serverside paging tests', () => {
     await element(by.css('.btn-modal-primary')).click();
 
     expect(await lookupEl.getAttribute('value')).toEqual('214220,214221,214225,214226');
+  });
+});
+
+describe('Lookup custom matching tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/lookup/test-custom-matching');
+  });
+
+  it('Paging lookup should work with custom matching', async () => {
+    const buttonEl = await element.all(by.className('trigger')).first();
+    const lookupEl = await element(by.id('product-lookup'));
+
+    await buttonEl.click();
+
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('lookup-datagrid'))), config.waitsFor);
+    await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1)')).click();
+
+    await browser.driver.wait(protractor.ExpectedConditions.invisibilityOf(element(by.css('.overlay'))), config.waitsFor);
+    await browser.driver.sleep(301);
+
+    expect(await lookupEl.getAttribute('value')).toEqual('2142201|Compressor');
+    await buttonEl.click();
+
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('lookup-datagrid'))), config.waitsFor);
+    await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(3) td:nth-child(1)')).click();
+
+    expect(await lookupEl.getAttribute('value')).toEqual('2342203|Compressor');
+  });
+});
+
+describe('Lookup modal tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/lookup/test-modal-lookup');
+  });
+
+  it('Paging lookup should work on a modal', async () => {
+    const buttonEl = await element.all(by.className('btn-secondary')).first();
+    await buttonEl.click();
+
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('modal-1-text'))), config.waitsFor);
+    await element(by.css('#modal-1-text .trigger')).click();
+
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('lookup-datagrid'))), config.waitsFor);
+    await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1)')).click();
+
+    const lookupEl = await element(by.id('product-lookup'));
+
+    await browser.driver.sleep(301);
+
+    expect(await lookupEl.getAttribute('value')).toEqual('2142201|Compressor');
+    await element(by.css('#modal-1-text .trigger')).click();
+
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('lookup-datagrid'))), config.waitsFor);
+    await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(2) td:nth-child(1)')).click();
+    await browser.driver.sleep(301);
+
+    expect(await lookupEl.getAttribute('value')).toEqual('2241202|Different Compressor');
   });
 });

--- a/test/components/lookup/lookup.e2e-spec.js
+++ b/test/components/lookup/lookup.e2e-spec.js
@@ -72,11 +72,11 @@ describe('Lookup', () => {
     expect(await lookupEl.getAttribute('value')).toEqual('2241202');
   });
 
-  it('should be able to validate', async () => {
+  fit('should be able to validate', async () => { //eslint-disable-line
     const lookupEl = await element(by.id('product-lookup'));
     await element.all(by.className('trigger')).first().click();
 
-    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('lookup-datagrid'))), config.waitsFor);
+    await browser.driver.wait(protractor.ExpectedConditions.visibilityOf(element(by.id('lookup-datagrid'))), config.waitsFor);
     await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1)')).click();
 
     await browser.driver.sleep(301);
@@ -88,7 +88,7 @@ describe('Lookup', () => {
     await element.all(by.id('product-lookup')).clear();
     await element.all(by.id('product-lookup')).sendKeys(protractor.Key.TAB);
 
-    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.css('.message-text'))), config.waitsFor);
+    await browser.driver.wait(protractor.ExpectedConditions.visibilityOf(element(by.css('.message-text'))), config.waitsFor);
 
     expect(await element(by.css('.message-text')).getText()).toBe('Required');
     expect(await element(by.css('.icon-error')).isPresent()).toBe(true);

--- a/test/components/monthview/monthview.e2e-spec.js
+++ b/test/components/monthview/monthview.e2e-spec.js
@@ -1,5 +1,7 @@
 const { browserStackErrorReporter } = requireHelper('browserstack-error-reporter');
 const utils = requireHelper('e2e-utils');
+const config = require('../../helpers/e2e-config.js');
+
 requireHelper('rejection');
 
 jasmine.getEnv().addReporter(browserStackErrorReporter);
@@ -70,6 +72,8 @@ describe('MonthView disable month selection tests', () => {
   });
 
   it('Should disable specified days', async () => {
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.css('.monthview-table td.is-disabled'))), config.waitsFor);
+
     expect(await element.all(by.css('.monthview-table td.is-disabled')).first().getText()).toEqual('1');
   });
 

--- a/test/components/multiselect/multiselect.e2e-spec.js
+++ b/test/components/multiselect/multiselect.e2e-spec.js
@@ -60,30 +60,11 @@ describe('Multiselect example-states tests', () => {
   });
 
   if (!utils.isSafari()) {
-    xit('Should show validation message error "Required" on tab out', async () => {
-      // Disabled until dropdown fixes are in 4.9
+    it('Should show validation message error "Required" on tab out', async () => {
       const multiselectEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).get(2);
       await browser.driver
         .wait(protractor.ExpectedConditions.presenceOf(multiselectEl), config.waitsFor);
       await multiselectEl.sendKeys(protractor.Key.TAB);
-      await browser.driver
-        .wait(protractor.ExpectedConditions.presenceOf(element(by.className('message-text'))), config.waitsFor);
-
-      expect(await element(by.css('.message-text')).getText()).toEqual('Required');
-    });
-
-    xit('Should show validation message error "Required" on click', async () => {
-      // Disabled until dropdown fixes are in 4.9
-      const multiselectEl = await element.all(by.css('div[aria-controls="dropdown-list"]')).get(2);
-      await browser.driver
-        .wait(protractor.ExpectedConditions.presenceOf(multiselectEl), config.waitsFor);
-      await element(by.css('body')).sendKeys(protractor.Key.TAB);
-      await element(by.css('body')).sendKeys(protractor.Key.TAB);
-      await element(by.css('body')).sendKeys(protractor.Key.TAB);
-      await multiselectEl.sendKeys(protractor.Key.ENTER);
-      await multiselectEl.sendKeys(protractor.Key.ENTER);
-      await multiselectEl.sendKeys(protractor.Key.ENTER);
-      await element.all(by.css('.trigger')).first().click();
       await browser.driver
         .wait(protractor.ExpectedConditions.presenceOf(element(by.className('message-text'))), config.waitsFor);
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Recent pr's to allow multiselect across pages broke some selection in lookup in different cases. This was raised as 3 issues all fixed by the same thing. The problem is that now the selected rows are kept on a separate array, this array got out of sync.

Added new tests for all the test scenarios mentioned.

**Related github/jira issue (required)**:
Closes #949
Closes #953
Closes #928

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/example-multiselect
* open list
* tab once to grid
* down and up arrow to pick one
* space to select

http://localhost:4000/components/datagrid/example-multiselect
* select first row
* select second row
* sort (twice) on product id so selected rows go to bottom
* select first row
* deselect second last row
* should be two rows selected

http://localhost:4000/components/lookup/example-index.html
* open the lookup on the first field
* pick one
* open it again
* pick a different one
* clear the field and tab out (shows error)
* open the lookup on the first field
* pick one

http://localhost:4000/components/lookup/test-custom-modal.html
* open the lookup on the first field
* pick one
* open it again
* pick a different one
