### PR TITLE
393 - Contextual Action Panel Control

### DIFF
--- a/app/views/components/contextualactionpanel/example-workspaces.html
+++ b/app/views/components/contextualactionpanel/example-workspaces.html
@@ -5,7 +5,7 @@
     <button type="button" class="btn-secondary contextual-action-panel-trigger">
       Show Contextual Action Panel
     </button>
-    <div class="contextual-action-panel" style="display:none">
+    <div class="contextual-action-panel" style="display:none;">
       <div class="flex-toolbar">
         <div class="toolbar-section">
           <button id="cancel" class="btn close-button">

--- a/src/components/contextualactionpanel/_contextualactionpanel.scss
+++ b/src/components/contextualactionpanel/_contextualactionpanel.scss
@@ -26,7 +26,8 @@
   }
 
   .flex-toolbar {
-    margin: 0 16px;
+    margin: 0 auto;
+    padding: 0 16px;
   }
 
   .toolbar {

--- a/src/components/contextualactionpanel/_contextualactionpanel.scss
+++ b/src/components/contextualactionpanel/_contextualactionpanel.scss
@@ -27,7 +27,7 @@
 
   .flex-toolbar {
     margin: 0 auto;
-    padding: 0 16px;
+    padding: 0 5px;
   }
 
   .toolbar {

--- a/src/components/contextualactionpanel/contextualactionpanel.js
+++ b/src/components/contextualactionpanel/contextualactionpanel.js
@@ -331,7 +331,7 @@ ContextualActionPanel.prototype = {
           }
           if (!selected.length && self.toolbar.is('.flex-toolbar')) {
             selected = self.toolbar.find('button').first();
-            selected.focus();
+            selected.blur();
             return;
           }
           const toolbarData = self.toolbar.data('toolbar');

--- a/src/components/contextualactionpanel/contextualactionpanel.js
+++ b/src/components/contextualactionpanel/contextualactionpanel.js
@@ -331,7 +331,7 @@ ContextualActionPanel.prototype = {
           }
           if (!selected.length && self.toolbar.is('.flex-toolbar')) {
             selected = self.toolbar.find('button').first();
-            selected.blur();
+            selected.focus();
             return;
           }
           const toolbarData = self.toolbar.data('toolbar');

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -696,7 +696,7 @@ Modal.prototype = {
   resize() {
     // 90% -(180 :extra elements-height)
     let calcHeight = ($(window).height() * 0.9) - this.settings.frameHeight;
-    const calcWidth = ($(window).width() * 1) - this.settings.frameWidth;
+    const calcWidth = ($(window).width() * 1.05) - this.settings.frameWidth;
 
     const wrapper = this.element.find('.modal-body-wrapper');
 

--- a/src/components/toolbar-flex/_toolbar-flex.scss
+++ b/src/components/toolbar-flex/_toolbar-flex.scss
@@ -45,6 +45,14 @@
       display: inline;
     }
 
+    span {
+      display: inline;
+
+      @media (max-width: $breakpoint-big-phone) {
+        display: none;
+      }
+    }
+
     .page-title,
     .section-title {
       display: block;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

It seems that the cancel button is working properly now.

The remaining issues:
1. Cancel Button is at highlighting state when modal pops up.
2. Alignment issue upon resizing.

_Fix (1. Cancel Button)_

In the `contextualactionpanel.js`, changing the `focus()` event to `blur()`, instead of removing the condition for selecting the first button element in the `.flex-toolbar`.

```
if (!selected.length && self.toolbar.is('.flex-toolbar')) {
  selected = self.toolbar.find('button').first();
  selected.blur();
  return;
}
```

_Fix (2. Alignment issue)_

Alignment issue is visible in the mobile view, at max width of 500px.

Since the title is a bit longer, what I did was to not display it on the mobile perspective at the max width of 480px and leave the icon. Pretty sure that the icon will be use on the functional side.
And also, I made some adjustments on the margin, padding to make the flex-toolbar align properly even when resizing.


**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/393

**Steps necessary to review your pull request (required)**:

- Run http://localhost:4000/components/contextualactionpanel/example-workspaces.html
- Click Show Contextual Action Panel Button
- Click Cancel (this should be fixed)
- Upon opening the modal, Cancel Button should be focused
- Resize the browser. Check all the elements if it's aligned correctly and should be responsive too.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
