### PR TITLE
933 - Fix back arrow button gets cut off on responsive view

### DIFF
--- a/src/components/hierarchy/_hierarchy.scss
+++ b/src/components/hierarchy/_hierarchy.scss
@@ -72,6 +72,10 @@ $hierarchy-line-width: 1.34px; //Fixes zoom somewhat
           position: relative;
           top: 55px;
 
+          @media only screen and (max-width: $breakpoint-big-phone - 30px) and (min-width: $breakpoint-phone) {
+            left: -175px;
+          }
+
           button {
             background: $color-primary;
             color: $white;
@@ -308,6 +312,10 @@ $hierarchy-line-width: 1.34px; //Fixes zoom somewhat
   ul > li > .leaf {
     width: 315px;
 
+    @media only screen and (max-width: $breakpoint-big-phone - 30px) and (min-width: $breakpoint-phone) {
+      width: 200px;
+    }
+
     .btn-actions,
     .btn-expand,
     .btn-collapse {
@@ -402,6 +410,10 @@ $hierarchy-line-width: 1.34px; //Fixes zoom somewhat
       overflow: visible;
       position: relative;
 
+      @media only screen and (max-width: $breakpoint-big-phone - 30px) and (min-width: $breakpoint-phone) {
+        margin: 0 0 20px 20px;
+      }
+
       &::after {
         border-top: $hierarchy-line-width solid $hierarchy-line-color;
         content: '';
@@ -411,6 +423,10 @@ $hierarchy-line-width: 1.34px; //Fixes zoom somewhat
         top: 50%;
         width: 50%;
         z-index: -1;
+
+        @media only screen and (max-width: $breakpoint-big-phone - 30px) and (min-width: $breakpoint-phone) {
+          left: -25px;
+        }
       }
     }
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adding this fix for responsive view, aiming a width from 320px to 450px so the back button will not cut off, and also, it will eliminate the scroll bar.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/933

**Steps necessary to review your pull request (required)**:

- Run http://localhost:4000/components/hierarchy/example-paging.html
- Make the page responsive (minimum width of 320px, max width of 450px).
- On the first load of the page, scrollbar should now be unseeable.
- Click on Kaylee Edwards and you will be able to see the back button.
- Back button should be in a proper position and not cutoff.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
