### PR TITLE
972 - Fix incorrect searchfield background color [v4.11.x]

### DIFF
--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -673,7 +673,7 @@ $toolbarsearchfield-category-empty-width: 51px;
       }
     }
   }
-
+  
   .header,
   .masthead,
   .module-tabs {
@@ -702,27 +702,6 @@ $toolbarsearchfield-category-empty-width: 51px;
       }
     }
   }
-
-  .header,
-  .masthead {
-    .toolbar-searchfield-wrapper.non-collapsible {
-      .searchfield {
-        background-color: rgba($searchfield-moduletabs-bg-color, 0.5);
-        border-bottom-color: rgba($searchfield-moduletabs-border-color, 0.7);
-      }
-    }
-  }
-
-  .module-tabs {
-    .toolbar-searchfield-wrapper.non-collapsible {
-      // reset all the styling for the searchfield to correctly appear open.
-      .searchfield {
-        background-color: rgba($searchfield-header-bg-color, 0.5);
-        border-bottom-color: rgba($searchfield-header-border-color, 0.7);
-      }
-    }
-  }
-
 }
 
 html[dir='rtl'] {

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -673,7 +673,7 @@ $toolbarsearchfield-category-empty-width: 51px;
       }
     }
   }
-  
+
   .header,
   .masthead,
   .module-tabs {

--- a/src/components/tabs-module/_tabs-module.scss
+++ b/src/components/tabs-module/_tabs-module.scss
@@ -753,13 +753,3 @@ html[dir='rtl'] {
     }
   }
 }
-
-// For non-collapsible searchfields:  Only be non-collapsible on larger breakpoints.
-@media (min-width: $breakpoint-phone-to-tablet) {
-  .toolbar-searchfield-wrapper.non-collapsible {
-    .searchfield {
-      background-color: rgba($searchfield-moduletabs-bg-color, 0.4);
-      border-bottom-color: rgba($searchfield-moduletabs-border-color, 0.4);
-    }
-  }
-}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed incorrect bg color on "in-page" non-collapsible searchfields

**Related github/jira issue (required)**:
Closes #972 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- open a browser to http://localhost:4000/components/datagrid/test-click-event-on-rows.html
- in-page searchfield background color should match to IDS color `graphite02`, appearing like this...

![screen shot 2018-10-10 at 1 21 59 pm](https://user-images.githubusercontent.com/3249601/46754179-cefee100-cc8f-11e8-9fa0-2b4daa4e7a59.png)
...and not like this...
![screen shot 2018-10-10 at 1 22 20 pm](https://user-images.githubusercontent.com/3249601/46754180-cefee100-cc8f-11e8-8370-2f975793f6be.png)
