### PR TITLE
910 Fixed issue regarding dirty tracking

### DIFF
--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -777,6 +777,10 @@ Editor.prototype = {
         self.execAction(action, e);
       }
 
+      if (self.isIe) {
+        self.getCurrentElement().trigger('change');
+      }
+
       return false;
     });
 

--- a/src/components/trackdirty/trackdirty.js
+++ b/src/components/trackdirty/trackdirty.js
@@ -1,3 +1,4 @@
+import { Environment as env } from '../../utils/environment';
 import * as debug from '../../utils/debug';
 import { utils } from '../../utils/utils';
 import { Locale } from '../locale/locale';
@@ -28,6 +29,8 @@ function Trackdirty(element, settings) {
 Trackdirty.prototype = {
 
   init() {
+    this.isIe = env.browser.name === 'ie';
+
     this.handleEvents();
   },
 
@@ -224,6 +227,10 @@ Trackdirty.prototype = {
           const textArea = field.find('textarea');
           original = textArea.data('original');
           current = this.valMethod(textArea);
+        }
+
+        if (this.isIe) {
+          current = input[0].innerHTML;
         }
 
         if (current === original || (input.attr('multiple') && utils.equals(current, original))) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Manually triggered 'change' event if using IE browser
- Get raw text from innerHTML if using IE browser
- http://localhost:4000/components/editor/example-dirty-tracking.html

**Related github/jira issue (required)**:
Closes #910

**Steps necessary to review your pull request (required)**:
- Open test page on IE browser
- Apply H4, Align Right and Block Quote or anything you want in the second paragraph
- Yellow dirty tracking indicator should now be displayed
