### PR TITLE
1337 - Fixed selected dates with range datepicker [v4.13.x]

### DIFF
--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -1208,6 +1208,11 @@ DatePicker.prototype = {
       (s.range.start && s.range.end) ||
       (s.range.data && s.range.data.startDate && s.range.data.endDate))) {
       if (!this.setRangeValueFromField()) {
+        if (this.currentDate && typeof this.currentDate.getMonth === 'function') {
+          this.currentMonth = this.currentDate.getMonth();
+          this.currentYear = this.currentDate.getFullYear();
+          this.currentDay = this.currentDate.getDate();
+        }
         return;
       }
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Datepicker with range was not display on selected range when opened again.

**Related github/jira issue (required)**:
Closes #1337

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datepicker/example-range.html
- Open above link
- Open the "Range - No initial value" date picker
- Select some date range from different then current month
- Soon date range selected, date picker should be close out
- Reopen the date picker and see it should open with selected month view