### PR TITLE
1124 - Fixed header text alignment with datagrid

### DIFF
--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -115,10 +115,18 @@ $datagrid-short-row-height: 23px;
     > .datagrid-header .datagrid-column-wrapper {
       position: relative;
       top: -4px;
+
+      &.l-right-text {
+        top: -15px;
+      }
     }
 
     .is-filterable .datagrid-column-wrapper {
       top: -3px;
+
+      &.l-right-text {
+        top: -3px;
+      }
     }
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The header text was not aligning when used with left/right align and filter option with datagrid.

**Related github/jira issue (required)**:
Closes #1124

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-fixed-header-toolbar-filter.html
- Open above link
- See all header text should align (top to bottom) fine.