### PR TITLE
971 - Added fix for tab content being cutoff in mobile

### DIFF
--- a/src/components/tabs-module/_tabs-module.scss
+++ b/src/components/tabs-module/_tabs-module.scss
@@ -95,7 +95,7 @@
     @include font-size(12);
 
     color: $module-tabs-inactive-text-color;
-    min-width: 120px;
+    min-width: 135px;
     overflow: hidden;
     text-align: center;
 
@@ -121,9 +121,13 @@
       font-weight: $theme-number-font-weight-bold;
       margin: 0 auto;
       overflow: hidden;
-      padding: 10px;
+      padding: 10px 10px 10px 0;
       text-overflow: ellipsis;
       white-space: nowrap;
+
+      @media (min-width: $breakpoint-phone + 60) {
+        padding: 10px;
+      }
 
       > * {
         display: inline-block;
@@ -219,7 +223,11 @@
   }
 
   .tab-more {
-    width: 120px;
+    width: 70px;
+
+    @media (min-width: $breakpoint-big-phone) {
+      width: 120px;
+    }
   }
 
   .tab-more,
@@ -460,12 +468,24 @@
   // Change state when the spillover button is necessary
   &.has-more-button {
     .tab-list {
-      width: calc(100% - 119px);
+      width: calc(100% - 70px);
+
+      @media (min-width: $breakpoint-big-phone) {
+        width: calc(100% - 120px);
+      }
     }
 
     .tab-more {
       right: 0;
       top: 0;
+
+      .more-text {
+        display: none;
+
+        @media (min-width: $breakpoint-big-phone) {
+          display: inline-block;
+        }
+      }
     }
 
     &.has-toolbar {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The tab content is a bit unreadable in mobile view. Adjusted some elements. Seems that when you resize it on browser there's no issue, but in actual device specifically in Android, there are some discrepancies on two different sections

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/971

**Steps necessary to review your pull request (required)**:

- Checkout this branch
- Open http://localhost:4000/components/tabs-multi/example-index
- Test it in browser then resize it to `320px` or test it actual device
- Tab should be more readable then previously

