### PR TITLE
405 - Fixed update row was misaligning indentation with treegrid

### DIFF
--- a/app/views/components/datagrid/test-tree-update-row.html
+++ b/app/views/components/datagrid/test-tree-update-row.html
@@ -1,0 +1,225 @@
+<div class="row">
+  <div class="twelve columns">
+    <div class="compound-field">
+      <p>Select value and click &quot;Update Row&quot;.</p>
+      <div class="field">
+        <label for="dd-rows" class="audible label">Pick row to update</label>
+        <select id="dd-rows" name="dd-rows"  class="dropdown dropdown-sm"></select>
+      </div>
+      <div class="field">
+        <button type="button" id="update-row" class="btn-secondary"><span>Update Row</span></button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="full-height full-width">
+    <div id="datagrid" >
+    </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    // Some data
+    var data = [
+      {
+        somePrimaryKey: 1,
+        name: 'beijing',
+        hostName: 'localhost',
+        port: 21230,
+        dataPort: 21231
+      },
+      {
+        somePrimaryKey: 2,
+        name: 'default',
+        hostName: 'localhost',
+        port: 21230,
+        dataPort: 21231,
+        expanded: false,
+        children: [
+          {
+            somePrimaryKey: 3,
+            name: 'default1',
+            hostName: 'localhost',
+            port: 21230,
+            dataPort: 21231
+          }
+        ]
+      },
+      {
+        somePrimaryKey: 4,
+        name: 'guangzhou',
+        hostName: 'localhost',
+        port: 21230,
+        dataPort: 21231
+      },
+      {
+        somePrimaryKey: 5,
+        name: 'hangzhou',
+        hostName: 'localhost',
+        port: 21230,
+        dataPort: 21231
+      },
+      {
+        somePrimaryKey: 6,
+        name: 'shanghai',
+        hostName: 'localhost',
+        port: 21232,
+        dataPort: 21233
+      },
+      {
+        somePrimaryKey: 7,
+        name: 'suzhou',
+        hostName: 'localhost',
+        port: 21230,
+        dataPort: 21231,
+        expanded: true,
+        children: [
+          {
+            somePrimaryKey: 8,
+            name: 'suzhou1',
+            hostName: 'localhost',
+            port: 20033,
+            dataPort: 2000
+          },
+          {
+            somePrimaryKey: 9,
+            name: 'suzhou2',
+            hostName: 'localhost',
+            port: 20033,
+            dataPort: 2000
+          }
+        ]
+      },
+      {
+        somePrimaryKey: 10,
+        name: 'testg',
+        hostName: 'localhost',
+        port: 21230,
+        dataPort: 21231
+      },
+      {
+        somePrimaryKey: 11,
+        name: 'tianjing',
+        hostName: 'localhost',
+        port: 21230,
+        dataPort: 21233
+      },
+      {
+        somePrimaryKey: 12,
+        name: 'tibet',
+        hostName: 'localhost',
+        port: 21230,
+        dataPort: 21231
+      },
+      {
+        somePrimaryKey: 13,
+        name: 'xian',
+        hostName: 'localhost',
+        port: 21230,
+        dataPort: 21231
+      }
+    ];
+
+    // Define columns
+    var columns = [
+      {
+        id: 'selectionCheckbox',
+        sortable: false,
+        resizable: false,
+        width: 50,
+        formatter: Formatters.SelectionCheckbox,
+        align: 'center'
+      },
+      {
+        id: 'name',
+        name: 'Name',
+        field: 'name',
+        expanded: 'expanded',
+        formatter: Formatters.Tree
+      },
+      {
+        id: 'id',
+        name: 'Id',
+        field: 'somePrimaryKey'
+      },
+      {
+        id: 'hostName',
+        name: 'Host Name',
+        field: 'hostName',
+        width: 250
+      },
+      {
+        id: 'port',
+        name: 'Port',
+        field: 'port'
+      },
+      {
+        id: 'dataPort',
+        name: 'Data Port',
+        field: 'dataPort'
+      }
+    ];
+
+    // Cache vars
+    var gridEl = $('#datagrid');
+    var dropdownEl = $('#dd-rows');
+
+    // Initialized datagrid
+    gridEl.datagrid({
+      columns: columns,
+      dataset: data,
+      treeGrid: true
+    });
+
+    // Set datagrid api object
+    var gridApi = gridEl.data('datagrid');
+
+    // Set top dropdown to add list of rows
+    if (gridApi) {
+      var getOptionText = function (idx) {
+        var node = gridApi.settings.treeDepth[idx].node;
+        var optionText = 'Row: ' + idx;
+        optionText += ', Id: ' + node.somePrimaryKey;
+
+        return optionText;
+      };
+      var itemsHtml = '';
+      for (let i = 0, l = gridApi.settings.treeDepth.length; i < l; i++) {
+        itemsHtml += '<option value="'+ i +'">'+ getOptionText(i) +'</option>';
+      }
+      dropdownEl.append(itemsHtml).trigger('updated');
+    }
+
+    // Update row
+    $('#update-row').click(function () {
+      if (gridApi) {
+        var row = parseInt(dropdownEl.val(), 10);
+        var rowData = gridApi.settings.treeDepth[row];
+        if (rowData) {
+          var data = rowData.node;
+          data.hostName = 'Updatedxxxxxxxxx';
+          gridApi.updateRow(row);
+          console.log('Row is updated');
+        } else {
+          console.log('Can not find given row to update');
+        }
+
+        /***
+         *** Example to pass new dataset for row to be updated
+         ***/
+        /*
+        data = {
+          somePrimaryKey: 9999,
+          name: 'suzhou9999',
+          hostName: 'localhost9999',
+          port: 20033,
+          dataPort: 2000
+        };
+        gridApi.updateRow(7, data);
+        */
+      }
+    });
+
+  });
+</script>

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -365,14 +365,15 @@ const formatters = {
   },
 
   // Tree Expand / Collapse Button and Paddings
