### PR TITLE
379 - Refactor message HTML tag allowance

### DIFF
--- a/app/views/components/message/example-index.html
+++ b/app/views/components/message/example-index.html
@@ -5,7 +5,9 @@
     <button class="btn-secondary" type="button" id="show-application-alert">Alert Example</button><br><br>
     <button class="btn-secondary" type="button" id="show-application-confirm">Confirm Example</button><br><br>
     <button class="btn-secondary" type="button" id="show-fileupload-confirmation">Complete Example</button><br><br>
-    <button class="btn-secondary" type="button" id="show-delete-confirmation">Confirmation Example</button>
+    <button class="btn-secondary" type="button" id="show-delete-confirmation">Confirmation Example</button><br><br>
+    <button class="btn-secondary" type="button" id="allow-tags">Allow Tags</button><br><br>
+    <button class="btn-secondary" type="button" id="disallow-tags">Disallow Tags</button>
 
   </div>
 </div>
@@ -20,7 +22,6 @@
         status: 'error',
         returnFocus: $(this),
         message: 'This application has experienced a <b>system error</b> due to the lack of internet access.<br><em>Please</em> restart the application in order to proceed.',
-        allowHTMLTags: true,
         buttons: [{
             text: 'Restart Now',
             click: function() {
@@ -60,7 +61,7 @@
         title: '<span>Application Confirm</span>',
         status: 'confirm',
         returnFocus: $(this),
-        message: 'Success! You\'ve done the thing!',
+        message: 'Success! You\'ve done the thing! Here\'s a <a href="#" class="hyperlink hide-focus longpress-target" title="Link">link</a>.',
         buttons: [{
             text: 'Confirm',
             click: function() {
@@ -75,7 +76,7 @@
     $('#show-fileupload-confirmation').on('click', function() {
       $('body').message({
         title: 'File Upload Complete',
-        message: 'Your file "<b>photo.png</b>" was successfully uploaded to your personal folder and is now <em>public for viewing</em>.',
+        message: 'Your file "<em>photo.png</em>" was successfully uploaded to your personal folder and is now <strong>public for viewing</strong>.',
         returnFocus: $(this),
         buttons: [{
           text: 'Done',
@@ -91,9 +92,8 @@
     $('#show-delete-confirmation').on('click', function() {
       $('body').message({
         title: 'Delete this Application?',
-        message: 'You are about to delete this application permanently.<br>Would you like to proceed?',
+        message: 'You are about to delete<br>this application permanently.<br/>Would you like to proceed?',
         returnFocus: $(this),
-        allowHTMLTags: true,
         buttons: [{
           text: 'Yes',
           click: function(e, modal) {
@@ -107,6 +107,51 @@
             modal.close();
           },
           isDefault: true
+        }]
+      });
+    });
+
+    $('#allow-tags').on('click', function() {
+      $('body').message({
+        title: 'Tags are present',
+        message: '<a href="#" class="hyperlink hide-focus longpress-target"><b>You</b> </a>have <br>allowed <br/>any <del>tags</del> <em>to</em> <i>appear</i> <ins>in</ins> <mark>this</mark> <small>message</small>. <strong>All </strong> <sub>are</sub> <sup>default allowed</sup>.',
+        returnFocus: $(this),
+        buttons: [{
+          text: 'Ok',
+          click: function(e, modal) {
+            console.log('Ok');
+            modal.close();
+          },
+          isDefault: true
+        }, {
+          text: 'Dismiss',
+          click: function(e, modal) {
+            console.log('Dismiss');
+            modal.close();
+          }
+        }]
+      });
+    });
+
+    $('#disallow-tags').on('click', function() {
+      $('body').message({
+        title: 'No tags are present',
+        message: '<a href="#" class="hyperlink hide-focus longpress-target"><b>You</b> </a>have <br>disallowed <br/>any <del>tags</del> <em>from</em> <i>appearing</i> <ins>in</ins> <mark>this</mark> <small>message</small>. <strong>All</strong> <sub>are</sub> <sup>stripped</sup>.',
+        returnFocus: $(this),
+        allowedTags: '',
+        buttons: [{
+          text: 'Ok',
+          click: function(e, modal) {
+            console.log('Ok');
+            modal.close();
+          },
+          isDefault: true
+        }, {
+          text: 'Dismiss',
+          click: function(e, modal) {
+            console.log('Dismiss');
+            modal.close();
+          }
         }]
       });
     });

--- a/src/components/message/message.js
+++ b/src/components/message/message.js
@@ -20,7 +20,7 @@ const COMPONENT_NAME = 'message';
  * @param {object} [settings.buttons=null]  Array of buttons to add to the message (see modal examples as well)
  * @param {string} [settings.cssClass=null]  Extra Class to add to the dialog for customization.
  * @param {string} [settings.returnFocus=null]  JQuery Element selector to focus on return.
- * @param {string} [settings.allowHTMLTags=false]  Change to true to allow supported tags instead of stripping all HTML.
+ * @param {string} [allowedTags='<a><b><br><br/><del><em><i><ins><mark><small><strong><sub><sup>']  String of allowed HTML tags.
  */
 const MESSAGE_DEFAULTS = {
   title: 'Message Title',
@@ -30,7 +30,7 @@ const MESSAGE_DEFAULTS = {
   buttons: null,
   cssClass: null,
   returnFocus: null,
-  allowHTMLTags: false
+  allowedTags: '<a><b><br><br/><del><em><i><ins><mark><small><strong><sub><sup>'
 };
 
 function Message(element, settings) {
@@ -46,13 +46,19 @@ Message.prototype = {
   init() {
     const self = this;
     let content;
-    const allowedHTML = '<b><strong><i><em><mark><small><del><ins><sub><sup><br>';
+    const tags = this.settings.allowedTags;
+    let allowTags = true;
+
+    // Check for any allowed tags in settings string
+    if (!(this.settings.allowedTags.length > 0)) {
+      allowTags = false;
+    }
 
     // Create the Markup
     this.message = $('<div class="modal message"></div>');
     this.messageContent = $('<div class="modal-content"></div>');
-    this.title = $(`<h1 class="modal-title" id="message-title">${this.settings.allowHTMLTags ? xssUtils.stripTags(this.settings.title, allowedHTML) : xssUtils.stripHTML(this.settings.title)}</h1>`).appendTo(this.messageContent).wrap('<div class="modal-header"></div>');
-    this.content = $(`<div class="modal-body"><p class="message" id="message-text">${this.settings.allowHTMLTags ? xssUtils.stripTags(this.settings.message, allowedHTML) : xssUtils.stripHTML(this.settings.message)}</p></div>`).appendTo(this.messageContent);
+    this.title = $(`<h1 class="modal-title" id="message-title">${allowTags ? xssUtils.stripTags(this.settings.title, tags) : xssUtils.stripHTML(this.settings.title)}</h1>`).appendTo(this.messageContent).wrap('<div class="modal-header"></div>');
+    this.content = $(`<div class="modal-body"><p class="message" id="message-text">${allowTags ? xssUtils.stripTags(this.settings.message, tags) : xssUtils.stripHTML(this.settings.message)}</p></div>`).appendTo(this.messageContent);
 
     // Append The Content if Passed in
     if (!this.element.is('body')) {

--- a/test/components/message/message-xss.func-spec.js
+++ b/test/components/message/message-xss.func-spec.js
@@ -37,4 +37,21 @@ describe('Message XSS Prevention', () => {
     expect(messageTitleEl.innerText).toEqual('Application Message alert("GOTCHA!");');
     expect(messageContentEl.innerText).toEqual('This is a potentially dangerous Message. alert("GOTCHA!");');
   });
+
+  it('Can disallow HTML tags based on component setting', () => {
+    const messageTitleWithTags = '<a href="#" class="hyperlink hide-focus longpress-target"><b>You</b> </a>have <br>disallowed <br/>any <del>tags</del> <em>from</em> <i>appearing</i> <ins>in</ins> <mark>this</mark> <small>message</small>. <strong>All</strong> <sub>are</sub> <sup>stripped</sup>.';
+    const messageContentWithTags = '<a href="#" class="hyperlink hide-focus longpress-target"><b>You</b> </a>have <br>disallowed <br/>any <del>tags</del> <em>from</em> <i>appearing</i> <ins>in</ins> <mark>this</mark> <small>message</small>. <strong>All</strong> <sub>are</sub> <sup>stripped</sup>.';
+
+    messageAPI = new Message(messageEl, {
+      title: messageTitleWithTags,
+      message: messageContentWithTags,
+      allowedTags: ''
+    });
+
+    messageTitleEl = document.querySelector('.modal .modal-title');
+    messageContentEl = document.querySelector('.modal .modal-body');
+
+    expect(messageTitleEl.innerText).toEqual('You have disallowed any tags from appearing in this message. All are stripped.');
+    expect(messageContentEl.innerText).toEqual('You have disallowed any tags from appearing in this message. All are stripped.');
+  });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Creates a setting to allow customization of allowed HTML tags in a message. Default tags are `<a><b><br><br/><del><em><i><ins><mark><small><strong><sub><sup>`. Empty string results in all tags being stripped. Adds a test to ensure all tags are stripped if empty string is used.

**Related github/jira issue (required)**:
References #379 .
Supersedes #1275 .

**Steps necessary to review your pull request (required)**:
- Pull branch
- Run app
- http://localhost:4000/components/message/example-index
- Click Allow Tags button. Tags should format message (looks like a ransom note).
- Dismiss message.
- Click Disallow Tags button. Tags should be stripped and no formatting appear in message.
