### PR TITLE
1421 - Fixed background color for editing cells with datagrid

### DIFF
--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1693,7 +1693,7 @@ $datagrid-short-row-height: 23px;
 
     //Cell Editting
     &.is-editing {
-      background-color: $panel-bg-color;
+      background-color: $datagrid-cell-editing-bg-color;
       position: relative;
 
       .datagrid-cell-wrapper {

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -571,6 +571,7 @@ $datagrid-required-icon-color: $theme-color-palette-white;
 
 $datagrid-cell-color: $theme-color-font-base;
 $datagrid-cell-bg-color: $theme-color-palette-white;
+$datagrid-cell-editing-bg-color: $theme-color-palette-white;
 $datagrid-cell-readonly-bg-color: $theme-color-palette-graphite-10;
 $datagrid-cell-readonly-color: $theme-color-font-base;
 $datagrid-cell-border-color: $theme-color-palette-graphite-30;

--- a/src/themes/dark-theme.scss
+++ b/src/themes/dark-theme.scss
@@ -495,6 +495,7 @@ $datagrid-required-icon-color: $theme-color-palette-slate-100;
 
 $datagrid-cell-color: $theme-color-palette-white;
 $datagrid-cell-bg-color: $theme-color-palette-slate-80;
+$datagrid-cell-editing-bg-color: $panel-bg-color;
 $datagrid-cell-readonly-bg-color: $theme-color-palette-slate-70;
 $datagrid-cell-readonly-color: $theme-color-palette-white;
 $datagrid-cell-border-color: $theme-color-palette-slate-50;

--- a/src/themes/high-contrast-theme.scss
+++ b/src/themes/high-contrast-theme.scss
@@ -514,6 +514,7 @@ $datagrid-required-icon-color: $theme-color-palette-white;
 
 $datagrid-cell-color: $font-color;
 $datagrid-cell-bg-color: $theme-color-palette-graphite-10;
+$datagrid-cell-editing-bg-color: $theme-color-palette-white;
 $datagrid-cell-readonly-bg-color: $input-color-readonly-background;
 $datagrid-cell-readonly-color: $font-color;
 $datagrid-cell-border-color: $theme-color-palette-graphite-60;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
When editing cells in High Contrast theme, the background color was not filling to whole cell.

**Related github/jira issue (required)**:
Closes #1421

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/example-editable.html
- Open above link
- Change the theme to High Contrast
- Type "test edit" in the Activity column of the first row
- See the background color should fill to whole cell