### PR TITLE
1009 - Datagrid reset to default does not work on second attempt

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4045,7 +4045,7 @@ Datagrid.prototype = {
     if (this.originalColumns) {
       const columnGroups = this.settings.columnGroups && this.originalColGroups ?
         this.originalColGroups : null;
-      this.updateColumns(this.originalColumns, columnGroups);
+      this.updateColumns(this.columnsFromString(JSON.stringify(this.originalColumns)), columnGroups);
     }
 
     this.clearFilter();

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4045,7 +4045,8 @@ Datagrid.prototype = {
     if (this.originalColumns) {
       const columnGroups = this.settings.columnGroups && this.originalColGroups ?
         this.originalColGroups : null;
-      this.updateColumns(this.columnsFromString(JSON.stringify(this.originalColumns)), columnGroups);
+      this.updateColumns(this.columnsFromString(JSON.stringify(this.originalColumns)), 
+        columnGroups);
     }
 
     this.clearFilter();

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4043,10 +4043,10 @@ Datagrid.prototype = {
     }
 
     if (this.originalColumns) {
+      const originalColumns = this.columnsFromString(JSON.stringify(this.originalColumns));
       const columnGroups = this.settings.columnGroups && this.originalColGroups ?
         this.originalColGroups : null;
-      this.updateColumns(this.columnsFromString(JSON.stringify(this.originalColumns)), 
-        columnGroups);
+      this.updateColumns(originalColumns, columnGroups);
     }
 
     this.clearFilter();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Takes a deep copy of the originalcolumns so that any change is not updated via Javascripts reference to the object.

**Related github/jira issue (required)**:
Closes #1009 

**Steps necessary to review your pull request (required)**:
Go to '/components/datagrid/example-reorder.html'
reorder the datagrid buttons
Click on 'the reset to default button under the more button for the datagrid'
repeat steps 2 and 3.

