### PR TITLE
1087 - Fix on Datepicker Issue when Clicking Today button

### DIFF
--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -22,7 +22,7 @@ const COMPONENT_NAME = 'datepicker';
  * @param {jQuery[]|HTMLElement} element The component element.
  * @param {object} [settings] The component settings.
  * @param {boolean} [settings.showTime=false] If true the time selector will be shown.
- * @param {boolean} [settings.useCurrentTime=false] If true current time will be used for the time portion otherwise 12:00 midnight is used
+ * @param {boolean} [settings.useCurrentTime=true] If true current time will be used for the time portion otherwise 12:00 midnight is used
  * @param {string} [settings.timeFormat] Format to use time section fx HH:mm,
  *  defaults current locale settings.
  * @param {number} [settings.minuteInterval]
@@ -80,7 +80,7 @@ const COMPONENT_NAME = 'datepicker';
  */
 const DATEPICKER_DEFAULTS = {
   showTime: false,
-  useCurrentTime: false,
+  useCurrentTime: true,
   timeFormat: undefined,
   minuteInterval: undefined,
   secondInterval: undefined,
@@ -1515,19 +1515,19 @@ DatePicker.prototype = {
 
     if (!this.settings.useCurrentTime) {
       this.currentDate.setHours(0, 0, 0, 0);
-    }
 
-    if (this.element.val() !== '') {
-      if (this.timepicker && this.timepicker.hourSelect) {
-        this.currentDate.setHours(this.timepicker.hourSelect.val());
-      }
+      if (this.element.val() !== '') {
+        if (this.timepicker && this.timepicker.hourSelect) {
+          this.currentDate.setHours(this.timepicker.hourSelect.val());
+        }
 
-      if (this.timepicker && this.timepicker.minuteSelect) {
-        this.currentDate.setMinutes(this.timepicker.minuteSelect.val());
-      }
+        if (this.timepicker && this.timepicker.minuteSelect) {
+          this.currentDate.setMinutes(this.timepicker.minuteSelect.val());
+        }
 
-      if (this.timepicker && this.timepicker.secondSelect) {
-        this.currentDate.setSeconds(this.timepicker.secondSelect.val());
+        if (this.timepicker && this.timepicker.secondSelect) {
+          this.currentDate.setSeconds(this.timepicker.secondSelect.val());
+        }
       }
     }
 

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -22,7 +22,7 @@ const COMPONENT_NAME = 'datepicker';
  * @param {jQuery[]|HTMLElement} element The component element.
  * @param {object} [settings] The component settings.
  * @param {boolean} [settings.showTime=false] If true the time selector will be shown.
- * @param {boolean} [settings.useCurrentTime=true] If true current time will be used for the time portion otherwise 12:00 midnight is used
+ * @param {boolean} [settings.useCurrentTime=false] If true current time will be used for the time portion otherwise 12:00 midnight is used
  * @param {string} [settings.timeFormat] Format to use time section fx HH:mm,
  *  defaults current locale settings.
  * @param {number} [settings.minuteInterval]
@@ -80,7 +80,7 @@ const COMPONENT_NAME = 'datepicker';
  */
 const DATEPICKER_DEFAULTS = {
   showTime: false,
-  useCurrentTime: true,
+  useCurrentTime: false,
   timeFormat: undefined,
   minuteInterval: undefined,
   secondInterval: undefined,


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->

Error on the time when clicking today if set to 1 AM

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->

Closes #1087 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

Visit http://localhost:4000/components/datepicker/example-timeformat
Note: useCurrentTime must be set to true. Other pages will not work if useCurrentTime is set to false which is the default.

Repeat the steps on the ticket.
To Reproduce
Steps:

1. Open the date picker on the "Date-Time Picker in Locale (Time to Current)"
2. Select 1:00 AM on the time picker
3. Click "Today" button
See Issue happen, values on the time picker (1:00 AM) will be applied, not the current time.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
