### PR TITLE
1183 - Fixed expand and collapse all with tree

### DIFF
--- a/app/views/components/tree/test-expand-collapse-all.html
+++ b/app/views/components/tree/test-expand-collapse-all.html
@@ -1,0 +1,61 @@
+<div class="row top-padding">
+  <div class="six columns">
+    <h3>Tree Control: Expand All and Collapse All Folders</h3>
+    <p>This example shows to use of expand all and collapse all tree folder nodes.</p>
+    <p>
+      <button type="button" id="expand-all" class="btn-secondary">Expand All</button>
+      <button type="button" id="collapse-all" class="btn-secondary">Collapse All</button>
+    </p>
+    <br />
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+
+    <ul role="tree" id="addnode-tree" aria-label="Asset Types" class="tree" data-init="false">
+      <li>
+          <a href="#" id="home">Home</a>
+      </li>
+      <li><a href="#" id="about">About Us</a></li>
+      <li class="is-open">
+        <a href="#" id="public">Public Folders</a>
+        <ul class="is-open root">
+          <li class="is-open">
+              <a href="#" id="leadership">Leadership</a>
+              <ul class="is-open">
+                <li>
+                  <a href="#" id="managers" class="icon-tree-image">Managers</a>
+                </li>
+                <li class="is-selected">
+                  <a href="#" id="history" class="my-class">History</a>
+                </li>
+                <li>
+                  <a href="#" id="careers" class="is-disabled">Careers</a>
+                </li>
+              </ul>
+          </li>
+        </ul>
+      </li>
+    </ul>
+
+  </div>
+</div>
+
+<script>
+  var treeApi = $('#addnode-tree').tree().data('tree');
+
+  // Expand all
+  $('#expand-all').on('click', function () {
+    if (treeApi) {
+      treeApi.expandAll();
+    }
+  });
+
+  // Collapse all
+  $('#collapse-all').on('click', function () {
+    if (treeApi) {
+      treeApi.collapseAll();
+    }
+  });
+</script>

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -274,16 +274,27 @@ Tree.prototype = {
    * @returns {void}
    */
   expandAll(nodes) {
-    const self = this;
-    nodes = nodes || this.element.find('ul[role=group]');
+    let groups = nodes;
 
-    nodes.each(function () {
-      const node = $(this);
-      node.addClass('is-open');
-      self.setTreeIcon(node.prev('a').find('svg.icon-tree'), self.settings.folderIconOpen);
+    if (typeof groups !== 'undefined') {
+      groups = this.isjQuery(groups) ? $.makeArray(groups) : groups;
+    } else {
+      groups = [].slice.call(this.element[0].querySelectorAll('ul[role=group]'));
+    }
 
-      if (self.hasIconClass(node.prev('a'))) {
-        self.setTreeIcon(node.prev('svg.icon-tree'), node.prev('a').attr('class'));
+    groups.forEach((group) => {
+      const prev = group.previousElementSibling;
+      group.parentNode.classList.add('is-open');
+      group.classList.add('is-open');
+      group.style.height = '';
+
+      if (prev && prev.tagName.toLowerCase() === 'a') {
+        const svg = prev.querySelector('svg.icon-tree');
+        this.setTreeIcon(svg, this.settings.folderIconOpen);
+        prev.setAttribute('aria-expanded', true);
+        if (this.hasIconClass(prev)) {
+          this.setTreeIcon(svg, prev.getAttribute('class'));
+        }
       }
     });
   },
@@ -295,22 +306,28 @@ Tree.prototype = {
    * @returns {void}
    */
   collapseAll(nodes) {
-    const self = this;
-    nodes = nodes || this.element.find('ul[role=group]');
+    let groups = nodes;
 
-    nodes.each(function () {
-      const node = $(this);
-      node.removeClass('is-open');
-      self.setTreeIcon(node.prev('a').find('svg.icon-tree'), self.settings.folderIconClosed);
+    if (typeof groups !== 'undefined') {
+      groups = this.isjQuery(groups) ? $.makeArray(groups) : groups;
+    } else {
+      groups = [].slice.call(this.element[0].querySelectorAll('ul[role=group]'));
+    }
 
-      if (self.hasIconClass(node.prev('a'))) {
-        self.setTreeIcon(node.prev('a').find('svg.icon-tree'), node.prev('a').attr('class')
-          .replace('open', 'closed')
-          .replace(/\s?is-selected/, ''));
-      }
+    groups.forEach((group) => {
+      const prev = group.previousElementSibling;
+      group.parentNode.classList.remove('is-open');
+      group.classList.remove('is-open');
+      group.style.height = 0;
 
-      if (self.hasIconClass(node.prev('a'))) {
-        self.setTreeIcon(node.prev('svg.icon-tree'), node.prev('a').attr('class').replace('open', 'closed'));
+      if (prev && prev.tagName.toLowerCase() === 'a') {
+        const svg = prev.querySelector('svg.icon-tree');
+        this.setTreeIcon(svg, this.settings.folderIconClosed);
+        prev.setAttribute('aria-expanded', false);
+        prev.classList.remove('is-selected');
+        if (this.hasIconClass(prev)) {
+          this.setTreeIcon(svg, prev.getAttribute('class').replace('open', 'closed'));
+        }
       }
     });
   },

--- a/test/components/tree/tree.func-spec.js
+++ b/test/components/tree/tree.func-spec.js
@@ -54,12 +54,23 @@ describe('Tree Methods', () => {
     expect(secondDir.querySelectorAll('ul[role=group].is-open').length).toEqual(1);
   });
 
-  it('Should expand all tree nodes', () => {
-    expect(treeEl.querySelectorAll('li.folder ul[role=group].is-open').length).toEqual(2);
+  it('Should expand all tree nodes', (done) => {
+    expect(treeEl.querySelectorAll('li.folder ul[role=group]').length).toEqual(3);
+    expect(treeEl.querySelectorAll('li.folder.is-open ul[role=group].is-open').length).toEqual(2);
+    expect(treeEl.querySelectorAll('li.folder.is-open a[aria-expanded="true"').length).toEqual(2);
 
-    treeObj.expandAll();
+    treeEl.querySelector('li.folder a[role="treeitem"]').click();
 
-    expect(treeEl.querySelectorAll('li.folder ul[role=group].is-open').length).toEqual(3);
+    setTimeout(() => {
+      expect(treeEl.querySelectorAll('li.folder.is-open ul[role=group].is-open').length).toEqual(1);
+      expect(treeEl.querySelectorAll('li.folder.is-open a[aria-expanded="true"').length).toEqual(1);
+      treeObj.expandAll();
+      setTimeout(() => {
+        expect(treeEl.querySelectorAll('li.folder.is-open ul[role=group].is-open').length).toEqual(3);
+        expect(treeEl.querySelectorAll('li.folder.is-open a[aria-expanded="true"').length).toEqual(3);
+        done();
+      }, 300);
+    }, 300);
   });
 
   it('Should collapse a collection of tree nodes', () => {
@@ -72,12 +83,23 @@ describe('Tree Methods', () => {
     expect(firstDir.querySelectorAll('ul[role=group].is-open').length).toEqual(0);
   });
 
-  it('Should collapse all tree nodes', () => {
-    expect(treeEl.querySelectorAll('li.folder ul[role=group].is-open').length).toEqual(2);
+  it('Should collapse all tree nodes', (done) => {
+    expect(treeEl.querySelectorAll('li.folder ul[role=group]').length).toEqual(3);
+    expect(treeEl.querySelectorAll('li.folder.is-open ul[role=group].is-open').length).toEqual(2);
+    expect(treeEl.querySelectorAll('li.folder.is-open a[aria-expanded="true"').length).toEqual(2);
 
-    treeObj.collapseAll();
+    treeEl.querySelector('li.folder a[role="treeitem"]').click();
 
-    expect(treeEl.querySelectorAll('li.folder ul[role=group].is-open').length).toEqual(0);
+    setTimeout(() => {
+      expect(treeEl.querySelectorAll('li.folder.is-open ul[role=group].is-open').length).toEqual(1);
+      expect(treeEl.querySelectorAll('li.folder.is-open a[aria-expanded="true"').length).toEqual(1);
+      treeObj.collapseAll();
+      setTimeout(() => {
+        expect(treeEl.querySelectorAll('li.folder.is-open ul[role=group].is-open').length).toEqual(0);
+        expect(treeEl.querySelectorAll('li.folder.is-open a[aria-expanded="true"').length).toEqual(0);
+        done();
+      }, 300);
+    }, 300);
   });
 
   it('Should select a node specifically using its ID attribute', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
When expands/collapse one node with tree, expand al and collapse all was no longer working.

**Related github/jira issue (required)**:
Closes #1183

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/tree/test-expand-collapse-all.html
- Open above link
- Click on any folder node to expand/collapse
- Now use top buttons (Expand All / Collapse All)
- It should show/hide tree nodes