### PR TITLE
975 - Fix month view tests [v4.11.x]

### DIFF
--- a/test/components/monthview/monthview-api.func-spec.js
+++ b/test/components/monthview/monthview-api.func-spec.js
@@ -72,12 +72,12 @@ describe('Monthview API', () => {
 
     Locale.set('ar-SA');
     Soho.Locale.set('ar-SA'); //eslint-disable-line
-    monthviewAPI.showMonth(7, 2018);
+    monthviewAPI.showMonth(7, 1440);
 
-    expect(document.getElementById('monthview-datepicker-field').value).toEqual('محرم 1440');
+    expect(document.getElementById('monthview-datepicker-field').value).toEqual('صفر 1440');
     expect(document.body.querySelector('thead tr th:first-child').textContent.trim()).toEqual('السبت');
-    expect(document.body.querySelector('tbody tr:first-child td:first-child').textContent.trim()).toEqual('28');
-    expect(document.body.querySelector('tbody tr:first-child td:last-child').textContent.trim()).toEqual('4');
+    expect(document.body.querySelector('tbody tr:first-child td:first-child').textContent.trim()).toEqual('26');
+    expect(document.body.querySelector('tbody tr:first-child td:last-child').textContent.trim()).toEqual('3');
   });
 
   it('Should render disabled days', () => {
@@ -128,7 +128,7 @@ describe('Monthview API', () => {
     Soho.Locale.set('ar-SA'); //eslint-disable-line
     monthviewAPI.showMonth(7, 2018);
 
-    expect(document.getElementById('monthview-datepicker-field').value).toEqual('محرم 1440');
+    expect(document.getElementById('monthview-datepicker-field').value).toEqual('صفر 1440');
 
     Locale.set('de-DE');
     Soho.Locale.set('de-DE'); //eslint-disable-line


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Some tests started to fail because the arabic month changed. Trying to stablize these.
Because the calendar is driven by gregorian and then "converted" to arabic the month starts out on a gregorian month and then is changed, but the starting day might be someplace in the middle of the month it gets off. This should fix , but have to keep an eye on this when the next month changes.

**Related github/jira issue (required)**:
Closes #975

**Steps necessary to review your pull request (required)**:
Ensure functional tests pass on CI.