### PR TITLE
1213 - Fixed dropdown validation in modals

### DIFF
--- a/app/views/components/modal/example-validation.html
+++ b/app/views/components/modal/example-validation.html
@@ -13,9 +13,9 @@
         <div class="modal-body">
 
           <div class="field">
-            <label for="context-type">Type</label>
-            <select class="dropdown" id="context-type" name="type">
-              <option value="0"></option>
+            <label for="context-type" class="required label">Type</label>
+            <select class="dropdown" id="context-type" name="type" data-validate="required">
+              <option value=""></option>
               <option value="1">Context 01</option>
               <option value="2">Context 02</option>
               <option value="3">Context 03</option>

--- a/src/components/validation/validator.js
+++ b/src/components/validation/validator.js
@@ -962,8 +962,7 @@ Validator.prototype = {
       return;
     }
 
-    field.removeClass(`${rule.type} custom-icon`);
-    loc.data('isValid', true);
+    field.removeClass(`${rule.type} custom-icon`).data('isValid', true);
 
     if (field.hasClass('dropdown') || field.hasClass('multiselect')) {
       field.next().next().removeClass(`${rule.type} custom-icon`);

--- a/test/components/modal/modal.e2e-spec.js
+++ b/test/components/modal/modal.e2e-spec.js
@@ -164,10 +164,18 @@ describe('Modal example-validation tests', () => {
       await browser.driver.sleep(config.sleep);
       await element(by.id('context-desc')).click();
       await browser.driver.sleep(config.sleep);
+      await element(by.id('context-name')).click();
+      await browser.driver.sleep(config.sleep);
 
-      const messageEl = await element.all(by.className('message-text')).first();
+      const errors = [
+        await element.all(by.className('message-text')).get(0),
+        await element.all(by.className('message-text')).get(1),
+        await element.all(by.className('message-text')).get(2)
+      ];
 
-      expect(await messageEl.getText()).toEqual('Email address not valid');
+      expect(await errors[0].getText()).toEqual('Required');
+      expect(await errors[1].getText()).toEqual('Email address not valid');
+      expect(await errors[2].getText()).toEqual('Required');
     });
 
     it('Should enable submit', async () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
If dropdown use with validation in modal window. It was not let is pass validation and causing the not to submit form.

**Related github/jira issue (required)**:
Closes #1213

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/modal/example-validation.html
- Open above link
- Clock button "Add Context" to open modal window
- In modal window see button "Submit" should be disabled
- Soon fill/remove all required fields with (*) in label text
- See the button "Submit" it should be enabled/disabled