### PR TITLE
1349 - Added a better context menu / accordion fix [v4.13.x]

### DIFF
--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -79,11 +79,11 @@ Accordion.prototype = {
       headers = this.element.find('.accordion-header');
       this.anchors = headers.children('a');
       anchors = headers.children('a');
-      this.panes = headers.nextAll().not('.audible').first('.accordion-pane');
-      panes = headers.nextAll().not('.audible').first('.accordion-pane');
+      this.panes = headers.next('.accordion-pane');
+      panes = headers.next('.accordion-pane');
     } else {
       anchors = headers.children('a');
-      panes = headers.nextAll().not('.audible').first('.accordion-pane');
+      panes = headers.next('.accordion-pane');
       isGlobalBuild = false;
 
       // update internal refs
@@ -137,7 +137,7 @@ Accordion.prototype = {
       }
 
       // Don't continue if there's no pane
-      if (!header.nextAll().not('.audible').first().hasClass('accordion-pane')) {
+      if (!header.next('.accordion-pane').length) {
         checkIfIcons();
         return;
       }
@@ -284,7 +284,7 @@ Accordion.prototype = {
   handleAnchorClick(e, anchor) {
     const self = this;
     const header = anchor.parent('.accordion-header');
-    const pane = header.nextAll().not('.audible').first('.accordion-pane');
+    const pane = header.next('.accordion-pane');
     const ngLink = anchor.attr('ng-reflect-href');
 
     if (e && !ngLink) {
@@ -324,15 +324,7 @@ Accordion.prototype = {
       e.stopPropagation();
     }
 
-    const openPopup = $('.popupmenu.is-open');
-    if (openPopup.length) {
-      const headers = this.element.find('.accordion-header[aria-haspopup="true"]');
-      headers.each(function () {
-        const api = $(this).data('popupmenu');
-        api.close();
-        e.stopPropagation();
-      });
-    }
+    this.closePopups();
 
     /**
      * If the anchor is a real link, follow the link and die here.
@@ -379,6 +371,25 @@ Accordion.prototype = {
   },
 
   /**
+  * Close any open popup menus.
+  * @private
+  * @param {object} e The click event object.
+  */
+  closePopups(e) {
+    const openPopup = $('.popupmenu.is-open');
+    if (openPopup.length) {
+      const headers = this.element.find('.accordion-header[aria-haspopup="true"]');
+      headers.each(function () {
+        const api = $(this).data('popupmenu');
+        api.close();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+        return false;
+      });
+    }
+  },
+
+  /**
   * Expander-Button Click Handler
   * @private
   * @param {object} e The click event object.
@@ -399,6 +410,8 @@ Accordion.prototype = {
     if (e) {
       e.stopPropagation();
     }
+
+    this.closePopups(e);
 
     const pane = header.next('.accordion-pane');
     if (pane.length) {
@@ -688,7 +701,7 @@ Accordion.prototype = {
     }
 
     const self = this;
-    const pane = header.nextAll().not('.audible').first('.accordion-pane');
+    const pane = header.next('.accordion-pane');
     const a = header.children('a');
     const dfd = $.Deferred();
 
@@ -819,7 +832,7 @@ Accordion.prototype = {
     }
 
     const self = this;
-    const pane = header.nextAll().not('.audible').first('.accordion-pane');
+    const pane = header.next('.accordion-pane');
     const a = header.children('a');
     const dfd = $.Deferred();
 

--- a/src/components/applicationmenu/applicationmenu.js
+++ b/src/components/applicationmenu/applicationmenu.js
@@ -209,7 +209,7 @@ ApplicationMenu.prototype = {
   handleKeyDown(e) {
     const key = e.which;
 
-    if (key === 121) { // F10
+    if (key === 121 && !e.shiftKey) { // F10 - opens the menu
       e.preventDefault();
 
       if (this.isOpen()) {

--- a/src/components/applicationmenu/readme.md
+++ b/src/components/applicationmenu/readme.md
@@ -46,6 +46,7 @@ In IDS Enterprise Controls, the following keyboard shortcuts are implemented in 
 
 - When pressing <kbd>Enter</kbd> while focused on an Application Menu Trigger, the Application Menu will be toggled open/closed.
 - When pressing <kbd>Escape</kbd> while the Application Menu is opened, the Application Menu will close and (if applicable) the Trigger Button that originally caused the Application Menu to open will be re-focused.
+- Pressing <kbd>F10</kbd> will toggle the menu open or closed, depending on the current state.
 
 In all other cases, the Application Menu uses a IDS Enterprise [Accordion Control](./accordion) internally, and will utilize its keyboard shortcuts when focus lies inside of the menu.
 

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -148,8 +148,6 @@ PopupMenu.prototype = {
    */
   addMarkup() {
     let id;
-    const leftClick = this.settings.trigger !== 'rightClick';
-    const immediate = this.settings.trigger === 'immediate';
 
     switch (typeof this.settings.menu) {
       case 'string': // ID Selector

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -275,20 +275,6 @@ PopupMenu.prototype = {
 
     this.markupItems();
 
-    // Add an Audible Label
-    if (!leftClick && !immediate) {
-      const audibleSpanId = 'popupmenu-f10-label';
-      if ($(`#${audibleSpanId}`).length === 0) {
-        this.element.after(`
-          <span class="audible" id="${audibleSpanId}">
-            ${Locale.translate('PressShiftF10')}
-          </span>
-        `);
-      }
-      // PressShiftF10
-      this.element.attr('aria-describedby', audibleSpanId);
-    }
-
     // Unhide the menu markup, if hidden
     if (this.menu.is('.hidden')) {
       this.menu.removeClass('hidden');

--- a/src/components/popupmenu/readme.md
+++ b/src/components/popupmenu/readme.md
@@ -150,7 +150,7 @@ Or it can be attached on the fly in the page.
 
 ## Keyboard Shortcuts
 
-- <kbd>Shift + F10</kbd> opens the popup menu when it is used as a [Contextual Menu](http://en.wikipedia.org/wiki/Context_menu) and places input focus on the first available menuitem in the Popup Menu. Note that the browser's contextual menu pops up if the element with input focus does not have a popup menu attached
+- <kbd>Shift + F10</kbd> opens the popup menu when it is used as a [Contextual Menu](http://en.wikipedia.org/wiki/Context_menu) and places input focus on the first available menu item in the Popup Menu. Note that the browser's contextual menu pops up if the element with input focus does not have a popup menu attached
 - <kbd>ESC</kbd> causes no menu action and dismisses popup menu. Input focus is returned to the element from which the popup menu was called
 - <kbd>Up</kbd> and <kbd>Down</kbd> arrows moves input focus vertically between each menu item. Input focus wraps from the last to the first menu item on a <kbd>Down</kbd> key press and vice-versa when the <kbd>Up</kbd> key is pressed.
 - <kbd>Right</kbd> and <kbd>Left</kbd> arrows, where applicable, causes a sub-menu to open or close. Causes no action if there is no sub-menu

--- a/src/components/trackdirty/trackdirty.js
+++ b/src/components/trackdirty/trackdirty.js
@@ -231,7 +231,7 @@ Trackdirty.prototype = {
         }
 
         if (this.isIe || this.isIeEdge) {
-          current = input[0].innerHTML;
+          current = input[0].innerHTML || input[0].value;
         }
 
         if (current === original || (input.attr('multiple') && utils.equals(current, original))) {

--- a/test/components/accordion/accordion.e2e-spec.js
+++ b/test/components/accordion/accordion.e2e-spec.js
@@ -204,7 +204,7 @@ describe('Accordion expand multiple tests', () => {
     await utils.checkForErrors();
   });
 
-  xit('Should expand both panes', async () => { // will remove this on another PR
+  it('Should expand both panes', async () => {
     expect(await element.all(by.css('#nested-accordion > .accordion-header.is-expanded')).count()).toEqual(2);
     await element.all(by.css('#nested-accordion > .accordion-header.is-expanded + .accordion-pane.is-expanded')).get(0).getSize().then((size) => {
       expect(size.height).not.toBeLessThan(50);

--- a/test/components/trackdirty/trackdirty.e2e-spec.js
+++ b/test/components/trackdirty/trackdirty.e2e-spec.js
@@ -1,0 +1,30 @@
+const { browserStackErrorReporter } = requireHelper('browserstack-error-reporter');
+const utils = requireHelper('e2e-utils');
+requireHelper('rejection');
+
+jasmine.getEnv().addReporter(browserStackErrorReporter);
+
+describe('Track Dirty Tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/input/example-index?nofrills=true');
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should trigger and reset dirty', async () => {
+    expect(await element(await by.id('department-code-trackdirty')).getAttribute('value')).toBeFalsy();
+    await element(await by.id('department-code-trackdirty')).sendKeys('9090');
+    await element(await by.id('department-code-trackdirty')).sendKeys(protractor.Key.TAB);
+
+    expect(await element.all(await by.css('.icon-dirty')).count()).toEqual(1);
+    expect(await element(await by.id('department-code-trackdirty')).getAttribute('class')).toContain('dirty');
+
+    await element(await by.id('department-code-trackdirty')).clear();
+    await element(await by.id('department-code-trackdirty')).sendKeys(protractor.Key.TAB);
+
+    expect(await element.all(await by.css('.icon-dirty')).count()).toEqual(0);
+    expect(await element(await by.id('department-code-trackdirty')).getAttribute('class')).not.toContain('dirty');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The context menu + accordion support added in 4.13 caused some issues. So to fix it went with a different and better fix. To fix this i removed the audible span which was for screen readers and probably a bit too much noise so considered unneeded.

Also added a fix for the dirty indicator on edge which was pushed on the wrong branch.

**Related github/jira issue (required)**:
Fixes #1349
Fixes #1335 (moves fix to 4.13)
Fixes #639 (again)

**Steps necessary to review your pull request (required)**:

Need to go through the various cases on accordion that failed lately.

http://localhost:4000/components/accordion/example-index.html
- many panes can open
- toggle some panes with both the header + the arrow
- click stuff in the panes

http://localhost:4000/components/accordion/test-expand-all.html
- both panes will be open initially
- toggle some panes with both the header + the arrow
- click sub items multiple times

http://localhost:4000/components/accordion/example-accordion-panels.html
- toggle some panes with both the header + the arrow
- click sub items multiple times (thing were disappearing before)

http://localhost:4000/components/accordion/test-with-contextmenu.html
- right click on the header and open the menu
- click the header, body and arrow area to close
- click sub items

http://localhost:4000/components/input/example-index.html
- in IE edge 18 type in the dirty tracking field
- tab out

Surprisingly related
http://localhost:4000/components/contextmenu/example-index.html
- focus the field and hit shift+F10

http://localhost:4000/components/input/example-index.html
- (actually any page)
- hit F10 -> menu should open 
