### PR TITLE
1135 - Fixes colorpicker clearable=false adding Azure01

### DIFF
--- a/app/views/components/colorpicker/test-clearable.html
+++ b/app/views/components/colorpicker/test-clearable.html
@@ -19,6 +19,15 @@
     </div>
 
     <div class="field">
+      <label for="cp-clearable-false">Clearable (false with custom color)</label>
+      <input class="colorpicker" id="cp-clearable-false" type="text" data-options="{clearable: false, customColors: true, colors: [
+        {label: 'Grape', value: '2578a9', number: '10'},
+        {label: 'Blueberry', value: '368ac0', number: '08'},
+        {label: 'Banana', value: 'efa836', number: '09'}
+      ]}" />
+    </div>
+
+    <div class="field">
       <label for="cp-clearable-true-2">Clearable (true and init value)</label>
       <input class="colorpicker" id="cp-clearable-true-2" type="text" value="#B94E4E"
         data-options="{clearable: true}" />

--- a/src/components/colorpicker/colorpicker.js
+++ b/src/components/colorpicker/colorpicker.js
@@ -45,6 +45,7 @@ const COLORPICKER_DEFAULTS = {
     dark: { border: 'matched-only', checkmark: { one: [1, 2], two: [3, 10] } },
     'high-contrast': { border: 'all', checkmark: { one: [1, 3], two: [4, 10] } }
   },
+  customColors: false,
   colors: [
     { label: 'Slate', number: '10', value: '1a1a1a' },
     { label: 'Slate', number: '09', value: '292929' },
@@ -539,7 +540,7 @@ ColorPicker.prototype = {
         const a = $(`<a href="#" title="${s.clearableText}"><span class="swatch is-empty${isBorderAll ? ' is-border' : ''}"></span></a>`).appendTo(li);
         a.data('label', s.clearableText).data('value', '').tooltip();
         menu.append(li);
-      } else {
+      } else if (!this.settings.customColors) {
         const li = $('<li></li>');
         $('<a href="#" title="Azure01 #C8E9F4"><span class="swatch" style="background-color: rgb(173 ,216, 235);"></span></a>').appendTo(li).tooltip();
         menu.append(li);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adds an `customColors` option to colorpicker settings. When set to true, the colorpicker will not append Azure01 to the color list.

Added a demo to http://localhost:4000/components/colorpicker/test-clearable.html

This could cause issues when/if the intention is to add custom colors on top of default colors. Not sure if that is an actual use case.

**Related github/jira issue (required)**:
closes #1135 

**Steps necessary to review your pull request (required)**:
* pull branch
* go to http://localhost:4000/components/colorpicker/test-clearable.html
* Make sure default color Azure01 is not added to color list when `clearable = false` and `customColors = true`

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
