### PR TITLE
667 - Add click event option to emptyMessage button.

### DIFF
--- a/app/views/components/datagrid/test-empty-message-contained.html
+++ b/app/views/components/datagrid/test-empty-message-contained.html
@@ -30,7 +30,11 @@
         selectable: 'single',
         editable: true,
         //emptyMessage: {title: 'No Stock Found', 'info': 'Could not find any stock data matching the results', icon: 'icon-empty-generic', button: {id: 'test', text: 'Reload'}},
-        emptyMessage: {title: 'No Stock Found', icon: 'icon-empty-generic'},
+        emptyMessage: {
+          title: 'No Stock Found',
+          icon: 'icon-empty-generic',
+          button: { id: 'test', text: 'Retry', click: () => { alert('emptyMessage button click event invoked'); } }
+        },
         toolbar: {title: 'Filterable Datagrid', filterRow: true, results: true, dateFilter: false ,keywordFilter: false, actions: true, views: false, rowHeight: true, collapsibleFilter: false}
       })
 

--- a/src/components/emptymessage/emptymessage.js
+++ b/src/components/emptymessage/emptymessage.js
@@ -78,6 +78,10 @@ EmptyMessage.prototype = {
         '</div>').appendTo(this.element);
     }
 
+    if (opts.button.click) {
+      this.element.on('click', opts.button.click);
+    }
+
     return this;
   },
 

--- a/src/components/emptymessage/emptymessage.js
+++ b/src/components/emptymessage/emptymessage.js
@@ -76,10 +76,10 @@ EmptyMessage.prototype = {
             `<span>${opts.button.text}</span>` +
           '</button>' +
         '</div>').appendTo(this.element);
-    }
 
-    if (opts.button.click) {
-      this.element.on('click', opts.button.click);
+      if (opts.button.click) {
+        this.element.on('click', opts.button.click);
+      }
     }
 
     return this;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Click event is not invoked on `emptyMessage` button.

**Related github/jira issue (required)**:
Closes #667 

**Steps necessary to review your pull request (required)**:
- Pull branch
- Run app
- http://localhost:4000/components/datagrid/test-empty-message-contained
- Click `dataqrid` header to make `emptyMessage` appear
- Click `emptyMessage` button to invoke `emptyMessage` button click event and ensure event invokes.
