### PR TITLE
1162 - Added a fix for paging issues with landmark [v4.12.x]

### DIFF
--- a/app/views/components/datagrid/test-paging-indeterminate-landmark.html
+++ b/app/views/components/datagrid/test-paging-indeterminate-landmark.html
@@ -93,8 +93,8 @@
       setTimeout(function () {
 
         switch (request.type) {
-          case 'initial': beginIndex = 0; break;
           case 'first':   beginIndex = 0; break;
+          case 'initial':
           case 'last':    beginIndex = getData().length - request.pagesize; break;
           case 'next':    beginIndex = beginIndex + request.pagesize; break;
           case 'prev':    beginIndex = beginIndex - request.pagesize; break;

--- a/app/views/components/datagrid/test-paging-indeterminate-pagetwo.html
+++ b/app/views/components/datagrid/test-paging-indeterminate-pagetwo.html
@@ -43,12 +43,10 @@
         indeterminate: true,
         source: function(req, response) {
 
-          //Load a specific page and set the page - simulating a page state
-          //Then we call load data with that.
-          // if (req.type === 'initial') {
-          //req.activePage = 2;
-          //   return; //Or can ignore and call loadData
-          // }
+          if (req.type === 'initial') {
+            req.activePage = 2;
+          }
+
           if (req.type === 'last') {
             req.activePage = lastPage;
           }
@@ -84,14 +82,5 @@
         },
         toolbar: {title: 'Data Grid Header Title', results: true, dateFilter: false ,keywordFilter: true, advancedFilter: true, actions: true, views: true, rowHeight: true}
       });
-
-      /* Option 2: Bi-Pass Source Function
-        var url = '{{basepath}}api/compressors?pageNum='+ 2 +'&pageSize='+ pageSize;
-        $.getJSON(url, function(res) {
-          lastPage = Math.floor(res.total / pageSize);
-          var pageInfo = {total: res.total, activePage: 2, pagesize: pageSize, firstPage: false, lastPage: false};
-          grid.data('datagrid').loadData(res.data, pageInfo);
-        });
-      */
   });
 </script>

--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -292,6 +292,10 @@ Pager.prototype = {
       }
 
       if (li.is('.pager-prev')) {
+        if (self.settings.indeterminate && self.activePage <= 1) {
+          self.activePage = self.pageCount();
+        }
+
         self.setActivePage(self.activePage - 1, false, 'prev');
         if (self.settings.onPreviousPage) {
           self.settings.onPreviousPage(this, opts);
@@ -310,6 +314,10 @@ Pager.prototype = {
       }
 
       if (li.is('.pager-first')) {
+        if (self.settings.indeterminate && self.activePage <= 1) {
+          self.activePage = self.pageCount();
+        }
+
         self.setActivePage(1, false, 'first');
         if (self.settings.onFirstPage) {
           self.settings.onFirstPage(this, opts);

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -215,6 +215,56 @@ describe('Datagrid paging (client side) tests', () => {
   });
 });
 
+describe('Datagrid paging indeterminate tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/example-paging-indeterminate');
+
+    const datagridEl = await element(by.id('datagrid'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should be able to move to last', async () => {
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(3) a')).getText()).toEqual('Compressor 0');
+    expect(await element(by.css('tbody tr:nth-child(10) td:nth-child(3) a')).getText()).toEqual('Compressor 9');
+
+    await element(by.css('.pager-last a')).click();
+
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(3) a')).getText()).toEqual('Compressor 990');
+    expect(await element(by.css('tbody tr:nth-child(10) td:nth-child(3) a')).getText()).toEqual('Compressor 999');
+  });
+
+  it('Should be able to move to first', async () => {
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(3) a')).getText()).toEqual('Compressor 0');
+    expect(await element(by.css('tbody tr:nth-child(10) td:nth-child(3) a')).getText()).toEqual('Compressor 9');
+
+    await element(by.css('.pager-last a')).click();
+    await element(by.css('.pager-first a')).click();
+
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(3) a')).getText()).toEqual('Compressor 0');
+    expect(await element(by.css('tbody tr:nth-child(10) td:nth-child(3) a')).getText()).toEqual('Compressor 9');
+  });
+
+  it('Should be able to move to next/prev', async () => {
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(3) a')).getText()).toEqual('Compressor 0');
+    expect(await element(by.css('tbody tr:nth-child(10) td:nth-child(3) a')).getText()).toEqual('Compressor 9');
+
+    await element(by.css('.pager-next a')).click();
+
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(3) a')).getText()).toEqual('Compressor 10');
+    expect(await element(by.css('tbody tr:nth-child(10) td:nth-child(3) a')).getText()).toEqual('Compressor 19');
+
+    await element(by.css('.pager-prev a')).click();
+
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(3) a')).getText()).toEqual('Compressor 0');
+    expect(await element(by.css('tbody tr:nth-child(10) td:nth-child(3) a')).getText()).toEqual('Compressor 9');
+  });
+});
+
 describe('Datagrid page size selector tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/example-paging-page-size-selector');
