### PR TITLE
1094 - Fixes responsive issue on bar chart

### DIFF
--- a/app/views/components/bar/example-long-text.html
+++ b/app/views/components/bar/example-long-text.html
@@ -20,18 +20,24 @@ $('body').on('initialized', function () {
  var dataset = [{
       data: [{
           name: 'Requirements Exceeding Net Change',
-          value: 373
+          value: 373,
+          abbrName: 'Req ex Net Change',
+          shortName: 'RENC'
       }, {
           name: 'Schedules with Requirements Rejected',
-          value: 372
+          value: 372,
+          abbrName: 'Schds w/ req rej',
+          shortName: 'SRR'
       }, {
           name: 'Open Premium Freight Authorization',
-          value: 236.35
+          value: 236.35,
+          abbrName: 'Open Prem frght autho',
+          shortName: 'OPFA'
       }],
       name: ''  //Can be optionally passed in makes less sense with one: Group 1
     }];
 
-  $('#bar-example').chart({type: 'bar', dataset: dataset});
+  $('#bar-example').chart({type: 'bar', dataset: dataset, ticks: {largeNumber: 10, mediumNumber: 5, smallNumber: 2}});
 
 });
 </script>

--- a/app/views/components/bar/test-axis-formatter.html
+++ b/app/views/components/bar/test-axis-formatter.html
@@ -43,7 +43,8 @@ $('body').on('initialized', function () {
       type:  'bar',
       dataset:  dataset,
       showLegend:  false,
-      ticks: {number: 10, format: ',.1s'}});
+      useLogScale: false,
+      ticks: {largeNumber: 10, mediumNumber: 5, smallNumber: 3, format: ',.1s'}});
 
 });
 </script>

--- a/src/components/bar/bar.js
+++ b/src/components/bar/bar.js
@@ -333,8 +333,14 @@ Bar.prototype = {
       }
     }
 
-    if (self.settings.ticks) {
-      xAxis.ticks(self.settings.ticks.number, self.settings.ticks.format);
+    if (self.settings.ticks && !self.settings.useLogScale) {
+      if (innerWidth < 480) {
+        xAxis.ticks(self.settings.ticks.smallNumber, self.settings.ticks.format);
+      } else if (innerWidth >= 481 && innerWidth <= 992) {
+        xAxis.ticks(self.settings.ticks.mediumNumber, self.settings.ticks.format);
+      } else if (innerWidth > 992) {
+        xAxis.ticks(self.settings.ticks.largeNumber, self.settings.ticks.format);
+      }
     }
 
     const yAxis = d3.axisLeft()
@@ -614,8 +620,31 @@ Bar.prototype = {
     charts.appendTooltip();
 
     this.setInitialSelected();
+    this.setTextValues();
     this.element.trigger('rendered');
     return this;
+  },
+
+  /**
+   * Set the text value in three viewport of bar chart
+   * @private
+   */
+  setTextValues() {
+    const elems = document.querySelectorAll('.bar-chart .axis.y .tick text');
+    const dataset = this.settings.dataset;
+    for (let i = 0; i < dataset.length; i++) {
+      Object.values(dataset[i]).forEach((key) => {
+        for (let j = 0; j < key.length; j++) {
+          if (innerWidth <= 480) {
+            elems[j].textContent = key[j].shortName;
+          } else if (innerWidth >= 481 && innerWidth <= 992) {
+            elems[j].textContent = key[j].abbrName;
+          } else if (innerWidth > 992) {
+            elems[j].textContent = key[j].name;
+          }
+        }
+      });
+    }
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Implementing two solutions for the issues of unresponsive chart.

- Ticks w/ 3 options on number
Adding 3 options on ticks `(largeNumber, mediumNumber, smallNumber)` which will be used on the responsiveness of the graph.

- Introduce `abbrName` and `shortName` in data
`shortName` will be shown at a lower viewport, and `abbrName` will be at the medium viewport and the `name` will be at the large viewport.

This solution will fixed the two examples,

http://localhost:4000/components/bar/example-long-text.html
http://localhost:4000/components/bar/test-axis-formatter.html


**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/1094

**Steps necessary to review your pull request (required)**:

- Pull this branch
- Run http://localhost:4000/components/bar/example-long-text.html and http://localhost:4000/components/bar/test-axis-formatter.html
- Resize the screen to mobile size. Or just open the page on Android/iOS.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
