### PR TITLE
1174 - ValidateForm may not return a resolved state

### DIFF
--- a/app/views/components/validation/example-validation-form.html
+++ b/app/views/components/validation/example-validation-form.html
@@ -110,7 +110,7 @@
 
         $('input').on('change', function() {
           $('#test-form').data('validate').validateForm(function (result) { 
-          console.log('validateForm retult', result);
+          console.log('validateForm result:', result);
           });
         });
         

--- a/app/views/components/validation/example-validation-form.html
+++ b/app/views/components/validation/example-validation-form.html
@@ -21,7 +21,7 @@
 
       <div class="field">
         <label for="credit-code">Code</label>
-        <input type="text" id="credit-code" class="input-sm" name="credit-code" data-validate="customWarningRule" data-mask="###" data-mask-mode="number"/>
+        <input type="text" id="credit-code" class="input-sm" name="credit-code" data-validate="customWarningRule customWarningRule2" data-mask="###" data-mask-mode="number"/>
       </div>
 
       <div class="field">
@@ -66,7 +66,7 @@
         $.fn.validation.rules.customErrorRule = {
           check: function (value) {
 
-            return false;
+            return (value === '');
           },
           message: 'Custom Error',
 		      type: 'error'
@@ -74,22 +74,46 @@
 
     		$.fn.validation.rules.customWarningRule = {
           check: function (value) {
-
+           
             return false;
           },
-          message: 'Custom Warning',
+          message: 'Custom Warning 1',
+          type: 'alert'
+        };
+        
+        $.fn.validation.rules.customWarningRule2 = {
+          check: function (value) {
+
+            return true;
+          },
+          message: 'Custom Warning 2',
           type: 'alert'
         };
 
     		$.fn.validation.rules.customInformationRule = {
           check: function (value) {
-
-            return false;
+            var pass = (value === '');
+            return pass;
           },
-          message: 'Custom Information',
+          message: 'Custom Information 1',
+          type: 'info'
+        };
+        
+        $.fn.validation.rules.customInformationRule2 = {
+          check: function (value) {
+            var pass = (value !== '');
+            return pass;
+          },
+          message: 'Custom Information 2',
           type: 'info'
         };
 
+        $('input').on('change', function() {
+          $('#test-form').data('validate').validateForm(function (result) { 
+          console.log('validateForm retult', result);
+          });
+        });
+        
         $('#test-form').on('validated', function (e, isValid) {
 
           if (isValid) {

--- a/src/components/validation/validator.js
+++ b/src/components/validation/validator.js
@@ -526,6 +526,9 @@ Validator.prototype = {
 
           self.addPositive(field);
         }
+      } else if (!validationType.errorsForm) {
+        // Rules that do not error the form need to resolve
+        dfrd.resolve();  
       }
 
       self.setIconOnParent(field, rule.type);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The change makes sure that if all the form rules return that the form passes the validation, eg no errors, that the result is returned. There was an issue if one of the alert rules failed, but another passed.

The expected result would be that validateForm returns the true result and the alert message is displayed on the control

**Related github/jira issue (required)**:
Closes #1174 

**Steps necessary to review your pull request (required)**:
1. open 'http://localhost:4000/components/validation/example-validation-form.html'
2. enter a value into all of the fields.
3. check the browser console for the validateForm result


