### PR TITLE
910 - Fixed issue regarding editor dirty tracking on ie edge

### DIFF
--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -778,7 +778,7 @@ Editor.prototype = {
         self.execAction(action, e);
       }
 
-      if (self.isIe) {
+      if (self.isIe || self.isIeEdge) {
         self.getCurrentElement().trigger('change');
       }
 

--- a/src/components/trackdirty/trackdirty.js
+++ b/src/components/trackdirty/trackdirty.js
@@ -30,6 +30,7 @@ Trackdirty.prototype = {
 
   init() {
     this.isIe = env.browser.name === 'ie';
+    this.isIeEdge = env.browser.name === 'edge';
 
     this.handleEvents();
   },
@@ -229,7 +230,7 @@ Trackdirty.prototype = {
           current = this.valMethod(textArea);
         }
 
-        if (this.isIe) {
+        if (this.isIe || this.isIeEdge) {
           current = input[0].innerHTML;
         }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Fixed issue regarding editor dirty tracking on ie edge
- localhost:4000/components/editor/example-dirty-tracking.html 

**Related github/jira issue (required)**:
Closes #910 

**Steps necessary to review your pull request (required)**:
- Open test page on IE Edge
- Click on second paragraph then click on H4 on toolbar
- Dirty tracking icon should now be seen
