### PR TITLE
1259 - Prevent searchfield's`selected` event from firing twice [v4.13.x]

### DIFF
--- a/app/views/components/searchfield/example-index.html
+++ b/app/views/components/searchfield/example-index.html
@@ -14,10 +14,8 @@
     clearable: true,
     source: '{{basepath}}api/states?term='
   }).on('selected', function (e, a) {
-    if (a.hasClass('more-results')) {
-      console.log('More results was clicked');
-    }
-  }).on('selected', function (e, a) {
+    console.log('`Selected` event was fired');
+
     if (a.hasClass('more-results')) {
       console.log('More results was clicked');
     }

--- a/app/views/components/searchfield/example-index.html
+++ b/app/views/components/searchfield/example-index.html
@@ -15,7 +15,6 @@
     source: '{{basepath}}api/states?term='
   }).on('selected', function (e, a) {
     console.log('`Selected` event was fired');
-
     if (a.hasClass('more-results')) {
       console.log('More results was clicked');
     }

--- a/src/components/autocomplete/autocomplete.js
+++ b/src/components/autocomplete/autocomplete.js
@@ -779,7 +779,6 @@ Autocomplete.prototype = {
       ret.value = a.text().trim();
     }
 
-    this.closeList();
     this.highlight(a);
 
     this.noSelect = true;
@@ -802,13 +801,14 @@ Autocomplete.prototype = {
     * @memberof Autocomplete
     * @param {array} args An array containing the link and the return object.
     */
-    this.element
-      .trigger('selected', [a, ret])
-      .focus();
+    this.element.trigger('selected', [a, ret]);
 
     if (isEvent) {
       anchorOrEvent.preventDefault();
     }
+
+    this.closeList();
+    this.element.focus();
 
     return ret;
   },

--- a/src/components/searchfield/searchfield.js
+++ b/src/components/searchfield/searchfield.js
@@ -856,7 +856,7 @@ SearchField.prototype = {
 
     // Override the 'click' listener created by Autocomplete (which overrides the
     // default Popupmenu method) to act differntly when the More Results link is activated.
-    self.element.on(`listopen.${this.id}`, (e, items) => {
+    self.element.on(`listopen.${this.id}`, () => {
       const list = $('#autocomplete-list');
 
       // Visual indicator class

--- a/src/components/searchfield/searchfield.js
+++ b/src/components/searchfield/searchfield.js
@@ -862,31 +862,16 @@ SearchField.prototype = {
       // Visual indicator class
       self.wrapper.addClass('popup-is-open');
 
-      list.on(`click.${this.id}`, 'a', (thisE) => {
-        const a = $(thisE.currentTarget);
-        let ret = a.text().trim();
+      // Trigger the `allResultsCallback` if one is defined
+      self.element.on(`selected.${this.id}`, (thisE, a, ret) => {
         const isMoreLink = a.hasClass('more-results');
-        const isNoneLink = a.hasClass('no-results');
-
-        if (!isMoreLink && !isNoneLink) {
-          // Only write text into the field on a regular result pick.
-          self.element.attr('aria-activedescendant', a.parent().attr('id'));
+        if (!isMoreLink) {
+          return;
         }
 
-        if (a.parent().attr('data-value')) {
-          for (let i = 0; i < items.length; i++) {
-            if (items[i].value.toString() === a.parent().attr('data-value')) {
-              ret = items[i];
-            }
-          }
-        }
-
-        if (isMoreLink) {
-          // Trigger callback if one is defined
-          const callback = self.settings.allResultsCallback;
-          if (callback && typeof callback === 'function') {
-            callback(ret);
-          }
+        const callback = self.settings.allResultsCallback;
+        if (callback && typeof callback === 'function') {
+          callback(ret);
         }
       });
 
@@ -901,7 +886,7 @@ SearchField.prototype = {
     }).on(`listclose.${this.id}`, () => {
       const list = $('#autocomplete-list');
 
-      list.off(`click.${this.id}`);
+      self.element.off(`selected.${this.id}`);
       list.off(`focus.${this.id}`);
     });
 
@@ -1979,6 +1964,7 @@ SearchField.prototype = {
       `listopen.${this.id}`,
       `listclose.${this.id}`,
       `safe-blur.${this.id}`,
+      `selected.${this.id}`,
       `populated.${this.id}`,
       `cleared.${this.id}`].join(' '));
 

--- a/src/components/searchfield/searchfield.js
+++ b/src/components/searchfield/searchfield.js
@@ -187,6 +187,14 @@ SearchField.prototype = {
   },
 
   /**
+   * @private
+   * @returns {Autocomplete|undefined} a reference to the Searchfield's optional Autocomplete API
+   */
+  get autocompleteAPI() {
+    return $(this.element).data('autocomplete');
+  },
+
+  /**
    * @returns {boolean} whether or not this is a context searchfield.
    */
   get isContextSearch() {
@@ -865,14 +873,6 @@ SearchField.prototype = {
           self.element.attr('aria-activedescendant', a.parent().attr('id'));
         }
 
-        if (isMoreLink) {
-          // Trigger callback if one is defined
-          const callback = self.settings.allResultsCallback;
-          if (callback && typeof callback === 'function') {
-            callback(ret);
-          }
-        }
-
         if (a.parent().attr('data-value')) {
           for (let i = 0; i < items.length; i++) {
             if (items[i].value.toString() === a.parent().attr('data-value')) {
@@ -881,13 +881,13 @@ SearchField.prototype = {
           }
         }
 
-        self.element.trigger('selected', [a, ret]);
-
-        const popup = self.element.data('popupmenu');
-        if (popup) {
-          popup.close();
+        if (isMoreLink) {
+          // Trigger callback if one is defined
+          const callback = self.settings.allResultsCallback;
+          if (callback && typeof callback === 'function') {
+            callback(ret);
+          }
         }
-        return false;
       });
 
       // Override the focus event created by the Autocomplete control to make the more link


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR changes Searchfield to prevent a double `selected` event from firing.  The `selected` event is already fired by the Autocomplete component (which is built into some Searchfield components), so the duplicate code firing the event in Searchfield is unnecessary.  

Along with removing this came a small refactor in the Searchfield that only fires the `allResultsCallback` if it's provided.  Previously there was an entire secondary code path that was "re-selecting" the autocomplete list item inside Searchfield.  This extraneous code has been removed.

**Related github/jira issue (required)**:
Closes #1259

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp.
- Open http://localhost:4000/components/searchfield/example-index and a dev tools console.
- Type "New" in the Searchfield
- Select any one of the actual results
- Check the dev tools console.  The notification that an item was selected should only appear once.

Additionally, make sure the Searchfield functional tests (specifcially [this one](https://github.com/infor-design/enterprise/blob/master/test/components/searchfield/searchfield-api.func-spec.js#L63-L86)) all pass.
