### PR TITLE
NA - Fix visual calendar test

### DIFF
--- a/app/views/components/calendar/test-specific-month.html
+++ b/app/views/components/calendar/test-specific-month.html
@@ -44,6 +44,7 @@ $('body').one('initialized', function () {
         year: 2018,
         eventTypes: eventTypes,
         events: events,
+        upcomingEventDays: 0,
         template: 'tmpl-readonly',
         modalTemplate: 'tmpl-modal',
         menuId: 'calendar-actions-menu'

--- a/test/components/calendar/calendar.e2e-spec.js
+++ b/test/components/calendar/calendar.e2e-spec.js
@@ -120,6 +120,7 @@ describe('Calendar specific month tests', () => {
     it('Should not visual regress', async () => {
       const calendarEl = await element(by.className('calendar'));
       await browser.driver.sleep(config.sleep);
+      await element.all(by.cssContainingText('.monthview-table td', '2')).first().click();
 
       expect(await browser.protractorImageComparison.checkElement(calendarEl, 'calendar-index')).toBeLessThan(1);
     });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Because the event data had some events in the next 14 days the upcoming event section is now being rendered and the visual tests is failing. This fixes that issue by "not" rendering that section for the visual test.

Please merge this first!