### PR TITLE
269 - Replace usage of `Array.from()` in Flex Toolbar for IE support [v4.13.x]

### DIFF
--- a/src/components/toolbar-flex/toolbar-flex.js
+++ b/src/components/toolbar-flex/toolbar-flex.js
@@ -42,7 +42,7 @@ ToolbarFlex.prototype = {
    * @returns {void}
    */
   init() {
-    this.sections = Array.from(this.element.querySelectorAll('.toolbar-section'));
+    this.sections = utils.getArrayFromList(this.element.querySelectorAll('.toolbar-section'));
     this.items = this.getElements().map((item) => {
       $(item).toolbarflexitem({
         toolbarAPI: this
@@ -246,7 +246,7 @@ ToolbarFlex.prototype = {
     // Get all possible Toolbar Element matches
     // NOTE: Important that the toolbar items are picked up by the querySelector
     // in their actual, physical DOM order.
-    const thisElems = Array.from(this.element.querySelectorAll(allSelectors));
+    const thisElems = utils.getArrayFromList(this.element.querySelectorAll(allSelectors));
 
     // Check each element for each type of toolbar item.
     // If there's a match, push to the item array.

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -179,7 +179,7 @@ utils.uniqueId = function (element, className, prefix, suffix) {
 
   prefix = (!prefix ? '' : `${prefix}-`);
   suffix = (!suffix ? '' : `-${suffix}`);
-  className = (!className ? Array.from(element.classList).join('-') : className);
+  className = (!className ? utils.getArrayFromList(element.classList).join('-') : className);
 
   const str = `${prefix}${className}-${uniqueIdCount}${suffix}`;
   uniqueIdCount += 1;
@@ -1018,6 +1018,18 @@ math.sign = function (x) {
     return x;
   }
   return x > 0 ? 1 : -1;
+};
+
+/**
+ * Convenience method for using `Array.prototype.slice()` on an Array-like object (or an actual array)
+ * to make a copy.
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice#Array-like_objects
+ * @param {Array|NodeList} listObj an array-like object
+ * @returns {array} containing the list in array format.
+ */
+utils.getArrayFromList = function (listObj) {
+  const unboundSlice = Array.prototype.slice;
+  return Function.prototype.call.bind(unboundSlice)(listObj);
 };
 
 export { utils, math };


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a bug that was found during Q/A testing on `4.13.x`, where the Flex Toolbar was not working due to the usage of `Array.from()` in key parts of its initialization.  This method is not supported in IE.

**Related github/jira issue (required)**:
- #269 
- Fixes #285
- #1244  

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp in IE11
- Open http://localhost:4000/components/toolbar-flex/example-index (use `10.0.2.2` instead of `localhost` if on a Windows VM in Virtualbox)
- Click any of the regular toolbar buttons or the action button.  A toast should appear.
- Use the keyboard to navigate the toolbar.  Navigation should be possible.
- Try to open the "More Actions" menu on any toolbar.  The menu should open.
