### PR TITLE
406 - Datagrid: use Mask component with Lookup Editors

### DIFF
--- a/app/views/components/datagrid/test-editable-lookup-mask.html
+++ b/app/views/components/datagrid/test-editable-lookup-mask.html
@@ -39,7 +39,7 @@
   </div>
 </div>
 
-<script>
+<script id="test-script">
   var gridApi = null;
 
   $('body').one('initialized', function () {
@@ -88,10 +88,12 @@
           }
         };
 
-        maskOptions = {
-          pattern: [/\d/,/\d/,/\d/,/\d/,/\d/,/\d/,/\d/],
-          patternOptions: {},
-          process: undefined
+        maskOptions = function () {
+          return {
+            pattern: [/\d/,/\d/,/\d/,/\d/,/\d/,/\d/,/\d/],
+            patternOptions: {},
+            process: undefined
+          };
         };
 
         // Some Sample Data
@@ -105,7 +107,7 @@
 
         //Define Columns for the Grid.
         columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input});
-        columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, validate: 'required', editorOptions: lookupOptions, mask: '#######', maskOptions: maskOptions, width: 120 });
+        columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, validate: 'required', editor: Editors.Lookup, editorOptions: lookupOptions, mask: '#######', maskOptions: maskOptions, width: 120 });
         columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, align: 'right', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###.000'});
         columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date5});
 

--- a/app/views/components/datagrid/test-editable-lookup-mask.html
+++ b/app/views/components/datagrid/test-editable-lookup-mask.html
@@ -1,0 +1,130 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <div role="toolbar" class="toolbar">
+
+      <div class="title">
+        Data Grid Header Title
+        <span class="datagrid-result-count">(N Results)</span>
+      </div>
+
+      <div class="buttonset">
+        <label class="audible" for="searchfield-01">Keyword Search</label>
+        <input id="searchfield-01" name="searchfield-01" class="searchfield" />
+      </div>
+      <div class="more">
+        <button class="btn-actions" type="button">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-more"></use>
+          </svg>
+          <span class="audible">More Actions</span>
+        </button>
+        <ul class="popupmenu">
+          <li><a href="#">Option One</a></li>
+          <li><a href="#">Option Two</a></li>
+          <li><a href="#">Option Three</a></li>
+          <li class="separator single-selectable-section"></li>
+          <li class="heading">Row Height</li>
+          <li class="is-selectable"><a data-option="row-short" href="#">Short</a></li>
+          <li class="is-selectable"><a data-option="row-medium" href="#">Medium</a></li>
+          <li class="is-selectable is-checked"><a data-option="row-normal" href="#">Normal</a></li>
+        </ul>
+
+      </div>
+    </div>
+
+    <div id="datagrid">
+
+    </div>
+  </div>
+</div>
+
+<script>
+  var gridApi = null;
+
+  $('body').one('initialized', function () {
+
+    Locale.set('en-US').done(function () {
+        var grid,
+          data = [],
+          columns = [],
+
+          //lookup data
+          lookupOptions,
+          maskOptions,
+          lookupData = [],
+          lookupColumns = [];
+
+        // Some Sample Data for Lookup
+        lookupData.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+        lookupData.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+        lookupData.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+        lookupData.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+        lookupData.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+        lookupData.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+        lookupData.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+
+        //Define Columns for the Lookup Grid.
+        lookupColumns.push({ id: 'productId', name: 'Product Id', field: 'productId', width: 140});
+        lookupColumns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', width: 250, formatter: Formatters.Hyperlink});
+        lookupColumns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', width: 125});
+        lookupColumns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', width: 125});
+        lookupColumns.push({ id: 'price', name: 'Price', field: 'price', width: 125, formatter: Formatters.Decimal});
+        lookupColumns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+
+        lookupOptions = {
+          // field: 'productId',
+          field: function (row, field, grid) {
+            return row.productId;
+          },
+          match: function (value, row, field, grid) {
+            return (row.productId) === value;
+          },
+          options: {
+            columns: lookupColumns,
+            dataset: lookupData,
+            selectable: 'single', //multiselect or single
+            toolbar: {title: 'Products', results: true, dateFilter: false ,keywordFilter: false, advancedFilter: true, actions: true, views: true , rowHeight: true},
+          }
+        };
+
+        maskOptions = {
+          pattern: [/\d/,/\d/,/\d/,/\d/,/\d/,/\d/,/\d/],
+          patternOptions: {},
+          process: undefined
+        };
+
+        // Some Sample Data
+        data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  '<svg/onload=alert(1)>', quantity: 1, price: 210.99, status: 'OK', orderDate:  new Date(2016, 2, 15, 12, 30, 36), portable: false, action: 'ac', description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning'});
+        data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, status: '', orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false, action: 'oh', description: 'The kit has an air blow gun that can be used for cleaning'});
+        data.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity:  'Inspect and Repair', portable: true, quantity: 1, price: 120.992, status: null, orderDate: new Date(2014, 6, 3), action: 'ac'});
+        data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', portable: true, quantity: 3, price: null, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'ac', description: 'Compressor comes with with air tool kit'});
+        data.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'oh'});
+        data.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', portable: false, quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'oh'});
+        data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'oh'});
+
+        //Define Columns for the Grid.
+        columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input});
+        columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, validate: 'required', editorOptions: lookupOptions, mask: '#######', maskOptions: maskOptions, width: 120 });
+        columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, align: 'right', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###.000'});
+        columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date5});
+
+        //Init and get the api for the grid
+        grid = $('#datagrid').datagrid({
+          columns: columns,
+          dataset: data,
+          editable: true,
+          toolbar: {keywordFilter: true, results: true}
+        }).on('cellchange', function (e, args) {
+          console.log(e, args);
+        }).on('rowadd', function (e, args) {
+          console.log(e, args);
+        }).on('rowremove', function (e, args) {
+          console.log(e, args);
+        });
+
+        gridApi = $('#datagrid').data('datagrid');
+    });
+  });
+
+</script>

