### PR TITLE
420-add-header-align

### DIFF
--- a/app/views/components/datagrid/test-align-header-text.html
+++ b/app/views/components/datagrid/test-align-header-text.html
@@ -1,0 +1,41 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+      var grid,
+        columns = [],
+        data = [];
+
+      // Some Sample Data
+      data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+      data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+      data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+      data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+      data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+      data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+      data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+
+      //Define Columns for the Grid.
+      columns.push({ id: 'productId', headerAlign: 'center', name: 'Product Id', field: 'productId', width: 120});
+      columns.push({ id: 'productName', headerAlign: 'right', name: 'Product Name', field: 'productName', width: 200, formatter: Formatters.Hyperlink});
+      columns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', width: 120});
+      columns.push({ id: 'quantity', align: 'center', headerAlign: 'left', name: 'Quantity', field: 'quantity', width: 120});
+      columns.push({ id: 'status',  align: 'center', headerAlign: 'right', name: 'Tag', field: 'price', width: 120, formatter: Formatters.Tag, ranges: [{'min': 151, 'max': 9999, 'classes': 'azure07'}]});
+      columns.push({ id: 'price', align: 'right', headerAlign: 'left', name: 'Price', field: 'price', width: 120, formatter: Formatters.Decimal});
+      columns.push({ id: 'orderDate', align: 'right', headerAlign: 'center', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+
+      //Init and get the api for the grid
+      grid = $('#datagrid').datagrid({
+        columns: columns,
+        dataset: data,
+      }).data('datagrid');
+
+ });
+
+</script>

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -972,11 +972,11 @@ Datagrid.prototype = {
       const isResizable = (column.resizable === undefined ? true : column.resizable);
       const isExportable = (column.exportable === undefined ? true : column.exportable);
       const isSelection = column.id === 'selectionCheckbox';
-      const alignmentClass = (column.align === 'center' ? ` l-${column.align}-text` : '');// Disable right align for now as this was acting wierd
+      const headerAlignmentClass = (column.headerAlign === undefined ? ` l-${column.align}-text` : ` l-${column.headerAlign}-text`); // note there is a space at the front of the classname
 
       headerRow += `<th scope="col" role="columnheader" class="${isSortable ? 'is-sortable' : ''}${isResizable ? ' is-resizable' : ''
       }${column.hidden ? ' is-hidden' : ''}${column.filterType ? ' is-filterable' : ''
-      }${alignmentClass || ''}" id="${id}" data-column-id="${column.id}"${column.field ? ` data-field="${column.field}"` : ''
+      }${headerAlignmentClass || ''}" id="${id}" data-column-id="${column.id}"${column.field ? ` data-field="${column.field}"` : ''
       }${column.headerTooltip ? `title="${column.headerTooltip}"` : ''
       }${column.reorderable === false ? ' data-reorder="false"' : ''
       }${colGroups ? ` headers="${self.getColumnGroup(j)}"` : ''}${isExportable ? 'data-exportable="yes"' : 'data-exportable="no"'}>`;
@@ -988,7 +988,14 @@ Datagrid.prototype = {
           `<span class="sort-desc">${$.createIcon({ icon: 'dropdown' })}</div>`;
       }
 
-      headerRow += `<div class="${isSelection ? 'datagrid-checkbox-wrapper ' : 'datagrid-column-wrapper'}${column.align === undefined ? '' : ` l-${column.align}-text`}"><span class="datagrid-header-text${column.required ? ' required' : ''}">${self.headerText(this.settings.columns[j])}${column.align === 'center' ? sortIndicator : ''}</span>`;
+      // If header text is center aligned, for proper styling,
+      // place the sortIndicator as a child of datagrid-header-text.
+      headerRow += `<div class="${isSelection ? 'datagrid-checkbox-wrapper ' : 'datagrid-column-wrapper'}
+      ${headerAlignmentClass}"><span class="datagrid-header-text
+      ${column.required ? ' required' : ''}">
+      ${self.headerText(this.settings.columns[j])}
+      ${headerAlignmentClass === ' l-center-text' ? sortIndicator : ''}
+      </span>`;
       cols += `<col${this.columnWidth(column, j)}${column.hidden ? ' class="is-hidden"' : ''}>`;
 
       if (isSelection) {
@@ -999,7 +1006,10 @@ Datagrid.prototype = {
         }
       }
 
-      if (isSortable && column.align !== 'center') {
+      // Note the space in classname.
+      // Place sortIndicator via concatenation if
+      // header text is not center aligned.
+      if (isSortable && headerAlignmentClass !== ' l-center-text') {
         headerRow += sortIndicator;
       }
 
@@ -1544,7 +1554,7 @@ Datagrid.prototype = {
       for (let i = 0; i < conditions.length; i++) {
         const columnDef = self.columnById(conditions[i].columnId)[0];
 
-        let rowValue = rowData && rowData[columnDef.field] !== undefined ? 
+        let rowValue = rowData && rowData[columnDef.field] !== undefined ?
           rowData[columnDef.field] : self.fieldValue(rowData, columnDef.field);
         let rowValueStr = (rowValue === null || rowValue === undefined) ? '' : rowValue.toString().toLowerCase();
         let conditionValue = conditions[i].value.toString().toLowerCase();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adds option to include headerAlign on a column in datagrid to align the header text independently of the column cell text. If no headerAlign is declared, defaults back to align.

**Related github/jira issue (required)**:
Closes #420 .

**Steps necessary to review your pull request (required)**:
- Pull branch
- Run app
- Browse to http://localhost:4000/components/datagrid/test-align-header-text
- Ensure there are no funky stylings on the header texts 
- Feel free to play around with changing value of `align` and `headerAlign` in the markup