### PR TITLE
1216 - Blocking context menu being opening on a datagrid if the menu doesn't exist in the dom

### DIFF
--- a/app/views/components/datagrid/test-contextmenu-dynamic.html
+++ b/app/views/components/datagrid/test-contextmenu-dynamic.html
@@ -1,0 +1,83 @@
+
+{{={{{ }}}=}}
+
+<div class="row">
+  <div class="twelve columns">
+    <div id="readonly-datagrid">
+    </div>
+  </div>
+  <ul id="grid-header-menu" class="popupmenu">
+    <li><a href="#">Split</a></li>
+    <li><a href="#">Sort</a></li>
+    <li><a href="#">Hide</a></li>
+  </ul>
+</div>
+
+<button class="btn-primary" type="button" id="insert-context-menu-button">Insert Context Menu</button><br><br><br>
+
+
+
+<script>
+  $('body').on('initialized', function () {
+    //Locale.set('en-US').done(function () {
+    var grid,
+      columns = [],
+      data = [];
+
+    // Some Sample Data
+    data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action', ordered: 1, setting: {optionOne: 'One', optionTwo: 'One'}});
+    data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold', ordered: true, setting: {optionOne: 'One', optionTwo: 'One'}});
+    data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action', ordered: true, comment: 'Dynamic harness out-of-the-box /n syndicate models deliver. Disintermediate, technologies /n scale deploy social streamline, methodologies, killer podcasts innovate. Platforms A-list disintermediate, value visualize dot-com /n tagclouds platforms incentivize interactive vortals disintermediate networking, webservices envisioneer; tag share value-added, disintermediate, revolutionary.'});
+    data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 9, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action', ordered: true});
+    data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 18.00, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold', ordered: false});
+    data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 18, price: 9, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', comment: 'B2C ubiquitous communities maximize B2C synergies extend dynamic revolutionize, world-class robust peer-to-peer. Action-items semantic technologies clicks-and-mortar iterate min'});
+    data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', ordered: 0});
+    data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '100.99', status: 'OK', orderDate: new Date(2014, 6, 9, 12, 12, 12), action: 'On Hold', ordered: 0});
+
+    //Define Columns for the Grid.
+
+    var cellTemplate = '<p class="datagrid-row-heading">{{productId}}</p>' +
+      '<p class="datagrid-row-subheading">{{productName}}</p>';
+
+    columns.push({ id: 'drilldown', name: 'Drill In', field: '', width: 80, formatter: Formatters.Drilldown, cssClass: 'l-center-text', click: function (e, args) {console.log('clicked', args);}});
+    //columns.push({ id: 'productName', name: 'Product Name', field: 'productName', width: 125, formatter: Formatters.Template, template: cellTemplate});
+    columns.push({ id: 'productId', hidden: true, name: 'Product Id', field: 'productId', width: 140, formatter: Formatters.Readonly });
+    columns.push({ id: 'productDesc', name: 'Product Desc', sortable: false, field: 'productName', width: 125, formatter: Formatters.Hyperlink, click: function (e, args) {console.log('link was clicked', args);}});
+    columns.push({ id: 'activity', name: 'Activity', field: 'activity', width: 160});
+    columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', width: 200});
+    columns.push({ id: 'price1', name: 'Price', field: 'price', width: 100, formatter: Formatters.Decimal});
+    columns.push({ id: 'price2', name: 'Price', field: 'price', width: 100, formatter: Formatters.Integer});
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, width: 100, dateFormat: 'yy/MM/dd'});
+
+    //{date: 'datetime'
+    columns.push({ id: 'status', name: 'Status', field: 'status', width: 200, formatter: Formatters.Text});
+    columns.push({ id: 'alert', name: 'Alert', field: 'quantity', width: 200, formatter: Formatters.Alert, ranges: [{'min': 0, 'max': 8, 'classes': 'info', 'text': 'value'}, {'min': 9, 'max': 1000, 'classes': 'error', 'text': 'value'}]});
+    columns.push({ id: 'ordered', name: 'Ordered', field: 'ordered', width: 200, formatter: Formatters.Checkbox});
+    columns.push({ id: '', name: 'Actions', field: '', width: 200, formatter: Formatters.Actions, menuId: 'grid-actions-menu'});
+    columns.push({ id: 'nested', name: 'Nested Prop', field: 'setting.optionOne', width: 200, formatter: Formatters.Text});
+    columns.push({ id: 'comment', name: 'Comment', field: 'comment', formatter: Formatters.TextArea, width: 200});
+
+    //Init and get the api for the grid
+    $('#readonly-datagrid').datagrid({
+      columns: columns,
+      dataset: data,
+      menuId: 'grid-actions-menu',
+      headerMenuId: 'grid-header-menu',
+      menuSelected: function (e, args) {
+        console.log('header item selected', args);
+      },
+      headerMenuSelected: function (e, args) {
+        console.log('header item selected', args);
+      }
+    }).on('contextmenu', function (e, args) {
+      console.log('contextmenu fired', args);
+    });
+
+    $('#insert-context-menu-button').on('click', function (e, args) {
+      // var html = $('body');
+      $('#grid-header-menu').after('<ul id="grid-actions-menu" class="popupmenu"><li><a href="#">Action One</a></li><li><a href="#">Action Two</a></li><li><a href="#">Action Three</a><ul class="popupmenu"><li><a href="#">Action Four</a></li><li><a href="#">Action Five</a></li></ul></li></ul>');
+    });
+
+  });
+
+</script>

