### PR TITLE
381 - Added fix for busy indicator closed after each click on menu

### DIFF
--- a/src/utils/lifecycle.js
+++ b/src/utils/lifecycle.js
@@ -1,6 +1,6 @@
 // Lifecycle Methods for jQuery Controls
 // Recursive methods that "globally" call certain methods on large groups of controls
-const EXCLUDED_FROM_CLOSE_CHILDREN = ['.expandable-area', '.accordion'];
+const EXCLUDED_FROM_CLOSE_CHILDREN = ['.expandable-area', '.accordion', ['soho-busyindicator']];
 const EXCLUDED_FROM_HANDLE_RESIZE = [];
 
 // Used by several of these plugins to detect whether or not the "data" property in question

--- a/src/utils/lifecycle.js
+++ b/src/utils/lifecycle.js
@@ -1,6 +1,6 @@
 // Lifecycle Methods for jQuery Controls
 // Recursive methods that "globally" call certain methods on large groups of controls
-const EXCLUDED_FROM_CLOSE_CHILDREN = ['.expandable-area', '.accordion', ['soho-busyindicator']];
+const EXCLUDED_FROM_CLOSE_CHILDREN = ['.expandable-area', '.accordion', ['soho-busyindicator'], '.busyindicator'];
 const EXCLUDED_FROM_HANDLE_RESIZE = [];
 
 // Used by several of these plugins to detect whether or not the "data" property in question


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Busy indicator tends to close right after it's started because the `close()` method is called after clicking on menu accordions.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise-ng/issues/281

**Steps necessary to review your pull request (required)**:

- Checkout this branch
- Run the enterprise on your local machine to generate the build js
- Get the zip file attached here https://github.com/infor-design/enterprise-ng/issues/281
- Download and run `npm prune && npm install`
- Run `npm run build` then after, `ng s`
- Copy the build js file of enterprise from `dist/js/sohoxi.js`
- Then paste it to `node_modules/ids-enterprise/js/sohoxi.js`
- Open http://localhost:4200/
- Click on 'Open Busy Loading Indicator' link or Open the 'Open Sub Menu' and click the 'Sub Element' link.
- Busy indicator should not interrupt or close right after it's started. 