### PR TITLE
1354 - Fix for non-selectable inputs with tooltips

### DIFF
--- a/app/views/components/input/test-tooltips.html
+++ b/app/views/components/input/test-tooltips.html
@@ -1,0 +1,8 @@
+<div class="row">
+  <div class="one-half column">
+    <div class="field">
+      <label for="first-name">First Name</label>
+      <input type="text" id="first-name" title="Born Oct 12, 1980" name="first-name" value="John Johnson"/>
+    </div>
+  </div>
+</div>

--- a/scripts/configs/chokidar.js
+++ b/scripts/configs/chokidar.js
@@ -3,6 +3,7 @@ module.exports = {
   chokidar: {
     sass: {
       files: [
+        'src/behaviors/**/*.scss',
         'src/themes/*.scss',
         'src/core/**/*.scss',
         'src/layouts/**/*.scss',

--- a/src/behaviors/initialize/initialize.js
+++ b/src/behaviors/initialize/initialize.js
@@ -104,7 +104,7 @@ const PLUGIN_MAPPINGS = [
   ['editor'],
 
   // Tooltips
-  ['tooltip', 'button[title], span[title], .hyperlink[title], .icon[title]'],
+  ['tooltip', 'button[title], span[title], .hyperlink[title], .icon[title], input[title]'],
 
   // Tree
   ['tree'],

--- a/src/behaviors/longpress/longpress.scss
+++ b/src/behaviors/longpress/longpress.scss
@@ -3,3 +3,7 @@
 
   -webkit-touch-callout: none;
 }
+
+input.longpress-target {
+  @include css3(user-select, initial);
+}

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -89,6 +89,7 @@ Tooltip.prototype = {
    */
   init() {
     this.uniqueId = utils.uniqueId(this.element, 'tooltip');
+    this.isTouch = env.features.touch;
     this.setup();
     this.appendTooltip();
 
@@ -132,7 +133,7 @@ Tooltip.prototype = {
       this.element.removeAttr('title');
     }
 
-    if (this.settings.trigger === 'hover') {
+    if (this.settings.trigger === 'hover' && this.isTouch) {
       this.element.addClass('longpress-target');
     }
 
@@ -246,13 +247,16 @@ Tooltip.prototype = {
     if (this.settings.trigger === 'hover' && !this.settings.isError) {
       ((this.element.is('.dropdown, .multiselect, span.longpress-target')) ? this.activeElement : this.element)
         .on(`mouseenter.${COMPONENT_NAME}`, () => {
+          if (self.isTouch) {
+            return;
+          }
           showOnTimer();
         })
         .on(`mouseleave.${COMPONENT_NAME}`, () => {
           hideOnTimer();
         })
         .on(`click.${COMPONENT_NAME}`, () => {
-          if (!env.features.touch) {
+          if (self.isTouch) {
             return;
           }
           showImmediately();
@@ -618,7 +622,7 @@ Tooltip.prototype = {
      */
     this.element.trigger('show', [this.tooltip]);
 
-    const mouseUpEventName = env.features.touch ? 'touchend' : 'mouseup';
+    const mouseUpEventName = this.isTouch ? 'touchend' : 'mouseup';
 
     setTimeout(() => {
       $(document)

--- a/test/components/input/input.e2e-spec.js
+++ b/test/components/input/input.e2e-spec.js
@@ -45,3 +45,34 @@ describe('Input example-index tests', () => {
     });
   }
 });
+
+describe('Input tooltip tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/input/test-tooltips?layout=nofrills');
+    await browser.driver
+      .wait(protractor.ExpectedConditions
+        .presenceOf(element(by.id('first-name'))), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  // This test is more important as a windows test
+  it('Should be able to select text', async () => {
+    const inputEl = await element(by.id('first-name'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(inputEl), config.waitsFor);
+
+    await inputEl.sendKeys(protractor.Key.chord(
+      protractor.Key.COMMAND,
+      protractor.Key.SHIFT,
+      protractor.Key.ARROW_LEFT
+    ));
+
+    // get highlighted text
+    const highligtedText = utils.getSelectedText();
+
+    expect(highligtedText).toEqual('John Johnson');
+  });
+});

--- a/test/helpers/e2e-utils.js
+++ b/test/helpers/e2e-utils.js
@@ -28,5 +28,16 @@ module.exports = {
       }
       expect(browserLog.length).toEqual(0);
     });
+  },
+  getSelectedText: async () => {
+    await browser.executeScript(() => {
+      let text = '';
+      if (window.getSelection) {
+        text = window.getSelection().toString();
+      } else if (document.selection && document.selection.type !== 'Control') {
+        text = document.selection.createRange().text;
+      }
+      return text;
+    });
   }
 };

--- a/test/protractor.local.debug.conf.js
+++ b/test/protractor.local.debug.conf.js
@@ -14,9 +14,7 @@ exports.config = {
   specs: specs,
   SELENIUM_PROMISE_MANAGER: false,
   capabilities: {
-    browserName: 'chrome' || 'firefox',
-    shardTestFiles: true,
-    maxInstances: 2,
+    browserName: 'chrome' || 'firefox'
   },
   directConnect: true,
   baseUrl: 'http://localhost:4000',


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When a tooltip is on an input, you cannot select the text. Addressed this. In the process noticed that the long press did not work right on tooltips, so fixed that too.

Also:
- Fix unusable broken e2e debug config.
- Made watch work on behaviors folder css
- Added a check selected text test util

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/input/test-tooltips.html
- on hover see a tool tip
- open the page in IE and try to select the text - this should work too.
- not that the behavior will never be ideal on IOS/Android because you want to be able to edit the text primarily

http://localhost:4000/components/tooltip/example-index.html
- hover on desktop to see the tooltip
- on IOS/Android long press for 400ms at least to see the tooltip