### PR TITLE
1050 - Close colorpicker when you click into the field

### DIFF
--- a/src/components/colorpicker/colorpicker.js
+++ b/src/components/colorpicker/colorpicker.js
@@ -662,6 +662,10 @@ ColorPicker.prototype = {
     return this;
   },
 
+  closeColorPicker(isPickerOpen) {
+
+  },
+
   /**
   * Detach events and restore DOM to default.
   * @private

--- a/src/components/colorpicker/colorpicker.js
+++ b/src/components/colorpicker/colorpicker.js
@@ -662,10 +662,6 @@ ColorPicker.prototype = {
     return this;
   },
 
-  closeColorPicker(isPickerOpen) {
-
-  },
-
   /**
   * Detach events and restore DOM to default.
   * @private

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -1621,6 +1621,8 @@ PopupMenu.prototype = {
     // Close on Document Click ect..
     setTimeout(() => {
       $(document).on(`touchend.popupmenu.${self.id} click.popupmenu.${self.id}`, (thisE) => {
+        const isPicker = (self.settings.menu === 'colorpicker-menu');
+
         if (thisE.button === 2) {
           return;
         }
@@ -1631,12 +1633,16 @@ PopupMenu.prototype = {
         }
 
         // Click functionality will toggle the menu - otherwise it closes and opens
-        if ($(thisE.target).is(self.element)) {
+        if ($(thisE.target).is(self.element) && !isPicker) {
           return;
         }
 
         if ($(thisE.target).closest('.popupmenu').length === 0) {
           self.close(true, self.settings.trigger === 'rightClick');
+        }
+
+        if ($(thisE.target).hasClass('colorpicker')) {
+          self.close();
         }
       });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adds close event to colorpicker when you click into the input field.

**Related github/jira issue (required)**:
closes #1050 

**Steps necessary to review your pull request (required)**:
* pull branch
* got to http://localhost:4000/components/colorpicker/example-index.html
* check that the colorpicker closes when you click into the background color input field. The color list should now close

Note: the colorpicker should now close with the following actions:
* you click out, including both on the body or into the field again
* you hit enter on a color as your arrowing through (like the drop down)

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
