### PR TITLE
1310 - Updated margin-left of image-placeholder to 0px

### DIFF
--- a/src/components/hierarchy/_hierarchy.scss
+++ b/src/components/hierarchy/_hierarchy.scss
@@ -798,7 +798,7 @@ html[dir='rtl'] {
       img,
       .image-placeholder {
         float: right;
-        margin-left: inherit;
+        margin-left: 0px;
         margin-right: 14px;
       }
 

--- a/src/components/hierarchy/_hierarchy.scss
+++ b/src/components/hierarchy/_hierarchy.scss
@@ -798,7 +798,7 @@ html[dir='rtl'] {
       img,
       .image-placeholder {
         float: right;
-        margin-left: 0px;
+        margin-left: 0;
         margin-right: 14px;
       }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Updated margin-left of image-placeholder to 0px
- http://localhost:4000/components/hierarchy/example-context-menu-with-details.html?locale=ar-SA

**Related github/jira issue (required)**:
Closes #1310 

**Steps necessary to review your pull request (required)**:
- On load, top leaf should now be closer to the image on the upper right
