### PR TITLE
1422 - Added support to allowChildExpandOnMatch with datagrid

### DIFF
--- a/app/views/components/datagrid/test-tree-filter-child-on-match.html
+++ b/app/views/components/datagrid/test-tree-filter-child-on-match.html
@@ -1,0 +1,88 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <h3>Api setting: <strong>allowChildExpandOnMatch</strong></h3>
+    <p>
+      if true
+      <ul>
+        <li>&mdash; and if only parent got match then add all children nodes too</li>
+        <li>&mdash; or if one or more child node got match then add parent node and all the children nodes</li>
+      </ul>
+    </p>
+    <p>
+      if false
+      <ul>
+        <li>&mdash; and if only parent got match then make expand/collapse button to be collapsed, disabled and do not add any children nodes</li>
+        <li>&mdash; or if one or more child node got match then add parent node and only matching children nodes</li>
+      </ul>
+    </p>
+    <br><br>
+  </div>
+</div>
+<div class="row">
+  <div class="twelve columns">
+    <div class="switch">
+      <input type="checkbox" class="switch" id="toggle" name="toggle" />
+      <label for="toggle">allowChildExpandOnMatch: <strong class="toggle-val"></strong></label>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    // Set vars
+    var elem = $('#datagrid');
+    var toggleSwitch = $('#toggle');
+    var toggleSwitchVal = $('.toggle-val');
+    var allowChildExpandOnMatch = true;
+    var columns = [];
+
+    // Make switch default to checked/unchecked
+    toggleSwitch.prop('checked', allowChildExpandOnMatch);
+    toggleSwitchVal.text(allowChildExpandOnMatch);
+
+    // Define columns for the grid.
+    columns.push({ id: 'taskName', name: 'Task', field: 'taskName', expanded: 'expanded', formatter: Formatters.Tree, filterType: 'text', width: 500});
+    columns.push({ id: 'id', name: 'Id', field: 'id', filterType: 'text', filterDisabled: true});
+    columns.push({ id: 'portable', name: 'Portable', field: 'portable', align: 'center', formatter: Formatters.Checkbox, filterType: 'checkbox'});
+    columns.push({ id: 'desc', name: 'Description', field: 'desc', filterType: 'text'});
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'MM/dd/yyyy', filterType: 'date'});
+
+    // Get some data via ajax
+    var url = '{{basepath}}api/tree-tasks';
+    $.getJSON(url, function(data) {
+
+      // Initialize the datagrid
+      elem.datagrid({
+        columns: columns,
+        dataset: data,
+        treeGrid: true,
+        filterable: true,
+        allowChildExpandOnMatch: allowChildExpandOnMatch,
+        toolbar: {title: 'Tasks (Hierarchical)', results: true, personalize: true}
+      });
+
+      // Get datagrid api
+      var datagridApi = elem.data('datagrid');
+
+      // Bind switch toggles on change
+      toggleSwitch.on('change', function() {
+        allowChildExpandOnMatch = this.checked
+        toggleSwitchVal.text(allowChildExpandOnMatch);
+
+        if (datagridApi) {
+          datagridApi.settings.allowChildExpandOnMatch = allowChildExpandOnMatch;
+          datagridApi.applyFilter();
+        }
+      });
+
+    });
+
+  });
+</script>

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -366,10 +366,24 @@ const formatters = {
 
   // Tree Expand / Collapse Button and Paddings
   Tree(row, cell, value, col, item, api) {
-    const isOpen = item ? item.expanded : true;
+    let isOpen = item ? item.expanded : true;
     const depth = api && api.settings.treeDepth && api.settings.treeDepth[row] ?
       api.settings.treeDepth[row].depth : 0;
-    const button = `<button type="button" class="btn-icon datagrid-expand-btn${(isOpen ? ' is-expanded' : '')}" tabindex="-1"${(depth ? ` style="margin-left: ${(depth ? `${(30 * (depth - 1))}px` : '')}"` : '')}>
+
+    // When use filter then
+    // If (settings.allowChildExpandOnMatch === false) and only parent node got match
+    // then make expand/collapse button to be collapsed and disabled
+    const isExpandedBtnDisabled = item && item.isAllChildrenFiltered;
+    const expandedBtnDisabledHtml = isExpandedBtnDisabled ? ' disabled' : '';
+    if (isOpen && isExpandedBtnDisabled) {
+      isOpen = false;
+    }
+    if (item && typeof item.isAllChildrenFiltered !== 'undefined') {
+      // Remove key after use to reset
+      delete item.isAllChildrenFiltered;
+    }
+
+    const button = `<button type="button" class="btn-icon datagrid-expand-btn${(isOpen ? ' is-expanded' : '')}" tabindex="-1"${(depth ? ` style="margin-left: ${(depth ? `${(30 * (depth - 1))}px` : '')}"` : '')}${expandedBtnDisabledHtml}>
       <span class="icon plus-minus ${(isOpen ? ' active' : '')}"></span>
       <span class="audible">${Locale.translate('ExpandCollapse')}</span>
       </button>${(value ? ` <span>${value}</span>` : '')}`;

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1397,10 +1397,10 @@ Datagrid.prototype = {
       const lookupEl = elem.find('.lookup');
       if (lookupEl.length && typeof $().lookup === 'function') {
         lookupEl
-          .lookup(col.editorOptions || {});
-        elem.on('change', () => {
-          self.applyFilter(null, 'selected');
-        });
+          .lookup(col.editorOptions || {})
+          .on('change', () => {
+            self.applyFilter(null, 'selected');
+          });
       }
 
       const timepickerEl = elem.find('.timepicker');

--- a/test/components/datagrid/datagrid-settings.func-spec.js
+++ b/test/components/datagrid/datagrid-settings.func-spec.js
@@ -102,7 +102,8 @@ describe('Datagrid Settings', () => {
       onEditCell: null,
       onExpandRow: null,
       emptyMessage: { title: (Locale ? Locale.translate('NoData') : 'No Data Available'), info: '', icon: 'icon-empty-no-data' },
-      searchExpandableRow: true
+      searchExpandableRow: true,
+      allowChildExpandOnMatch: false
     };
     datagridObj = new Datagrid(datagridEl, { dataset: data, columns });
   });

--- a/test/components/datagrid/datagrid-tree.func-spec.js
+++ b/test/components/datagrid/datagrid-tree.func-spec.js
@@ -15,7 +15,7 @@ let datagridObj;
 
 // Define Columns for the Grid.
 const columns = [];
-columns.push({ id: 'taskName', name: 'Task', field: 'taskName', expanded: 'expanded', formatter: Formatters.Tree });
+columns.push({ id: 'taskName', name: 'Task', field: 'taskName', expanded: 'expanded', formatter: Formatters.Tree, filterType: 'text' });
 columns.push({ id: 'id', name: 'Id', field: 'id' });
 columns.push({ id: 'desc', name: 'Description', field: 'desc', editor: Editors.Input });
 columns.push({ id: 'comments', name: 'Comments', field: 'comments', formatter: Formatters.Hyperlink });
@@ -160,5 +160,52 @@ describe('Datagrid Tree', () => {
 
     expect(document.querySelectorAll('.is-dirty-cell').length).toEqual(0);
     expect(cell1.classList.contains('is-dirty-cell')).toBeFalsy();
+  });
+
+  it('Should be able to set children by allowChildExpandOnMatch:true', () => {
+    const filter = [{ columnId: 'taskName', operator: 'contains', value: 'hmm' }];
+    datagridObj.destroy();
+    datagridObj = new Datagrid(datagridEl, {
+      columns,
+      dataset: data,
+      treeGrid: true,
+      filterable: true,
+      allowChildExpandOnMatch: true
+    });
+
+    expect(document.body.querySelectorAll('tbody tr:not(.is-hidden)').length).toEqual(19);
+    datagridObj.applyFilter(filter);
+
+    expect(document.body.querySelectorAll('tbody tr:not(.is-hidden)').length).toEqual(18);
+    datagridObj.clearFilter();
+
+    expect(document.body.querySelectorAll('tbody tr:not(.is-hidden)').length).toEqual(19);
+  });
+
+  it('Should be able to set children by allowChildExpandOnMatch:false', () => {
+    const filter = [{ columnId: 'taskName', operator: 'contains', value: 'hmm' }];
+    datagridObj.destroy();
+    datagridObj = new Datagrid(datagridEl, {
+      columns,
+      dataset: data,
+      treeGrid: true,
+      filterable: true,
+      allowChildExpandOnMatch: false
+    });
+    let expandBtn = document.querySelector('tr:nth-child(1) .datagrid-expand-btn');
+
+    expect(expandBtn.disabled).toBeFalsy();
+    expect(document.body.querySelectorAll('tbody tr:not(.is-hidden)').length).toEqual(19);
+    datagridObj.applyFilter(filter);
+    expandBtn = document.querySelector('tr:nth-child(1) .datagrid-expand-btn');
+
+    expect(expandBtn.disabled).toBeTruthy();
+    expect(document.body.querySelectorAll('tbody tr:not(.is-hidden)').length).toEqual(6);
+    expect(expandBtn.querySelector('.plus-minus').classList.contains('active')).toBeFalsy();
+    datagridObj.clearFilter();
+    expandBtn = document.querySelector('tr:nth-child(1) .datagrid-expand-btn');
+
+    expect(expandBtn.disabled).toBeFalsy();
+    expect(document.body.querySelectorAll('tbody tr:not(.is-hidden)').length).toEqual(19);
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Make filtered child rows a setting `allowChildExpandOnMatch` to display the children nodes with tree datagrid.

**Related github/jira issue (required)**:
Closes #1422

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-tree-filter-child-on-match.html
- Open above link
- Use switch "allowChildExpandOnMatch" to toggle the settings
- Apply "Contains" filter on "Task" column with the word "HMM"
- if "allowChildExpandOnMatch" is "true"
- there should be 21 rows, 18-visible, 3-hidden(2,3,4 -in column "id")
- and in first row "+" button should be enabled
- if "allowChildExpandOnMatch" is "false"
- there should be 6 rows, all 6-should be visible
- and in first row "+" button should be disabled