### PR TITLE
639 - Fix for popup not dismissing [v4.13.x]

### DIFF
--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -232,9 +232,13 @@ Accordion.prototype = {
 
       if (this.settings.allowOnePane) {
         targetsToExpand = targetsToExpand.first();
+        this.expand(targetsToExpand);
+      } else {
+        targetsToExpand.each((idx) => {
+          this.expand($(targetsToExpand[idx]));
+        });
       }
 
-      this.expand(targetsToExpand);
       this.select(targetsToExpand.last());
       targetsToExpand.next('.accordion-pane').removeClass('no-transition');
     }
@@ -393,15 +397,6 @@ Accordion.prototype = {
     // cases where it shouldn't be clicked.
     if (e) {
       e.stopPropagation();
-    }
-
-    const openPopup = $('.popupmenu.is-open');
-    if (openPopup.length) {
-      const headers = this.element.find('.accordion-header[aria-haspopup="true"]');
-      headers.each(function () {
-        const api = $(this).data('popupmenu');
-        api.close();
-      });
     }
 
     const pane = header.next('.accordion-pane');

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -395,6 +395,15 @@ Accordion.prototype = {
       e.stopPropagation();
     }
 
+    const openPopup = $('.popupmenu.is-open');
+    if (openPopup.length) {
+      const headers = this.element.find('.accordion-header[aria-haspopup="true"]');
+      headers.each(function () {
+        const api = $(this).data('popupmenu');
+        api.close();
+      });
+    }
+
     const pane = header.next('.accordion-pane');
     if (pane.length) {
       this.toggle(header);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Fixed issue regarding popup not able to dismiss
- http://localhost:4000/components/accordion/test-with-contextmenu.html

**Related github/jira issue (required)**:
Closes #639

**Steps necessary to review your pull request (required)**:
- Right click on "Personal" and the context menu pop opens with "Menu1 and Menu 2"
- Click on "Position" or anywhere else on the page
- Popup menu should now be dismissed
