### PR TITLE
619 - Fix tabs spillover dropdown

### DIFF
--- a/app/views/components/tabs-multi/example-index.html
+++ b/app/views/components/tabs-multi/example-index.html
@@ -2,7 +2,7 @@
   <a href="#maincontent" class="skip-link" data-translate="text">SkipToMain</a>
   {{> includes/svg-inline-refs}}
 
-  <section id="test-multitabs" class="multitabs-container side-by-side" data-options='{"trigger": "rightClick"}' data-popupmenu="action-popupmenu">
+  <section id="test-multitabs" class="multitabs-container side-by-side">
     <div class="multitabs-section">
       <div id="tab-list-one" class="tab-container module-tabs">
         <ul class="tab-list">
@@ -163,6 +163,15 @@
 
       $('#tabset-name').text(currentTabset.children('.tab-container').attr('id'));
     });
+
+
+    // Only enable `rightClick` menu on desktop for this demo.
+    if(!Soho.env.features.touch) {
+      multitabs.popupmenu({
+        trigger: 'rightClick',
+        menu: 'action-popupmenu'
+      });
+    }
 
 
     // Simple Tab Removal

--- a/app/views/components/tabs-multi/example-index.html
+++ b/app/views/components/tabs-multi/example-index.html
@@ -154,6 +154,14 @@
       multiAPI = multitabs.data('multitabs');
     });
 
+    // Only enable `rightClick` menu on desktop for this demo.
+    if (!Soho.env.features.touch) {
+      multitabs.popupmenu({
+        trigger: 'rightClick',
+        menu: 'action-popupmenu'
+      });
+    }
+
     // Use mouseover/click to store reference to the target tabset
     multitabs.on('click.test, mouseover.test', function(e) {
       currentTabset = $(e.target);
@@ -163,15 +171,6 @@
 
       $('#tabset-name').text(currentTabset.children('.tab-container').attr('id'));
     });
-
-
-    // Only enable `rightClick` menu on desktop for this demo.
-    if(!Soho.env.features.touch) {
-      multitabs.popupmenu({
-        trigger: 'rightClick',
-        menu: 'action-popupmenu'
-      });
-    }
 
 
     // Simple Tab Removal

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -805,6 +805,9 @@ PopupMenu.prototype = {
           this.element
             .on('touchstart.popupmenu', (e) => {
               // iOS needs this prevented to prevent its own longpress feature in Safari
+              if (e.target.hasClass('tab-more')) {
+                self.open(e);
+              }
               if (env.os.name === 'ios') {
                 e.preventDefault();
               }

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -788,7 +788,6 @@ PopupMenu.prototype = {
           });
       }
 
-
       // Right-Click activation
       if (!leftClick) {
         this.menu.parent().on('contextmenu.popupmenu', disableBrowserContextMenu);

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -788,6 +788,7 @@ PopupMenu.prototype = {
           });
       }
 
+
       // Right-Click activation
       if (!leftClick) {
         this.menu.parent().on('contextmenu.popupmenu', disableBrowserContextMenu);
@@ -805,9 +806,6 @@ PopupMenu.prototype = {
           this.element
             .on('touchstart.popupmenu', (e) => {
               // iOS needs this prevented to prevent its own longpress feature in Safari
-              if (e.target.hasClass('tab-more')) {
-                self.open(e);
-              }
               if (env.os.name === 'ios') {
                 e.preventDefault();
               }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes the spillover `popupmenu` not opening on mobile by changing the multi-tab demo to only enable `action-popupmenu` on desktop.

**Related github/jira issue (required)**:
closes #619 

**Steps necessary to review your pull request (required)**:
* Open http://localhost:4000/components/tabs-multi/example-index.html
* Open mobile devtools in Chrome.
* Tap/Click on the "More" button in the tab menu.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
