### PR TITLE
1301 - Added fix for caps lock not working in no-search settings

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1406,7 +1406,8 @@ Dropdown.prototype = {
       this.filterTerm = this.searchInput.val();
     } else {
       this.filterTerm += $.actualChar(e);
-      if (e.key !== this.filterTerm && e.key.toLowerCase() === this.filterTerm) {
+      if (e.key !== this.filterTerm && e.key.toLowerCase() === this.filterTerm
+          && !self.settings.noSearch) {
         this.filterTerm = e.key;
       }
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When no-search setting is in `true`, it is unable to type ahead to select values when `Capslock` key is enabled.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/1301
Related PR #363 

**Steps necessary to review your pull request (required)**:

- Checkout this branch
- Run http://localhost:4000/components/dropdown/example-no-search.html
- `Caps lock` key should enabled
- Type `S`
- Expected to see value starts with letter 'S' in the dropdown

**AdditIonal Expected Behavior**
- Run http://localhost:4000/components/dropdown/example-index
- Caps lock should also work on this test page.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
