### PR TITLE
985 - Remove unnecessary limits on demoapp file names

### DIFF
--- a/app/src/js/routes/directory-list.js
+++ b/app/src/js/routes/directory-list.js
@@ -13,11 +13,7 @@ const GENERAL_LISTING_EXCLUDES = [
   /listing\.html/,
   /footer\.html/,
   /_header\.html/,
-  /(api.md$)/,
-  /(api.html$)/,
   /partial/,
-  /functional/,
-  /unit/,
   /\.DS_Store/
 ];
 

--- a/app/views/tests/listing/api.html
+++ b/app/views/tests/listing/api.html
@@ -1,0 +1,5 @@
+<div class="row">
+  <div class="six columns">
+    <p>This is working!</p>
+  </div>
+</div>

--- a/app/views/tests/listing/functional.html
+++ b/app/views/tests/listing/functional.html
@@ -1,0 +1,5 @@
+<div class="row">
+  <div class="six columns">
+    <p>This is working!</p>
+  </div>
+</div>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes an issue in the demoapp's directory listing we discovered where some old regex matches that were meant to strip out `.JS/.SCSS/.MD` files from the index pages was causing test files with certain names to be removed from the list.

**Related github/jira issue (required)**:
Closes #985 

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp
- Open http://localhost:4000/tests/listing/list
- Ensure that there are two files in the list, called `Api` and `Functional`.