--- a/app/views/components/datagrid/test-contextmenu-dynamic.html
+++ b/app/views/components/datagrid/test-contextmenu-dynamic.html
@@ -3,6 +3,16 @@
 
 <div class="row">
   <div class="twelve columns">
+    <div class="toolbar" role="toolbar">
+      <div class="buttonset">
+        <button type="button" class="btn" id="insert-context-menu-button">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-add"></use>
+          </svg>
+          <span>Insert Context Menu</span>
+        </button>
+      </div>
+    </div>
     <div id="readonly-datagrid">
     </div>
   </div>
@@ -12,9 +22,6 @@
     <li><a href="#">Hide</a></li>
   </ul>
 </div>
-
-<button class="btn-primary" type="button" id="insert-context-menu-button">Insert Context Menu</button><br><br><br>
-
 
 
 <script>

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -88,7 +88,9 @@ PopupMenu.prototype = {
     // Allow for an external click event to be passed in from outside this code.
     // This event can be used to pass clientX/clientY coordinates for mouse cursor positioning.
     if (this.settings.trigger === 'immediate') {
-      this.open(this.settings.eventObj);
+      if (this.menu.length) {
+        this.open(this.settings.eventObj);
+      }
     }
 
     // Use some css rules on submenu parents

--- a/test/components/popupmenu/popupmenu.e2e-spec.js
+++ b/test/components/popupmenu/popupmenu.e2e-spec.js
@@ -201,3 +201,32 @@ describe('Popupmenu example-selectable-multiple tests', () => {
     });
   }
 });
+
+describe('Contextmenu created dynamically tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/test-contextmenu-dynamic');
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('No errors when right click on row without the menu in the dom', async () => {
+    const tableRow = await element(by.css('tbody > tr:first-of-type > td:first-of-type'));
+    await browser.actions().mouseMove(tableRow).perform();
+    await browser.actions().click(protractor.Button.RIGHT).perform();
+
+    await utils.checkForErrors();
+
+    const insertContextButton = await element(by.id('insert-context-menu-button'));
+    await browser.actions().mouseMove(insertContextButton).perform();
+    await browser.actions().click(protractor.Button.LEFT).perform();
+
+    await browser.actions().mouseMove(tableRow).perform();
+    await browser.actions().click(protractor.Button.RIGHT).perform();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('grid-actions-menu'))), config.waitsFor);
+
+    expect(await element(by.id('grid-actions-menu')).getAttribute('class')).toContain('is-open');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixing issue where an error is thrown in the console if a popupmenu's ul doesn't exist in the dom when right clicking on a datagrid row. This is because the default setting for popupmenu is a trigger of immediate, so the init method was trying to open and display a menu that didn't exist.

**Related github/jira issue (required)**:
Closes #1216 

**Steps necessary to review your pull request (required)**:
You can test this fix by navigating to the test case in the PR, right clicking on a row on the table. No menu should open up, and no error should be seen in the log.

Then on that test page, you can click the "Insert Context Menu" button, and right click on a row again. The menu should open up successfully this time.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
