### PR TITLE
1130 - Math.sign error on rating component in ie11 [v4.12.x]

### DIFF
--- a/src/components/rating/rating.js
+++ b/src/components/rating/rating.js
@@ -1,5 +1,5 @@
 import * as debug from '../../utils/debug';
-import { utils } from '../../utils/utils';
+import { utils, math } from '../../utils/utils';
 
 // Component Name
 const COMPONENT_NAME = 'rating';
@@ -55,7 +55,7 @@ Rating.prototype = {
    * @returns {number} current value
    */
   val(value) {
-    if (value === '' || isNaN(value) || Math.sign(value) === -1) {
+    if (value === '' || isNaN(value) || math.sign(value) === -1) {
       return this.currentValue;
     }
 

--- a/src/components/rating/rating.js
+++ b/src/components/rating/rating.js
@@ -69,7 +69,7 @@ Rating.prototype = {
       if (i < value) {
         input.addClass('is-filled').removeClass('is-half');
       } else {
-        input.removeClass('is-filled').removeClass('is-half');
+        input.removeClass('is-filled').removeClass('is-half').prop('checked', false);
       }
 
       // Handle Half Star

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -983,4 +983,21 @@ utils.forEach = function forEach(array, callback, scope) {
   }
 };
 
+/**
+ * Returns the sign of a number, indicating whether the number is positive, negative or zero
+ * @param {number} x A number.
+ * @returns {number} A number representing the sign of the given argument. If the argument is a positive number, negative number, positive zero or negative zero, the function will return 1, -1, 0 or -0 respectively. Otherwise, NaN is returned.
+ */
+math.sign = function (x) {
+  if (Math.sign) {
+    return Math.sign(x);
+  }
+
+  x = +x;
+  if (x === 0 || isNaN(x)) {
+    return x;
+  }
+  return x > 0 ? 1 : -1;
+};
+
 export { utils, math };


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
IE 11 was giving an error on the rating component because IE 11 doesnt not have `Math.rating`

**Related github/jira issue (required)**:
Closes #1130

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/rating/list
- test all these pages on IE 11 and Chrome...
