### PR TITLE
1179 - Fixes calendar date move as the first day of week [4.14.x]

### DIFF
--- a/src/components/monthview/monthview.js
+++ b/src/components/monthview/monthview.js
@@ -363,7 +363,7 @@ MonthView.prototype = {
     // Adjust days of the week
     // lead days
     const firstDayOfMonth = this.firstDayOfMonth(year, month);
-    const leadDays = ((firstDayOfMonth - (this.currentCalendar.firstDayofWeek || 0)) + 7) % 7;
+    const leadDays = ((firstDayOfMonth - firstDayofWeek) + 7) % 7;
     const lastMonthDays = this.daysInMonth(year, month + (this.isIslamic ? 1 : 0));
     const thisMonthDays = this.daysInMonth(year, month + (this.isIslamic ? 0 : 1));
     let nextMonthDayCnt = 1;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This is a follow up fix for setting the first day of week. 

_**Issue**_: The corresponding date doesn't move or change the same as the first day of week. It should expect to be the same date even it change the setting of `firstDayOfWeek`.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/1179
Related PR https://github.com/infor-design/enterprise/pull/1326

**Steps necessary to review your pull request (required)**:

- Checkout this branch
- Run http://localhost:4000/components/datepicker/test-set-first-day-of-week.html
- Click the calendar icon
- The calendar should start on Monday
- In test html, you can manipulate the `firstDayofWeek`
- It should correspond the date even if you change the `firstDayofWeek`


<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
