### PR TITLE
ie11-no-rowstatus-tooltip

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -8473,7 +8473,7 @@ Datagrid.prototype = {
     if (typeof tooltip === 'undefined') {
       const contentTooltip = elem.querySelector('.is-editor.content-tooltip');
       const aTitle = elem.querySelector('a[title]');
-      const isRowstatus = elem.classList.contains('rowstatus-cell');
+      const isRowstatus = elem.getAttribute('class').match(/rowstatus-cell/g);
       const isSvg = elem.tagName.toLowerCase() === 'svg';
       const isTh = elem.tagName.toLowerCase() === 'th';
       let title;
@@ -8487,7 +8487,7 @@ Datagrid.prototype = {
 
       // Cache rowStatus cell
       if (isRowstatus || isSvg) {
-        const rowNode = this.closest(elem, el => el.classList.contains('datagrid-row'));
+        const rowNode = this.closest(elem, el => el.getAttribute('class').match(/datagrid-row/g));
         const classList = rowNode ? rowNode.classList : [];
         tooltip.isError = classList.contains('rowstatus-row-error') || classList.contains('rowstatus-row-dirtyerror');
         tooltip.placement = 'right';
@@ -8530,7 +8530,7 @@ Datagrid.prototype = {
       }
 
       if (tooltip.content !== '') {
-        const isEllipsis = elem.classList.contains('text-ellipsis');
+        const isEllipsis = elem.getAttribute('class').match(/text-ellipsis/g);
         tooltip.textwidth = stringUtils.textWidth(tooltip.content) + (isEllipsis ? 8 : 0);
         tooltip.content = contentTooltip ? tooltip.content : `<p>${tooltip.content}</p>`;
         if (title) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
A bug where new row added with rowstatus did not display tooltip on hover in IE11.

**Related github/jira issue (required)**:
Closes #1081 .
Came out of #227 and #994 . Failed QA as this bug was reported. This bug existed prior to completion of related PR and Issue previously mentioned here.

**Steps necessary to review your pull request (required)**:
- Pull branch
- Run app
- Go to IE11 on Windows and browse up app
- Click Add Row Status
- Click Add Row under "..."
- Verify hover works on tooltip hover of all rows (especially new row)
- Extra credit for checking on another OS/Browser as well