@@ -413,6 +463,122 @@ describe('Datagrid hide selection checkbox tests', () => {
 
   it('Should not show selection checkbox', async () => {
     expect(await element(by.css('#datagrid .datagrid-header thead .datagrid-checkbox')).isDisplayed()).toBeFalsy();
+  });
+});
+
+describe('Datagrid paging indeterminate landmark tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/test-paging-indeterminate-landmark');
+
+    const datagridEl = await element(by.css('tbody tr:nth-child(1) td:nth-child(2) span'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should start on last page', async () => {
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(2) span')).getText()).toEqual('214315');
+    expect(await element(by.css('tbody tr:nth-child(5) td:nth-child(2) span')).getText()).toEqual('214319');
+  });
+
+  it('Should be able to move to last', async () => {
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(2) span')).getText()).toEqual('214315');
+    expect(await element(by.css('tbody tr:nth-child(5) td:nth-child(2) span')).getText()).toEqual('214319');
+
+    await element(by.css('.pager-first a')).click();
+    await element(by.css('.pager-last a')).click();
+
+    await browser.driver.sleep(config.waitsFor);
+
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(2) span')).getText()).toEqual('214315');
+    expect(await element(by.css('tbody tr:nth-child(5) td:nth-child(2) span')).getText()).toEqual('214319');
+  });
+
+  it('Should be able to move to first', async () => {
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(2) span')).getText()).toEqual('214315');
+    expect(await element(by.css('tbody tr:nth-child(5) td:nth-child(2) span')).getText()).toEqual('214319');
+
+    await element(by.css('.pager-first a')).click();
+
+    await browser.driver.sleep(config.waitsFor);
+
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(2) span')).getText()).toEqual('214220');
+    expect(await element(by.css('tbody tr:nth-child(5) td:nth-child(2) span')).getText()).toEqual('214224');
+  });
+
+  it('Should be able to move to next/prev', async () => {
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(2) span')).getText()).toEqual('214315');
+    expect(await element(by.css('tbody tr:nth-child(5) td:nth-child(2) span')).getText()).toEqual('214319');
+
+    await element(by.css('.pager-prev a')).click();
+    await browser.driver.sleep(config.waitsFor);
+
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(2) span')).getText()).toEqual('214310');
+    expect(await element(by.css('tbody tr:nth-child(5) td:nth-child(2) span')).getText()).toEqual('214314');
+
+    await element(by.css('.pager-next a')).click();
+    await browser.driver.sleep(config.waitsFor);
+
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(2) span')).getText()).toEqual('214315');
+    expect(await element(by.css('tbody tr:nth-child(5) td:nth-child(2) span')).getText()).toEqual('214319');
+  });
+});
+
+describe('Datagrid paging indeterminate start on page 2 tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/test-paging-indeterminate-pagetwo');
+
+    const datagridEl = await element(by.id('datagrid'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should start on page 2', async () => {
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(3) a')).getText()).toEqual('Compressor 10');
+    expect(await element(by.css('tbody tr:nth-child(10) td:nth-child(3) a')).getText()).toEqual('Compressor 19');
+  });
+
+  it('Should be able to move to last', async () => {
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(3) a')).getText()).toEqual('Compressor 10');
+    expect(await element(by.css('tbody tr:nth-child(10) td:nth-child(3) a')).getText()).toEqual('Compressor 19');
+
+    await element(by.css('.pager-last a')).click();
+
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(3) a')).getText()).toEqual('Compressor 990');
+    expect(await element(by.css('tbody tr:nth-child(10) td:nth-child(3) a')).getText()).toEqual('Compressor 999');
+  });
+
+  it('Should be able to move to first', async () => {
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(3) a')).getText()).toEqual('Compressor 10');
+    expect(await element(by.css('tbody tr:nth-child(10) td:nth-child(3) a')).getText()).toEqual('Compressor 19');
+
+    await element(by.css('.pager-last a')).click();
+    await element(by.css('.pager-first a')).click();
+
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(3) a')).getText()).toEqual('Compressor 0');
+    expect(await element(by.css('tbody tr:nth-child(10) td:nth-child(3) a')).getText()).toEqual('Compressor 9');
+  });
+
+  it('Should be able to move to next/prev', async () => {
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(3) a')).getText()).toEqual('Compressor 10');
+    expect(await element(by.css('tbody tr:nth-child(10) td:nth-child(3) a')).getText()).toEqual('Compressor 19');
+
+    await element(by.css('.pager-next a')).click();
+
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(3) a')).getText()).toEqual('Compressor 20');
+    expect(await element(by.css('tbody tr:nth-child(10) td:nth-child(3) a')).getText()).toEqual('Compressor 29');
+
+    await element(by.css('.pager-prev a')).click();
+
+    expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(3) a')).getText()).toEqual('Compressor 10');
+    expect(await element(by.css('tbody tr:nth-child(10) td:nth-child(3) a')).getText()).toEqual('Compressor 19');
   });
 });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Some recent changes made the paging stop work for Landmark, if a specific page other than page one is loaded initially. Fixed this and added several test pages and tests to cover the scenarios around this.

**Related github/jira issue (required)**:
Closes #1162

**Steps necessary to review your pull request (required)**:

These 3 cases are now covered by the added tests

http://localhost:4000/components/datagrid/test-paging-indeterminate-landmark.html
- this starts on last page
- previous should work
- try all the paging buttons 
- try each of the button on a fresh loading of the page 

http://localhost:4000/components/datagrid/test-paging-indeterminate-pagetwo.html
- This should start on page 2, otherwise its the same as test-paging-indeterminate-landmark

http://localhost:4000/components/datagrid/example-paging-indeterminate.html
- starts on page one
- test all the buttons

Tip: You can see the data "Compressor N" is numbered in order so you can glean what page of data is active

CC @pwpatton 
