### PR TITLE
Have Jenkins deploy script check auth and optionally queue

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -10,7 +10,7 @@
     "commitMessage": "Release v%s",
     "tagAnnotation": "Release v%s",
     "beforeStartCommand": "npm run eslint:error-only",
-    "afterReleaseCommand": ""
+    "afterReleaseCommand": "./scripts/after-release.sh ${npm.tag} ${version}"
   },
   "npm": {
     "publish": true,

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
     "zip-dist": "npx grunt zip-dist",
     "documentation": "node ./scripts/deploy-documentation.js",
     "publish-aws": "AWS_PROFILE=sohoxi directory-to-s3 -d dist infor-devops-core-soho-us-east-1/sohoxi/4.9.0 -v",
-    "release:beta": "release-it minor --preRelease=beta --no-github.release",
-    "release:rc": "release-it --preRelease=rc --no-github.release",
-    "release:final": "release-it",
+    "release:beta": "npx release-it minor --preRelease=beta --no-github.release",
+    "release:rc": "npx release-it --preRelease=rc --no-github.release",
+    "release:final": "npx release-it",
     "prepublishOnly": "npm run build",
     "test": "npm run mdlint && npm run eslint && npm run stylelint && npm run functional:ci && npm run e2e:ci"
   },

--- a/scripts/after-release.sh
+++ b/scripts/after-release.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# ./scripts/after-release.sh latest 4.12.1
+# ./scripts/after-release.sh beta 4.13.0-beta.0
+
+RELEASE_TAG=$1
+RELEASE_VERSION=$2
+
+echo "Queuing builds using jenkins-deploy.sh"
+echo ""
+
+# Add version build to queue
+./scripts/jenkins-deploy.sh -b $RELEASE_VERSION -q
+
+# Also add latest build to queue
+if [[ "$RELEASE_TAG" == "latest" ]]; then
+    ./scripts/jenkins-deploy.sh -b $RELEASE_VERSION -l -q
+fi


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Previously, the jenkins script could just fail quietly when credentials weren't correct. This adds a credential check before doing anything else. It also adds a flag where you can optionally queue the build if there's an existing build running rather than cancelling that build (the default behavior).

**Related github/jira issue (required)**:
n/a

**Steps necessary to review your pull request (required)**:
Should work on it's own when we merge in the PR. I'll check back on how the Travis builds handle this.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
