### PR TITLE
1473 - Allow hrefs to redirect 

### DIFF
--- a/app/views/components/datagrid/test-link-hrefs.html
+++ b/app/views/components/datagrid/test-link-hrefs.html
@@ -1,0 +1,59 @@
+<div class="row">
+  <div class="twelve columns">
+    <br />
+    <h3>Grid Example: Core</h3>
+    <p>
+    Shows you can use a function for link attributes. Each link has a special url thats built dynamically with this function.
+    </p><br />
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+    <div id="readonly-datagrid">
+    </div>
+  </div>
+</div>
+
+{{={{{ }}}=}}
+<script>
+    $('body').on('initialized', function () {
+     //Locale.set('en-US').done(function () {
+      var grid,
+        columns = [],
+        data = [];
+
+      // Some Sample Data
+      data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action', ordered: 1, setting: {optionOne: 'One', optionTwo: 'One'}});
+      data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold', ordered: true, setting: {optionOne: 'One', optionTwo: 'One'}});
+      data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action', ordered: true, comment: 'Dynamic harness out-of-the-box /n syndicate models deliver. Disintermediate, technologies /n scale deploy social streamline, methodologies, killer podcasts innovate. Platforms A-list disintermediate, value visualize dot-com /n tagclouds platforms incentivize interactive vortals disintermediate networking, webservices envisioneer; tag share value-added, disintermediate, revolutionary.'});
+      data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 9, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action', ordered: true});
+      data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 18.00, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold', ordered: false});
+      data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 18, price: 9, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', comment: 'B2C ubiquitous communities maximize B2C synergies extend dynamic revolutionize, world-class robust peer-to-peer. Action-items semantic technologies clicks-and-mortar iterate min'});
+      data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', ordered: 0});
+      data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '100.99', status: 'OK', orderDate: new Date(2014, 6, 9, 12, 12, 12), action: 'On Hold', ordered: 0});
+
+      var dynamicHref = function(row, cell, item, col) {
+        //These links will be just text if null is returned
+        if (item.id === 1 || item.id === 2) {
+          return null;
+        }
+        return '/'+ item.productId;
+      };
+
+      //Define Columns for the Grid.
+      columns.push({ id: 'productId', hidden: true, name: 'Product Id', field: 'productId', formatter: Formatters.Readonly });
+      columns.push({ id: 'productDesc', name: 'Product Desc', field: 'productName', formatter: Formatters.Hyperlink, href: dynamicHref });
+      columns.push({ id: 'activity', name: 'Activity', field: 'activity', formatter: Formatters.Hyperlink, href: '/{{value}}'});
+      columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity'});
+      columns.push({ id: 'price1', name: 'Price', field: 'price', formatter: Formatters.Decimal});
+      columns.push({ id: 'price2', name: 'Price', field: 'price', formatter: Formatters.Integer});
+
+      //Init the grid
+      $('#readonly-datagrid').datagrid({
+        columns: columns,
+        dataset: data
+      });
+    });
+
+</script>

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4796,7 +4796,10 @@ Datagrid.prototype = {
     this.table
       .off('click.datagrid')
       .on('click.datagrid', '.datagrid-row a', (e) => {
-        e.preventDefault();
+        const href = e.currentTarget.getAttribute('href');
+        if (!href || href === '#') {
+          e.preventDefault();
+        }
       });
 
     // Handle Row Clicking


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Probably had this question 10 times now. After adding this code in 4.6 links no longer redirect unless you use the click function. Correcting this.

**Related github/jira issue (required)**:
Closes #1473 

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-link-hrefs.html
- click any links in the datagrid
- they will now redirect the url
NOTE: I dont have real URLS so the urls will fail but the page will redirect is the point.