-  Tree(row, cell, value, col, item) {
+  Tree(row, cell, value, col, item, api) {
     const isOpen = item ? item.expanded : true;
-    const depth = item && item.depth ? item.depth : 0;
+    const depth = api && api.settings.treeDepth && api.settings.treeDepth[row] ?
+      api.settings.treeDepth[row].depth : 0;
     const button = `<button type="button" class="btn-icon datagrid-expand-btn${(isOpen ? ' is-expanded' : '')}" tabindex="-1"${(depth ? ` style="margin-left: ${(depth ? `${(30 * (depth - 1))}px` : '')}"` : '')}>
       <span class="icon plus-minus ${(isOpen ? ' active' : '')}"></span>
       <span class="audible">${Locale.translate('ExpandCollapse')}</span>
-      </button>${(value ? `<span> ${value}</span>` : '')}`;
-    const node = `<span class="datagrid-tree-node"${(depth ? ` style="margin-left: ${(depth ? `${(30 * (depth))}px` : '')}"` : '')}> ${value}</span>`;
+      </button>${(value ? ` <span>${value}</span>` : '')}`;
+    const node = ` <span class="datagrid-tree-node"${(depth ? ` style="margin-left: ${(depth ? `${(30 * (depth))}px` : '')}"` : '')}>${value}</span>`;
 
     return (item && item[col.children ? col.children : 'children'] ? button : node);
   },

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1779,7 +1779,7 @@ Datagrid.prototype = {
       let dataset;
       let isFiltered;
       let i;
-      let ii;
+      let i2;
       let len;
       let dataSetLen;
 
@@ -1818,9 +1818,9 @@ Datagrid.prototype = {
       } else if (this.settings.groupable) {
         for (i = 0, len = this.settings.dataset.length; i < len; i++) {
           let isGroupFiltered = true;
-          for (ii = 0, dataSetLen = this.settings.dataset[i].values.length; ii < dataSetLen; ii++) {
-            isFiltered = !checkRow(this.settings.dataset[i].values[ii]);
-            this.settings.dataset[i].values[ii].isFiltered = isFiltered;
+          for (i2 = 0, dataSetLen = this.settings.dataset[i].values.length; i2 < dataSetLen; i2++) {
+            isFiltered = !checkRow(this.settings.dataset[i].values[i2]);
+            this.settings.dataset[i].values[i2].isFiltered = isFiltered;
 
             if (!isFiltered) {
               isGroupFiltered = false;
@@ -2915,14 +2915,14 @@ Datagrid.prototype = {
       for (let i = 0; i < self.settings.treeDepth.length; i++) {
         const treeDepthItem = self.settings.treeDepth[i];
 
-        if (rowData.id === treeDepthItem.node.id) {
+        if (dataRowIdx === (treeDepthItem.idx - 1)) {
           let parentNode = null;
           let currentDepth = 0;
-          for (let ii = i; ii >= 0; ii--) {
-            currentDepth = self.settings.treeDepth[ii].node.depth < currentDepth ||
-            currentDepth === 0 ? self.settings.treeDepth[ii].node.depth : currentDepth;
-            if (currentDepth < treeDepthItem.node.depth) {
-              parentNode = self.settings.treeDepth[ii];
+          for (let i2 = i; i2 >= 0; i2--) {
+            currentDepth = self.settings.treeDepth[i2].depth < currentDepth ||
+            currentDepth === 0 ? self.settings.treeDepth[i2].depth : currentDepth;
+            if (currentDepth < treeDepthItem.depth) {
+              parentNode = self.settings.treeDepth[i2];
 
               if (parentNode.node.isExpanded !== undefined && !parentNode.node.isExpanded
                 || currentDepth === 1) {
@@ -3813,7 +3813,12 @@ Datagrid.prototype = {
    * @returns {void}
    */
   updateRow(idx, data) {
-    const rowData = (data || this.settings.dataset[idx]);
+    const s = this.settings;
+    let rowData = data;
+
+    if (!rowData) {
+      rowData = s.treeGrid ? s.treeDepth[idx].node : s.dataset[idx];
+    }
 
     for (let j = 0; j < this.settings.columns.length; j++) {
       const col = this.settings.columns[j];
@@ -7032,7 +7037,7 @@ Datagrid.prototype = {
       return false; // eslint-disable-line
     }
 
-    // In Show Ediitor mode the editor is on form already
+    // In Show Editor mode the editor is on form already
     if (!col.inlineEditor) {
       if (isEditor) {
         cellNode.css({ position: 'static', height: cellNode.outerHeight() });
@@ -7861,9 +7866,8 @@ Datagrid.prototype = {
 
     // update cell value
     const escapedVal = xssUtils.escapeHTML(coercedVal);
-    const rowIdx = (isTreeGrid ? row + 1 : row);
     const val = (isEditor ? coercedVal : escapedVal);
-    formatted = this.formatValue(formatter, rowIdx, cell, val, col, rowData);
+    formatted = this.formatValue(formatter, row, cell, val, col, rowData);
 
     if (col.contentVisible) {
       const canShow = col.contentVisible(row, cell, escapedVal, col, rowData);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
if a row contains sub-rows, updateRow() was causing to row extra one indent space.
If a row was the last row of sub-rows, updateRow() causing to row one less indent pace.

**Related github/jira issue (required)**:
Closes #405
Closes #1361 - fixed id issue

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-tree-update-row.html
- Open above link
- See the rows indentation in grid tree should be fine
- Select value from top dropdown and
- Click button "Update Row" it will update row data for given row
- See the rows indentation in grid tree should not change