### PR TITLE
1432- Allowed pager to have a custom pageSizeButton text

### DIFF
--- a/app/views/components/pager/example-standalone.html
+++ b/app/views/components/pager/example-standalone.html
@@ -49,6 +49,7 @@
       type: 'standalone',
       pagesize: 10,
       showPageSizeSelector: false,
+      pageSizeLabelText: 'Recs {0}', // must be translated text.
       showFirstButton: true,
       enableFirstButton: true,
       showPreviousButton: true,
@@ -57,6 +58,7 @@
       enableNextButton: true,
       showLastButton: true,
       enableLastButton: true,
+
       onFirstPage: function (elem, args) {
         console.log(elem, args);
       },

--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -12,6 +12,8 @@ import '../tooltip/tooltip.jquery';
 // The name of this component.
 const COMPONENT_NAME = 'pager';
 
+const RECORD_PER_PAGE_TEXT = 'RecordsPerPage';
+
 /**
 * The Pager Component supports paging on lists.
 * @class Pager
@@ -62,6 +64,7 @@ const PAGER_DEFAULTS = {
   pagesizes: [15, 25, 50, 75],
   showPageSizeSelector: true,
   onPageSizeChange: null,
+  pageSizeLabelText: null,
   showFirstButton: true,
   enableFirstButton: true,
   showPreviousButton: true,
@@ -677,8 +680,10 @@ Pager.prototype = {
     // Add functionality to change page size.
     if (self.settings.showPageSizeSelector && this.pagerBar.find('.btn-menu').length === 0) {
       const pageSize = $('<li class="pager-pagesize"></li>');
+
+      const buttonText = self.settings.pageSizeLabelText || Locale.translate(RECORD_PER_PAGE_TEXT);
       const pageSizeButton = $(`${'<button type="button" class="btn-menu">' +
-        '<span>'}${Locale.translate('RecordsPerPage').replace('{0}', this.settings.pagesize)}</span> ${
+        '<span>'}${buttonText.replace('{0}', this.settings.pagesize)}</span> ${
         $.createIcon({ icon: 'dropdown' })
       } </button>`).appendTo(pageSize);
 
@@ -731,8 +736,10 @@ Pager.prototype = {
         });
 
         // Update the number of records per page
+        const buttonText2 = self.settings.pageSizeLabelText ||
+          Locale.translate(RECORD_PER_PAGE_TEXT);
         self.pagerBar.find('.btn-menu span')
-          .text(Locale.translate('RecordsPerPage').replace('{0}', self.settings.pagesize));
+          .text(buttonText2.replace('{0}', self.settings.pagesize));
       });
     }
 
@@ -817,8 +824,9 @@ Pager.prototype = {
     }
 
     // Update the number of records per page
+    const buttonText = this.settings.pageSizeLabelText || Locale.translate(RECORD_PER_PAGE_TEXT);
     this.pagerBar.find('.btn-menu span')
-      .text(Locale.translate('RecordsPerPage').replace('{0}', this.settings.pagesize));
+      .text(buttonText.replace('{0}', this.settings.pagesize));
 
     // Refresh Disabled
     const prev = pb.find('.pager-prev a');
@@ -1086,6 +1094,10 @@ Pager.prototype = {
 
     if (settings.pagesizes) {
       this.settings.pagesizes = settings.pagesizes;
+    }
+
+    if (settings.pageSizeLabelText) {
+      this.settings.pageSizeLabelText = settings.pageSizeLabelText;
     }
 
     this.updatePagingInfo(this.settings);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Add ability to change pageSizeButton text on a stand alone pager bar.

**Related github/jira issue (required)**:
Closes #1432

**Steps necessary to review your pull request (required)**:
1. edit `app/views/components/pager/example-standalone.html`
2. Add pageSizeLabelText: 'Recs {0}', // must be translated text.
3. Run the example and see text change

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