--- a/app/views/components/datagrid/test-editable-lookup-mask.html
+++ b/app/views/components/datagrid/test-editable-lookup-mask.html
@@ -29,13 +29,10 @@
           <li class="is-selectable"><a data-option="row-medium" href="#">Medium</a></li>
           <li class="is-selectable is-checked"><a data-option="row-normal" href="#">Normal</a></li>
         </ul>
-
       </div>
     </div>
 
-    <div id="datagrid">
-
-    </div>
+    <div id="datagrid"></div>
   </div>
 </div>
 

--- a/src/components/datagrid/datagrid.editors.js
+++ b/src/components/datagrid/datagrid.editors.js
@@ -4,6 +4,70 @@ import { Locale } from '../locale/locale';
 import { Formatters } from './datagrid.formatters';
 import { xssUtils } from '../../utils/xss';
 
+// Adds all the basic input features to any Datagrid Editor.
+function addStandardInputFeatures(input, row, cell, value, container, column, e, api, item) {
+  if (column.align) {
+    input.addClass(`l-${column.align}-text`);
+  }
+
+  if (column.maxLength) {
+    input.attr('maxlength', column.maxLength);
+  }
+
+  if (column.uppercase) {
+    input.addClass('uppercase-text');
+  }
+
+  if (column.mask && typeof column.mask === 'function') {
+    const mask = column.mask(row, cell, value, column, item);
+    input.mask({ pattern: mask, mode: column.maskMode });
+  } else if (column.maskOptions && typeof column.maskOptions === 'function') {
+    const maskOptions = column.maskOptions(row, cell, value, column, item);
+    input.mask(maskOptions);
+  } else if (column.mask) {
+    input.mask({ pattern: column.mask, mode: column.maskMode });
+  }
+
+  let defaults = {
+    patternOptions: {
+      allowNegative: true,
+      allowDecimal: true,
+      integerLimit: 4,
+      decimalLimit: 2,
+      symbols: {
+        thousands: Locale.currentLocale.data.numbers ? Locale.currentLocale.data.numbers.group : ',',
+        decimal: Locale.currentLocale.data.numbers ? Locale.currentLocale.data.numbers.decimal : '.',
+        negative: Locale.currentLocale.data.numbers ? Locale.currentLocale.data.numbers.minusSign : '-'
+      }
+    },
+    process: 'number'
+  };
+
+  let useMask = false;
+
+  if (column.maskOptions) {
+    useMask = true;
+  }
+
+  if (column.numberFormat) {
+    useMask = true;
+    defaults = { patternOptions: { decimalLimit: column.numberFormat.maximumFractionDigits } };
+  }
+
+  if (column.maskOptions && typeof column.maskOptions === 'function') {
+    useMask = false;
+  }
+
+  if (useMask) {
+    column.maskOptions = utils.extend(true, {}, defaults, column.maskOptions);
+    input.mask(column.maskOptions);
+  }
+
+  if (!column.align || column.align !== 'right') {
+    input.removeClass('is-number-mask');
+  }
+}
+
 /**
 *  A object containing all the supported Editors
 * @private
@@ -24,66 +88,7 @@ const editors = {
           .appendTo(container);
       }
 
-      if (column.align) {
-        this.input.addClass(`l-${column.align}-text`);
-      }
-
-      if (column.maxLength) {
-        this.input.attr('maxlength', column.maxLength);
-      }
-
-      if (column.uppercase) {
-        this.input.addClass('uppercase-text');
-      }
-
-      if (column.mask && typeof column.mask === 'function') {
-        const mask = column.mask(row, cell, value, column, item);
-        this.input.mask({ pattern: mask, mode: column.maskMode });
-      } else if (column.maskOptions && typeof column.maskOptions === 'function') {
-        const maskOptions = column.maskOptions(row, cell, value, column, item);
-        this.input.mask(maskOptions);
-      } else if (column.mask) {
-        this.input.mask({ pattern: column.mask, mode: column.maskMode });
-      }
-
-      let defaults = {
-        patternOptions: {
-          allowNegative: true,
-          allowDecimal: true,
-          integerLimit: 4,
-          decimalLimit: 2,
-          symbols: {
-            thousands: Locale.currentLocale.data.numbers ? Locale.currentLocale.data.numbers.group : ',',
-            decimal: Locale.currentLocale.data.numbers ? Locale.currentLocale.data.numbers.decimal : '.',
-            negative: Locale.currentLocale.data.numbers ? Locale.currentLocale.data.numbers.minusSign : '-'
-          }
-        },
-        process: 'number'
-      };
-
-      let useMask = false;
-
-      if (column.maskOptions) {
-        useMask = true;
-      }
-
-      if (column.numberFormat) {
-        useMask = true;
-        defaults = { patternOptions: { decimalLimit: column.numberFormat.maximumFractionDigits } };
-      }
-
-      if (column.maskOptions && typeof column.maskOptions === 'function') {
-        useMask = false;
-      }
-
-      if (useMask) {
-        column.maskOptions = utils.extend(true, {}, defaults, column.maskOptions);
-        this.input.mask(column.maskOptions);
-      }
-
-      if (!column.align || column.align !== 'right') {
-        this.input.removeClass('is-number-mask');
-      }
+      addStandardInputFeatures(this.input, row, cell, value, container, column, e, api, item);
     };
 
     this.val = function (v) {
@@ -720,13 +725,10 @@ const editors = {
     this.init = function () {
       this.input = $(`<input class="lookup ${column.align === 'right' ? 'align-text-right' : ''}" data-init="false" />`).appendTo(container);
 
-      if (column.maxLength) {
-        this.input.attr('maxlength', column.maxLength);
-      }
-
-      if (column.uppercase) {
-        this.input.addClass('uppercase-text');
-      }
+      addStandardInputFeatures(
+        this.input,
+        row, cell, value, container, column, event, grid, rowData
+      );
 
       this.input.lookup(column.editorOptions);
 

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -153,7 +153,7 @@ describe('Datagrid mixed selection tests', () => {
   });
 });
 
-fdescribe('Datagrid Lookup Editor', () => {
+describe('Datagrid Lookup Editor', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-editable-lookup-mask');
 

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -153,7 +153,7 @@ describe('Datagrid mixed selection tests', () => {
   });
 });
 
-describe('Datagrid Lookup Editor', () => {
+fdescribe('Datagrid Lookup Editor', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-editable-lookup-mask');
 
@@ -163,22 +163,18 @@ describe('Datagrid Lookup Editor', () => {
   });
 
   it('should be usable with a Mask', async () => {
-    await browser.actions()
-      .mouseMove(await element(by.css('#datagrid .datagrid-body tr:nth-child(3) td:nth-child(1)')))
-      .click(protractor.Button.LEFT)
-      .perform();
+    await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(3) td:nth-child(2)')).click();
 
-    const editCellSelector = '.has-editor.is-editing';
-
+    const editCellSelector = '.has-editor.is-editing input';
     const inputEl = await element(by.css(editCellSelector));
     await browser.driver.wait(protractor.ExpectedConditions.presenceOf(inputEl), config.waitsFor);
     await element(by.css(editCellSelector)).sendKeys('aaa');
 
-    expect(await element(by.css(editCellSelector))).toEqual('');
+    expect(await element(by.css(editCellSelector)).getAttribute('value')).toEqual('');
 
     await element(by.css(editCellSelector)).sendKeys('12345678');
 
-    expect(await element(by.css(editCellSelector))).toEqual('1234567');
+    expect(await element(by.css(editCellSelector)).getAttribute('value')).toEqual('1234567');
   });
 });
 

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -153,6 +153,35 @@ describe('Datagrid mixed selection tests', () => {
   });
 });
 
+describe('Datagrid Lookup Editor', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/test-editable-lookup-mask');
+
+    const datagridEl = await element(by.id('datagrid'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('should be usable with a Mask', async () => {
+    await browser.actions()
+      .mouseMove(await element(by.css('#datagrid .datagrid-body tr:nth-child(3) td:nth-child(1)')))
+      .click(protractor.Button.LEFT)
+      .perform();
+
+    const editCellSelector = '.has-editor.is-editing';
+
+    const inputEl = await element(by.css(editCellSelector));
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(inputEl), config.waitsFor);
+    await element(by.css(editCellSelector)).sendKeys('aaa');
+
+    expect(await element(by.css(editCellSelector))).toEqual('');
+
+    await element(by.css(editCellSelector)).sendKeys('12345678');
+
+    expect(await element(by.css(editCellSelector))).toEqual('1234567');
+  });
+});
+
 describe('Datagrid editor dropdown source tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-editor-dropdown-source');

--- a/test/protractor.local.debug.conf.js
+++ b/test/protractor.local.debug.conf.js
@@ -2,7 +2,6 @@
 const basePath = __dirname;
 const { SpecReporter } = require('jasmine-spec-reporter');
 const protractorImageComparison = require('protractor-image-comparison');
-const customSpecs = require('./helpers/detect-custom-spec-list')('e2e');
 const specs = require('./helpers/detect-custom-spec-list')('e2e', process.env.PROTRACTOR_SPECS);
 
 exports.config = {
@@ -15,8 +14,7 @@ exports.config = {
   SELENIUM_PROMISE_MANAGER: false,
   capabilities: {
     browserName: 'chrome' || 'firefox',
-    shardTestFiles: true,
-    maxInstances: 2,
+    shardTestFiles: false
   },
   directConnect: true,
   baseUrl: 'http://localhost:4000',


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR enables the ability to use Masks on Lookup Editor fields in a Datagrid, the same way you'd use a mask in a normal input field.

**Related github/jira issue (required)**:
Closes #406

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp
- Navigate to http://localhost:4000/components/datagrid/test-editable-lookup-mask
- Select any cell in the "Product ID" column
- Attempt to key letters as the value.  See that no letters are allowed to be used.  Using numbers will work.

There's also a new e2e test for this page/case that should pass
