### PR TITLE
1270 - Fixed selected nodes and ajax loading with tree

### DIFF
--- a/app/views/components/tree/example-ajax.html
+++ b/app/views/components/tree/example-ajax.html
@@ -21,7 +21,7 @@
 <script>
   var sampleData;
 
-  
+
   sampleData = [{
     "id": "node1",
     "text": "Node One",
@@ -44,7 +44,7 @@
     "extra": "test 2"
   }];
 
-  
+
 
   //Can refer to the data set here
   $('#json-tree').tree({dataset: sampleDataNoID, source: function (req, response) {
@@ -63,7 +63,7 @@
     }, 2000);
 
   }}).on('selected', function (e, args) {
-    console.log(args);
+    console.log('selected:', args);
   });
 
 

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -486,7 +486,16 @@ Tree.prototype = {
         a.parentNode.classList.add('is-selected');
       });
     } else {
+      if (node[0].classList.contains('is-selected')) {
+        return;
+      }
       links.forEach((a) => {
+        const link = $(a);
+        const data = link.data('jsonData');
+        if (data) {
+          delete data.selected;
+          link.data('jsonData', data);
+        }
         a.setAttribute('aria-selected', 'false');
         a.classList.remove('is-selected');
         a.parentNode.classList.remove('is-selected');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Previously selected nodes were being selected again after child nodes are loaded via AJAX.

**Related github/jira issue (required)**:
Closes #1270

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/tree/example-ajax.html
- Open above link
- Open developer tools
- Click "Node One" to select
- Click "Node Two" to load its child nodes
- See "Node One" should deselect and only "Node Two" be selected
- See console log for `selected` should fire one per click