### PR TITLE
1454 - Added fix for accordion text wrapping incorrectly

### DIFF
--- a/app/views/includes/applicationmenu-menubutton.html
+++ b/app/views/includes/applicationmenu-menubutton.html
@@ -7,7 +7,7 @@
         <use xlink:href="#icon-user-avatar-dark"></use>
       </svg>
       <span class="content">
-        <span class="name">BessyLou Jones</span>
+        <span class="name">Dikembe Mutombo Mpolondo Mukamba Jean-Jacques Wamutombo</span>
         <button type="button" class="btn-menu inverse hide-focus" data-options="{'attachToBody' : 'true', 'isInverse' : 'true', 'replaceText': 'true'}">
           <span>Add Item</span>
         </button>

--- a/src/components/applicationmenu/_applicationmenu.scss
+++ b/src/components/applicationmenu/_applicationmenu.scss
@@ -60,6 +60,13 @@
       display: table;
     }
 
+    .accordion-content {
+      .content {
+        display: inline-block;
+        max-width: calc(100% - 46px);
+      }
+    }
+
     .panel {
       padding-left: 49px;
 
@@ -206,25 +213,26 @@
     border-bottom-color: $theme-color-palette-slate-90 !important;
     margin: 0 auto;
     min-height: 85px;
-    padding: 10px 30px;
+    padding: 10px 0 10px 30px;
 
     .icon.avatar {
       border-radius: 20px;
       height: 40px;
-      top: 18px;
+      top: 10px;
+      vertical-align: top;
       width: 40px;
     }
 
     .name {
       @include font-size(18);
 
+      display: block;
+      line-height: 1.5em;
       padding: 10px;
       position: relative;
-      top: -3px;
     }
 
     .btn-menu {
-      left: 43px;
       margin-top: -5px;
 
       span {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Having a long name will overlap the icon image. Adjust some css properties to fix it.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/1454

**Steps necessary to review your pull request (required)**:

- Checkout this branch
- Run http://localhost:4000/components/applicationmenu/example-menubutton
- Click hamburger menu.
- I change the text to a long name.
- You can also add it to validate via inspecting the element in the browser.
- There should be no alignment/layout issue.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
