### PR TITLE
1242 - Prevent Tooltips from staying open when a Popupmenu is activated [v4.13.x]

### DIFF
--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -109,6 +109,13 @@ PopupMenu.prototype = {
   },
 
   /**
+   * @returns {boolean} whether or not the popupmenu is currently open
+   */
+  get isOpen() {
+    return this.element[0].className.indexOf('is-open') > -1;
+  },
+
+  /**
    * @private
    * @returns {void}
    */
@@ -1588,6 +1595,12 @@ PopupMenu.prototype = {
         api.close();
       }
     });
+
+    // Close open tooltips associated with this menu's trigger element
+    const tooltipAPI = this.element.data('tooltip');
+    if (tooltipAPI && tooltipAPI.visible) {
+      tooltipAPI.hide();
+    }
 
     // Close open dropdowns
     $('#dropdown-list').remove();

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -112,7 +112,7 @@ PopupMenu.prototype = {
    * @returns {boolean} whether or not the popupmenu is currently open
    */
   get isOpen() {
-    return this.element[0].className.indexOf('is-open') > -1;
+    return DOM.hasClass(this.element[0], 'is-open');
   },
 
   /**

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -72,7 +72,7 @@ Tooltip.prototype = {
    * @returns {boolean} whether or not the tooltip/popover is currently showing
    */
   get visible() {
-    return this.element[0].className.indexOf('is-hidden') === -1;
+    return DOM.hasClass(this.element[0], 'is-hidden') === false;
   },
 
   /**

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -69,6 +69,20 @@ function Tooltip(element, settings) {
 Tooltip.prototype = {
 
   /**
+   * @returns {boolean} whether or not the tooltip/popover is currently showing
+   */
+  get visible() {
+    return this.element[0].className.indexOf('is-hidden') === -1;
+  },
+
+  /**
+   * @returns {Popupmenu|undefined} if a Popupmenu API exists on the trigger element
+   */
+  get popupmenuAPI() {
+    return this.element.data('popupmenu');
+  },
+
+  /**
    * Initializes the component
    * @private
    * @returns {void}
@@ -202,19 +216,34 @@ Tooltip.prototype = {
     const delay = 400;
     let timer;
 
+    function showOnTimer() {
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        self.show();
+      }, delay);
+    }
+
     function hideOnTimer() {
       clearTimeout(timer);
-      setTimeout(() => {
+      timer = setTimeout(() => {
         self.hide();
       }, delay);
+    }
+
+    function showImmediately() {
+      clearTimeout(timer);
+      self.show();
+    }
+
+    function hideImmediately() {
+      clearTimeout(timer);
+      self.hide();
     }
 
     if (this.settings.trigger === 'hover' && !this.settings.isError) {
       ((this.element.is('.dropdown, .multiselect')) ? this.activeElement : this.element)
         .on(`mouseenter.${COMPONENT_NAME}`, () => {
-          timer = setTimeout(() => {
-            self.show();
-          }, delay);
+          showOnTimer();
         })
         .on(`mouseleave.${COMPONENT_NAME}`, () => {
           hideOnTimer();
@@ -223,10 +252,10 @@ Tooltip.prototype = {
           if (!env.features.touch) {
             return;
           }
-          hideOnTimer();
+          showImmediately();
         })
         .on(`longpress.${COMPONENT_NAME}`, () => {
-          self.show();
+          showImmediately();
         })
         .on(`updated.${COMPONENT_NAME}`, () => {
           self.updated();
@@ -234,10 +263,10 @@ Tooltip.prototype = {
     }
 
     function toggleTooltipDisplay() {
-      if (!self.tooltip.hasClass('is-hidden')) {
-        self.hide();
+      if (!self.visible) {
+        hideImmediately();
       } else {
-        self.show();
+        showImmediately();
       }
     }
 
@@ -257,22 +286,21 @@ Tooltip.prototype = {
     if (isFocusable) {
       this.element
         .on(`focus.${COMPONENT_NAME}`, () => {
-          self.show();
+          showImmediately();
         })
         .on(`blur.${COMPONENT_NAME}`, () => {
           if (!self.settings.keepOpen) {
-            self.hide();
+            hideImmediately();
           }
         });
     }
 
     // Close the popup/tooltip on orientation changes (but not when keyboard is open)
     $(window).on(`orientationchange.${COMPONENT_NAME}`, () => {
-      // Match every time.
-      if (self.tooltip.hasClass('is-hidden')) {
+      if (!self.visible) {
         return;
       }
-      self.close();
+      hideImmediately();
     }, false);
   },
 
@@ -526,7 +554,7 @@ Tooltip.prototype = {
     }
 
     // Don't open if this is an Actions Button with an open popupmenu
-    if (DOM.hasClass(this.element[0], 'btn-actions') && DOM.hasClass(this.element[0], 'is-open')) {
+    if (this.popupmenuAPI && this.popupmenuAPI.isOpen) {
       return;
     }
 
@@ -755,7 +783,7 @@ Tooltip.prototype = {
    * @returns {void}
    */
   hide() {
-    if (this.settings.keepOpen) {
+    if (this.settings.keepOpen || !this.visible) {
       return;
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds a more comprehensive set of changes to the Popupmenu/Tooltip components that allow for better state checking between the two components, if they're established on the same trigger element.  This PR improves a set of changes added in PR #1245 that only half-fixed the original issue.

**Related github/jira issue (required)**:
- Fixes #1242
- Supersedes #1245

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp
- Open http://localhost:4000/components/toolbar-flex/example-eyebrow.html?locale=ar-SA in IE11 (use http://10.0.2.2 if running IE in a virtual machine)
- Hover the "More Actions" menu of the in-page toolbar, which is the left-most button.  A tooltip should appear
- Click the "More Actions" button to open its popupmenu.  The tooltip should disappear.
- Close the menu by clicking out in the page area.
- Hover the "More Actions" button again, but attempt to click the button within 100-200ms.  If a tooltip appears, it should immediately disappear as soon as the popupmenu opens.
