### PR TITLE
1101 - Fix for cutoff placeholder in searchfield component

### DIFF
--- a/src/components/searchfield/searchfield.js
+++ b/src/components/searchfield/searchfield.js
@@ -1392,7 +1392,7 @@ SearchField.prototype = {
 
     // NOTE: final width can only be 100% if no value is subtracted for other elements
     if (subtractWidth > 0) {
-      subtractWidth = subtractWidth - 10;
+      subtractWidth -= 10;
       targetWidthProp = `calc(100% - ${subtractWidth}px)`;
     }
     if (targetWidthProp) {

--- a/src/components/searchfield/searchfield.js
+++ b/src/components/searchfield/searchfield.js
@@ -1392,6 +1392,7 @@ SearchField.prototype = {
 
     // NOTE: final width can only be 100% if no value is subtracted for other elements
     if (subtractWidth > 0) {
+      subtractWidth = subtractWidth - 10;
       targetWidthProp = `calc(100% - ${subtractWidth}px)`;
     }
     if (targetWidthProp) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Take away a 10px on calculating the searchfield width to fix the issue.

This solution also fix this example

http://localhost:4000/components/searchfield/example-go-button.html

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/1101

**Steps necessary to review your pull request (required)**:

- Pull this branch
- Run http://localhost:4000/components/searchfield/example-categories-and-go-button.html
- Placeholder should not be cutoff.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
