### PR TITLE
285 - fix for high contrast background color in contextual panel

### DIFF
--- a/src/components/contextualactionpanel/_contextualactionpanel.scss
+++ b/src/components/contextualactionpanel/_contextualactionpanel.scss
@@ -14,6 +14,7 @@
     padding: 0;
 
     .modal-body-wrapper {
+      background: $panel-bg-color;
       padding: 0;
     }
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

By default, the background color that was used in the contextual action panel modal inherits the modal content bg color which is white. So the white background that you're seeing is still the modal, not the detail section of contextual panel.
To fix this, adding a background color on the modal body wrapper of the contextual action panel so that it will not affect the entire page that uses the modal. Reuse the variable that was utilized in detail section.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/285
Relates https://github.com/infor-design/enterprise/issues/393

**Steps necessary to review your pull request (required)**:

- Run http://localhost:4000/components/contextualactionpanel/example-workspaces.html
- Switch to High Contrast theme under the (…) Menu
- Click Show Contextual Action Panel button
- There should be no irrelevant color at the bottom of the modal.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
