### PR TITLE
Fix modal test-dynamic-content page console error.

### DIFF
--- a/app/views/components/modal/test-dynamic-content.html
+++ b/app/views/components/modal/test-dynamic-content.html
@@ -103,7 +103,7 @@
       // Initial update of view
       update();
 
-      $('#context-type').on('change', () => {update()});
+      $('#context-type').on('change', function() {update()});
    </script>
 </div>
 </div>

--- a/app/views/components/modal/test-dynamic-content.html
+++ b/app/views/components/modal/test-dynamic-content.html
@@ -17,7 +17,7 @@
          <div id="modal-add-context" style="display: none;">
             <div class="field">
                <label for="context-type">Type</label>
-               <select class="dropdown-lg" id="context-type" name="context-type" onchange="update()">
+               <select class="dropdown-lg" id="context-type" name="context-type">
                   <option value="">Change Me</option>
                   <option value="2">This Value Shows More Content</option>
                </select>
@@ -102,6 +102,8 @@
 
       // Initial update of view
       update();
+
+      $('#context-type').on('change', () => {update()});
    </script>
 </div>
 </div>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Chrome console error:
_Refused to execute inline event handler because it violates the following Content Security Policy directive: "script-src 'self' 'nonce-012427b8' http://squizlabs.github.io http://myserver.com". Either the 'unsafe-inline' keyword, a hash ('sha256-...'), or a nonce ('nonce-...') is required to enable inline execution._

**Related github/jira issue (required)**:
N/A

**Steps necessary to review your pull request (required)**:
- Pull branch
- Run app
- Browse to http://localhost:4000/components/modal/test-dynamic-content
- Open Chrome Dev Tools
- Click "Open Modal"
- Select second option in Type input field ("This Value Shows More Content")
- Ensure there are no errors in Chrome Dev Tools Console