### PR TITLE
947 - Fix disabled tab accessible

### DIFF
--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -2538,7 +2538,6 @@ Tabs.prototype = {
       }
     }
 
-    console.log(prevLi);
     this.focusBar(prevLi);
     a.focus();
 

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -2500,12 +2500,12 @@ Tabs.prototype = {
      */
     this.element.trigger('close', [targetLi]);
 
-    // If any tabs are left in the list, set the previous tab as the currently selected one.
+    // If any tabs are left in the list, set the first available tab as the currently selected one.
     let count = targetLiIndex - 1;
     while (count > -1) {
       count = -1;
       if (prevLi.is(notATab)) {
-        prevLi = prevLi.prev();
+        prevLi = this.tablist.children('li').not(notATab)[0];
         count -= 1;
       }
     }
@@ -2538,6 +2538,7 @@ Tabs.prototype = {
       }
     }
 
+    console.log(prevLi);
     this.focusBar(prevLi);
     a.focus();
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
If `prevLi.is(notATab)` set the first available tab to selected instead of the previous tab.

**Related github/jira issue (required)**:
closes #947 

**Steps necessary to review your pull request (required)**:
* go to http://localhost:4000/components/tabs/example-enable-disable-individual-tabs.html
* Disable the "Form Elements" tab
* dismiss the dismissable tab
* the first available selectable tab will be selected and focused

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
