### PR TITLE
1355 - Fix edge / ie from showing unneeded dirty indicator

### DIFF
--- a/src/components/trackdirty/trackdirty.js
+++ b/src/components/trackdirty/trackdirty.js
@@ -221,19 +221,17 @@ Trackdirty.prototype = {
 
         d.field = field;
         this.settings.d = d;
-
         if (field.is('.editor-container')) {
           // editors values are further down it's tree in a textarea,
           // so get the elements with the value
           const textArea = field.find('textarea');
           original = textArea.data('original');
           current = this.valMethod(textArea);
-        }
 
-        if (this.isIe || this.isIeEdge) {
-          current = input[0].innerHTML || input[0].value;
+          if (this.isIe || this.isIeEdge) {
+            current = input[0].innerHTML;
+          }
         }
-
         if (current === original || (input.attr('multiple') && utils.equals(current, original))) {
           input.removeClass('dirty');
           $('.icon-dirty, .msg-dirty', field).add(d.icon).add(d.msg).remove();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

As per #1355 some forms are showing the dirty indicator when the form loads (because the landmark team is calling dirty manually on the forms and its running a code section on load that checks if the form is dirty. In angular the innerHTML has angular stuff in it so logic thinks the form is dirty when its not. This section is only needed for the editor so moved it.

**Related github/jira issue (required)**:
Closes #1355 

**Steps necessary to review your pull request (required)**:
- this was confirmed by dropping the updated code in by @fitzorama 

Regression Tests
http://localhost:4000/components/editor/example-dirty-tracking.html
- run in ie/edge/chrome and change stuff - should show dirty still

http://localhost:4000/components/input/example-index
- run in ie/edge/chrome and change stuff on the dirty field - should show dirty still


