### PR TITLE
1069 - Dropdown in mobile doesn't close when scrolling

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1751,7 +1751,7 @@ Dropdown.prototype = {
 
         if ((newPos.x >= pos.x + threshold) || (newPos.x <= pos.x - threshold) ||
             (newPos.y >= pos.y + threshold) || (newPos.y <= pos.y - threshold)) {
-          self.touchPrevented = true;
+           self.touchPrevented = false;
         }
       });
     }

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1715,6 +1715,7 @@ Dropdown.prototype = {
     function scrollDocument(e) {
       const focus = $('*:focus'); // dont close on timepicker arrow down and up
       if (self.touchPrevented || isDropdownElement($(e.target)) || focus.is('.timepicker')) {
+        self.touchPrevented = false;
         return;
       }
       self.closeList('cancel');
@@ -1751,7 +1752,7 @@ Dropdown.prototype = {
 
         if ((newPos.x >= pos.x + threshold) || (newPos.x <= pos.x - threshold) ||
             (newPos.y >= pos.y + threshold) || (newPos.y <= pos.y - threshold)) {
-           self.touchPrevented = false;
+           self.touchPrevented = true;
         }
       });
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When scrolling in the form, while dropdown list is open, it doesn't close (in mobile).

Changing the touchPrevented to false in `scrollDocument` function will fix this. 

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/1069

**Steps necessary to review your pull request (required)**:

- Pull this branch
- Run http://localhost:4000/components/form/example-inputs.html in mobile device or in browserstack
- After clicking the the dropdown list, scrolling should close the list and not floating.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
