### PR TITLE
1500 - Updated separator css to prevent separator from being out of place

### DIFF
--- a/app/views/components/searchfield/test-long-options.html
+++ b/app/views/components/searchfield/test-long-options.html
@@ -1,0 +1,44 @@
+<div class="row">
+  <div class="six columns">
+
+    <h2>Searchfield Test: Long Options</h2>
+
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+    <div class="field">
+      <label for="searchfield-objects">Searchfield Long Option</label>
+      <input data-init="false" id="searchfield-objects" type="text" class="searchfield"/>
+    </div>
+
+  </div>
+</div>
+
+<script>
+  $('body').on('initialized', function() {
+
+    var items1 = ['Item One', 'Item Two', 'Item Three', 'Item Four','Item Five'];
+
+    var items2 = [
+      {value: '1', label: 'Item One Item One Item One Item One Item One Item One Item One'},
+      {value: '2', label: 'Item Two'},
+      {value: '3', label: 'Item Three Item Three Item Three Item Three Item Three Item Three'},
+      {value: '4', label: 'Item Four'},
+      {value: '4', label: 'Item Five'}
+    ];
+
+    // Objects Example
+    var objectsField = $('#searchfield-objects').searchfield({
+      filterMode: 'contains',
+      delay: 500,
+      source: function(term, response) {
+        console.log(this);
+        response(objectsField.val(), items2);
+      }
+    });
+
+  });
+</script>
+  

--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -427,8 +427,8 @@
   .separator {
     border-bottom: 1px solid $popupmenu-border-color;
     margin: 5px 0;
-    position: sticky;
     left: 0;
+    position: sticky;
 
     &:first-child {
       border: medium none;

--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -427,6 +427,8 @@
   .separator {
     border-bottom: 1px solid $popupmenu-border-color;
     margin: 5px 0;
+    position: sticky;
+    left: 0;
 
     &:first-child {
       border: medium none;

--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -426,8 +426,8 @@
   // separator
   .separator {
     border-bottom: 1px solid $popupmenu-border-color;
-    margin: 5px 0;
     left: 0;
+    margin: 5px 0;
     position: sticky;
 
     &:first-child {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
- Updated separator css to prevent separator from being out of place
- http://localhost:4000/components/searchfield/test-long-options.html

**Related github/jira issue (required)**:
Closes #1500 

**Steps necessary to review your pull request (required)**:
- Click on searchfield and type in "item" and a dropdown with long item names should popup
- Scroll the dropdown to the right to see the long item names
- The separator should now be in place and not being scrolled
