### PR TITLE
1213 - Fixed invalid email validation after cancel in modals [v4.14.x]

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -300,6 +300,10 @@ Modal.prototype = {
           }
         }
 
+        if (isVisible && field.is('.error')) {
+          allValid = false;
+        }
+
         if (allValid) {
           primaryButton.removeAttr('disabled');
         }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
If invalid email use with validation in modal window and canceled to close modal. Then reopen model was let user to submit the form because submit button was enabled.

**Related github/jira issue (required)**:
#1213

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/modal/example-validation.html
- Open above link
- Click button "Add Context" to open modal window
- In modal window see button "Submit" should be disabled
- Fill all the fields, but keep INVALID email e.g 'test123!@yahoo.com'
- Button "Submit" should be disabled
- Click button "Cancel"
- Open the Modal again
- See button "Submit" should be disabled
- Soon fill/remove all required fields with (*) in label text
- And valid email e.g 'test123@yahoo.com'
- See the button "Submit" it should be enabled