### PR TITLE
1002 - Fixed clear formatting with editor

### DIFF
--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -1903,6 +1903,7 @@ Editor.prototype = {
       };
       if (this.parentElements.indexOf(parentTag) > -1) {
         if (parentTag !== 'p') {
+          document.execCommand('removeFormat', false, null);
           replaceTag(parentEl);
         }
       } else {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Clear formatting was not working with `blockquote` and editor.

**Related github/jira issue (required)**:
Closes #1002

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/editor/test-clear-formatting.html
- Open above link
- Select some text
- Click on `Background-color` and choose any color
- Click on `Block quote`
- Now click `Clear Formatting`
- It should clear the formatting