### PR TITLE
1008 - Fixed validation icon tooltips with Datagrid

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7067,7 +7067,6 @@ Datagrid.prototype = {
       };
       this.cacheTooltip(icon, tooltip);
       this.setupTooltips(false, true);
-      this.showTooltip(tooltip);
     }
   },
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3585,10 +3585,11 @@ Datagrid.prototype = {
    * Setup tooltips on the cells.
    * @private
    * @param  {boolean} rowstatus true set tootip with row status
+   * @param  {boolean} isForced true set tootip
    * @returns {void}
    */
-  setupTooltips(rowstatus) {
-    if (!rowstatus && !this.settings.enableTooltips) {
+  setupTooltips(rowstatus, isForced) {
+    if (!rowstatus && !isForced && !this.settings.enableTooltips) {
       return;
     }
 
@@ -3602,14 +3603,15 @@ Datagrid.prototype = {
       td: '.datagrid-body tr.datagrid-row td[role="gridcell"]:not(.rowstatus-cell)',
       rowstatus: '.datagrid-body tr.datagrid-row td[role="gridcell"] .icon-rowstatus'
     };
+    selector.errorIcon = `${selector.td} .icon-error`;
 
     // Selector string
     if (rowstatus && this.settings.enableTooltips) {
-      selector.str = `${selector.th}, ${selector.td}, ${selector.rowstatus}`;
+      selector.str = `${selector.th}, ${selector.td}, ${selector.errorIcon}, ${selector.rowstatus}`;
     } else if (rowstatus) {
       selector.str = `${selector.th}, ${selector.rowstatus}`;
     } else {
-      selector.str = `${selector.th}, ${selector.td}`;
+      selector.str = `${selector.th}, ${selector.td}, ${selector.errorIcon}`;
     }
 
     // Handle tooltip to show
@@ -7064,6 +7066,7 @@ Datagrid.prototype = {
         wrapper: icon
       };
       this.cacheTooltip(icon, tooltip);
+      this.setupTooltips(false, true);
       this.showTooltip(tooltip);
     }
   },

--- a/test/components/hierarchy/hierarchy.func-spec.js
+++ b/test/components/hierarchy/hierarchy.func-spec.js
@@ -49,12 +49,12 @@ describe('hierarchy API', () => {
     const nodes = document.body.querySelectorAll('.leaf');
 
     expect(nodes.length).toEqual(27);
-    expect(nodes[0].innerText.replace(/(\r\n\t|\n|\r\t)/gm, '')).toEqual('Jonathan CargillDirectorFT');
-    expect((nodes[1].innerText.replace(/(\r\n\t|\n|\r\t)/gm, '')).replace(/Expand\/Collapse/gm, '')).toEqual('Kaylee EdwardsRecords ManagerFT');
-    expect(nodes[2].innerText.replace(/(\r\n\t|\n|\r\t)/gm, '')).toEqual('Tony ClevelandRecords ClerkC');
-    expect(nodes[3].innerText.replace(/(\r\n\t|\n|\r\t)/gm, '')).toEqual('Julie DawesRecords ClerkPT');
-    expect(nodes[4].innerText.replace(/(\r\n\t|\n|\r\t)/gm, '')).toEqual('Richard FairbanksRecords ClerkFT');
-    expect(nodes[5].innerText.replace(/(\r\n\t|\n|\r\t)/gm, '')).toEqual('Jason AyersHR ManagerFT');
+    expect(nodes[0].innerText.replace(/(\r\n\t|\n|\r\t|Expand\/Collapse)/gm, '')).toEqual('Jonathan CargillDirectorFT');
+    expect(nodes[1].innerText.replace(/(\r\n\t|\n|\r\t|Expand\/Collapse)/gm, '')).toEqual('Kaylee EdwardsRecords ManagerFT');
+    expect(nodes[2].innerText.replace(/(\r\n\t|\n|\r\t|Expand\/Collapse)/gm, '')).toEqual('Tony ClevelandRecords ClerkC');
+    expect(nodes[3].innerText.replace(/(\r\n\t|\n|\r\t|Expand\/Collapse)/gm, '')).toEqual('Julie DawesRecords ClerkPT');
+    expect(nodes[4].innerText.replace(/(\r\n\t|\n|\r\t|Expand\/Collapse)/gm, '')).toEqual('Richard FairbanksRecords ClerkFT');
+    expect(nodes[5].innerText.replace(/(\r\n\t|\n|\r\t|Expand\/Collapse)/gm, '')).toEqual('Jason AyersHR ManagerFT');
   });
 
   it('Can be empty', () => {

--- a/test/components/hierarchy/hierarchy.func-spec.js
+++ b/test/components/hierarchy/hierarchy.func-spec.js
@@ -50,7 +50,7 @@ describe('hierarchy API', () => {
 
     expect(nodes.length).toEqual(27);
     expect(nodes[0].innerText.replace(/(\r\n\t|\n|\r\t)/gm, '')).toEqual('Jonathan CargillDirectorFT');
-    expect(nodes[1].innerText.replace(/(\r\n\t|\n|\r\t)/gm, '')).toEqual('Kaylee EdwardsRecords ManagerFT');
+    expect((nodes[1].innerText.replace(/(\r\n\t|\n|\r\t)/gm, '')).replace(/Expand\/Collapse/gm, '')).toEqual('Kaylee EdwardsRecords ManagerFT');
     expect(nodes[2].innerText.replace(/(\r\n\t|\n|\r\t)/gm, '')).toEqual('Tony ClevelandRecords ClerkC');
     expect(nodes[3].innerText.replace(/(\r\n\t|\n|\r\t)/gm, '')).toEqual('Julie DawesRecords ClerkPT');
     expect(nodes[4].innerText.replace(/(\r\n\t|\n|\r\t)/gm, '')).toEqual('Richard FairbanksRecords ClerkFT');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Error icon tooltips were not showing after hide one time.

**Related github/jira issue (required)**:
Closes #1008

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/example-editable.html
- Open above link
- Click on empty cell in column "activity" (row 3)
- Click on another cell to validate the cell
- The error icon displays, but tooltip for this error icon should be hidden
- Hover on the icon should be able to see the error message tooltip