### PR TITLE
1400 - Better fix for missing tooltip that doesn't modify widths [v4.14.x]

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -130,7 +130,7 @@
       "declarations"
     ],
     "order/properties-alphabetical-order": true,
-    "number-leading-zero": "never",
+    "number-leading-zero": "always",
     "number-no-trailing-zeros": true,
     "property-case": "lower",
     "rule-empty-line-before": [

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -130,7 +130,7 @@
       "declarations"
     ],
     "order/properties-alphabetical-order": true,
-    "number-leading-zero": "always",
+    "number-leading-zero": "never",
     "number-no-trailing-zeros": true,
     "property-case": "lower",
     "rule-empty-line-before": [

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1826,8 +1826,8 @@ $datagrid-short-row-height: 23px;
       .dropdown {
         border: medium none;
         line-height: normal;
-        padding: 0 20px;
-        width: calc(100% - 30px);
+        padding: 0 30px 0 20px;
+        width: 100%;
 
         &:focus {
           box-shadow: none;

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -85,7 +85,6 @@ div.multiselect {
   cursor: pointer;
   overflow: hidden;
   padding: 8px 30px 8px 10px;
-  -webkit-text-fill-color: $dropdown-color-initial-font;
   text-overflow: ellipsis;
   vertical-align: middle;
   white-space: nowrap;
@@ -100,11 +99,10 @@ div.multiselect {
 
   > span {
     display: inline-block;
-    max-width: 100%;
+    // max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
     vertical-align: top;
-    width: inherit;
 
     &:empty::before {
       color: $input-placeholder-color;

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -77,7 +77,7 @@ div.multiselect {
   @include input-style();
   @include css3(touch-callout, none);
   @include css3(user-select, none);
-  @include transition(background-color .2s ease);
+  @include transition(background-color 0.2s ease);
 
   background-color: $input-color-initial-background;
   border-color: $input-color-initial-border;

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -77,7 +77,7 @@ div.multiselect {
   @include input-style();
   @include css3(touch-callout, none);
   @include css3(user-select, none);
-  @include transition(background-color 0.2s ease);
+  @include transition(background-color .2s ease);
 
   background-color: $input-color-initial-background;
   border-color: $input-color-initial-border;

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -108,6 +108,13 @@ Dropdown.prototype = {
   },
 
   /**
+   * @returns {boolean} whether or not the text inside the in-page pseudo element too big to fit
+   */
+  get overflowed() {
+    return this.pseudoElem.find('span').width() > this.pseudoElem.width();
+  },
+
+  /**
    * Initialize the dropdown.
    * @private
    * @returns {object} The api for chaining
@@ -315,9 +322,10 @@ Dropdown.prototype = {
     this.setInitial();
     this.setWidth();
 
-    this.tooltipApi = null;
-    if (this.pseudoElem.find('span').width() > this.pseudoElem.width()) {
+    if (this.overflowed) {
       this.setTooltip();
+    } else if (this.tooltipApi) {
+      this.removeTooltip();
     }
 
     this.element.triggerHandler('rendered');
@@ -488,14 +496,25 @@ Dropdown.prototype = {
 
   /**
    * Triggers tooltip in multiselect
+   * @returns {void}
    */
   setTooltip() {
     const opts = this.element.find('option:selected');
     const optText = this.getOptionText(opts);
     this.tooltipApi = this.pseudoElem.find('span').tooltip({
       content: optText,
+      parentElement: this.pseudoElem,
       trigger: 'hover',
     });
+  },
+
+  /**
+   * Removes a tooltip
+   * @returns {void}
+   */
+  removeTooltip() {
+    this.tooltipApi.destroy();
+    this.tooltipApi = null;
   },
 
   /**
@@ -2405,10 +2424,10 @@ Dropdown.prototype = {
       // Fire the change event with the new value if the noTrigger flag isn't set
       this.element.trigger('change').triggerHandler('selected', [option, isAdded]);
 
-      if (this.pseudoElem.find('span').width() > this.pseudoElem.width()) {
+      if (this.overflowed) {
         this.setTooltip();
       } else if (this.tooltipApi) {
-        this.tooltipApi.destroy();
+        this.removeTooltip();
       }
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a regression where the "overflow" tooltip that displays the full contents of a Dropdown/Multiselect component whose inner text is too long to fit.  A series of several changes against `v4.14.x` caused this to stop working.

**Related github/jira issue (required)**:
- Closes #1400 
- Related: #1214 
- Related: #1380

**Steps necessary to review your pull request (required)**:
_For this issue:_
- Open a browser to http://localhost:4000/components/dropdown/test-multiselect-with-tooltip
- Hover the multiselect.  Ensure no tooltip is displayed (content isn't overflowed)
- Open the multiselect and pick all the items
- Close the multiselect and hover it. A tooltip should display containing its full text contents.

Also, recheck #1214 and #1380 to make sure they are working and unaffected by these changes.
