### PR TITLE
931 - Added fix for hierarchy profile text cut off

### DIFF
--- a/src/components/hierarchy/_hierarchy.scss
+++ b/src/components/hierarchy/_hierarchy.scss
@@ -847,3 +847,13 @@ html[dir='rtl'] {
     }
   }
 }
+
+// For IE layout issues
+.ie,
+.ie11 {
+  .hierarchy {
+    .detail-fields {
+      padding: 10px 25px 10px 10px;
+    }
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Windows 10 IE 11: Hierarchy Context Menu With Details Component: Profile text is cut off. Fixing it by adding some padding specific only in IE and IE11.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/931

**Steps necessary to review your pull request (required)**:

- Pull this branch
- Run http://localhost:4000/components/hierarchy/example-context-menu-with-details.html
- Click on the three dot eclipse button for Kaylee Edwards on Windows 10 IE 11 (Test it via Browserstack)
- Her profile should not cut off

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
