### PR TITLE
959 - Added demoapp middleware for stripping out identifying headers

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -11,7 +11,6 @@ const crypto = require('crypto');
 const getJSONFile = require('./src/js/get-json-file');
 
 const app = express();
-app.disable('x-powered-by');
 
 const BASE_PATH = process.env.BASEPATH || '/';
 const packageJSON = getJSONFile('../../../package.json');
@@ -86,6 +85,7 @@ app.use(require('./src/js/middleware/option-handler')(app, DEFAULT_RESPONSE_OPTS
 app.use(require('./src/js/middleware/basepath-handler')(app));
 app.use(require('./src/js/middleware/global-data-handler')(app));
 app.use(require('./src/js/middleware/response-throttler')(app));
+app.use(require('./src/js/middleware/remove-headers')(app));
 app.use(require('./src/js/middleware/csp-handler')(app));
 
 app.use(router);

--- a/app/src/js/middleware/remove-headers.js
+++ b/app/src/js/middleware/remove-headers.js
@@ -1,0 +1,13 @@
+/*
+ * Simple middleware for removing identifying application headers
+ * See https://github.com/infor-design/enterprise/issues/959
+ */
+module.exports = function (app) {
+  app.disable('x-powered-by');
+
+  return function removeHeaders(req, res, next) {
+    delete req.headers['x-powered-by'];
+    delete req.headers.server;
+    next();
+  };
+};


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
To comply with our agreed-upon Veracode dynamic scan mitigations, this PR strips out identifying headers from the demoapp.

**Related github/jira issue (required)**:
Closes #959 

**Steps necessary to review your pull request (required)**:
- Pull down this branch
- Run the demoapp
- Open http://localhost:4000
- Open a dev tools console to the network tab and click the entry for `localhost`.  Ensure that there are no entries in the "Response Headers" that have a key of `Server` or `X-Powered-By`:

![screen shot 2018-10-23 at 10 52 14 am](https://user-images.githubusercontent.com/3249601/47369490-cfe13b00-d6b1-11e8-8288-e16cb0722e08.png)

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
