### PR TITLE
Fix tests for 2018 & Add IE 11 fix for Object.values [v4.14.x]

### DIFF
--- a/src/components/bar/bar.js
+++ b/src/components/bar/bar.js
@@ -655,7 +655,8 @@ Bar.prototype = {
     const elems = document.querySelectorAll('.bar-chart .axis.y .tick text');
     const dataset = this.settings.dataset;
     for (let i = 0; i < dataset.length; i++) {
-      Object.values(dataset[i]).forEach((key) => {
+      const values = Object.keys(dataset[i]).map(e => dataset[i][e]);
+      values.forEach((key) => {
         if (key && key.constructor === Array) {
           for (let j = 0; j < key.length; j++) {
             if (innerWidth <= 480) {

--- a/test/components/about/about.e2e-spec.js
+++ b/test/components/about/about.e2e-spec.js
@@ -47,7 +47,7 @@ describe('About translation tests', () => {
     await browser.driver
       .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('about-modal'))), config.waitsFor);
 
-    const ukText = 'Авторські права © Infor, 2018. Усі права збережено. Усі зазначені у цьому документі назви та дизайн елементів є товарними знаками або захищеними товарними знаками Infor та/або афілійованих організацій і філіалів Infor. Усі права збережено. Усі інші товарні знаки, перелічені тут, є власністю відповідних власників. www.infor.com.';
+    const ukText = `Авторські права © Infor, ${new Date().getFullYear()}. Усі права збережено. Усі зазначені у цьому документі назви та дизайн елементів є товарними знаками або захищеними товарними знаками Infor та/або афілійованих організацій і філіалів Infor. Усі права збережено. Усі інші товарні знаки, перелічені тут, є власністю відповідних власників. www.infor.com.`;
 
     expect(await element(by.css('.additional-content + p')).getText()).toEqual(ukText);
   });

--- a/test/components/calendar/calendar.e2e-spec.js
+++ b/test/components/calendar/calendar.e2e-spec.js
@@ -70,6 +70,7 @@ describe('Calendar ajax loading tests', () => {
     const testDate = new Date();
     await testDate.setDate(1);
     await testDate.setMonth(7);
+    await testDate.setFullYear(2018);
 
     expect(await element(by.id('monthview-datepicker-field')).getAttribute('value')).toEqual(testDate.toLocaleDateString('en-US', { month: 'long', year: 'numeric' }));
   });
@@ -110,6 +111,7 @@ describe('Calendar specific month tests', () => {
     const testDate = new Date();
     await testDate.setDate(1);
     await testDate.setMonth(9);
+    await testDate.setFullYear(2018);
 
     expect(await element(by.id('monthview-datepicker-field')).getAttribute('value')).toEqual(testDate.toLocaleDateString('en-US', { month: 'long', year: 'numeric' }));
   });

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -653,15 +653,13 @@ describe('Datagrid paging multiselect tests', () => {
 
     await element(by.css('.pager-next')).click();
 
-    await browser.driver
-      .wait(protractor.ExpectedConditions.elementToBeClickable(await element(by.css('.pager-prev'))), config.waitsFor);
+    await browser.driver.sleep(config.sleep);
 
     expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(0);
 
     await element(by.css('.pager-prev')).click();
 
-    await browser.driver
-      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.css('tr:nth-child(1) td[aria-colindex="2"]'))), config.waitsFor);
+    await browser.driver.sleep(config.sleep);
 
     expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(0);
   });

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -482,16 +482,20 @@ describe('Datepicker Month Year Picker Tests', () => {
 
   it('Should be able to function as month/year picker', async () => {
     const datepickerEl = await element(by.id('month-year'));
+    await datepickerEl.sendKeys('10/2018');
     await datepickerEl.sendKeys(protractor.Key.ARROW_DOWN);
 
-    const dropdownEl = await element(by.css('#year-dropdown + .dropdown-wrapper div[aria-controls="dropdown-list"]'));
+    let dropdownEl = await element(by.css('#year-dropdown + .dropdown-wrapper div[aria-controls="dropdown-list"]'));
+    await dropdownEl.sendKeys(protractor.Key.ARROW_DOWN);
+    dropdownEl = await element(by.css('.dropdown-search'));
+    await dropdownEl.sendKeys(protractor.Key.ARROW_DOWN);
     await dropdownEl.sendKeys(protractor.Key.ARROW_DOWN);
     await dropdownEl.sendKeys(protractor.Key.ENTER);
 
     const buttonEl = await element(by.css('.select-month.btn-tertiary'));
     await buttonEl.click();
 
-    expect(await element(by.id('month-year')).getAttribute('value')).toEqual('01/2019');
+    expect(await element(by.id('month-year')).getAttribute('value')).toEqual('10/2020');
   });
 
   it('Should be able to function as month/year picker long', async () => {

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -484,19 +484,19 @@ describe('Datepicker Month Year Picker Tests', () => {
     const datepickerEl = await element(by.id('month-year'));
     await datepickerEl.sendKeys(protractor.Key.ARROW_DOWN);
 
-    const dropdownEl = await element(by.css('#month-dropdown + .dropdown-wrapper div[aria-controls="dropdown-list"]'));
-    await dropdownEl.sendKeys(protractor.Key.ARROW_DOWN);
+    const dropdownEl = await element(by.css('#year-dropdown + .dropdown-wrapper div[aria-controls="dropdown-list"]'));
     await dropdownEl.sendKeys(protractor.Key.ARROW_DOWN);
     await dropdownEl.sendKeys(protractor.Key.ENTER);
 
     const buttonEl = await element(by.css('.select-month.btn-tertiary'));
     await buttonEl.click();
 
-    expect(await element(by.id('month-year')).getAttribute('value')).toEqual('12/2018');
+    expect(await element(by.id('month-year')).getAttribute('value')).toEqual('01/2019');
   });
 
   it('Should be able to function as month/year picker long', async () => {
     const datepickerEl = await element(by.id('month-year-long'));
+    await datepickerEl.sendKeys('Oct 2018');
     await datepickerEl.sendKeys(protractor.Key.ARROW_DOWN);
 
     const dropdownEl = await element(by.css('#month-dropdown + .dropdown-wrapper div[aria-controls="dropdown-list"]'));
@@ -525,17 +525,20 @@ describe('Datepicker Month Year Changer Tests', () => {
 
   it('Should be able to change month and year from the pickers', async () => {
     const datepickerEl = await element(by.id('date-field-normal'));
+    await datepickerEl.sendKeys('10/1/2018');
     await datepickerEl.sendKeys(protractor.Key.ARROW_DOWN);
     await browser.driver.sleep(config.sleep);
 
-    const dropdownEl = await element(by.css('#month-dropdown + .dropdown-wrapper div[aria-controls="dropdown-list"]'));
+    let dropdownEl = await element(by.css('#month-dropdown + .dropdown-wrapper div[aria-controls="dropdown-list"]'));
     await dropdownEl.sendKeys(protractor.Key.ARROW_DOWN);
+    dropdownEl = await element(by.css('.dropdown-search'));
     await dropdownEl.sendKeys(protractor.Key.ARROW_DOWN);
     await dropdownEl.sendKeys(protractor.Key.ENTER);
     await browser.driver.sleep(config.sleep);
 
-    const yearEl = await element(by.css('#year-dropdown + .dropdown-wrapper div[aria-controls="dropdown-list"]'));
+    let yearEl = await element(by.css('#year-dropdown + .dropdown-wrapper div[aria-controls="dropdown-list"]'));
     await yearEl.sendKeys(protractor.Key.ARROW_DOWN);
+    yearEl = await element.all(by.css('.dropdown-search')).last();
     await yearEl.sendKeys(protractor.Key.ARROW_DOWN);
     await yearEl.sendKeys(protractor.Key.ARROW_DOWN);
     await yearEl.sendKeys(protractor.Key.ENTER);
@@ -553,7 +556,7 @@ describe('Datepicker Month Year Changer Tests', () => {
     await buttonEl.click();
     await browser.driver.sleep(config.sleep);
 
-    expect(await element(by.id('date-field-normal')).getAttribute('value')).toEqual('12/1/2018');
+    expect(await element(by.id('date-field-normal')).getAttribute('value')).toEqual('11/1/2020');
   });
 });
 

--- a/test/components/lookup/lookup.e2e-spec.js
+++ b/test/components/lookup/lookup.e2e-spec.js
@@ -283,13 +283,13 @@ describe('Lookup multiselect serverside paging tests', () => {
     const lookupEl = await element(by.id('product-lookup'));
 
     await buttonEl.click();
-
-    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.className('datagrid-cell-wrapper'))), config.waitsFor);
+    await browser.driver.sleep(301);
     await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1)')).click();
     await element(by.css('#lookup-datagrid .datagrid-body tbody tr:nth-child(2) td:nth-child(1)')).click();
 
-    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.className('pager-next'))), config.waitsFor);
+    await browser.driver.sleep(301);
     await element(by.className('pager-next')).click();
+    await browser.driver.sleep(301);
 
     expect(await element(by.name('pager-pageno')).getAttribute('value')).toEqual('2');
 

--- a/test/components/tabs/tabs-api.func-spec.js
+++ b/test/components/tabs/tabs-api.func-spec.js
@@ -289,11 +289,15 @@ describe('Tabs API', () => {
     expect(tab.length).toBeFalsy();
   });
 
-  it('Should select tab, and focus', () => {
+  it('Should select tab, and focus', (done) => {
     tabsObj.select('#tabs-normal-contracts');
 
     expect(document.querySelector('.tab.is-selected').innerText).toEqual('Contracts');
-    expect(parseInt(document.querySelector('.animated-bar').style.left, 10)).toBeCloseTo(0, 1);
+
+    setTimeout(() => {
+      expect(parseInt(document.querySelector('.animated-bar').style.left, 10)).toBeCloseTo(0, 1);
+      done();
+    }, 500);
   });
 
   it('Should return false whether tabs are overflowed at 300px', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fix a few tests that broke on chrome driver 45 and 2018 year change.
Fix an IE error where Object.values is used.

**Related github/jira issue (required)**:
NA

**Steps necessary to review your pull request (required)**:
- let tests run
- run http://localhost:4000/ and check all charts load at the bottom 
- test page http://localhost:4000/components/bar/example-long-text.html 