### PR TITLE
1095 - Add `SohoConfig` setting to allow a manual start of the RenderLoop

### DIFF
--- a/app/src/index.scss
+++ b/app/src/index.scss
@@ -23,4 +23,5 @@
 @import 'sass/grid';
 @import 'sass/forms';
 @import 'sass/patterns';
+@import 'sass/typography';
 @import 'sass/wizard';

--- a/app/src/js/custom-route-options.js
+++ b/app/src/js/custom-route-options.js
@@ -1,6 +1,9 @@
 const extend = require('extend');
 const utils = require('./utils');
 
+// Object with settings that gets stringify
+const SohoConfig = {};
+
 // Augments the current set of options for a specific route's needs
 module.exports = function customRouteOptions(req, res) {
   if (!utils.canChangeLayout(req, res)) {
@@ -54,6 +57,14 @@ module.exports = function customRouteOptions(req, res) {
     customOpts.layout = 'components/place/scrolling/layout-nested';
   }
 
+  // RenderLoop
+  if (url.match(/renderloop\/example-delayed-start/)) {
+    debugger;
+
+    SohoConfig.renderLoop = {};
+    SohoConfig.renderLoop.noAutoStart = true;
+  }
+
   // Searchfield in Headers (needs to load the Header layout)
   if (url.match(/searchfield\/example-header/)) {
     customOpts.layout = 'components/header/layout';
@@ -62,6 +73,13 @@ module.exports = function customRouteOptions(req, res) {
   // Sign-in Dialog
   if (url.match(/tests\/signin/)) {
     customOpts.layout = 'tests/layout-noheader';
+  }
+
+  // If there have been properties added to SohoConfig,
+  // stringify and pass it to the view options
+  if (Object.keys(SohoConfig).length) {
+    debugger;
+    customOpts.SohoConfig = JSON.stringify(SohoConfig);
   }
 
   return extend({}, res.opts, customOpts);

--- a/app/src/js/custom-route-options.js
+++ b/app/src/js/custom-route-options.js
@@ -59,8 +59,6 @@ module.exports = function customRouteOptions(req, res) {
 
   // RenderLoop
   if (url.match(/renderloop\/example-delayed-start/)) {
-    debugger;
-
     SohoConfig.renderLoop = {};
     SohoConfig.renderLoop.noAutoStart = true;
   }
@@ -78,7 +76,6 @@ module.exports = function customRouteOptions(req, res) {
   // If there have been properties added to SohoConfig,
   // stringify and pass it to the view options
   if (Object.keys(SohoConfig).length) {
-    debugger;
     customOpts.SohoConfig = JSON.stringify(SohoConfig);
   }
 

--- a/app/src/sass/_code.scss
+++ b/app/src/sass/_code.scss
@@ -1,9 +1,9 @@
 // Code Example Styles
 // ===============================================
 
-$code-bg-color: #cccccc;
-$code-border-color: #aaaaaa;
-$code-text-color: #555555;
+$code-bg-color: #ccc;
+$code-border-color: #aaa;
+$code-text-color: #555;
 
 @mixin code-style() {
   background: $code-bg-color;

--- a/app/src/sass/_code.scss
+++ b/app/src/sass/_code.scss
@@ -1,11 +1,28 @@
 // Code Example Styles
 // ===============================================
 
-.code-block {
-  background: #555;
-  border: 2px solid #333;
-  color: #ccc;
+$code-bg-color: #cccccc;
+$code-border-color: #aaaaaa;
+$code-text-color: #555555;
+
+@mixin code-style() {
+  background: $code-bg-color;
+  border: 1px solid $code-border-color;
+  border-radius: 2px;
+  color: $code-text-color;
+  font-family: monospace;
   font-size: 14px;
+}
+
+span.code {
+  @include code-style();
+
+  padding: 3px 8px;
+}
+
+.code-block {
+  @include code-style();
+
   margin: 1em 0;
   overflow: auto;
   -moz-tab-size: 2;

--- a/app/src/sass/_typography.scss
+++ b/app/src/sass/_typography.scss
@@ -1,0 +1,4 @@
+.count-style {
+  font-family: monospace;
+  font-weight: 700;
+}

--- a/app/views/components/renderloop/example-delayed-start.html
+++ b/app/views/components/renderloop/example-delayed-start.html
@@ -1,0 +1,61 @@
+<div class="row">
+  <div class="six columns">
+    <h2>RenderLoop Example: No Automatic Start</h2>
+    <p>Related Issue: <a class="hyperlink" href="https://github.com/infor-design/enterprise/issues/1095" target="_blank">#1095</a></p>
+    <p>This page sets up a <span class="code">window.SohoConfig.renderLoop</span> setting that turns off automatic start
+    of the renderLoop.  Clicking the buttons below toggles the renderLoop.</p>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="six columns">
+    <div class="field">
+      <span>Count: </span>
+      <span class="count-style" id="timercounts">0</span>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="six columns">
+    <div class="field">
+      <button id="start-btn" class="btn-secondary">
+        <span>Start RenderLoop</span>
+      </button>
+
+      <button id="stop-btn" class="btn-secondary" disabled>
+        <span>Stop RenderLoop</span>
+      </button>
+    </div>
+  </div>
+</div>
+
+<script>
+  var TIMER_COUNT = 0,
+    span = $('#timercounts'),
+    startBtn = $('#start-btn'),
+    stopBtn = $('#stop-btn');
+
+  function updateCount() {
+    TIMER_COUNT++;
+    span.text(TIMER_COUNT);
+  }
+
+  $('body').on('initialized', function() {
+
+    // Register Once
+    Soho.renderLoop.register(updateCount, undefined, 'test-timer-count');
+
+    startBtn.on('click.test', function() {
+      Soho.renderLoop.start();
+      startBtn.prop('disabled', true);
+      stopBtn.prop('disabled', false);
+    });
+
+    stopBtn.on('click.test', function() {
+      Soho.renderLoop.stop();
+      stopBtn.prop('disabled', true);
+      startBtn.prop('disabled', false);
+    });
+  });
+</script>

--- a/app/views/components/renderloop/example-hook-into-counter.html
+++ b/app/views/components/renderloop/example-hook-into-counter.html
@@ -5,19 +5,12 @@
   </div>
 </div>
 
-<style>
-  #timercounts {
-    font-weight: bold;
-    font-family: monospace;
-  }
-</style>
-
 <div class="row">
   <div class="six columns">
 
     <div class="field">
       <span>Count: </span>
-      <span id="timercounts">0</span>
+      <span class="count-style" id="timercounts">0</span>
     </div>
 
   </div>

--- a/app/views/includes/head.html
+++ b/app/views/includes/head.html
@@ -21,6 +21,13 @@
 
   <script src="{{basepath}}js/jquery-3.3.1.js"></script>
   <script src="{{basepath}}js/d3.v4.js"></script>
+
+  {{#SohoConfig}}
+  <script type="text/javascript">
+    window.SohoConfig = JSON.parse('{{{SohoConfig}}}');
+  </script>
+  {{/SohoConfig}}
+
   {{#minify}}
   <script src="{{basepath}}js/sohoxi.min.js"></script>
   {{/minify}}

--- a/src/utils/renderloop.js
+++ b/src/utils/renderloop.js
@@ -1,3 +1,16 @@
+import { utils } from './utils';
+
+// Default RenderLoop Settings
+const RENDERLOOP_DEFAULTS = {
+  noAutoStart: false
+};
+
+// Only start the renderloop if it's not disabled by a Global config setting.
+let instanceSettings = {};
+if (typeof window.SohoConfig === 'object' && typeof window.SohoConfig.renderLoop === 'object') {
+  instanceSettings = utils.extend({}, RENDERLOOP_DEFAULTS, window.SohoConfig.renderLoop);
+}
+
 /**
  * Gets an accurate timestamp from
  * @private
@@ -77,10 +90,17 @@ RenderLoopItem.prototype = {
  * Sets up a timed rendering loop that can be used for controlling animations
  * globally in an application that implements Soho.
  * @constructor
+ * @param {object} [settings] incoming settings
+ * @param {boolean} [settings.noAutoStart] if true, will not auto-start the renderLoop
  */
-function RenderLoop() {
+function RenderLoop(settings) {
   this.items = [];
   this.element = $('body');
+  this.settings = utils.mergeSettings(null, settings, RENDERLOOP_DEFAULTS);
+
+  if (this.settings.noAutoStart !== true) {
+    this.start();
+  }
 
   return this;
 }
@@ -403,7 +423,6 @@ RenderLoop.prototype = {
 };
 
 // Setup a single instance of RenderLoop for export.
-const renderLoop = new RenderLoop();
-renderLoop.start();
+const renderLoop = new RenderLoop(instanceSettings);
 
 export { RenderLoopItem, renderLoop };

--- a/test/components/renderloop/_sohoConfig.js
+++ b/test/components/renderloop/_sohoConfig.js
@@ -1,0 +1,6 @@
+// Window-level settings for the manually-started RenderLoop Functional Tests
+window.SohoConfig = {
+  renderLoop: {
+    noAutoStart: true
+  }
+};

--- a/test/components/renderloop/renderloop-manual.func-spec.js
+++ b/test/components/renderloop/renderloop-manual.func-spec.js
@@ -1,0 +1,11 @@
+import './_sohoConfig';
+import { renderLoop } from '../../../src/utils/renderloop';
+
+describe('RenderLoop API (Manual Start)', () => {
+  it('Should not loop if `start()` has not been called', (done) => {
+    setTimeout(() => {
+      expect(renderLoop.startTime).toBeUndefined();
+      done();
+    }, 500);
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds a detectable setting for the RenderLoop via the optional `SohoConfig` object that allows the RenderLoop to be started manually, instead of the default automatic method.  When setting `SohoConfig.renderLoop.noAutoStart = true;`, the RenderLoop must be started manually in order to have any affect on the components in which it's utilized.

In addition, some related, demoapp-specific CSS was organized/moved around while creating examples related to this issue.

**Related github/jira issue (required)**:
- Blocks infor-design/enterprise-ng#214
- Closes #1095

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp
- Open http://localhost:4000/components/renderloop/example-delayed-start.html
- Ensure that the number next to `Count: ` remains at zero
- Click the "Start RenderLoop" button
- Ensure that the number next to `Count: ` begins to increment on each loop tick.

Additionally, there has been a functional test added for this feature.  All functional tests should pass.

----

paging @krishollenbeck @pwpatton 