### PR TITLE
378 - Datagrid csv export

### DIFF
--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -309,7 +309,7 @@ excel.exportToExcel = function (fileName, worksheetName, customDs, self) {
  * @param {string} self The grid api to use (if customDs is not used)
  * @returns {void}
  */
-excel.exportToCsv = function (fileName, customDs, self) {
+excel.exportToCsv = function (fileName, customDs, self, seperator = 'sep=,') {
   const formatCsv = function (table) {
     const csv = [];
     const rows = [].slice.call(table[0].querySelectorAll('tr'));
@@ -319,6 +319,7 @@ excel.exportToCsv = function (fileName, customDs, self) {
       cols.forEach(col => rowContent.push(col.textContent.replace(/\r?\n|\r/g, '').replace(/"/g, '""').trim()));
       csv.push(rowContent.join('","'));
     });
+    csv.unshift([`${seperator}`]);
     return `"${csv.join('"\n"')}"`;
   };
 

--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -307,6 +307,7 @@ excel.exportToExcel = function (fileName, worksheetName, customDs, self) {
  * @param {string} fileName The desired export filename in the download.
  * @param {string} customDs An optional customized version of the data to use.
  * @param {string} self The grid api to use (if customDs is not used)
+ * @param {string} seperator (optional) If user's machine is configured for a locale with alternate default seperator.
  * @returns {void}
  */
 excel.exportToCsv = function (fileName, customDs, self, seperator = 'sep=,') {

--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -307,10 +307,10 @@ excel.exportToExcel = function (fileName, worksheetName, customDs, self) {
  * @param {string} fileName The desired export filename in the download.
  * @param {string} customDs An optional customized version of the data to use.
  * @param {string} self The grid api to use (if customDs is not used)
- * @param {string} seperator (optional) If user's machine is configured for a locale with alternate default seperator.
+ * @param {string} separator (optional) If user's machine is configured for a locale with alternate default seperator.
  * @returns {void}
  */
-excel.exportToCsv = function (fileName, customDs, self, seperator = 'sep=,') {
+excel.exportToCsv = function (fileName, customDs, self, separator = 'sep=,') {
   const formatCsv = function (table) {
     const csv = [];
     const rows = [].slice.call(table[0].querySelectorAll('tr'));
@@ -320,7 +320,7 @@ excel.exportToCsv = function (fileName, customDs, self, seperator = 'sep=,') {
       cols.forEach(col => rowContent.push(col.textContent.replace(/\r?\n|\r/g, '').replace(/"/g, '""').trim()));
       csv.push(rowContent.join('","'));
     });
-    csv.unshift([`${seperator}`]);
+    csv.unshift([`${separator}`]);
     return `"${csv.join('"\n"')}"`;
   };
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adds an optional parameter of "sep=," to the `exportToCsv` method. Fixes issue when a user's locale setting uses `;` as default separator in csv files. 

**Related github/jira issue (required)**:
closes #378 

**Steps necessary to review your pull request (required)**:
* change your machine's language setting to Swedish in System Preferences > Language & Region
* go to http://localhost:4000/components/datagrid/example-export-from-button.html 
* export to csv 

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
