### PR TITLE
392 - Unable to change the background color of previously highlighted words in Chrome

### DIFF
--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -2068,6 +2068,13 @@ Editor.prototype = {
         const parent = this.getSelectionParentElement().parentNode;
         const els = parent.getElementsByTagName('font');
 
+        // Clearing all the background style in any element node in selection's parent
+        for (let i = 0, j = els.length; i < j; i++) {
+          if (els[i].hasAttribute('style')) {
+            els[i].style.backgroundColor = '';
+          }
+        }
+
         // Using timeout, firefox not executes with current call stack
         setTimeout(() => {
           for (let i = 0, l = els.length; i < l; i++) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Unable to change the background color of words that were previously changed in Chrome. Looping thru each elements found in selection's parent and remove style with the background color.  Adding a clearing background style in any element node of selection's parent before the setTimeout will fix the issue. 

```
        for (let i = 0, j = els.length; i < j; i++) {
          if (els[i].hasAttribute('style')) {
            els[i].style.backgroundColor = '';
          }
        }
```


**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/392

**Steps necessary to review your pull request (required)**:

- Run http://localhost:4000/components/editor/example-with-backcolor.html
- Highlight the word "Cross-platform" then change it's color to green
- Highlight the phrase "Cross-platform, evolve" then change it's color to blue
- "Cross-platform, evolve" should be color blue. "Cross-platform" should not retain the first color selected which is green.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
