### PR TITLE
1253 - Error Icon not visible when Datagrid Row Height is 'Short'

### DIFF
--- a/app/views/components/datagrid/test-editable-validation.html
+++ b/app/views/components/datagrid/test-editable-validation.html
@@ -62,7 +62,7 @@
         //Define Columns for the Grid.
         columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, validate: 'required customRule', editor: Editors.Input});
         columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Input, editor: Editors.Input, validate: 'required customAsyncRule'});
-        columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, align: 'right', editor: Editors.Input, formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###.000'});
+        columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, align: 'right', editor: Editors.Input, formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###.000', validate: 'required'});
         columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date, validate: 'required date'});
 
         //Init and get the api for the grid

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1139,13 +1139,6 @@ $datagrid-short-row-height: 23px;
       left: -9px !important;
     }
 
-    .icon-error,
-    .icon-alert,
-    .icon-confirm,
-    .icon-info {
-      margin-left: -29px !important;
-    }
-
     .chart-completion-target {
       top: -2px;
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The .short-rowheight was applying a margin to error-icon that would make any .l-right-text not visible within the cell.

**Related github/jira issue (required)**:
Closes #1253 


**Steps necessary to review your pull request (required)**:
1. Go to 'http://localhost:4000/components/datagrid/test-editable-validation.html' 
2. Remove the price from the field
3. change row height to short

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
