### PR TITLE
1055 - Restore the v4.8.0 readonly input color [4.12.x]

### DIFF
--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -171,7 +171,7 @@ $menubutton-height: $button-height;
 $input-color: $input-text-color;
 $input-disabled-color: $input-disabled-text-color;
 $input-placeholder-color: $input-placeholder-text-color;
-$input-readonly-color: $input-readonly-text-color;
+$input-readonly-color: $graphite10;
 
 //States
 $error-color: $color-danger;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Restore original color of readonly input text.

**Related github/jira issue (required)**:
Fixes #1055 

**Steps necessary to review your pull request (required)**:
1. `npm run start`
1. Visit http://localhost:4000/components/input/example-index?font=source-sans and compare the input readonly state to urls listed in the issue. It should match `v4.8.0`.