### PR TITLE
Adding returning the grid object when the lookup filter is using a custom click function

### DIFF
--- a/app/views/components/datagrid/test-filter-lookup-click-function.html
+++ b/app/views/components/datagrid/test-filter-lookup-click-function.html
@@ -1,0 +1,87 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    var grid,
+      columns = [],
+      data = [];
+
+    // Define Some Sample Data
+    data.push({ id: 1, productId: undefined, productName: 'Compressor', inStock: true, activity:  'Assemble Paint', quantity: 1, price: 410.99, orderDate: new Date(2014, 12, 8), action: 'Action', status: 'Error'});
+    data.push({ id: 2, productId: 2241202, productName: '1 Different Compressor', inStock: true, activity:  'Inspect and Repair', quantity: 2, price: 310.99, orderDate: new Date(2015, 7, 3), action: 'On Hold', status: 'Error'});
+    data.push({ id: 3, productId: 2342203, productName: 'Compressor', inStock: true, activity:  'Inspect and Repair', quantity: 1, price: 620.99, orderDate: new Date(2014, 6, 3), action: 'Action', status: 'Error'});
+    data.push({ id: 4, productId: 2445204, productName: undefined, inStock: false, activity:  'Assemble Paint', quantity: 3, price: 1210.99, orderDate: new Date(2015, 3, 3), action: 'Action', status: 'Confirmed'});
+    data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', inStock: true, activity:  'Inspect and Repair', quantity: 4, price: 810.99, orderDate: new Date(2015, 5, 5), action: 'On Hold', status: 'Confirmed'});
+    data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', inStock: false, activity:  'Inspect and Repair', quantity: 41, price: 1120.99, orderDate: new Date(2014, 6, 9), action: 'On Hold', status: 'Error'});
+    data.push({ id: 6, productId: null, productName: 'Some Compressor', inStock: true, activity:  'inspect and Repair', quantity: 41, price: 123.99, orderDate: new Date(2014, 6, 9), action: 'On Hold', status: 'Confirmed'});
+    data.push({ id: 7, productId: null, productName: null, activity:  '', quantity: null, price: null, orderDate: null, action: 'Blank Row', status: 'Confirmed'});
+    data.push({ id: 8, productId: null, productName: null, activity:  null, quantity: null, price: null, orderDate: null, action: 'Blank Row', status: 'Confirmed'});
+
+    var statuses = [{id: '', value: '', label:'&nbsp;'},
+      {id:'Confirmed', value:'Confirmed', label:'Confirmed'},
+      {id:'Error', value:'Error', label:'Error'}];
+
+    var activities = [{id: 'Assemble Paint', value:'Assemble Paint', label: 'Assemble Paint'},
+      {id: '', value: '', label: 'Default Activity'},
+      {id: 'Inspect and Repair', value:'Inspect and Repair', label: 'Inspect and Repair'}];
+
+    //lookup data
+    var lookupOptions;
+
+    lookupOptions = {
+      // field: 'productId',
+      field: function (row, field, grid) {
+        return row.productId;
+      },
+      match: function (value, row, field, grid) {
+        return (row.productId) === value;
+      },
+      click: function (event, lookup, clickArguments) {
+        console.log(event, lookup, clickArguments);
+        if ($.isEmptyObject(clickArguments)) {
+          alert('No click arguments returned');
+        } else {
+          if (!$.isEmptyObject(clickArguments.grid)) {
+            alert('Grid information found');
+          }
+        }
+      },
+
+      options: {
+        selectable: 'single', //multiselect or single
+        toolbar: {title: 'Products', results: true, dateFilter: false ,keywordFilter: false, advancedFilter: true, actions: true, views: true , rowHeight: true}
+      }
+    };
+
+    // Define Columns for the Grid.
+    columns.push({ id: 'id', name: 'Id', field: 'id', formatter: Formatters.Readonly, filterType: 'text'});
+    columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, validate: 'required', editorOptions: lookupOptions, width: 170, filterType: 'lookup' });
+    columns.push({ id: 'productName', name: 'Product Name', field: 'productName',  formatter: Formatters.Hyperlink, filterType: 'text', click: function(e, args){ console.log(e, args);} , mask: '*****************'});
+    columns.push({ id: 'activity', name: 'Activity', field: 'activity', formatter: Formatters.Dropdown, filterType: 'multiselect', options: activities, editorOptions: {showSelectAll: true}});
+    columns.push({ id: 'quantity', name: 'Qty', field: 'quantity', align: 'right', filterType: 'integer'});
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'MM/dd/yyyy', filterType: 'date', width: 250});
+    columns.push({ id: 'inStock', name: 'In Stock', field: 'inStock', formatter: Formatters.Checkbox, align: 'center', filterType: 'checkbox'});
+    columns.push({ id: 'status', name: 'Status', align: 'center', field: 'status', formatter: Formatters.Alert, filterType: 'select', editorOptions: {clearable: true}, options: statuses, ranges: [{'value':'Confirmed', 'classes': 'success', text: 'Confirmed'}, {'value':'Error', 'classes': 'error', text: 'Error'}]});
+    columns.push({ id: 'price',  name: 'Price', field: 'price', formatter: Formatters.Decimal, filterType: 'decimal', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###,####.000'});
+
+    // Init and get the api for the grid
+    $('#datagrid').datagrid({
+      columns: columns,
+      dataset: data,
+      filterable: true,
+      selectable: 'single',
+      editable: true,
+      emptyMessage: {title: Locale.translate('NoData'), info: Locale.translate('NoDataFilter'), icon: 'icon-empty-no-data'},
+      toolbar: {title: 'Filterable Datagrid', filterRow: true, results: true, dateFilter: false ,keywordFilter: false, actions: true, views: false, rowHeight: true, collapsibleFilter: false}
+    }).on('filtered', function (e, args) {
+      console.log('filter ran', args);
+    });
+  });
+
+</script>

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1396,6 +1396,16 @@ Datagrid.prototype = {
 
       const lookupEl = elem.find('.lookup');
       if (lookupEl.length && typeof $().lookup === 'function') {
+        if (col.editorOptions) {
+          if (col.editorOptions.clickArguments) {
+            col.editorOptions.clickArguments.grid = self;
+          } else {
+            col.editorOptions.clickArguments = {
+              grid: self
+            };
+          }
+        }
+
         lookupEl
           .lookup(col.editorOptions || {})
           .on('change', () => {

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -593,8 +593,6 @@ describe('Datagrid filter lookup custom click function tests', () => {
   it('Should attempt to open the filter and have the correct popup', async () => {
     expect(await element.all(by.css('.datagrid-row')).count()).toEqual(9);
 
-    // spyOn(browser.driver., 'alert');
-
     await element(by.css('#test-filter-lookup-click-function-datagrid-1-header-1 div.datagrid-filter-wrapper span.lookup-wrapper span.trigger')).click();
 
     expect(browser.driver.switchTo().alert().getText()).toBe('Grid information found');

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -577,6 +577,31 @@ describe('Datagrid filter lookup tests', () => {
   });
 });
 
+describe('Datagrid filter lookup custom click function tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/test-filter-lookup-click-function');
+
+    const datagridEl = await element(by.id('datagrid'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should attempt to open the filter and have the correct popup', async () => {
+    expect(await element.all(by.css('.datagrid-row')).count()).toEqual(9);
+
+    // spyOn(browser.driver., 'alert');
+
+    await element(by.css('#test-filter-lookup-click-function-datagrid-1-header-1 div.datagrid-filter-wrapper span.lookup-wrapper span.trigger')).click();
+
+    expect(browser.driver.switchTo().alert().getText()).toBe('Grid information found');
+    await browser.driver.switchTo().alert().accept();
+  });
+});
+
 describe('Datagrid grouping multiselect tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-grouping-multiselect');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adding support for returning the datagrid object for a lookup filter using a custom click function.

**Related github/jira issue (required)**:
"Closes #1486"

**Steps necessary to review your pull request (required)**:
1. Pull in change and navigate to /components/datagrid/test-filter-lookup-click-function
2. Click the trigger icon for the lookup in the filter row for Product Id
3. An alert should popup with the message "Grid information found"

Can also run the e2e tests, since I automated the above test.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
