### PR TITLE
412 - Fixed row was not activating with tree datagrid [v4.12.x]

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5916,8 +5916,8 @@ Datagrid.prototype = {
       const oldActivated = this.tableBody.find('tr.is-rowactivated');
       if (oldActivated.length) {
         oldActivated.removeClass('is-rowactivated');
-
-        const oldIdx = this.dataRowIndex(oldActivated);
+        const oldIdx = (s.treeGrid || s.groupable) ?
+          this.actualRowIndex(oldActivated) : this.dataRowIndex(oldActivated);
         if (dataset[oldIdx]) { // May have changed page
           delete dataset[oldIdx]._rowactivated;
         }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
While selecting downwards from Id 1 to Id 10, then select upwards with a mixed selectable tree grid row was not activating.

**Related github/jira issue (required)**:
Closes #412

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-tree-row-activated.html
- Open above link
- Try clicking rows downwards from Id 1 to Id 10 (not on checkbox)
- Then click upwards
- It should activate row as soon clicked on it