### PR TITLE
1348 - Fix problems with builds on Windows

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -868,7 +868,7 @@ function runBuildProcesses(requested) {
   if (commandLineArgs.disableJs) {
     logger('alert', 'Ignoring build process for JS');
   } else if (!isCustom || (jsMatches.length || jQueryMatches.length)) {
-    buildPromises.push(runBuildProcess('rollup', rollupArgs));
+    buildPromises.push(runBuildProcess('npx', ['rollup', rollupArgs]));
   }
 
   // Build CSS

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -77,6 +77,9 @@ const TEMP_DIR = path.join(__dirname, '..', 'temp');
 const TEST_DIR = path.join(__dirname, '..', 'test');
 const RELATIVE_SRC_DIR = path.join('..', 'src');
 
+// CR-LF on Windows, LF on Linux/Mac
+const NL = process.platform === 'win32' ? '\r\n' : '\n';
+
 const bannerText = require('./generate-bundle-banner');
 
 const filePaths = {
@@ -596,7 +599,7 @@ function renderImportsToString(key, type) {
     } else {
       statement = writeJSImportStatement(lib, filePath, true);
     }
-    fileContents += `${statement}\n`;
+    fileContents += `${statement}${NL}`;
   });
 
   return fileContents;
@@ -637,9 +640,9 @@ function renderTargetJSFile(key, targetFilePath) {
     // be written to the target file in a specific order.
     const componentBuckets = ['foundational', 'mid', 'complex'];
     componentBuckets.forEach((thisBucket) => {
-      targetFile += `// ${capitalize(thisBucket)} ====/\n`;
+      targetFile += `// ${capitalize(thisBucket)} ====/${NL}`;
       targetFile += renderImportsToString(thisBucket, type);
-      targetFile += '\n';
+      targetFile += NL;
     });
   } else {
     // All other buckets simply get rendered directly
@@ -665,9 +668,9 @@ function renderTargetJQueryFile(key, targetFilePath) {
     // be written to the target file in a specific order.
     const componentBuckets = ['foundational', 'mid', 'complex'];
     componentBuckets.forEach((thisBucket) => {
-      targetFile += `// ${capitalize(thisBucket)} ====/\n`;
+      targetFile += `// ${capitalize(thisBucket)} ====/${NL}`;
       targetFile += renderImportsToString(thisBucket, type);
-      targetFile += '\n';
+      targetFile += NL;
     });
   } else if (key === 'initialize') {
     targetFile = getFileContents(filePaths.src.jQuery.initialize);
@@ -692,17 +695,17 @@ function renderTargetSassFile(key, targetFilePath, isNormalBuild) {
   const type = 'scss';
 
   if (key === 'components') {
-    targetFile = '// Required ====/\n@import \'../src/core/required\';\n\n';
+    targetFile = `// Required ====/${NL}@import '../src/core/required';${NL}${NL}`;
 
     // 'component' source code files are comprised of three buckets that need to
     // be written to the target file in a specific order.
     const componentBuckets = ['foundational', 'mid', 'complex', 'patterns', 'layouts'];
     componentBuckets.forEach((thisBucket) => {
-      targetFile += `// ${capitalize(thisBucket)} ====/\n`;
+      targetFile += `// ${capitalize(thisBucket)} ====/${NL}`;
       targetFile += renderImportsToString(thisBucket, type);
-      targetFile += '\n';
+      targetFile += NL;
     });
-    targetFile += '// These controls must come last\n@import \'../src/components/colors/colors\';\n';
+    targetFile += `// These controls must come last${NL}@import '../src/components/colors/colors';${NL}`;
   } else if (key === 'banner') {
     targetFile += bannerText;
   } else {
@@ -711,7 +714,7 @@ function renderTargetSassFile(key, targetFilePath, isNormalBuild) {
     const themeFile = getFileContents(themePath);
 
     // Inline the copyright banner
-    targetFile += '@import \'./banner\';\n\n';
+    targetFile += `@import './banner';${NL}`;
 
     // Add the theme contents
     targetFile += themeFile
@@ -739,7 +742,7 @@ function renderTestManifest(type) {
   }
 
   buckets[bucket].forEach((test) => {
-    targetFile += `${test}\n`;
+    targetFile += `${test}${NL}`;
   });
 
   return writeFile(filePaths.target.log[type], targetFile);
@@ -763,21 +766,21 @@ function renderSourceCodeList() {
   let targetFile = '';
 
   function logEmpty() {
-    targetFile += '\n';
+    targetFile += NL;
     if (commandLineArgs.verbose) {
-      process.stdout.write('\n');
+      process.stdout.write(NL);
     }
   }
 
   function logHeaderToBoth(str) {
-    targetFile += `${str}\n`;
+    targetFile += `${str}${NL}`;
     if (commandLineArgs.verbose) {
       logger(`${chalk.cyan(str)}`);
     }
   }
 
   function logItemToBoth(item) {
-    targetFile += `- ${item}\n`;
+    targetFile += `- ${item}${NL}`;
     if (commandLineArgs.verbose) {
       logger('bullet', `${item}`);
     }
@@ -866,7 +869,7 @@ function runBuildProcesses(requested) {
     rollupArgs += componentsArg;
   }
 
-  logger(`\nRunning build processes${hasCustom}...\n`);
+  logger(`${NL}Running build processes${hasCustom}...${NL}`);
 
   // Copy vendor libs/dependencies
   if (commandLineArgs.disableCopy) {
@@ -921,7 +924,7 @@ function buildFailure(reason) {
 // Main
 // -------------------------------------
 
-logger(`\n${chalk.red.bold('=========   IDS Enterprise Builder   =========')}\n`);
+logger(`${NL}${chalk.red.bold('=========   IDS Enterprise Builder   =========')}${NL}`);
 
 let requestedComponents = [];
 let normalBuild = false;
@@ -941,10 +944,10 @@ if (!commandLineArgs.components) {
 cleanAll(true).then(() => {
   if (!normalBuild) {
     // Display a list of requested components to the console
-    let loggedComponentList = `${(commandLineArgs.verbose ? '\n' : '')}${chalk.bold('Searching files in `src/` for the following terms:')}\n`;
+    let loggedComponentList = `${(commandLineArgs.verbose ? `${NL}` : '')}${chalk.bold('Searching files in `src/` for the following terms:')}${NL}`;
     requestedComponents.forEach((comp) => {
-      componentList += `${comp}\n`;
-      loggedComponentList += `- ${comp}\n`;
+      componentList += `${comp}${NL}`;
+      loggedComponentList += `- ${comp}${NL}`;
     });
     logger(loggedComponentList);
 
@@ -1000,7 +1003,7 @@ cleanAll(true).then(() => {
 
   renderTargetFiles(normalBuild).then(() => {
     if (commandLineArgs.dryRun) {
-      process.stdout.write('\n');
+      process.stdout.write(`${NL}`);
       logger('success', `Completed dry run!  Generated files are available in the "${chalk.yellow('temp/')}" folder.`);
       process.exit(0);
     }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -840,15 +840,15 @@ function runBuildProcesses(requested) {
   let isCustom = false;
   let hasCustom = '';
   let targetSassConfig = 'dist';
-  const rollupArgs = ['-c'];
+  let rollupArgs = '-c';
 
   // if Requested
   if (Array.isArray(requested) && requested.length) {
     isCustom = true;
     targetSassConfig = 'custom';
-    const componentsArg = `--components=${requested.join(',')}`;
+    const componentsArg = ` --components=${requested.join(',')}`;
     hasCustom = ' with custom entry points';
-    rollupArgs.push(componentsArg);
+    rollupArgs += componentsArg;
   }
 
   logger(`\nRunning build processes${hasCustom}...\n`);
@@ -857,25 +857,25 @@ function runBuildProcesses(requested) {
   if (commandLineArgs.disableCopy) {
     logger('alert', 'Ignoring build process for copied dependencies');
   } else {
-    buildPromises.push(runBuildProcess('npx', ['grunt', 'copy:main']));
+    buildPromises.push(runBuildProcess('npx grunt copy:main'));
   }
 
   if (buckets['test-func'].length || buckets['test-e2e'].length) {
-    buildPromises.push(runBuildProcess('npx', ['grunt', 'copy:custom-test']));
+    buildPromises.push(runBuildProcess('npx grunt copy:custom-test'));
   }
 
   // Build JS
   if (commandLineArgs.disableJs) {
     logger('alert', 'Ignoring build process for JS');
   } else if (!isCustom || (jsMatches.length || jQueryMatches.length)) {
-    buildPromises.push(runBuildProcess('npx', ['rollup', rollupArgs]));
+    buildPromises.push(runBuildProcess(`npx rollup ${rollupArgs}`));
   }
 
   // Build CSS
   if (commandLineArgs.disableCss) {
     logger('alert', 'Ignoring build process for CSS');
   } else if (!isCustom || sassMatches.length) {
-    buildPromises.push(runBuildProcess('node', ['./scripts/build-sass', `--type=${targetSassConfig}`]));
+    buildPromises.push(runBuildProcess(`node ${path.join('.', 'scripts', 'build-sass.js')} --type=${targetSassConfig}`));
   }
 
   return Promise.all(buildPromises);
@@ -883,17 +883,9 @@ function runBuildProcesses(requested) {
 
 /**
  * Handles a successful build
- * @param {array} logs contains the logs of all the build processes
  * @returns {Promise} resulting in a successful process exit
  */
-function buildSuccess(logs) {
-  if (commandLineArgs.verbose) {
-    logger(null, `\n${chalk.red('===== JS Build Output (Rollup) =====')}`);
-    logger(null, `${logs[1]}\n`);
-    logger(null, `${chalk.red('===== Sass Build Output (Node-Sass) =====')}`);
-    logger(null, `${logs[2]}`);
-  }
-
+function buildSuccess() {
   return cleanAll().then(() => {
     logger('success', `IDS Build was successfully created in "${chalk.yellow('dist/')}"`);
     process.exit(0);
@@ -994,7 +986,7 @@ cleanAll(true).then(() => {
   renderTargetFiles(normalBuild).then(() => {
     if (commandLineArgs.dryRun) {
       process.stdout.write('\n');
-      logger('success', `Completed dry run!  Generated files are avaiable in the "${chalk.yellow('temp/')}" folder.`);
+      logger('success', `Completed dry run!  Generated files are available in the "${chalk.yellow('temp/')}" folder.`);
       process.exit(0);
     }
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -347,11 +347,11 @@ function transformSlashesForFile(str) {
  */
 function writeJSImportStatement(libFile, libPath, isExport, noConstructor) {
   libFile = sanitizeLibFile(libFile, libPath);
-  const fixedRootDir = transformSlashesForFile(`${RELATIVE_SRC_DIR}`);
+  const importPath = transformSlashesForFile(`${RELATIVE_SRC_DIR}/${libPath}${libFile}`);
   const command = isExport ? 'export' : 'import';
 
   if (noConstructor) {
-    return `${command} '${fixedRootDir}/${libPath}${libFile}';`;
+    return `${command} '${importPath}';`;
   }
 
   // (Temporarily) replace the filename with one that dash-separates the words
@@ -366,7 +366,7 @@ function writeJSImportStatement(libFile, libPath, isExport, noConstructor) {
     constructorName = replaceDashesWithCaptials(libFile);
   }
 
-  return `${command} { ${constructorName} } from '${fixedRootDir}/${libPath}${libFile}';`;
+  return `${command} { ${constructorName} } from '${importPath}';`;
 }
 
 /**
@@ -377,8 +377,8 @@ function writeJSImportStatement(libFile, libPath, isExport, noConstructor) {
  */
 function writeSassImportStatement(libFile, libPath) {
   libFile = sanitizeLibFile(libFile, libPath);
-  const fixedRootDir = transformSlashesForFile(`${RELATIVE_SRC_DIR}`);
-  return `@import '${fixedRootDir}/${libPath}${libFile}';`;
+  const importPath = transformSlashesForFile(`${RELATIVE_SRC_DIR}/${libPath}${libFile}`);
+  return `@import '${importPath}';`;
 }
 
 /**

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -333,8 +333,8 @@ function sanitizeLibFile(libFile, libFolder) {
  * @returns {string} the correctly formatted string
  */
 function transformSlashesForFile(str) {
-  const slashRegex = /\\\//g;
-  return str.replace(slashRegex, '/');
+  const backslashRegex = /\\/g;
+  return str.replace(backslashRegex, '/');
 }
 
 /**

--- a/scripts/build/run-build-process.js
+++ b/scripts/build/run-build-process.js
@@ -1,19 +1,8 @@
+const path = require('path');
 const { spawn } = require('child_process');
 const commandLineArgs = require('yargs').argv;
 
 const logger = require('../logger');
-
-let log = '';
-
-function sanitizeData(data) {
-  return data.toString('utf8').trim();
-}
-
-function logLine(data) {
-  const line = sanitizeData(data);
-  log += line;
-  logger(line);
-}
 
 /**
  * Runs a single build process
@@ -21,22 +10,24 @@ function logLine(data) {
  * @param {array} terminalArgs series of command arguments
  * @returns {Promise} resolves the process's log
  */
-module.exports = function runBuildProcess(terminalCommand, terminalArgs) {
-  if (!terminalCommand) {
-    throw new Error(`"${terminalCommand}" must be a valid terminal command`);
-  }
-  if (!Array.isArray(terminalArgs)) {
-    terminalArgs = [];
+module.exports = function runBuildProcess(cmd) {
+  if (!cmd) {
+    throw new Error(`"${cmd}" must be a valid terminal command`);
   }
 
   return new Promise((resolve, reject) => {
     if (commandLineArgs.verbose) {
-      logger('info', `Running "${terminalCommand}" with args "${terminalArgs.join('", "')}"`);
+      logger('info', `Running "${cmd}"...`);
     }
 
-    const buildProcess = spawn(terminalCommand, terminalArgs);
-    buildProcess.stdout.on('data', logLine);
-    buildProcess.stderr.on('data', logLine);
+    const buildProcess = spawn(cmd, {
+      cwd: path.resolve(__dirname, '..', '..'),
+      shell: true,
+      stdio: 'inherit'
+    });
+
+    // buildProcess.stdout.on('data', logLine);
+    // buildProcess.stderr.on('data', logLine);
     buildProcess.on('error', (e, fileName, lineNumber) => {
       let lineText = '';
       if (lineNumber) {
@@ -47,13 +38,16 @@ module.exports = function runBuildProcess(terminalCommand, terminalArgs) {
         fileText = ` in "${fileName}"`;
       }
 
-      logger('error', `[${terminalCommand}]: ${e.message}${lineText}${fileText}`);
+      logger('error', `[${cmd}]: ${e.message}${lineText}${fileText}`);
     });
     buildProcess.on('exit', (code) => {
       if (code !== 0) {
-        reject(new Error(`"${terminalCommand}" process exited with error code (${code})\nArgs: ${terminalArgs.join(' ')}`));
+        reject(new Error(`"${cmd}" process exited with error code (${code})\nArgs:`));
       }
-      resolve(log);
+      if (commandLineArgs.verbose) {
+        logger('success', `Build process "${cmd}" finished sucessfully`);
+      }
+      resolve();
     });
   });
 };

--- a/scripts/build/run-build-process.js
+++ b/scripts/build/run-build-process.js
@@ -6,8 +6,7 @@ const logger = require('../logger');
 
 /**
  * Runs a single build process
- * @param {string} terminalCommand the base terminal command
- * @param {array} terminalArgs series of command arguments
+ * @param {string} cmd the entire terminal command, with arguments
  * @returns {Promise} resolves the process's log
  */
 module.exports = function runBuildProcess(cmd) {
@@ -26,8 +25,6 @@ module.exports = function runBuildProcess(cmd) {
       stdio: 'inherit'
     });
 
-    // buildProcess.stdout.on('data', logLine);
-    // buildProcess.stderr.on('data', logLine);
     buildProcess.on('error', (e, fileName, lineNumber) => {
       let lineText = '';
       if (lineNumber) {
@@ -40,6 +37,7 @@ module.exports = function runBuildProcess(cmd) {
 
       logger('error', `[${cmd}]: ${e.message}${lineText}${fileText}`);
     });
+
     buildProcess.on('exit', (code) => {
       if (code !== 0) {
         reject(new Error(`"${cmd}" process exited with error code (${code})\nArgs:`));

--- a/scripts/build/run-build-process.js
+++ b/scripts/build/run-build-process.js
@@ -1,4 +1,5 @@
 const { spawn } = require('child_process');
+const commandLineArgs = require('yargs').argv;
 
 const logger = require('../logger');
 
@@ -29,9 +30,16 @@ module.exports = function runBuildProcess(terminalCommand, terminalArgs) {
   }
 
   return new Promise((resolve, reject) => {
+    if (commandLineArgs.verbose) {
+      logger('info', `Running "${terminalCommand}" with args "${terminalArgs.join('", "')}"`);
+    }
+
     const buildProcess = spawn(terminalCommand, terminalArgs);
     buildProcess.stdout.on('data', logLine);
     buildProcess.stderr.on('data', logLine);
+    buildProcess.on('error', (e) => {
+      logger('error', `[${terminalCommand}]: ${e.message}`);
+    });
     buildProcess.on('exit', (code) => {
       if (code !== 0) {
         reject(new Error(`"${terminalCommand}" process exited with error code (${code})\nArgs: ${terminalArgs.join(' ')}`));

--- a/scripts/build/run-build-process.js
+++ b/scripts/build/run-build-process.js
@@ -37,8 +37,17 @@ module.exports = function runBuildProcess(terminalCommand, terminalArgs) {
     const buildProcess = spawn(terminalCommand, terminalArgs);
     buildProcess.stdout.on('data', logLine);
     buildProcess.stderr.on('data', logLine);
-    buildProcess.on('error', (e) => {
-      logger('error', `[${terminalCommand}]: ${e.message}`);
+    buildProcess.on('error', (e, fileName, lineNumber) => {
+      let lineText = '';
+      if (lineNumber) {
+        lineText = `at "${lineNumber}"`;
+      }
+      let fileText = '';
+      if (fileName) {
+        fileText = ` in "${fileName}"`;
+      }
+
+      logger('error', `[${terminalCommand}]: ${e.message}${lineText}${fileText}`);
     });
     buildProcess.on('exit', (code) => {
       if (code !== 0) {

--- a/scripts/generate-bundle-banner.js
+++ b/scripts/generate-bundle-banner.js
@@ -7,17 +7,20 @@ const childProcess = require('child_process');
 const pjson = require('../package.json');
 const args = require('yargs').argv;
 
+// CR-LF on Windows, LF on Linux/Mac
+const NL = process.platform === 'win32' ? '\r\n' : '\n';
+
 const projectName = 'IDS Enterprise Components';
 const commitHash = childProcess.execSync('git rev-parse HEAD') || '';
 
 function prependLines(str, prepender) {
   prepender = prepender || '';
-  const strArr = str.split('\n');
+  const strArr = str.split(NL);
   // eslint-disable-next-line
   for (let x in strArr) {
     strArr[x] = `${prepender}${strArr[x].trim()}`;
   }
-  return strArr.join('\n');
+  return strArr.join(NL);
 }
 
 /**
@@ -42,9 +45,9 @@ function render(useComments) {
 
     componentsList += 'Custom bundle containing the following components:';
     componentsArgs.forEach((comp) => {
-      componentsList += `\n${comment} - ${comp}`;
+      componentsList += `${NL}${comment} - ${comp}`;
     });
-    componentsList += `\n${comment}`;
+    componentsList += `${NL}${comment}`;
   }
 
   // Project Name and Version Headline
@@ -54,13 +57,13 @@ function render(useComments) {
   let license = fs.readFileSync(path.join(__dirname, '..', 'LICENSE'), 'utf8');
   license = prependLines(license, comment);
 
-  return `${startComment}\n${
-    comment}${headline}\n${
-    comment}${date}\n${
-    comment}${revision}\n${
-    comment}\n${
-    comment}${componentsList}\n${
-    license}\n${
+  return `${startComment}${NL}${
+    comment}${headline}${NL}${
+    comment}${date}${NL}${
+    comment}${revision}${NL}${
+    comment}${NL}${
+    comment}${componentsList}${NL}${
+    license}${NL}${
     endComment}`;
 }
 

--- a/scripts/minify.js
+++ b/scripts/minify.js
@@ -26,8 +26,8 @@ if (commandLineArgs.verbose) {
 }
 
 const minifyPromises = [
-  runBuildProcess('node', cssArgs),
-  runBuildProcess('node', jsArgs)
+  runBuildProcess(`node ${cssArgs.join(' ')}`),
+  runBuildProcess(`node ${jsArgs.join(' ')}`)
 ];
 
 Promise.all(minifyPromises).then(() => {

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -255,6 +255,7 @@ describe('Datagrid paging (client side) tests', () => {
     expect(await element(by.css('tbody tr:nth-child(10) td:nth-child(2) span')).getText()).toEqual('9');
 
     await element(by.css('.pager-last a')).click();
+    await browser.driver.sleep(300);
 
     expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(2) span')).getText()).toEqual('990');
     expect(await element(by.css('tbody tr:nth-child(10) td:nth-child(2) span')).getText()).toEqual('999');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes issues when attempting to run the IDS Custom Builder on Windows, mainly:
- Bad CMD syntax on windows machines when attempting to run Node child processes via the build script (Rollup and Node-Sass were being passed bad strings)
- Missing line feeds in files generated on Windows due to the usage of `\n`.

Note that these problems are recent, as of the changes in #962 

**Related github/jira issue (required)**:
Closes #1348

**Steps necessary to review your pull request (required)**:
On a Windows machine:
- pull this branch and run `npx grunt`.  The entire process should complete without errors.
- run `npm run build:custom -- --test-mode --dry-run`.  
- Open the `temp/` folder in your project folder and open any of the generated JS or SCSS files.  Ensure that there are no `\` in the paths, and all paths are using `/`.
