### PR TITLE
1213 - Fixed dropdown validation after cancel in modals [v4.14.x]

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -265,9 +265,17 @@ Modal.prototype = {
    */
   disableSubmit() {
     const body = this.element;
-    const fields = body.find('[data-validate]:visible');
     const inlineBtns = body.find('.modal-buttonset button');
     const primaryButton = inlineBtns.filter('.btn-modal-primary').not('.no-validation');
+    const dropdowns = body.find('select.dropdown[data-validate]');
+    let fields = body.find('[data-validate]:visible');
+
+    dropdowns.each(function () {
+      const dropdown = $(this);
+      if (dropdown.next('.dropdown-wrapper').is(':visible')) {
+        fields = fields.add(this);
+      }
+    });
 
     if (fields.length > 0) {
       primaryButton.removeAttr('disabled');
@@ -279,7 +287,7 @@ Modal.prototype = {
           return;
         }
 
-        const isVisible = field[0].offsetParent !== null;
+        const isVisible = field.is('.dropdown') && field.next('.dropdown-wrapper').is(':visible') || field[0].offsetParent !== null;
 
         if (field.is('.required')) {
           if (isVisible && !field.val()) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
If dropdown use with validation in modal window. It was not let is pass validation and causing the not to submit form.

**Related github/jira issue (required)**:
#1213

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/modal/example-validation.html
- Open above link
- Click button "Add Context" to open modal window
- In modal window see button "Submit" should be disabled
- Fill "Email and Description" fields
- Leave the "Type" dropdown list blank
- Click button "Cancel"
- Open the Modal again
- See button "Submit" should be disabled
- Soon fill/remove all required fields with (*) in label text
- See the button "Submit" it should be enabled/disabled