### PR TITLE
1150 - Added fix for addError and removeError [v4.12.x]

### DIFF
--- a/app/src/js/routes/general.js
+++ b/app/src/js/routes/general.js
@@ -70,6 +70,10 @@ function generalRoute(req, res, next) {
 
   // Return the directory listing if we're looking at a directory
   if (utils.isType('directory', directoryPath)) {
+    if (directoryPath.substring(directoryPath.length - 1) === '/') {
+      res.redirect(req.originalUrl.substring(0, req.originalUrl.length - 1));
+      return;
+    }
     directoryListing(directoryPath, viewsRoot, req, res, next);
     return;
   }

--- a/src/components/icons/_icons.scss
+++ b/src/components/icons/_icons.scss
@@ -51,9 +51,9 @@ svg.icon-dirty,
   .icon-error,
   .icon-confirm {
     height: 14px;
-    position: absolute;
-    right: 5px;
-    top: 24px;
+    position: relative;
+    right: 0;
+    top: -8px;
     width: 18px;
   }
 

--- a/src/components/validation/validation.jquery.js
+++ b/src/components/validation/validation.jquery.js
@@ -9,7 +9,8 @@ const VALIDATE_COMPONENT_NAME = 'validate';
 // Settings specific to error messages.
 // Used for backwards compatibility.
 const ERROR_MESSAGE_DEFAULTS = {
-  type: 'error'
+  type: 'error',
+  inline: true
 };
 
 /**
@@ -138,7 +139,12 @@ $.fn.addMessage = function (settings) {
  * @returns {jQuery[]} elements receiving errors
  */
 $.fn.addError = function (settings) {
+  let inline = true;
+  if (typeof settings.inline === 'boolean' && settings.inline === false) {
+    inline = false;
+  }
   settings = utils.extend({}, settings, ERROR_MESSAGE_DEFAULTS);
+  settings.inline = inline;
   return this.each(function () {
     $(this).addMessage(settings);
   });

--- a/src/components/validation/validator.js
+++ b/src/components/validation/validator.js
@@ -798,8 +798,11 @@ Validator.prototype = {
       tooltipAPI.hide();
     });
 
-    if (showTooltip && tooltipAPI) {
+    if (tooltipAPI) {
       field.attr('data-error-type', 'tooltip');
+    }
+
+    if (showTooltip && tooltipAPI) {
       tooltipAPI.show();
     }
   },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The default in addError is wrong, also removeError did not remove the icon in legacy mode.
Also fixed a problem with the routes.

**Related github/jira issue (required)**:
Closes #1150

**Steps necessary to review your pull request (required)**:
1) test this page http://localhost:4000/components/validation/test-legacy-tooltip.html

2) go to http://localhost:4000/components/validation/ and it should redirect to http://localhost:4000/components/validation

3) go to http://localhost:4000/components/input/example-placeholder.html
- in the console type `$("#text").addError({message: "test"})` and it should show the error below the field
- in the console type `$("#text").removeEror()` and it should remove the error
- reload
- in the console type `$("#text").addError({message: "test", inline: false})` and it should show the error below the field
- in the console type `$("#text").removeEror()` and it should remove the error

