### PR TITLE
1106 - Fix alignment of text and searchfield box

### DIFF
--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -378,8 +378,16 @@ $subheader-height: 60px;
   .full-searchfield-container {
     margin: 0 auto;
     max-width: $breakpoint-tablet-to-desktop;
-    padding: 1.4rem 4rem 0;
+    padding: 1.4rem 2rem 0;
     vertical-align: middle;
+
+    @media (max-width: $breakpoint-slim) {
+      padding: 1.4rem 0.5rem 0;
+    }
+
+    @media (min-width: $breakpoint-phone-to-tablet) {
+      padding: 1.4rem 4rem 0;
+    }
 
     .hyperlink {
       @include font-size(14);

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -68,7 +68,11 @@ $cubic-bezier-ease: cubic-bezier(0.17, 0.04, 0.03, 0.94);
 
   .searchfield {
     padding-left: 34px;
-    padding-right: 34px;
+    padding-right: 10px;
+
+    @media (min-width: $breakpoint-phablet) {
+      padding-right: 34px;
+    }
 
     @include transition(background-color 300ms $cubic-bezier-ease,
     border-color 300ms $cubic-bezier-ease);
@@ -482,14 +486,23 @@ html[dir='rtl'] {
   }
 }
 
-//for iOS fixes
-
+//for iOS & MAC fixes
 .ios,
 .is-mac {
   .searchfield-wrapper {
     &.context {
       > #searchfield-context-white.searchfield {
         background-color: $searchfield-context-bg;
+      }
+    }
+  }
+}
+
+.ios {
+  .searchfield-wrapper {
+    &.context {
+      .btn {
+        height: 35px;
       }
     }
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixing and adjusting alignments of elements in mobile perspective. Applied mobile first approach.
The alignment issue of list box exist only in iPhone device. 

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/1106

**Steps necessary to review your pull request (required)**:

- Pull this branch.
- Run http://localhost:4000/components/searchfield/example-header-compact.html
- Test it in an actual device (iPhone, for testing the alignment of the searchfield). BrowserStack will also do. (Did the testing, debugging, trial and error using it).
- Click on on the drop down and select " Product References".
- Type " Hello World" in the searchfield box.
- The list box and searchfield box should aligned.
- The text "Hello World" text should be visible.


<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
