### PR TITLE
1335 - Add fix for edge regression on dirty indicator [v.4.13.x]

### DIFF
--- a/src/components/trackdirty/trackdirty.js
+++ b/src/components/trackdirty/trackdirty.js
@@ -231,7 +231,7 @@ Trackdirty.prototype = {
         }
 
         if (this.isIe || this.isIeEdge) {
-          current = input[0].innerHTML;
+          current = input[0].innerHTML || input[0].value;
         }
 
         if (current === original || (input.attr('multiple') && utils.equals(current, original))) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

https://github.com/infor-design/enterprise/pull/1287 Caused a regression on normal input fields in regards to showing a dirty indicator on dirty fields.

**Related github/jira issue (required)**:
Closes #1335

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/editor/example-dirty-tracking.html
- Open test page on IE Edge
- Click on second paragraph then click on H4 on toolbar
- Dirty tracking icon should now be seen

http://localhost:4000/components/input/example-index.html
- Open test page on IE Edge
- edit the dirty tracking field and tab out