### PR TITLE
932 - Added fix for image placeholder color same as the left edge

### DIFF
--- a/src/components/hierarchy/_hierarchy.scss
+++ b/src/components/hierarchy/_hierarchy.scss
@@ -237,30 +237,58 @@ $hierarchy-line-width: 1.34px; //Fixes zoom somewhat
 
     &.azure08 {
       border-left-color: $azure08;
+
+      .image-placeholder {
+        border: 2px solid $azure08;
+      }
     }
 
     &.turquoise02 {
       border-left-color: $turquoise02;
+
+      .image-placeholder {
+        border: 2px solid $turquoise02;
+      }
     }
 
     &.amethyst06 {
       border-left-color: $amethyst06;
+
+      .image-placeholder {
+        border: 2px solid $amethyst06;
+      }
     }
 
     &.slate06 {
       border-left-color: $slate06;
+
+      .image-placeholder {
+        border: 2px solid $slate06;
+      }
     }
 
     &.amber06 {
       border-left-color: $amber06;
+
+      .image-placeholder {
+        border: 2px solid $amber06;
+      }
     }
 
     &.emerald07 {
       border-left-color: $emerald07;
+
+      .image-placeholder {
+        border: 2px solid $emerald07;
+      }
     }
 
     &.ruby06 {
       border-left-color: $ruby06;
+
+      .image-placeholder {
+        border: 2px solid $ruby06;
+      }
     }
 
     &.is-selected {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

In hierarchy component, the left edge of the leaf should be same with the image placeholder. 

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/932

**Steps necessary to review your pull request (required)**:

- Pull this branch
- Run http://localhost:4000/components/hierarchy/example-many-children.html
- Go to Mary Butler hierarchy
- Check the one that don't have image
- The color of left edge and the image placeholder border should be the same.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
