### PR TITLE
Improve 2 Nightly Tests 

### DIFF
--- a/test/components/accordion/accordion.e2e-spec.js
+++ b/test/components/accordion/accordion.e2e-spec.js
@@ -112,7 +112,7 @@ describe('Accordion Collapse Children tests', () => {
     const buttonEl = await element(by.css('#start-test'));
     await buttonEl.click();
 
-    await browser.driver.sleep(1000);
+    await browser.driver.sleep(1200);
 
     expect(await element.all(by.css('#dropdown-list')).count()).toBe(0);
     expect(await element.all(by.css('#monthview-popup')).count()).toBe(0);

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -1096,7 +1096,7 @@ describe('Datagrid select tree tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-tree-multiselect');
 
-    const datagridEl = await element(by.id('datagrid'));
+    const datagridEl = await element(by.css('.datagrid tr:nth-child(10)'));
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
   });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Saw a couple tests fail on master and browser stack. Hoping this solves it.
1. Needed possibly a longer sleep while it animates / opens/closes
1. Only waits for the datagrid not the rows to render