### PR TITLE
1507 - Fixed an issue where immediate popups would not reopen

### DIFF
--- a/app/views/components/tree/example-context-menu.html
+++ b/app/views/components/tree/example-context-menu.html
@@ -24,7 +24,6 @@
   <li><a id="explore" href="#" data-cmd="explorer">Explore</a></li>
 </ul>
 
-
 <script>
   var sampleData;
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5079,7 +5079,7 @@ Datagrid.prototype = {
       self.triggerRowEvent('contextmenu', e, (!!self.settings.menuId));
       e.preventDefault();
 
-      if (self.settings.menuId) {
+      if (self.settings.menuId && $(`#${self.settings.menuId}`).length > 0) {
         $(e.currentTarget).popupmenu({
           menuId: self.settings.menuId,
           eventObj: e,

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -27,6 +27,7 @@ const COMPONENT_NAME = 'popupmenu';
  * @param {string} [settings.ariaListbox=false]   Switches aria to use listbox construct instead of menu construct (internal).
  * @param {string} [settings.eventObj]  Can pass in the event object so you can do a right click with immediate.
  * @param {string} [settings.triggerSelect]  If false select event will not be triggered.
+ * @param {string} [settings.removeOnDestroy] Dispose of the menu from the DOM on destroy
  * @param {string} [settings.showArrow]  If true you can explicitly set an arrow on the menu.
  * @param {boolean|function} [settings.returnFocus]  If set to false, focus will not be
   returned to the calling element. Can also be defined as a callback that can determine how
@@ -46,6 +47,7 @@ const POPUPMENU_DEFAULTS = {
   autoFocus: true,
   mouseFocus: true,
   attachToBody: false,
+  removeOnDestroy: false,
   beforeOpen: null,
   ariaListbox: false,
   eventObj: undefined,
@@ -88,9 +90,7 @@ PopupMenu.prototype = {
     // Allow for an external click event to be passed in from outside this code.
     // This event can be used to pass clientX/clientY coordinates for mouse cursor positioning.
     if (this.settings.trigger === 'immediate') {
-      if (this.menu.length) {
-        this.open(this.settings.eventObj);
-      }
+      this.open(this.settings.eventObj);
     }
 
     // Use some css rules on submenu parents
@@ -2189,7 +2189,10 @@ PopupMenu.prototype = {
     }
     if (this.settings.attachToBody && insertTarget) {
       this.menu.unwrap();
-      this.menu.off().remove();
+
+      if (this.settings.removeOnDestroy) {
+        this.menu.off().remove();
+      }
     }
     if (this.menu && insertTarget && !this.settings.attachToBody) {
       this.menu.insertAfter(insertTarget);

--- a/test/components/popupmenu/popupmenu.e2e-spec.js
+++ b/test/components/popupmenu/popupmenu.e2e-spec.js
@@ -230,3 +230,37 @@ describe('Contextmenu created dynamically tests', () => {
     expect(await element(by.id('grid-actions-menu')).getAttribute('class')).toContain('is-open');
   });
 });
+
+describe('Contextmenu immediate tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/tree/example-context-menu');
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should more than once on right click', async () => {
+    let input = await element.all(by.css('.tree a')).first();
+    await browser.actions().mouseMove(input).perform();
+    await browser.actions().click(protractor.Button.RIGHT).perform();
+
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('tree-popupmenu'))), config.waitsFor);
+
+    expect(await element(by.id('tree-popupmenu')).getAttribute('class')).toContain('is-open');
+    await element.all(by.css('#tree-popupmenu a')).first().sendKeys(protractor.Key.ESCAPE);
+
+    await browser.driver
+      .wait(protractor.ExpectedConditions.invisibilityOf(await element(by.id('tree-popupmenu'))), config.waitsFor);
+
+    expect(await element(by.id('tree-popupmenu')).getAttribute('class')).not.toContain('is-open');
+
+    input = await element.all(by.css('.tree a')).first();
+    await browser.actions().mouseMove(input).perform();
+    await browser.actions().click(protractor.Button.RIGHT).perform();
+
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('tree-popupmenu'))), config.waitsFor);
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Noticed since 4.14 popupmenus that use immediate only worked once. This fixes that.
Had to unwind 3 other issues to address. Made removeOnDestroy as a new optional setting in case thats needed.

**Related github/jira issue (required)**:
Closes #1507 
Relates to https://github.com/infor-design/enterprise/pull/1483
Relates to https://github.com/infor-design/enterprise/pull/1217

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-contextmenu-dynamic.html
- should be able to right click several times

http://localhost:4000/components/datagrid/test-contextmenu-dynamic.html
- right click in grid - nothing happens
- hit button to insert the menu
- right click in grid - now works
- try more right clicks
- check console

http://localhost:4000/components/popupmenu/test-multiple-context-menu-destroy.html
- click Destroy button and check that the popupmenu still works on remaining
