### PR TITLE
1278 - datepicker wont close [v4.13.x]

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -74,6 +74,7 @@ Tooltip.prototype = {
    * @returns {void}
    */
   init() {
+    this.uniqueId = utils.uniqueId(this.element, 'tooltip');
     this.setup();
     this.appendTooltip();
 
@@ -210,7 +211,7 @@ Tooltip.prototype = {
     }
 
     if (this.settings.trigger === 'hover' && !this.settings.isError) {
-      ((this.element.is('.dropdown, .multiselect')) ? this.activeElement : this.element)
+      ((this.element.is('.dropdown, .multiselect, span.longpress-target')) ? this.activeElement : this.element)
         .on(`mouseenter.${COMPONENT_NAME}`, () => {
           timer = setTimeout(() => {
             self.show();
@@ -591,7 +592,7 @@ Tooltip.prototype = {
 
     setTimeout(() => {
       $(document)
-        .on(`${mouseUpEventName}.${COMPONENT_NAME}`, (e) => {
+        .on(`${mouseUpEventName}.${COMPONENT_NAME}-${self.uniqueId}`, (e) => {
           const target = $(e.target);
 
           if (self.settings.isError || self.settings.trigger === 'focus') {
@@ -611,7 +612,7 @@ Tooltip.prototype = {
             self.hide(e);
           }
         })
-        .on(`keydown.${COMPONENT_NAME}`, (e) => {
+        .on(`keydown.${COMPONENT_NAME}-${self.uniqueId}`, (e) => {
           if (e.which === 27 || self.settings.isError) {
             self.hide();
           }
@@ -818,9 +819,9 @@ Tooltip.prototype = {
     this.tooltip.off(`click.${COMPONENT_NAME}`);
 
     $(document).off([
-      `keydown.${COMPONENT_NAME}`,
-      `mouseup.${COMPONENT_NAME}`,
-      `touchend.${COMPONENT_NAME}`].join(' '));
+      `keydown.${COMPONENT_NAME}-${self.uniqueId}`,
+      `mouseup.${COMPONENT_NAME}-${self.uniqueId}`,
+      `touchend.${COMPONENT_NAME}-${self.uniqueId}`].join(' '));
 
     $('body').off([
       `resize.${COMPONENT_NAME}`,

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -26,7 +26,7 @@ $.fn.bindFirst = function (name, fn) {
  * uniqueIdCount is a baseline unique number that will be used when generating
  * uniqueIds for elements and components.
  */
-export let uniqueIdCount = 0; // eslint-disable-line
+export let uniqueIdCount = []; // eslint-disable-line
 
 /**
  * Detect whether or not a text string represents a valid CSS property.  This check
@@ -181,8 +181,11 @@ utils.uniqueId = function (element, className, prefix, suffix) {
   suffix = (!suffix ? '' : `-${suffix}`);
   className = (!className ? utils.getArrayFromList(element.classList).join('-') : className);
 
-  const str = `${prefix}${className}-${uniqueIdCount}${suffix}`;
-  uniqueIdCount += 1;
+  if (!uniqueIdCount[className]) {
+    uniqueIdCount[className] = 1;
+  }
+  const str = `${prefix}${className}-${uniqueIdCount[className]}${suffix}`;
+  uniqueIdCount[className] += 1;
   return str;
 };
 

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -825,14 +825,14 @@ describe('Datagrid paging serverside single select tests', () => {
 
     expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(1);
 
-    element(by.css('.pager-next')).click();
+    await element(by.css('.pager-next a')).click();
 
     await browser.driver
       .wait(protractor.ExpectedConditions.elementToBeClickable(await element(by.css('.pager-prev'))), config.waitsFor);
 
     expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(0);
 
-    await element(by.css('.pager-prev')).click();
+    await element(by.css('.pager-prev a')).click();
 
     await browser.driver
       .wait(protractor.ExpectedConditions.elementToBeClickable(await element(by.css('.pager-next'))), config.waitsFor);

--- a/test/components/tabs/tabs.e2e-spec.js
+++ b/test/components/tabs/tabs.e2e-spec.js
@@ -475,13 +475,15 @@ describe('Tabs ajax as href tests', () => {
     await utils.checkForErrors();
   });
 
-  it('Should be able to activate href tabs', async () => {
-    expect(await element(by.id('ajaxified-tabs-tab-1')).getAttribute('innerHTML')).not.toBe('');
+  if (!utils.isCI()) {
+    it('Should be able to activate href tabs', async () => {
+      expect(await element(by.id('ajaxified-tabs-tab-1')).getAttribute('innerHTML')).not.toBe('');
 
-    await element(by.css('#example-tab-two a')).click();
-    await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('#ajaxified-tabs-tab-2.is-visible'))), config.waitsFor);
+      await element(by.css('#example-tab-two a')).click();
+      await browser.driver
+        .wait(protractor.ExpectedConditions.presenceOf(element(by.css('#ajaxified-tabs-tab-2.is-visible'))), config.waitsFor);
 
-    expect(await element(by.id('ajaxified-tabs-tab-2')).getAttribute('innerHTML')).not.toBe('');
-  });
+      expect(await element(by.id('ajaxified-tabs-tab-2')).getAttribute('innerHTML')).not.toBe('');
+    });
+  }
 });

--- a/test/components/tabs/tabs.e2e-spec.js
+++ b/test/components/tabs/tabs.e2e-spec.js
@@ -475,10 +475,10 @@ describe('Tabs ajax as href tests', () => {
     await utils.checkForErrors();
   });
 
-  xit('Should be able to activate href tabs', async () => {
+  it('Should be able to activate href tabs', async () => {
     expect(await element(by.id('ajaxified-tabs-tab-1')).getAttribute('innerHTML')).not.toBe('');
 
-    await element.all(by.id('example-tab-two')).click();
+    await element(by.css('#example-tab-two a')).click();
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(element(by.css('#ajaxified-tabs-tab-2.is-visible'))), config.waitsFor);
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

If opening the time pickers on the date dialog it would never close after. While doing this i noticed the uniqueId function was not working for giving unique id's over a subset of items fx modal, tooltip datagrid. 
- Fixed this and adjusted test that relied on something inconsistent and out of order. 
- Fixed an additional test that was flaky.

**Related github/jira issue (required)**:
Closes #1278

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datepicker/example-timeformat.html
- open the picker on the first field
- select a time from either the min or hour dropdown
- try to click out of the dialog to close (it didnt before this fix)
