### PR TITLE
1053 - Fixed issue regarding tooltip being shown on modal

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -513,9 +513,8 @@ Modal.prototype = {
     let messageArea = null;
     let elemCanOpen = true;
 
-    if ($('.tooltip:visible').not('.is-hidden').length > 0) {
-      $('.tooltip:visible').hide();
-    }
+    // close any active tooltips
+    $('#validation-errors, #tooltip, #validation-tooltip').addClass('is-hidden');
 
     if (this.busyIndicator) {
       this.busyIndicator.remove();

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -513,6 +513,10 @@ Modal.prototype = {
     let messageArea = null;
     let elemCanOpen = true;
 
+    if ($('.tooltip:visible').not('.is-hidden').length > 0) {
+      $('.tooltip:visible').hide();
+    }
+
     if (this.busyIndicator) {
       this.busyIndicator.remove();
       delete this.busyIndicator;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Fixed issue regarding tooltip being shown on modal
- http://localhost:4000/

**Related github/jira issue (required)**:
Closes #1053 

**Steps necessary to review your pull request (required)**:
- On responsive view scroll down to the slider and move the slider
- Click on "Show Modal" button
- The numeric tooltip should now be hidden
