### PR TITLE
1186 - Fixed lookup editor tooltip with datagrid

### DIFF
--- a/app/views/components/datagrid/test-editable-lookup.html
+++ b/app/views/components/datagrid/test-editable-lookup.html
@@ -99,7 +99,7 @@
 
         //Define Columns for the Grid.
         columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input});
-        columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, validate: 'required', editorOptions: lookupOptions});
+        columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, validate: 'required', editorOptions: lookupOptions, width: 120 });
         columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, align: 'right', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###.000'});
         columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date5});
 

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -592,11 +592,10 @@ $datagrid-short-row-height: 23px;
             vertical-align: top;
 
             &.lookup {
-              width: calc(100% - 21px);
+              width: calc(100% - 13px);
 
               ~ .trigger .icon {
-                top: calc(50% - 6px);
-                width: inherit;
+                top: calc(50% - 4px);
               }
 
               &.align-text-right {
@@ -888,6 +887,15 @@ $datagrid-short-row-height: 23px;
         }
 
         &.datagrid-trigger-cell {
+          &:hover,
+          &:focus {
+            .icon-search-list {
+              ~ .icon-error {
+                margin-left: -48px !important;
+              }
+            }
+          }
+
           .icon {
             height: 16px;
             margin-bottom: -1px;
@@ -981,7 +989,6 @@ $datagrid-short-row-height: 23px;
             padding-left: 10px;
 
             .trigger {
-              margin-left: -18px;
               top: -7px;
             }
           }
@@ -1693,7 +1700,7 @@ $datagrid-short-row-height: 23px;
         }
 
         .trigger {
-          margin-left: -21px;
+          margin-left: -37px;
           margin-top: 1px;
         }
       }
@@ -1724,15 +1731,12 @@ $datagrid-short-row-height: 23px;
         width: 100%;
 
         &.lookup {
-          width: calc(100% - 31px);
-
           &.align-text-right {
             width: 100%;
           }
 
           ~ .trigger .icon {
             top: calc(50% - 6px);
-            width: inherit;
           }
 
           &.is-not-editable {
@@ -2596,14 +2600,24 @@ td .btn-actions {
     }
   }
 
-  &.has-editor:not(.is-readonly):not(.error):hover,
-  &.has-editor:not(.is-readonly):not(.error):focus {
-    .icon {
-      visibility: visible;
+  &.has-editor:not(.is-readonly) {
+    .icon-error {
+      @include css3(transition, margin-left 300ms ease);
     }
 
-    .icon-close {
-      margin-left: -22px;
+    &:hover,
+    &:focus {
+      .icon {
+        visibility: visible;
+      }
+
+      .icon-close {
+        margin-left: -22px;
+      }
+
+      .icon-error {
+        margin-left: -53px;
+      }
     }
   }
 
@@ -2969,20 +2983,84 @@ html[dir='rtl'] {
             }
           }
         }
+
+        td {
+          &.datagrid-trigger-cell {
+            .icon-error {
+              margin-left: 6px !important;
+            }
+
+            .icon-search-list {
+              left: 8px !important;
+            }
+
+            &:hover,
+            &:focus {
+              .icon-search-list {
+                ~ .icon-error {
+                  margin-left: 26px !important;
+                }
+              }
+            }
+          }
+        }
       }
     }
 
