### PR TITLE
1351 - Fix Editor pasted bulleted list

### DIFF
--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -13,7 +13,7 @@ import { DOM } from '../../utils/dom';
 const COMPONENT_NAME = 'editor';
 
 /**
-* The Editor Component is displays and edits markdown.
+* The Editor Component displays and edits markdown.
 *
 * @class Editor
 * @param {string} element The component element.
@@ -399,7 +399,7 @@ Editor.prototype = {
       h: 72, // {Ctrl + H} anchor
       i: 73, // {Ctrl + I} italic --------with SHIFT: {Ctrl + Shift + I} image
       l: 76, // {Ctrl + L} justifyLeft
-      bl: 55, // {Ctrl + + Shift + 7} bullet list
+      bl: 55, // {Ctrl + Shift + 7} bullet list
       n: 56, // {Ctrl + Shift + 8} numbered list
       q: 81, // {Ctrl + Q} blockquotes
       r: 82, // {Ctrl + R} justifyRight
@@ -1437,7 +1437,7 @@ Editor.prototype = {
               deferredIE11.reject();
               return;
             }
-            // If data has been processes by browser, process it
+            // If data has been processed by browser, process it
             if (elem.childNodes && elem.childNodes.length > 0) {
               // Retrieve pasted content via innerHTML
               // (Alternatively loop through elem.childNodes or elem.getElementsByTagName here)
@@ -1592,6 +1592,9 @@ Editor.prototype = {
     // Remove header tag and content
     s = s.replace(/<head\b[^>]*>(.*?)<\/head>/gi, '');
 
+    // Replace bullets with list item tags
+    s = s.replace(/(·|•)/g, '</li><li>');
+
     // Remove empty tags
     s = s.replace(/<[^/>]+>[\s]*<\/[^>]+>/gi, '');
 
@@ -1599,8 +1602,8 @@ Editor.prototype = {
   },
 
   htmlEntities(str) {
-    // converts special characters (like <) into their escaped/encoded values (like &lt;).
-    // This allows you to show to display the string without the browser reading it as HTML.
+    // converts special characters (e.g., <) into their escaped/encoded values (e.g., &lt;).
+    // This allows you to display the string without the browser reading it as HTML.
     return String(str)
       .replace(/&/g, '&amp;')
       .replace(/</g, '&lt;')

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -1595,6 +1595,12 @@ Editor.prototype = {
     // Remove empty tags
     s = s.replace(/<[^/>]+>[\s]*<\/[^>]+>/gi, '');
 
+    // Replace span and paragraph tags from bulleted list pasting
+    if (s.includes('·')) {
+      s = s.replace(/<\/p>/gi, '</li>');
+      s = s.replace(/<p><span><span>·<\/span><\/span>/gi, '<li>');
+    }
+
     return s;
   },
 
@@ -2367,9 +2373,6 @@ Editor.prototype = {
 
     // Remove line breaks / Mso classes
     s = s.replace(/(\n|\r| class=(\'|")?Mso[a-zA-Z]+(\'|")?)/g, ' ');
-
-    // Remove smart bullets
-    s = s.replace(/(·|•)/g, '');
 
     const badTags = ['style', 'script', 'applet', 'embed', 'noframes', 'noscript'];
 

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -1595,10 +1595,15 @@ Editor.prototype = {
     // Remove empty tags
     s = s.replace(/<[^/>]+>[\s]*<\/[^>]+>/gi, '');
 
-    // Replace span and paragraph tags from bulleted list pasting
     if (s.includes('·')) {
+      // Replace span and paragraph tags from bulleted list pasting
       s = s.replace(/<\/p>/gi, '</li>');
       s = s.replace(/<p><span><span>·<\/span><\/span>/gi, '<li>');
+      // Remove white space
+      s = s.replace(/<\/li>\s<li>/gi, '<\/li><li>');
+      // Add in opening and closing ul tags
+      s = [s.slice(0, s.indexOf('<li>')), '<ul>', s.slice(s.indexOf('<li>'))].join('');
+      s = [s.slice(0, s.lastIndexOf('</li>')), '</ul>', s.slice(s.lastIndexOf('</li>'))].join('');
     }
 
     return s;

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -1592,9 +1592,6 @@ Editor.prototype = {
     // Remove header tag and content
     s = s.replace(/<head\b[^>]*>(.*?)<\/head>/gi, '');
 
-    // Replace bullets with list item tags
-    s = s.replace(/(·|•)/g, '</li><li>');
-
     // Remove empty tags
     s = s.replace(/<[^/>]+>[\s]*<\/[^>]+>/gi, '');
 
@@ -2360,7 +2357,7 @@ Editor.prototype = {
     // Convert <s> into <strike> for line-though
     s = s.replace(/<(\/?)s>/gi, '<$1strike>');
 
-    // Replace nsbp entites to char since it's easier to handle
+    // Replace nbsp entites to char since it's easier to handle
     s = s.replace(/&nbsp;/gi, '\u00a0');
 
     // Convert <span style="mso-spacerun:yes"></span> to string of alternating
@@ -2370,6 +2367,9 @@ Editor.prototype = {
 
     // Remove line breaks / Mso classes
     s = s.replace(/(\n|\r| class=(\'|")?Mso[a-zA-Z]+(\'|")?)/g, ' ');
+
+    // Remove smart bullets
+    s = s.replace(/(·|•)/g, '');
 
     const badTags = ['style', 'script', 'applet', 'embed', 'noframes', 'noscript'];
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Replaces bullets pasted in from a Word doc with list items in Editor. Also cleaned up some comment typos.

**Related github/jira issue (required)**:
Closes #1351.

**Steps necessary to review your pull request (required)**:
- http://localhost:4000/components/editor/example-index.html
- Pull branch
- Run app
- Paste in a bulleted list from Word
    - [Test Doc.docx](https://github.com/infor-design/enterprise/files/2741551/Test.Doc.docx)
- Ensure bullets are converted to list items and appear correctly

Another solution to this would be to strip bullets upon pasting into editor and let user highlight their list and click the 'unordered list' button in the toolbar of the editor. Would create a cleaner list.