### PR TITLE
473 - Fixed alignment was not clear formatting with editor

### DIFF
--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -1974,7 +1974,11 @@ Editor.prototype = {
     }
 
     // Some browser (IE, Firefox) use attr 'align' instead style `text-align`
-    parentEl.removeAttribute('align');
+    const gParentEl = parentEl.parentNode;
+    if (gParentEl !== this.element[0]) {
+      const alignAttrElems = [].slice.call(gParentEl.querySelectorAll('[align]'));
+      alignAttrElems.forEach(el => el.removeAttribute('align'));
+    }
     document.execCommand('removeFormat', false, null);
 
     // Restore style `text-align`, some browser (chrome, safari) clear `text-align` on parent node with command `removeFormat`


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
On Windows Edge, IE and Firefox, alignment was not clear formatting when done with Select All.

**Related github/jira issue (required)**:
#473

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/editor/test-clear-formatting.html
- Open above link
- Apply Right Align on the first paragraph
- Press Command+A or Ctrl+A to select all
- Click Clear Formatting icon
- See it should clear the selected formatting