### PR TITLE
798 - Fixes data on given page number in datagrid

### DIFF
--- a/app/views/components/datagrid/test-save-settings.html
+++ b/app/views/components/datagrid/test-save-settings.html
@@ -46,17 +46,7 @@
   $('body').one('initialized', function () {
 
     var grid,
-      columns = [],
-      data = [];
-
-    // Some Sample Data
-    data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: '500', status: 'Confirmed', orderDate: new Date(2014, 12, 8), action: 'Action', ex: 'ç ñ ÄËÏÖÜ äëïöü'});
-    data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: '2', price: 210.99, status: 'Confirmed', orderDate: new Date(2015, 7, 3), action: 'On Hold', ex:'àèìòù'});
-    data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: '120.99', status: 'Error', orderDate: new Date(2014, 6, 3), action: 'Action', ex:'áéíóú'});
-    data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: '2345', status: 'Error', orderDate: new Date(2015, 3, 3), action: 'Action', ex:'ية (مصر'});
-    data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: '210.99', status: 'Error', orderDate: new Date(2015, 5, 5), action: 'On Hold', ex:''});
-    data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: '120.99', status: 'Confirmed', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
-    data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '123.99', status: 'Confirmed', orderDate: null, action: 'On Hold'});
+      columns = [];
 
     var statuses = [{id: '', value: '', label:'&nbsp;'},
                       {id:'Confirmed', value:'Confirmed', label:'Confirmed'},
@@ -75,7 +65,15 @@
     grid = $('#datagrid').datagrid({
       columns: columns,
       columnReorder: true,
-      dataset: data,
+      source: function(req, response) {
+        var url = '{{basepath}}api/compressors?pageNum='+ req.activePage +'&pageSize='+ req.pagesize;
+
+        //Get Page Based on info in Req, return results into response;
+        $.getJSON(url, function(res) {
+          req.total = res.total;
+          response(res.data, req);
+        });
+      },
       paging: true,
       pagesize: 10,
       pagesizes: [5, 10, 15],


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Rows of a given page number doesn't appear in Datagrid with save settings after reload page.

Changing the static data to a server side data, and adding HTTP request and HTTP response.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/798

**Steps necessary to review your pull request (required)**:

- Run http://localhost:4000/components/datagrid/test-save-settings.html
- Set on pagination text field a page number like 2
- Refresh the page
- You should be able to see the rows in the Datagrid related to that page number.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
