### PR TITLE
1003 - Rename tree dragstart and dragend

### DIFF
--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -1960,7 +1960,7 @@ Tree.prototype = {
                 startWidth: a.outerWidth()
               };
 
-              self.element.triggerHandler('dragstart', self.sortable);
+              self.element.triggerHandler('sortstart', self.sortable);
               e.preventDefault();
               e.stopImmediatePropagation();
             })
@@ -2022,7 +2022,7 @@ Tree.prototype = {
               // Fix: On windows 10 with IE-11 icons disappears
               utils.fixSVGIcons(start);
 
-              self.element.triggerHandler('dragend', self.sortable);
+              self.element.triggerHandler('sortend', self.sortable);
               // Sync dataset and ui
               self.syncDataset();
               if (self.isMultiselect) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Events were called twice.

**Related github/jira issue (required)**:
Closes #1003 

**Steps necessary to review your pull request (required)**:
- Pull branch
- Run app
- Browse to http://localhost:4000/components/tree/example-sortable.html
- Ensure `dragstart` and `dragend` only fire once each when dragging an item in tree.
