### PR TITLE
1145 - Fixed extra text expand-collapse with tree datagrid

### DIFF
--- a/app/views/components/datagrid/test-tree-editable.html
+++ b/app/views/components/datagrid/test-tree-editable.html
@@ -50,11 +50,11 @@
 
 
     //Define Columns for the Grid.
-    columns.push({ id: 'taskName', name: 'Task', field: 'taskName', expanded: 'expanded', formatter: Formatters.Tree, editor: Editors.Input, width: 250});
-    columns.push({ id: 'id', name: 'Id', field: 'id', width: 25});
+    columns.push({ id: 'taskName', name: 'Task', field: 'taskName', expanded: 'expanded', formatter: Formatters.Tree, editor: Editors.Input });
+    columns.push({ id: 'id', name: 'Id', field: 'id' });
     columns.push({ id: 'portable', name: 'Portable', field: 'portable', align: 'center', formatter: Formatters.Checkbox, editor: Editors.Checkbox});
     columns.push({ id: 'comments', name: 'Comments', field: 'comments',  formatter: Formatters.Hyperlink, editor: Editors.Input, width: 60});
-    columns.push({ id: 'desc', name: 'Description', field: 'desc', editor: Editors.Input, width: 200});
+    columns.push({ id: 'desc', name: 'Description', field: 'desc', editor: Editors.Input });
 
     //Get some data via ajax
     var url = '{{basepath}}api/tree-tasks';

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -6992,6 +6992,8 @@ Datagrid.prototype = {
     // Already in edit mode
     const cellNode = this.activeCell.node.find('.datagrid-cell-wrapper');
     const cellParent = cellNode.parent('td');
+    const treeNode = $('.datagrid-tree-node', cellNode).length > 0;
+    const treeExpandBtn = $('.datagrid-expand-btn', cellNode).length > 0;
 
     if (cellParent.hasClass('is-editing') || cellParent.hasClass('is-editing-inline')) {
       return false; // eslint-disable-line
@@ -7030,6 +7032,15 @@ Datagrid.prototype = {
 
     if (!this.isCellEditable(idx, cell)) {
       return false; // eslint-disable-line
+    }
+
+    if (treeExpandBtn || treeNode) {
+      if (treeExpandBtn) {
+        cellValue = $('> span', cellNode).text();
+      }
+      if (typeof cellValue === 'string') {
+        cellValue = cellValue.replace(/^\s/, '');
+      }
     }
 
     // In Show Ediitor mode the editor is on form already


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Using editable and treegrid, extra text (Expand / Collapse) was adding to the target node after edit parent node cell.

**Related github/jira issue (required)**:
Closes #1145

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-tree-editable.html
- Open above link
- Click on any parent node's cell text with (+/-) icon to get in edit mode
- Click anywhere else on the page or "Enter" key to get out from edit mode without make any changes
- See in that cell's content should not added any extra text (Expand / Collapse)