### PR TITLE
931 - Added fix hierarchy profile text cut off in firefox

### DIFF
--- a/src/components/hierarchy/_hierarchy.scss
+++ b/src/components/hierarchy/_hierarchy.scss
@@ -885,3 +885,12 @@ html[dir='rtl'] {
     }
   }
 }
+
+// For Firefox layout issues
+.is-firefox {
+  .hierarchy {
+    .detail-fields {
+      padding: 10px 25px 10px 10px;
+    }
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Hierarchy Context Menu With Details Component: Profile text is cut off. Fixing it by adding some padding specific only in Firefox.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/931
Related PR https://github.com/infor-design/enterprise/pull/1392

**Steps necessary to review your pull request (required)**:

- Pull this branch
- Run http://localhost:4000/components/hierarchy/example-context-menu-with-details.html
- Click on the three dot eclipse button for Kaylee Edwards on Firefox (Mac)
- Her profile should not cut off


<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
