### PR TITLE
Closes #982 - Fix Highlighted background on popupmenu items disabled

### DIFF
--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -339,6 +339,10 @@
     &:hover {
       background-color: transparent;
     }
+
+    &.is-focused {
+      background-color: transparent;
+    }
   }
 
   .submenu {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes the background on highlighted popupmenu items that are disabled  (is-disabled/disabled class) but keep the is-focused class after a :hover on them causing the background to be in highlighted status.

I added in the scss the background-color: transparent for those situations in which the is-focused is still on the disabled item.

**Related github/jira issue (required)**:
Fixes https://github.com/infor-design/enterprise/issues/982

**Steps necessary to review your pull request (required)**:
- compile scss
- check the example of popupmenu with disabled submenus and new css