### PR TITLE
1104 - Fix bg color in mobile ios, mac

### DIFF
--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -481,3 +481,16 @@ html[dir='rtl'] {
     }
   }
 }
+
+//for iOS fixes
+
+.ios,
+.is-mac {
+  .searchfield-wrapper {
+    &.context {
+      > .searchfield {
+        background-color: $searchfield-context-bg;
+      }
+    }
+  }
+}

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -488,7 +488,7 @@ html[dir='rtl'] {
 .is-mac {
   .searchfield-wrapper {
     &.context {
-      > .searchfield {
+      > #searchfield-context-white.searchfield {
         background-color: $searchfield-context-bg;
       }
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adding `.ios` and `.mac` as parent class and target the `.searchfield` as the child and adding the id of the input field will fix the issue in mac and iOS.

**Related github/jira issue (required)**:

Relate https://github.com/infor-design/enterprise/issues/1104

**Steps necessary to review your pull request (required)**:

- pull this branch
- Run http://localhost:4000/components/searchfield/example-context-search-style.html
- On Mac Chrome Click into the "Context Search" box and type in "Hello World"
- On iOS iPhone X Click into the "Context Search" box and type in "Hello World"
- The background color theme should not be different for both.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