-    td.l-right-text .datagrid-cell-wrapper {
-      text-align: left;
+    &.medium-rowheight {
+      td {
+        &.datagrid-trigger-cell {
+          .icon-search-list {
+            left: 2px;
+          }
+        }
+      }
     }
 
-    td.is-editing {
-      .datepicker ~ .icon {
-        margin-right: -8px;
+    td {
+      &.l-right-text .datagrid-cell-wrapper {
+        text-align: left;
       }
 
-      .dropdown-wrapper .icon {
-        left: 14px;
+      &.error {
+        .datagrid-cell-wrapper {
+          .icon-error {
+            left: 0;
+            margin-left: 5px;
+          }
+        }
+
+        &:hover,
+        &:focus {
+          .icon-error {
+            margin-left: 28px;
+          }
+        }
+      }
+
+      &.is-editing {
+        .datepicker ~ .icon {
+          margin-right: -8px;
+        }
+
+        .dropdown-wrapper .icon {
+          left: 14px;
+        }
+
+        .lookup-wrapper {
+          padding-left: 0 !important;
+
+          input.lookup {
+            padding-left: 0;
+            padding-right: 20px;
+            width: calc(100% - 31px);
+          }
+
+          .trigger {
+            margin: 1px 0 0;
+            width: auto;
+          }
+        }
       }
     }
   }

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -208,7 +208,7 @@ Datagrid.prototype = {
     this.isIe9 = html.is('.ie9');
     this.isSafari = html.is('.is-safari');
     this.isWindows = (navigator.userAgent.indexOf('Windows') !== -1);
-    this.appendTooltip('grid-tooltip');
+    this.appendTooltip();
     this.initSettings();
     this.originalColumns = this.columnsFromString(JSON.stringify(this.settings.columns));
     this.removeToolbarOnDestroy = false;
@@ -663,6 +663,7 @@ Datagrid.prototype = {
   * @returns {string} The unique id.
   */
   uniqueId(suffix) {
+    suffix = (suffix === undefined || suffix === null) ? '' : suffix;
     const uniqueid = this.settings.uniqueId ?
       `${this.settings.uniqueId}-${suffix}` :
       (`${window.location.pathname.split('/').pop()
@@ -671,7 +672,7 @@ Datagrid.prototype = {
         .replace(/\./g, '-')
         .replace(/ /g, '-')
         .replace(/%20/g, '-')}-${
-        this.element.attr('id') || 'datagrid'}-${this.gridCount}${suffix}`);
+        this.element.attr('id') || 'datagrid'}-${this.gridCount || 0}${suffix}`);
 
     return uniqueid.replace(/--/g, '-');
   },
@@ -8757,17 +8758,31 @@ Datagrid.prototype = {
   * @returns {void}
   */
   appendTooltip(extraClass) {
-    this.tooltip = document.getElementById('tooltip');
+    const defaultClass = 'grid-tooltip';
+    const regExp = new RegExp(`\\b${defaultClass}\\b`, 'g');
+
+    // Set default css class
+    if (typeof extraClass === 'string') {
+      if (!regExp.test(extraClass)) {
+        extraClass += ` ${defaultClass}`;
+      }
+    } else {
+      extraClass = defaultClass;
+    }
+
+    // Unique id for tooltip
+    const tooltipId = this.uniqueId('tooltip');
+    this.tooltip = document.getElementById(tooltipId);
 
     if (!this.tooltip) {
       const tooltip = '' +
-        `<div id="tooltip" class="tooltip ${extraClass} is-hidden">
+        `<div id="${tooltipId}" class="tooltip ${extraClass} is-hidden">
           <div class="arrow"></div>
           <div class="tooltip-content"></div>
         </div>`;
       document.body.insertAdjacentHTML('beforeend', tooltip);
 
-      this.tooltip = document.getElementById('tooltip');
+      this.tooltip = document.getElementById(tooltipId);
 
       if (this.isTouch) {
         this.tooltip.style.pointerEvents = 'auto';
@@ -8887,7 +8902,6 @@ Datagrid.prototype = {
    * @returns {void}
    */
   showTooltip(options) {
-    this.tooltip = document.getElementById('tooltip');
     if (this.tooltip) {
       const tooltip = $(this.tooltip);
       const tooltipContentEl = this.tooltip.querySelector('.tooltip-content');

--- a/test/components/datagrid/datagrid-api.func-spec.js
+++ b/test/components/datagrid/datagrid-api.func-spec.js
@@ -200,8 +200,8 @@ describe('Datagrid API', () => {
     $(td).trigger('mouseover');
 
     setTimeout(() => {
-      expect(document.body.querySelector('#tooltip')).toBeTruthy();
-      expect(document.body.querySelector('#tooltip.is-hidden')).toBeFalsy();
+      expect(document.body.querySelector('.grid-tooltip')).toBeTruthy();
+      expect(document.body.querySelector('.grid-tooltip.is-hidden')).toBeFalsy();
       done();
     }, 500);
   });
@@ -212,9 +212,9 @@ describe('Datagrid API', () => {
     $(rowstatusIcon).trigger('mouseover');
 
     setTimeout(() => {
-      expect(document.body.querySelector('#tooltip')).toBeTruthy();
-      expect(document.body.querySelector('#tooltip.is-error')).toBeFalsy();
-      expect(document.body.querySelector('#tooltip.is-hidden')).toBeFalsy();
+      expect(document.body.querySelector('.grid-tooltip')).toBeTruthy();
+      expect(document.body.querySelector('.grid-tooltip.is-error')).toBeFalsy();
+      expect(document.body.querySelector('.grid-tooltip.is-hidden')).toBeFalsy();
       done();
     }, 500);
   });
@@ -225,9 +225,9 @@ describe('Datagrid API', () => {
     $(rowstatusIcon).trigger('mouseover');
 
     setTimeout(() => {
-      expect(document.body.querySelector('#tooltip')).toBeTruthy();
-      expect(document.body.querySelector('#tooltip.is-error')).toBeTruthy();
-      expect(document.body.querySelector('#tooltip.is-hidden')).toBeFalsy();
+      expect(document.body.querySelector('.grid-tooltip')).toBeTruthy();
+      expect(document.body.querySelector('.grid-tooltip.is-error')).toBeTruthy();
+      expect(document.body.querySelector('.grid-tooltip.is-hidden')).toBeFalsy();
       done();
     }, 500);
   });

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -1048,15 +1048,15 @@ describe('Datagrid tooltip tests', () => {
   it('Should show tooltip on text cut off', async () => {
     await browser.actions().mouseMove(element(by.css('tbody tr[aria-rowindex="4"] td[aria-colindex="9"]'))).perform();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('.tooltip'))), config.waitsFor);
-    let tooltip = await element(by.id('tooltip'));
+      .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('.grid-tooltip'))), config.waitsFor);
+    let tooltip = await element(by.css('.grid-tooltip'));
 
     expect(await tooltip.getAttribute('class')).toContain('is-hidden');
 
     await browser.actions().mouseMove(element(by.css('tbody tr[aria-rowindex="5"] td[aria-colindex="9"]'))).perform();
     await browser.driver
-      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.css('.tooltip'))), config.waitsFor);
-    tooltip = await element(by.id('tooltip'));
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.css('.grid-tooltip'))), config.waitsFor);
+    tooltip = await element(by.css('.grid-tooltip'));
 
     expect(await tooltip.getAttribute('class')).not.toContain('is-hidden');
   });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
1. After opened lookup editor tooltips was stop displaying with datagrid. 
2. Soon lookup cell gets validation error icon, then if hover that cell only error icon was showing now  with this PR it will show both error and lookup icon in cell.
3. if lookup cell have validation error icon it should adjust the position for error icon soon hover to show lookup icon in that place.

**Related github/jira issue (required)**:
Closes #1186

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-editable-lookup.html
- Open above link
- Click on any cell in column "Product Id" to go in edit mode
- Remove all text and click somewhere else or press enter key to go out from edit mode
- It should display validation error
- Hover to error icon, should display tooltip "Required"
- Hover to same cell and click on lookup icon, to open lookup modal
- Choose any value or cancel to close the lookup modal
- If you had chosen some value, then click back to cell and remove the value
- It should display validation error
- Hover to error icon, should display tooltip "Required” again