### PR TITLE
1050 - Add keydown event to set color

### DIFF
--- a/src/components/colorpicker/colorpicker.js
+++ b/src/components/colorpicker/colorpicker.js
@@ -710,6 +710,9 @@ ColorPicker.prototype = {
       if (e.keyCode === 38 || e.keyCode === 40) {
         this.toggleList();
       }
+      if (e.keyCode === 13) {
+        this.setColor(elem.val());
+      }
     });
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes IE issue where color doesn't get set when keydown on return

**Related github/jira issue (required)**:
related to #1050 

**Steps necessary to review your pull request (required)**:
* pull branch
* open http://localhost:4000/components/colorpicker/example-index.html in IE 11
* type hex code in the input and press return. the color should be set

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
