### PR TITLE
639 - Fixed issue regarding popup not able to dismiss

### DIFF
--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -320,6 +320,15 @@ Accordion.prototype = {
       e.stopPropagation();
     }
 
+    const openPopup = $('.popupmenu.is-open');
+    if (openPopup.length) {
+      const headers = this.element.find('.accordion-header[aria-haspopup="true"]');
+      headers.each(function () {
+        const api = $(this).data('popupmenu');
+        api.close();
+      });
+    }
+
     /**
      * If the anchor is a real link, follow the link and die here.
      * This indicates the link has been followed.
@@ -674,13 +683,9 @@ Accordion.prototype = {
     }
 
     const self = this;
-    let pane = header.nextAll().not('.audible').first('.accordion-pane');
+    const pane = header.nextAll().not('.audible').first('.accordion-pane');
     const a = header.children('a');
     const dfd = $.Deferred();
-
-    if (this.settings.allowOnePane) {
-      pane = header.next('.accordion-pane').not('.audible');
-    }
 
     const canExpand = this.element.triggerHandler('beforeexpand', [a]);
     if (canExpand === false) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Fixed issue regarding popup not able to dismiss
- http://localhost:4000/components/accordion/test-with-contextmenu.html

**Related github/jira issue (required)**:
Closes #639 

**Steps necessary to review your pull request (required)**:
- Right click on "Personal" and the context menu pop opens with "Menu1 and Menu 2"
- Click on "Position" or anywhere else on the page
- Popup menu should now be dismissed


