### PR TITLE
1207 - Remove popstate event in modal

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -87,14 +87,6 @@ Modal.prototype = {
 
     self.isCancelled = false;
 
-    if (window.history && window.history.pushState) {
-      $(window).off('popstate.modal');
-
-      $(window).on('popstate.modal', () => {
-        self.destroy();
-      });
-    }
-
     // ensure is appended to body for new dom tree
     if (this.settings.content) {
       this.settings.trigger = this.settings.content instanceof jQuery ? this.settings.trigger : 'immediate';
@@ -914,8 +906,6 @@ Modal.prototype = {
 
       self.element.closest('.modal-page-container').remove();
       $.removeData(self.element[0], 'modal');
-
-      $(window).off('popstate.modal');
     }
 
     if (!this.isOpen()) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Removing all the code that closes the CAP on the `popstate` event.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/1207

**Steps necessary to review your pull request (required)**:

- Pull this branch
- Run http://localhost:4000/components/contextualactionpanel/example-index
- Click 'Contextual Action Panel' button
- In the browser console, type window.location.hash = "something"
- The modal should not be closed and it can be reopened by clicking the button.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
