### PR TITLE
435 - Modified example test page with datagrid

### DIFF
--- a/app/views/components/datagrid/test-group-headers-update-columns-landmark.html
+++ b/app/views/components/datagrid/test-group-headers-update-columns-landmark.html
@@ -1,0 +1,276 @@
+
+<div class="full-width full-height">
+  <div id="datagrid"></div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+
+    var grid, pageSize = 10, pageData, beginIndex, endIndex, PAGING_COLUMNS, PAGING_DATA, COLUMN_GROUPS;
+
+    // Global flag to keep track when columns need to be update or not.
+    var isColumnsChanged = false;
+
+    // Init and get the api for the grid
+    grid = $('#datagrid').datagrid({
+      columns: getColumns(),
+      selectable: 'mixed',
+      paging: true,
+      pagesize: pageSize,
+      rowHeight: 'short',
+      indeterminate: true,
+      source: datagridPagingFunction
+    })
+    .on('selected', function(e, args) {
+      if (args && args.length > 1) {
+        var indexString = "";
+        for (var i = 0; i < args.length; i++) {
+          indexString += args[i].data.id + (i < args.length - 1 ? ', ' : '');
+          // indexString += args[i].idx + (i < args.length - 1 ? ', ' : '');
+        }
+        console.log('selected row indexes', indexString);
+      } else if (args && args.length > 0) {
+        console.log('selected row index', args[0].data.id);
+        // console.log('selected row index', args[0].idx);
+      }
+    })
+    .on('rowactivated', function(e, args) {
+      console.log('activated row index', args.row);
+    })
+    .on('contextmenu', function(e, args) {
+      if (args) {
+        console.log('context menu event', e, args);
+        grid.unSelectAllRows();
+        grid.selectRow(args.row);
+        console.log('getSelectedRow', grid.selectedRows()[0].idx);
+      }
+    })
+    .on("dblclick", function(e, args) {
+      if (args) {
+        console.log("dblclick", e, args);
+        grid.unSelectAllRows();
+        grid.selectRow(args.row);
+        console.log('getSelectedRow', grid.selectedRows()[0].idx);
+      }
+    })
+    .data('datagrid');
+
+    function datagridPagingFunction(request, response) {
+      // -------------------------------------------------------------------------------------------------
+      // call async function to get first/last/previous/next page of data.
+      // -------------------------------------------------------------------------------------------------
+      getDataPage(request).then(function(result) {
+        var selectedRow = grid.selectedRows()[0];
+
+        // -------------------------------------------------------------------------------------------------
+        // activePage of -1 means only using firstPage, lastPage for the pager button enable/disable state.
+        // Also indexing should only be from 0 to pageSize. Any multiple selection across pages will have
+        // to have another strategy. For now only selecting records on the current page is acceptable.
+        // -------------------------------------------------------------------------------------------------
+        request.activePage = -1;
+
+        // -------------------------------------------------------------------------------------------------
+        // pager buttons should enable/disable based on firstPaget and lastPage only when activePage === -1;
+        // -------------------------------------------------------------------------------------------------
+        request.firstPage = result.firstPage;
+        request.lastPage = result.lastPage;
+
+        // -------------------------------------------------------------------------------------------------
+        // put the new page of data back into the datagrid
+        // -------------------------------------------------------------------------------------------------
+        response(result.data, request);
+
+        // Calling updateColumns here only when columns changed.
+        if (isColumnsChanged) {
+          grid.updateColumns(getColumns(), getColumnGroups());
+          isColumnsChanged = false;
+        }
+
+        if (selectedRow) {
+          grid.selectRow(selectedRow.idx);
+        }
+      });
+    }
+
+    /**
+     * Returns a promise to get data spoofing an async call to the back end.
+     */
+    function getDataPage(request) {
+      return new Promise(function(resolve, reject) {
+        switch (request.type) {
+          case 'initial': beginIndex = 0; break;
+          case 'first':   beginIndex = 0; break;
+          case 'last':    beginIndex = getData().length - request.pagesize; break;
+          case 'next':    beginIndex = beginIndex + request.pagesize; break;
+          case 'prev':    beginIndex = beginIndex - request.pagesize; break;
+
+          case 'sorted':   console.log('sorted stub called - implement me'); break;
+          case 'filtered': console.log('filtered stub called - implement me'); break;
+        }
+
+        endIndex = beginIndex + request.pagesize;
+
+        var result = {
+          data: getData().slice(beginIndex, endIndex),
+          firstPage: beginIndex === 0,
+          lastPage: endIndex >= getData().length - 1
+        };
+
+        resolve(result);
+      });
+    }
+
+    function checkIsColumnsChanged() {
+      /**
+       * Add functionality here to check if columns need to be changed.
+       * return true - if need to be changed.
+       * return false - if NO need to be changed.
+       */
+      return true;
+    }
+
+    function getColumns() {
+      // Updating global flag after check if columns need to be update or not.
+      isColumnsChanged = checkIsColumnsChanged();
+
+      if (!PAGING_COLUMNS) {
+        PAGING_COLUMNS = [
+          { id: 'selectionCheckbox', sortable: false, resizable: false, width: 50, formatter: Formatters.SelectionCheckbox, align: 'center' },
+          { id: 'productId',   name: 'Product Id',   field: 'productId',   sortable: false, filterType: 'integer', width: 140, formatter: Formatters.Readonly                     },
+          { id: 'productName', name: 'Product Name', field: 'productName', sortable: false, filterType: 'text',    width: 150, formatter: Formatters.Hyperlink                    },
+          { id: 'activity',    name: 'Activity',     field: 'activity',    sortable: false, filterType: 'text',    width: 125,                                      hidden: true  },
+          { id: 'quantity',    name: 'Quantity',     field: 'quantity',    sortable: false,                        width: 125                                                     },
+          { id: 'price',       name: 'Price',        field: 'price',       sortable: false, filterType: 'decimal', width: 125, formatter: Formatters.Decimal                      },
+          { id: 'orderDate',   name: 'Order Date',   field: 'orderDate',   sortable: false, filterType: 'date',                formatter: Formatters.Date, dateFormat: 'M/d/yyyy' }
+        ];
+      }
+
+      return PAGING_COLUMNS;
+    }
+
+    function getColumnGroups() {
+      if (!COLUMN_GROUPS) {
+        COLUMN_GROUPS = [
+          { colspan: 1, id: '',              name:    '' }, // selectcheckbox
+          { colspan: 2, id: 'product-stuff', name: 'Product Stuff' }, // productId, productName
+          { colspan: 1, id: '',              name:    '' }, // activity
+          { colspan: 1, id: '',              name:    '' }, // quantity
+          { colspan: 1, id: '',              name:    '' }, // price
+          { colspan: 1, id: '',              name:    '' }, // orderDate
+        ];
+      }
+      return COLUMN_GROUPS;
+    }
+
+    function getData() {
+      if (!PAGING_DATA) {
+        PAGING_DATA = [
+          { id: 0,  productId: 214220, productName: 'Compressor 1',  activity: 'Assemble Paint', quantity: 1,    price: 210.99,             status: 'Active',   orderDate: '2015-01-01T06:00:00.000Z', action: 'Action', rated: .32  },
+          { id: 1,  productId: 214221, productName: 'Compressor 2',  activity: 'Assemble Paint', quantity: 1.5,  price: 209.99,             status: 'Late',     orderDate: '2015-01-02T06:00:00.000Z', action: 'Action', rated: .76  },
+          { id: 2,  productId: 214222, productName: 'Compressor 3',  activity: 'Assemble Paint', quantity: 2,    price: 208.99,             status: 'Active',   orderDate: '2015-01-03T06:00:00.000Z', action: 'Action', rated: .32  },
+          { id: 3,  productId: 214223, productName: 'Compressor 4',  activity: 'Assemble Paint', quantity: 2.5,  price: 207.99,             status: 'Inactive', orderDate: '2015-01-04T06:00:00.000Z', action: 'Action', rated: .53  },
+          { id: 4,  productId: 214224, productName: 'Compressor 5',  activity: 'Assemble Paint', quantity: 3,    price: 206.99,             status: 'Inactive', orderDate: '2015-01-05T06:00:00.000Z', action: 'Action', rated: .42  },
+          { id: 5,  productId: 214225, productName: 'Compressor 6',  activity: 'Assemble Paint', quantity: 3.5,  price: 205.99,             status: 'Inactive', orderDate: '2015-01-06T06:00:00.000Z', action: 'Action', rated: .88  },
+          { id: 6,  productId: 214226, productName: 'Compressor 7',  activity: 'Assemble Paint', quantity: 4,    price: 204.99,             status: 'Active',   orderDate: '2015-01-07T06:00:00.000Z', action: 'Action', rated: .54  },
+          { id: 7,  productId: 214227, productName: 'Compressor 8',  activity: 'Assemble Paint', quantity: 4.5,  price: 203.99,             status: 'On Hold',  orderDate: '2015-01-08T06:00:00.000Z', action: 'Action', rated: .41  },
+/*
+          { id: 8,  productId: 214228, productName: 'Compressor 9',  activity: 'Assemble Paint', quantity: 5,    price: 202.99,             status: 'On Hold',  orderDate: '2015-01-09T06:00:00.000Z', action: 'Action', rated: .21  },
+          { id: 9,  productId: 214229, productName: 'Compressor 10', activity: 'Assemble Paint', quantity: 5.5,  price: 201.99,             status: 'Late',     orderDate: '2015-01-10T06:00:00.000Z', action: 'Action', rated: .23  },
+          { id: 10, productId: 214230, productName: 'Compressor 1',  activity: 'Assemble Paint', quantity: 6,    price: 200.99,             status: 'Late',     orderDate: '2015-01-01T06:00:00.000Z', action: 'Action', rated: .76  },
+          { id: 11, productId: 214231, productName: 'Compressor 2',  activity: 'Assemble Paint', quantity: 6.5,  price: 199.99,             status: 'Late',     orderDate: '2015-01-02T06:00:00.000Z', action: 'Action', rated: .23  },
+          { id: 12, productId: 214232, productName: 'Compressor 3',  activity: 'Assemble Paint', quantity: 7,    price: 198.99,             status: 'Active',   orderDate: '2015-01-03T06:00:00.000Z', action: 'Action', rated: 1.00 },
+          { id: 13, productId: 214233, productName: 'Compressor 4',  activity: 'Assemble Paint', quantity: 7.5,  price: 197.99,             status: 'Late',     orderDate: '2015-01-04T06:00:00.000Z', action: 'Action', rated: .36  },
+          { id: 14, productId: 214234, productName: 'Compressor 5',  activity: 'Assemble Paint', quantity: 8,    price: 196.99,             status: 'On Hold',  orderDate: '2015-01-05T06:00:00.000Z', action: 'Action', rated: 1.00 },
+          { id: 15, productId: 214235, productName: 'Compressor 6',  activity: 'Assemble Paint', quantity: 8.5,  price: 195.99,             status: 'Active',   orderDate: '2015-01-06T06:00:00.000Z', action: 'Action', rated: .96  },
+          { id: 16, productId: 214236, productName: 'Compressor 7',  activity: 'Assemble Paint', quantity: 9,    price: 194.99,                                 orderDate: '2015-01-07T06:00:00.000Z', action: 'Action', rated: .72  },
+          { id: 17, productId: 214237, productName: 'Compressor 8',  activity: 'Assemble Paint', quantity: 9.5,  price: 193.99,             status: 'Active',   orderDate: '2015-01-08T06:00:00.000Z', action: 'Action', rated: .35  },
+          { id: 18, productId: 214238, productName: 'Compressor 9',  activity: 'Assemble Paint', quantity: 10,   price: 192.99,             status: 'On Hold',  orderDate: '2015-01-09T06:00:00.000Z', action: 'Action', rated: .44  },
+          { id: 19, productId: 214239, productName: 'Compressor 10', activity: 'Assemble Paint', quantity: 10.5, price: 191.99,             status: 'On Hold',  orderDate: '2015-01-10T06:00:00.000Z', action: 'Action', rated: .24  },
+          { id: 20, productId: 214240, productName: 'Compressor 1',  activity: 'Assemble Paint', quantity: 11,   price: 190.99,                                 orderDate: '2015-01-01T06:00:00.000Z', action: 'Action', rated: .22  },
+          { id: 21, productId: 214241, productName: 'Compressor 2',  activity: 'Assemble Paint', quantity: 11.5, price: 189.99,             status: 'Late',     orderDate: '2015-01-02T06:00:00.000Z', action: 'Action', rated: .67  },
+          { id: 22, productId: 214242, productName: 'Compressor 3',  activity: 'Assemble Paint', quantity: 12,   price: 188.99,             status: 'Active',   orderDate: '2015-01-03T06:00:00.000Z', action: 'Action', rated: .66  },
+          { id: 23, productId: 214243, productName: 'Compressor 4',  activity: 'Assemble Paint', quantity: 12.5, price: 187.99,             status: 'Inactive', orderDate: '2015-01-04T06:00:00.000Z', action: 'Action',rated:  .24  },
+          { id: 24, productId: 214244, productName: 'Compressor 5',  activity: 'Assemble Paint', quantity: 13,   price: 186.99,             status: 'Inactive', orderDate: '2015-01-05T06:00:00.000Z', action: 'Action',rated:  .33  },
+          { id: 25, productId: 214245, productName: 'Compressor 6',  activity: 'Assemble Paint', quantity: 13.5, price: 185.99,             status: 'Inactive', orderDate: '2015-01-06T06:00:00.000Z', action: 'Action',rated:  .54  },
+          { id: 26, productId: 214246, productName: 'Compressor 7',  activity: 'Assemble Paint', quantity: 14,   price: 184.99,             status: 'On Hold',  orderDate: '2015-01-07T06:00:00.000Z', action: 'Action',rated:  .42  },
+          { id: 27, productId: 214247, productName: 'Compressor 8',  activity: 'Assemble Paint', quantity: 14.5, price: 183.99,             status: 'On Hold',  orderDate: '2015-01-08T06:00:00.000Z', action: 'Action',rated:  .46  },
+          { id: 28, productId: 214248, productName: 'Compressor 9',  activity: 'Assemble Paint', quantity: 15,   price: 182.99,             status: 'On Hold',  orderDate: '2015-01-09T06:00:00.000Z', action: 'Action',rated:  .33  },
+          { id: 29, productId: 214249, productName: 'Compressor 10', activity: 'Assemble Paint', quantity: 15.5, price: 181.99,             status: 'On Hold',  orderDate: '2015-01-10T06:00:00.000Z', action: 'Action',rated:  .23  },
+          { id: 30, productId: 214250, productName: 'Compressor 1',  activity: 'Assemble Paint', quantity: 16,   price: 180.99,                                 orderDate: '2015-01-01T06:00:00.000Z', action: 'Action',rated:  .37  },
+          { id: 31, productId: 214251, productName: 'Compressor 2',  activity: 'Assemble Paint', quantity: 16.5, price: 179.99,             status: 'Late',     orderDate: '2015-01-02T06:00:00.000Z', action: 'Action',rated:  .23  },
+          { id: 32, productId: 214252, productName: 'Compressor 3',  activity: 'Assemble Paint', quantity: 17,   price: 178.99,             status: 'Active',   orderDate: '2015-01-03T06:00:00.000Z', action: 'Action',rated:  .47  },
+          { id: 33, productId: 214253, productName: 'Compressor 4',  activity: 'Assemble Paint', quantity: 17.5, price: 177.99,             status: 'Inactive', orderDate: '2015-01-04T06:00:00.000Z', action: 'Action',rated:  .26  },
+          { id: 34, productId: 214254, productName: 'Compressor 5',  activity: 'Assemble Paint', quantity: 18,   price: 176.99,             status: 'Inactive', orderDate: '2015-01-05T06:00:00.000Z', action: 'Action',rated:  .12  },
+          { id: 35, productId: 214255, productName: 'Compressor 6',  activity: 'Assemble Paint', quantity: 18.5, price: 175.99,             status: 'Inactive', orderDate: '2015-01-06T06:00:00.000Z', action: 'Action',rated:  .71  },
+          { id: 36, productId: 214256, productName: 'Compressor 7',  activity: 'Assemble Paint', quantity: 19,   price: 174.99,             status: 'On Hold',  orderDate: '2015-01-07T06:00:00.000Z', action: 'Action',rated:  .11  },
+          { id: 37, productId: 214257, productName: 'Compressor 8',  activity: 'Assemble Paint', quantity: 19.5, price: 173.99,             status: 'On Hold',  orderDate: '2015-01-08T06:00:00.000Z', action: 'Action',rated:  .23  },
+          { id: 38, productId: 214258, productName: 'Compressor 9',  activity: 'Assemble Paint', quantity: 20,   price: 172.99,             status: 'On Hold',  orderDate: '2015-01-09T06:00:00.000Z', action: 'Action',rated:  .62  },
+          { id: 39, productId: 214259, productName: 'Compressor 10', activity: 'Assemble Paint', quantity: 20.5, price: 171.99,             status: 'On Hold',  orderDate: '2015-01-10T06:00:00.000Z', action: 'Action',rated:  .45  },
+          { id: 40, productId: 214260, productName: 'Compressor 1',  activity: 'Assemble Paint', quantity: 21,   price: 170.99,                                 orderDate: '2015-01-01T06:00:00.000Z', action: 'Action',rated:  .32  },
+          { id: 41, productId: 214261, productName: 'Compressor 2',  activity: 'Assemble Paint', quantity: 21.5, price: 169.99,             status: 'Late',     orderDate: '2015-01-02T06:00:00.000Z', action: 'Action',rated:  .23  },
+          { id: 42, productId: 214262, productName: 'Compressor 3',  activity: 'Assemble Paint', quantity: 22,   price: 168.99,             status: 'Active',   orderDate: '2015-01-03T06:00:00.000Z', action: 'Action',rated:  .67  },
+          { id: 43, productId: 214263, productName: 'Compressor 4',  activity: 'Assemble Paint', quantity: 22.5, price: 167.99,             status: 'Inactive', orderDate: '2015-01-04T06:00:00.000Z', action: 'Action',rated:  .45  },
+          { id: 44, productId: 214264, productName: 'Compressor 5',  activity: 'Assemble Paint', quantity: 23,   price: 166.99,             status: 'Inactive', orderDate: '2015-01-05T06:00:00.000Z', action: 'Action',rated:  .24  },
+          { id: 45, productId: 214265, productName: 'Compressor 6',  activity: 'Assemble Paint', quantity: 23.5, price: 165.99,             status: 'Inactive', orderDate: '2015-01-06T06:00:00.000Z', action: 'Action',rated:  .12  },
+          { id: 46, productId: 214266, productName: 'Compressor 7',  activity: 'Assemble Paint', quantity: 24,   price: 164.99,             status: 'On Hold',  orderDate: '2015-01-07T06:00:00.000Z', action: 'Action',rated:  .31  },
+          { id: 47, productId: 214267, productName: 'Compressor 8',  activity: 'Assemble Paint', quantity: 24.5, price: 163.99,             status: 'On Hold',  orderDate: '2015-01-08T06:00:00.000Z', action: 'Action',rated:  .71  },
+          { id: 48, productId: 214268, productName: 'Compressor 9',  activity: 'Assemble Paint', quantity: 25,   price: 162.99,             status: 'On Hold',  orderDate: '2015-01-09T06:00:00.000Z', action: 'Action',rated:  .53  },
+          { id: 49, productId: 214269, productName: 'Compressor 10', activity: 'Assemble Paint', quantity: 25.5, price: 161.99,             status: 'On Hold',  orderDate: '2015-01-10T06:00:00.000Z', action: 'Action',rated:  .73  },
+          { id: 50, productId: 214270, productName: 'Compressor 1',  activity: 'Assemble Paint', quantity: 26,   price: 160.99,                                 orderDate: '2015-01-01T06:00:00.000Z', action: 'Action',rated:  .36  },
+          { id: 51, productId: 214271, productName: 'Compressor 2',  activity: 'Assemble Paint', quantity: 26.5, price: 159.99,             status: 'Late',     orderDate: '2015-01-02T06:00:00.000Z', action: 'Action',rated:  .23  },
+          { id: 52, productId: 214272, productName: 'Compressor 3',  activity: 'Assemble Paint', quantity: 27,   price: 158.99,             status: 'Active',   orderDate: '2015-01-03T06:00:00.000Z', action: 'Action',rated:  .16  },
+          { id: 53, productId: 214273, productName: 'Compressor 4',  activity: 'Assemble Paint', quantity: 27.5, price: 157.99,             status: 'Inactive', orderDate: '2015-01-04T06:00:00.000Z', action: 'Action',rated:  .41  },
+          { id: 54, productId: 214274, productName: 'Compressor 5',  activity: 'Assemble Paint', quantity: 28,   price: 156.99,             status: 'Inactive', orderDate: '2015-01-05T06:00:00.000Z', action: 'Action',rated:  .44  },
+          { id: 55, productId: 214275, productName: 'Compressor 6',  activity: 'Assemble Paint', quantity: 28.5, price: 155.99,             status: 'Inactive', orderDate: '2015-01-06T06:00:00.000Z', action: 'Action',rated:  .53  },
+          { id: 56, productId: 214276, productName: 'Compressor 7',  activity: 'Assemble Paint', quantity: 29,   price: 154.99,             status: 'On Hold',  orderDate: '2015-01-07T06:00:00.000Z', action: 'Action',rated:  .23  },
+          { id: 57, productId: 214277, productName: 'Compressor 8',  activity: 'Assemble Paint', quantity: 29.5, price: 153.99,             status: 'On Hold',  orderDate: '2015-01-08T06:00:00.000Z', action: 'Action',rated:  .72  },
+          { id: 58, productId: 214278, productName: 'Compressor 9',  activity: 'Assemble Paint', quantity: 30,   price: 152.99,             status: 'On Hold',  orderDate: '2015-01-09T06:00:00.000Z', action: 'Action',rated:  .33  },
+          { id: 59, productId: 214279, productName: 'Compressor 10', activity: 'Assemble Paint', quantity: 30.5, price: 151.99,             status: 'On Hold',  orderDate: '2015-01-10T06:00:00.000Z', action: 'Action',rated:  .78  },
+          { id: 60, productId: 214280, productName: 'Compressor 1',  activity: 'Assemble Paint', quantity: 31,   price: 150.99,                                 orderDate: '2015-01-01T06:00:00.000Z', action: 'Action',rated:  .26  },
+          { id: 61, productId: 214281, productName: 'Compressor 2',  activity: 'Assemble Paint', quantity: 31.5, price: 149.99,             status: 'Late',     orderDate: '2015-01-02T06:00:00.000Z', action: 'Action',rated:  .52  },
+          { id: 62, productId: 214282, productName: 'Compressor 3',  activity: 'Assemble Paint', quantity: 32,   price: 148.99,             status: 'Active',   orderDate: '2015-01-03T06:00:00.000Z', action: 'Action',rated:  .10  },
+          { id: 63, productId: 214283, productName: 'Compressor 4',  activity: 'Assemble Paint', quantity: 32.5, price: 147.99,             status: 'Inactive', orderDate: '2015-01-04T06:00:00.000Z', action: 'Action',rated:  .40  },
+          { id: 64, productId: 214284, productName: 'Compressor 5',  activity: 'Assemble Paint', quantity: 33,   price: 146.99,             status: 'Inactive', orderDate: '2015-01-05T06:00:00.000Z', action: 'Action',rated:  .45  },
+          { id: 65, productId: 214285, productName: 'Compressor 6',  activity: 'Assemble Paint', quantity: 33.5, price: 145.99,             status: 'Inactive', orderDate: '2015-01-06T06:00:00.000Z', action: 'Action',rated:  .23  },
+          { id: 66, productId: 214286, productName: 'Compressor 7',  activity: 'Assemble Paint', quantity: 34,   price: 144.99,             status: 'On Hold',  orderDate: '2015-01-07T06:00:00.000Z', action: 'Action',rated:  .35  },
+          { id: 67, productId: 214287, productName: 'Compressor 8',  activity: 'Assemble Paint', quantity: 34.5, price: 143.99,             status: 'On Hold',  orderDate: '2015-01-08T06:00:00.000Z', action: 'Action',rated:  .41  },
+          { id: 68, productId: 214288, productName: 'Compressor 9',  activity: 'Assemble Paint', quantity: 35,   price: 142.99,             status: 'On Hold',  orderDate: '2015-01-09T06:00:00.000Z', action: 'Action',rated:  .23  },
+          { id: 69, productId: 214289, productName: 'Compressor 10', activity: 'Assemble Paint', quantity: 35.5, price: 141.99,             status: 'On Hold',  orderDate: '2015-01-10T06:00:00.000Z', action: 'Action',rated:  .26  },
+          { id: 70, productId: 214290, productName: 'Compressor 1',  activity: 'Assemble Paint', quantity: 36,   price: 140.99,                                 orderDate: '2015-01-01T06:00:00.000Z', action: 'Action',rated:  .66  },
+          { id: 71, productId: 214291, productName: 'Compressor 2',  activity: 'Assemble Paint', quantity: 36.5, price: 139.99,             status: 'Late',     orderDate: '2015-01-02T06:00:00.000Z', action: 'Action',rated:  .54  },
+          { id: 72, productId: 214292, productName: 'Compressor 3',  activity: 'Assemble Paint', quantity: 37,   price: 138.99,             status: 'Active',   orderDate: '2015-01-03T06:00:00.000Z', action: 'Action',rated:  .22  },
+          { id: 73, productId: 214293, productName: 'Compressor 4',  activity: 'Assemble Paint', quantity: 37.5, price: 137.99,             status: 'Inactive', orderDate: '2015-01-04T06:00:00.000Z', action: 'Action',rated:  .32  },
+          { id: 74, productId: 214294, productName: 'Compressor 5',  activity: 'Assemble Paint', quantity: 38,   price: 136.99,             status: 'Inactive', orderDate: '2015-01-05T06:00:00.000Z', action: 'Action',rated:  .41  },
+          { id: 75, productId: 214295, productName: 'Compressor 6',  activity: 'Assemble Paint', quantity: 38.5, price: 135.99,             status: 'Inactive', orderDate: '2015-01-06T06:00:00.000Z', action: 'Action',rated:  .34  },
+          { id: 76, productId: 214296, productName: 'Compressor 7',  activity: 'Assemble Paint', quantity: 39,   price: 134.99,             status: 'On Hold',  orderDate: '2015-01-07T06:00:00.000Z', action: 'Action',rated:  .11  },
+          { id: 77, productId: 214297, productName: 'Compressor 8',  activity: 'Assemble Paint', quantity: 39.5, price: 133.99,             status: 'On Hold',  orderDate: '2015-01-08T06:00:00.000Z', action: 'Action',rated:  .25  },
+          { id: 78, productId: 214298, productName: 'Compressor 9',  activity: 'Assemble Paint', quantity: 40,   price: 132.99,             status: 'On Hold',  orderDate: '2015-01-09T06:00:00.000Z', action: 'Action',rated:  .33  },
+          { id: 79, productId: 214299, productName: 'Compressor 10', activity: 'Assemble Paint', quantity: 40.5, price: 131.99,             status: 'On Hold',  orderDate: '2015-01-10T06:00:00.000Z', action: 'Action',rated:  .33  },
+          { id: 80, productId: 214300, productName: 'Compressor 1',  activity: 'Assemble Paint', quantity: 41,   price: 130.99,                                 orderDate: '2015-01-01T06:00:00.000Z', action: 'Action',rated:  .62  },
+          { id: 81, productId: 214301, productName: 'Compressor 2',  activity: 'Assemble Paint', quantity: 41.5, price: 129.99,             status: 'Late',     orderDate: '2015-01-02T06:00:00.000Z', action: 'Action',rated:  .52  },
+          { id: 82, productId: 214302, productName: 'Compressor 3',  activity: 'Assemble Paint', quantity: 42,   price: 128.99,             status: 'Active',   orderDate: '2015-01-03T06:00:00.000Z', action: 'Action',rated:  .23  },
+          { id: 83, productId: 214303, productName: 'Compressor 4',  activity: 'Assemble Paint', quantity: 42.5, price: 127.99000000000001, status: 'Inactive', orderDate: '2015-01-04T06:00:00.000Z', action: 'Action',rated:  .74  },
+          { id: 84, productId: 214304, productName: 'Compressor 5',  activity: 'Assemble Paint', quantity: 43,   price: 126.99000000000001, status: 'Inactive', orderDate: '2015-01-05T06:00:00.000Z', action: 'Action',rated:  .54  },
+          { id: 85, productId: 214305, productName: 'Compressor 6',  activity: 'Assemble Paint', quantity: 43.5, price: 125.99000000000001, status: 'Inactive', orderDate: '2015-01-06T06:00:00.000Z', action: 'Action',rated:  .21  },
+          { id: 86, productId: 214306, productName: 'Compressor 7',  activity: 'Assemble Paint', quantity: 44,   price: 124.99000000000001, status: 'On Hold',  orderDate: '2015-01-07T06:00:00.000Z', action: 'Action',rated:  .11  },
+          { id: 87, productId: 214307, productName: 'Compressor 8',  activity: 'Assemble Paint', quantity: 44.5, price: 123.99000000000001, status: 'On Hold',  orderDate: '2015-01-08T06:00:00.000Z', action: 'Action',rated:  .31  },
+          { id: 88, productId: 214308, productName: 'Compressor 9',  activity: 'Assemble Paint', quantity: 45,   price: 122.99000000000001, status: 'On Hold',  orderDate: '2015-01-09T06:00:00.000Z', action: 'Action',rated:  .76  },
+          { id: 89, productId: 214309, productName: 'Compressor 10', activity: 'Assemble Paint', quantity: 45.5, price: 121.99000000000001, status: 'On Hold',  orderDate: '2015-01-10T06:00:00.000Z', action: 'Action',rated:  .21  },
+          { id: 90, productId: 214310, productName: 'Compressor 1',  activity: 'Assemble Paint', quantity: 46,   price: 120.99000000000001,                     orderDate: '2015-01-01T06:00:00.000Z', action: 'Action',rated:  .83  },
+          { id: 91, productId: 214311, productName: 'Compressor 2',  activity: 'Assemble Paint', quantity: 46.5, price: 119.99000000000001, status: 'Late',     orderDate: '2015-01-02T06:00:00.000Z', action: 'Action',rated:  .42  },
+          { id: 92, productId: 214312, productName: 'Compressor 3',  activity: 'Assemble Paint', quantity: 47,   price: 118.99000000000001, status: 'Active',   orderDate: '2015-01-03T06:00:00.000Z', action: 'Action',rated:  .31  },
+          { id: 93, productId: 214313, productName: 'Compressor 4',  activity: 'Assemble Paint', quantity: 47.5, price: 117.99000000000001, status: 'Inactive', orderDate: '2015-01-04T06:00:00.000Z', action: 'Action',rated:  .64  },
+          { id: 94, productId: 214314, productName: 'Compressor 5',  activity: 'Assemble Paint', quantity: 48,   price: 116.99000000000001, status: 'Inactive', orderDate: '2015-01-05T06:00:00.000Z', action: 'Action',rated:  .26  },
+          { id: 95, productId: 214315, productName: 'Compressor 6',  activity: 'Assemble Paint', quantity: 48.5, price: 115.99000000000001, status: 'Inactive', orderDate: '2015-01-06T06:00:00.000Z', action: 'Action',rated:  .51  },
+          { id: 96, productId: 214316, productName: 'Compressor 7',  activity: 'Assemble Paint', quantity: 49,   price: 114.99000000000001, status: 'On Hold',  orderDate: '2015-01-07T06:00:00.000Z', action: 'Action',rated:  .43  },
+          { id: 97, productId: 214317, productName: 'Compressor 8',  activity: 'Assemble Paint', quantity: 49.5, price: 113.99000000000001, status: 'On Hold',  orderDate: '2015-01-08T06:00:00.000Z', action: 'Action',rated:  .11  },
+          { id: 98, productId: 214318, productName: 'Compressor 9',  activity: 'Assemble Paint', quantity: 50,   price: 112.99000000000001, status: 'On Hold',  orderDate: '2015-01-09T06:00:00.000Z', action: 'Action',rated:  .66  },
+          { id: 99, productId: 214319, productName: 'Compressor 10', activity: 'Assemble Paint', quantity: 50.5, price: 111.99000000000001, status: 'On Hold',  orderDate: '2015-01-10T06:00:00.000Z', action: 'Action',rated:  .34  }
+*/
+        ];
+      }
+
+      return PAGING_DATA;
+    }
+  });
+</script>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Modified example page to run `updateColumns()` in source callback method with datagrid.

**Related github/jira issue (required)**:
Closes #435 (formerly) https://jira.infor.com/browse/SOHO-6990

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-group-headers-update-columns-landmark.html
- Open above link
- Should be render with group-headers
- Group "Product Stuff" should be two columns "Product Id" and "Product Name"
- See pagination, should be all buttons disabled

**Additional notes**:
Modified the example page so `updateColumns()` method can run only once. In this example it is running in source callback method. Which caused to be stuck in loading loop. To fix this issue created a global flag `isColumnsChanged` in this example and local method `checkIsColumnsChanged()` to set this global flag's value. So it can now run only when there is a change in columns.