### PR TITLE
1396 - Add fix for touch tooltips in datagrid and some minor refactoring [v4.14.x]

### DIFF
--- a/src/components/arrange/arrange.js
+++ b/src/components/arrange/arrange.js
@@ -1,5 +1,6 @@
 import * as debug from '../../utils/debug';
 import { utils } from '../../utils/utils';
+import { Environment as env } from '../../utils/environment';
 
 // Component Name
 const COMPONENT_NAME = 'arrange';
@@ -41,7 +42,7 @@ Arrange.prototype = {
 
   // example from: https://github.com/farhadi/html5arrangeable/blob/master/jquery.arrangeable.js
   init() {
-    this.isTouch = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+    this.isTouch = env.features.touch;
     this.handleEvents();
   },
 

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -38,7 +38,7 @@ Button.prototype = {
   init() {
     const self = this;
 
-    this.isTouch = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+    this.isTouch = env.features.touch;
     this.isSafari = $('html').is('.is-safari');
     this.isFirefox = $('html').is('.is-firefox');
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3699,7 +3699,6 @@ Datagrid.prototype = {
         const containerEl = isHeaderColumn ? elem.parentNode : elem;
         const width = self.getOuterWidth(containerEl);
 
-        console.log(tooltip, tooltip.textwidth, (width - 35));
         if (tooltip && (tooltip.forced || (tooltip.textwidth > (width - 35))) && !isPopup) {
           self.showTooltip(tooltip);
         }
@@ -8901,6 +8900,10 @@ Datagrid.prototype = {
         tooltip.content = env.features.touch ? '' : select.options[select.selectedIndex].innerHTML.trim();
       }
 
+      if (isTh) {
+        tooltip.content = tooltip.content.trim();
+      }
+
       if (tooltip.content !== '') {
         const isEllipsis = utils.hasClass(elem, 'text-ellipsis');
         const icons = [].slice.call(elem.querySelectorAll('.icon'));
@@ -8909,6 +8912,11 @@ Datagrid.prototype = {
           extraWidth += icon.getBBox().width + 8;
         });
         tooltip.textwidth = stringUtils.textWidth(tooltip.content) + (select ? 0 : extraWidth);
+
+        if (isTh) {
+          tooltip.textwidth = stringUtils.textWidth(tooltip.content);
+        }
+
         tooltip.content = contentTooltip ? tooltip.content : `<p>${tooltip.content}</p>`;
         if (title || isHeaderFilter) {
           tooltip.forced = true;

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -8,6 +8,7 @@ import { debounce } from '../../utils/debounced-resize';
 import { stringUtils } from '../../utils/string';
 import { xssUtils } from '../../utils/xss';
 import { DOM } from '../../utils/dom';
+import { Environment as env } from '../../utils/environment';
 
 import { Formatters } from '../datagrid/datagrid.formatters';
 import { GroupBy, Aggregators } from '../datagrid/datagrid.groupby';
@@ -202,7 +203,7 @@ Datagrid.prototype = {
   init() {
     const html = $('html');
 
-    this.isTouch = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+    this.isTouch = env.features.touch;
     this.isFirefoxMac = (navigator.platform.indexOf('Mac') !== -1 && navigator.userAgent.indexOf(') Gecko') !== -1);
     this.isSafari = html.is('.is-safari');
     this.isWindows = (navigator.userAgent.indexOf('Windows') !== -1);
@@ -3698,6 +3699,7 @@ Datagrid.prototype = {
         const containerEl = isHeaderColumn ? elem.parentNode : elem;
         const width = self.getOuterWidth(containerEl);
 
+        console.log(tooltip, tooltip.textwidth, (width - 35));
         if (tooltip && (tooltip.forced || (tooltip.textwidth > (width - 35))) && !isPopup) {
           self.showTooltip(tooltip);
         }
@@ -8893,6 +8895,12 @@ Datagrid.prototype = {
         }
       }
 
+      // Clean up text in selects
+      const select = tooltip.wrapper.querySelector('select');
+      if (select && select.selectedIndex && select.options[select.selectedIndex].innerHTML) {
+        tooltip.content = env.features.touch ? '' : select.options[select.selectedIndex].innerHTML.trim();
+      }
+
       if (tooltip.content !== '') {
         const isEllipsis = utils.hasClass(elem, 'text-ellipsis');
         const icons = [].slice.call(elem.querySelectorAll('.icon'));
@@ -8900,7 +8908,7 @@ Datagrid.prototype = {
         icons.forEach((icon) => {
           extraWidth += icon.getBBox().width + 8;
         });
-        tooltip.textwidth = stringUtils.textWidth(tooltip.content) + extraWidth;
+        tooltip.textwidth = stringUtils.textWidth(tooltip.content) + (select ? 0 : extraWidth);
         tooltip.content = contentTooltip ? tooltip.content : `<p>${tooltip.content}</p>`;
         if (title || isHeaderFilter) {
           tooltip.forced = true;

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -810,7 +810,7 @@ Editor.prototype = {
       })
       .off('open')
       .on('open', function () {
-        const isTouch = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+        const isTouch = env.features.touch;
         const id = $(this).attr('id');
         const input = $('input:first', this);
         const button = $('.modal-buttonset .btn-modal-primary', this);

--- a/src/components/swaplist/swaplist.js
+++ b/src/components/swaplist/swaplist.js
@@ -1,6 +1,7 @@
 import * as debug from '../../utils/debug';
 import { utils } from '../../utils/utils';
 import { Locale } from '../locale/locale';
+import { Environment as env } from '../../utils/environment';
 
 // jQuery Components
 import '../listview/listview.jquery';
@@ -90,7 +91,7 @@ SwapList.prototype = {
   init() {
     const s = this.settings;
     s.draggable = $.extend(true, SWAPLIST_DEFAULTS.draggable, s.draggable);
-    this.isTouch = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+    this.isTouch = env.features.touch;
     this.isAdditional = $(`${s.additionalClass} .listview`, this.element).length > 0;
 
     if (this.isTouch) {

--- a/src/components/validation/validator.js
+++ b/src/components/validation/validator.js
@@ -6,7 +6,7 @@ import { Validation } from './validation';
 // jQuery Components
 import '../icons/icons.jquery';
 import '../toast/toast.jquery';
-import { Environment } from '../../utils/environment';
+import { Environment as env } from '../../utils/environment';
 
 // Component Name
 const COMPONENT_NAME = 'Validator';
@@ -210,7 +210,7 @@ Validator.prototype = {
         let tooltip = thisField.data('tooltip');
         const dropdownApi = thisField.data('dropdown');
 
-        if (Environment.features.touch) {
+        if (env.features.touch) {
           dropdownApi.pseudoElem.focus();
           setTimeout(() => {
             dropdownApi.pseudoElem.blur();

--- a/src/utils/behaviors.js
+++ b/src/utils/behaviors.js
@@ -1,4 +1,5 @@
 import { DOM } from './dom';
+import { Environment as env } from './environment';
 
 /**
  * HideFocus Behavior
@@ -60,7 +61,7 @@ HideFocus.prototype = {
         $el.addClass('hide-focus');
         $el.triggerHandler('hidefocusadd', [e]);
       };
-      const isTouch = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+      const isTouch = env.features.touch;
 
       if (isTouch) {
         $el.on('touchstart.hide-focus', (e) => {

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -821,16 +821,12 @@ describe('Datagrid paging serverside multi select tests', () => {
     expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(2);
 
     await element(await by.css('.pager-next')).click();
-
-    await browser.driver
-      .wait(protractor.ExpectedConditions.elementToBeClickable(await element(by.css('.pager-prev'))), config.waitsFor);
+    await browser.driver.sleep(config.sleep);
 
     expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(0);
 
     await element(by.css('.pager-prev')).click();
-
-    await browser.driver
-      .wait(protractor.ExpectedConditions.elementToBeClickable(await element(by.css('.pager-next'))), config.waitsFor);
+    await browser.driver.sleep(config.sleep);
 
     expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(0);
   });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed a bug in datagrid that made tooltips show up all the time on mobile on dropdown columns.
Some minor refactoring of the isTouch indication

**Related github/jira issue (required)**:
Fixes #1396 
Fixes #1395

**Steps necessary to review your pull request (required)**:

For 1396
http://localhost:4000/components/datagrid/test-dropdown-window-size.html
- on IOS sim...
- open the action column 
- should now not show tooltips (disabled entirely as it was clunky here)

For 1395
http://localhost:4000/components/datagrid/example-editable.html
- blank out a cell in the activty column so a validation error appears
- hover the first two headers (no tooltip should appear)
- resize row id column so that the text is half cut off
- hover the row id column (tooltip should appear)
