### PR TITLE
Use ids-identity@2.0.1 for dark theme fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "handlebars-registrar": "^1.5.2",
     "html-loader": "^0.5.5",
     "ids-css": "^1.3.0",
-    "ids-identity": "^2.0.0",
+    "ids-identity": "^2.0.1",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jasmine-core": "^3.2.1",
     "jasmine-jquery": "^2.1.1",


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The dark theme was incorrect in its coloring.

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise/issues/1062#issuecomment-438617201

**Steps necessary to review your pull request (required)**:
1. `npm i && npm start`
1. Verify the `dark theme` blue is `368ac0` for the check marks in the theme switcher (dropdown)