### PR TITLE
385 - Implement case-sensitive filtering in ListFilter/Autocomplete

### DIFF
--- a/app/views/components/autocomplete/example-case-sensitive.html
+++ b/app/views/components/autocomplete/example-case-sensitive.html
@@ -1,0 +1,28 @@
+<div class="row">
+  <div class="twelve columns">
+    <div class="field">
+      <p>Try typing "california" or "California"</p>
+      </div>
+    <div class="field">
+      <label for="autocomplete-default">States</label>
+      <input type="text" autocomplete="off" class='autocomplete' placeholder="Type to Search" id="autocomplete-default">
+    </div>
+  </div>
+</div>
+
+<script id="test-scripts">
+  $('#autocomplete-default').autocomplete({
+    caseSensitive: true,
+    source: [
+      'California',
+      'cAlIfOrNiA',
+      'CaLiFoRnIa',
+      'california',
+      'CALIFORNIA'
+    ]
+  });
+
+  $('#autocomplete-default').on('selected', function (e, args) {
+    console.log(args.parent().attr('data-value'));
+  });
+</script>

--- a/src/components/autocomplete/autocomplete.js
+++ b/src/components/autocomplete/autocomplete.js
@@ -267,6 +267,7 @@ Autocomplete.prototype = {
         if (self.settings.highlightMatchedText) {
           const filterOpts = {
             filterMode: self.settings.filterMode,
+            caseSensitive: self.settings.caseSensitive,
             term
           };
           if (result.highlightTarget) {

--- a/src/components/autocomplete/autocomplete.js
+++ b/src/components/autocomplete/autocomplete.js
@@ -94,8 +94,11 @@ const DEFAULT_AUTOCOMPLETE_HIGHLIGHT_CALLBACK = function highlightMatch(item, op
     }
   } else {
     // Handle "startsWith" filterMode highlighting a bit differently.
-    const originalItem = targetProp;
-    const pos = Locale.toLowerCase(originalItem).indexOf(options.term);
+    let originalItem = targetProp;
+    if (!options.caseSensitive) {
+      originalItem = Locale.toLowerCase(originalItem);
+    }
+    const pos = originalItem.indexOf(options.term);
 
     if (pos > 0) {
       targetProp = originalItem.substr(0, pos) + '<i>' + originalItem.substr(pos, options.term.length) + '</i>' + originalItem.substr(options.term.length + pos);
@@ -124,6 +127,7 @@ const DEFAULT_AUTOCOMPLETE_HIGHLIGHT_CALLBACK = function highlightMatch(item, op
 * @param {string} [settings.sourceArguments={}] If a source method is defined, this flexible object can be passed
 * into the source method, and augmented with parameters specific to the implementation.
 * @param {boolean} [settings.template If defined, use this to draw the contents of each search result instead of the default draw routine.
+* @param {boolean} [settings.caseSensitive=false] if true, causes filter results that don't match case to be thrown out
 * @param {string} [settings.filterMode='startsWith'] The matching algorithm, startsWith, keyword and contains are supported - false will not filter client side
 * @param {boolean} [settings.delay=300] The delay between key strokes on the keypad before it thinks you stopped typing
 * @param {string} [settings.width=null] Width of the open auto complete menu
@@ -141,6 +145,7 @@ const AUTOCOMPLETE_DEFAULTS = {
   sourceArguments: {},
   template: undefined,
   filterMode: 'startsWith',
+  caseSensitive: false,
   delay: 300,
   width: null,
   offset: null,
@@ -175,6 +180,7 @@ Autocomplete.prototype = {
 
     const listFilterSettings = {
       filterMode: this.settings.filterMode,
+      caseSensitive: this.settings.caseSensitive,
       highlightMatchedText: this.settings.highlightMatchedText,
       searchableTextCallback: this.settings.searchableTextCallback
     };
@@ -212,7 +218,9 @@ Autocomplete.prototype = {
     }
 
     const self = this;
-    term = Locale.toLowerCase(term);
+    if (!this.settings.caseSensitive) {
+      term = Locale.toLowerCase(term);
+    }
 
     // append the list
     this.list = $('#autocomplete-list');

--- a/src/components/autocomplete/autocomplete.js
+++ b/src/components/autocomplete/autocomplete.js
@@ -94,11 +94,12 @@ const DEFAULT_AUTOCOMPLETE_HIGHLIGHT_CALLBACK = function highlightMatch(item, op
     }
   } else {
     // Handle "startsWith" filterMode highlighting a bit differently.
-    let originalItem = targetProp;
+    const originalItem = targetProp;
+    let testContent = `${originalItem}`;
     if (!options.caseSensitive) {
-      originalItem = Locale.toLowerCase(originalItem);
+      testContent = Locale.toLowerCase(testContent);
     }
-    const pos = originalItem.indexOf(options.term);
+    const pos = testContent.indexOf(options.term);
 
     if (pos > 0) {
       targetProp = originalItem.substr(0, pos) + '<i>' + originalItem.substr(pos, options.term.length) + '</i>' + originalItem.substr(options.term.length + pos);

--- a/src/components/listfilter/listfilter.js
+++ b/src/components/listfilter/listfilter.js
@@ -115,31 +115,35 @@ ListFilter.prototype = {
 
     // Iterates through each list item and attempts to find the provided search term.
     function searchItemIterator(item) {
-      const text = getSearchableContent(item);
+      let text = getSearchableContent(item);
+      if (!self.settings.caseSensitive) {
+        text = text.toLowerCase();
+      }
+
       const parts = text.split(' ');
       let match = false;
 
       if (self.settings.filterMode === 'startsWith') {
         for (let a = 0; a < parts.length; a++) {
-          if (parts[a].toLowerCase().indexOf(term) === 0) {
+          if (parts[a].indexOf(term) === 0) {
             match = true;
             break;
           }
         }
 
         // Direct Match
-        if (text.toLowerCase().indexOf(term) === 0) {
+        if (text.indexOf(term) === 0) {
           match = true;
         }
 
         // Partial dual word match
-        if (term.indexOf(' ') > 0 && text.toLowerCase().indexOf(term) > 0) {
+        if (term.indexOf(' ') > 0 && text.indexOf(term) > 0) {
           match = true;
         }
       }
 
       if (self.settings.filterMode === 'contains') {
-        if (text.toLowerCase().indexOf(term) >= 0) {
+        if (text.indexOf(term) >= 0) {
           match = true;
         }
       }
@@ -148,7 +152,7 @@ ListFilter.prototype = {
         const keywords = term.split(' ');
         for (let i = 0; i < keywords.length; i++) {
           const keyword = keywords[i];
-          if (text.toLowerCase().indexOf(keyword) >= 0) {
+          if (text.indexOf(keyword) >= 0) {
             match = true;
             break;
           }

--- a/test/components/autocomplete/autocomplete-filtermode.func-spec.js
+++ b/test/components/autocomplete/autocomplete-filtermode.func-spec.js
@@ -6,11 +6,17 @@ const svgHTML = require('../../../src/components/icons/svg.html');
 const newTemplateHTML = require('../../../app/views/components/autocomplete/example-contains.html');
 const statesData = require('../../../app/data/states-all.json');
 
+const caseSensitiveData = [
+  'CALIFORNIA',
+  'california',
+  'CaLiFoRnIa'
+];
+
 let autocompleteInputEl;
 let autocompleteAPI;
 
 describe('Autocomplete API', () => {
-  it('can provide search results with a "contains" filter', () => {
+  beforeEach(() => {
     document.body.insertAdjacentHTML('afterbegin', svgHTML);
     document.body.insertAdjacentHTML('afterbegin', newTemplateHTML);
 
@@ -21,7 +27,17 @@ describe('Autocomplete API', () => {
     autocompleteInputEl = document.body.querySelector('#autocomplete-default');
     autocompleteInputEl.classList.add('no-init');
     autocompleteInputEl.removeAttribute('data-options');
+  });
 
+  afterEach(() => {
+    autocompleteAPI.destroy();
+    autocompleteInputEl.parentNode.remove(autocompleteInputEl);
+
+    autocompleteInputEl = null;
+    autocompleteAPI = null;
+  });
+
+  it('can provide search results with a "contains" filter', () => {
     autocompleteAPI = new Autocomplete(autocompleteInputEl, {
       source: statesData
     });
@@ -46,5 +62,19 @@ describe('Autocomplete API', () => {
     expect(resultItems).toBeDefined();
     expect(resultItems.length).toEqual(10);
     expect(resultItems[7].innerText.trim()).toBe('Pennsylvania');
+  });
+
+  it('can run case-sensitive searches', () => {
+    autocompleteAPI = new Autocomplete(autocompleteInputEl, {
+      source: caseSensitiveData,
+      caseSensitive: true
+    });
+    autocompleteAPI.openList('calif', caseSensitiveData);
+    const autocompleteListEl = document.querySelector('#autocomplete-list');
+    const resultItems = autocompleteListEl.querySelectorAll('li');
+
+    expect(resultItems).toBeDefined();
+    expect(resultItems.length).toEqual(1);
+    expect(resultItems[0].innerText.trim()).toBe('california');
   });
 });

--- a/test/components/listfilter/listfilter-api-string.func-spec.js
+++ b/test/components/listfilter/listfilter-api-string.func-spec.js
@@ -68,9 +68,7 @@ describe('Listfilter API (against arrays of strings)', () => {
     expect(items.length).toBe(3); // should get all results
   });
 
-  // NOTE: test is skipped because this doesn't currently work.
-  // SOHO-8083 has been raised to address it.
-  xit('can implement case-sensitive filtering', () => {
+  it('can implement case-sensitive filtering', () => {
     listfilterArrayAPI.updated({
       caseSensitive: true
     });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes/re-implements case sensitive filtering capability to the ListFilter and Autocomplete component.  In addition, tests and an example page for the feature have been added.

**Related github/jira issue (required)**:
Closes #385

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demo app
- Open a browser to http://localhost:4000/components/autocomplete/example-case-sensitive.html
- Type the word "california" with varying differences in case sensitivity.  There are several to choose from that should always match the case provided.

Additionally, run the functional tests for ListFilter and Autocomplete.
