### PR TITLE
Fix for #1528, Hierarchy, Back button wraps in mobile views.

### DIFF
--- a/src/components/hierarchy/_hierarchy.scss
+++ b/src/components/hierarchy/_hierarchy.scss
@@ -28,6 +28,7 @@ $hierarchy-line-width: 1.34px; //Fixes zoom somewhat
   legend {
     @include font-size(14);
 
+    display: inline-block;
     margin: 20px 40px;
 
     li {
@@ -55,103 +56,12 @@ $hierarchy-line-width: 1.34px; //Fixes zoom somewhat
       width: 100%;
     }
 
-    .display-for-paging {
-      @media only screen and (min-width: $breakpoint-slim) and (max-width: $breakpoint-phablet) {
-        left: 35px;
-      }
-    }
-
     li {
       @include transition(all 200ms cubic-bezier(0.17, 0.04, 0.03, 0.94));
     }
 
     .chart {
       position: relative;
-
-      &.display-for-paging {
-        &::after {
-          @include hierarchy-vertical-line;
-
-          height: calc(100% - 124px);
-          left: -15px;
-          top: 38px;
-
-          @media (min-width: $breakpoint-phablet) {
-            left: 0;
-          }
-        }
-
-        .back {
-          left: -152px;
-          position: relative;
-          top: -10px;
-
-          @media only screen and (min-width: $breakpoint-slim) and (max-width: $breakpoint-phablet) {
-            left: -205px;
-            top: 55px;
-          }
-
-          @media (min-width: $breakpoint-phablet) {
-            left: -245px;
-            top: 55px;
-          }
-
-          button {
-            background: $theme-color-brand-primary-base;
-            color: $theme-color-palette-white;
-            display: block;
-            margin: 0 0 0 122px;
-            max-width: 36px;
-
-            @media (min-width: $breakpoint-slim) {
-              margin: 0 auto;
-            }
-
-            svg {
-              fill: $theme-color-palette-white;
-            }
-          }
-        }
-
-        .root {
-          margin-left: -30px !important;
-          overflow: visible;
-          position: relative;
-
-          &::after {
-            content: '';
-            display: none;
-            height: $hierarchy-line-width;
-            left: 0;
-            position: absolute;
-            top: 50%;
-            width: 50%;
-            z-index: -1;
-
-            @media (min-width: $breakpoint-slim) {
-              display: block;
-            }
-          }
-        }
-
-        &.has-back .root {
-          &::after {
-            left: -25px;
-          }
-        }
-      }
-
-      &.has-back {
-        &::after {
-          height: calc(100% - 170px);
-          left: -15px;
-          top: 84px;
-
-          @media (min-width: $breakpoint-phablet) {
-            left: 0;
-          }
-        }
-      }
 
       &.has-single-child .sub-level > li:last-child::before,
       &.has-single-child .sub-level > li:first-child::before,
@@ -613,6 +523,193 @@ $hierarchy-line-width: 1.34px; //Fixes zoom somewhat
       line-height: 1.4rem;
     }
   }
+
+  &.display-for-paging {
+    legend {
+      margin: 10px;
+    }
+
+    .root {
+      margin-left: -10px;
+
+      @media (min-width: $breakpoint-slim) and (max-width: $breakpoint-phablet) {
+        margin-left: -25px;
+      }
+    }
+
+    ul > li > .leaf {
+      width: 300px;
+    }
+
+    .chart {
+      @media (min-width: $breakpoint-slim) and (max-width: $breakpoint-phablet) {
+        left: 35px;
+      }
+
+      &::after {
+        @include hierarchy-vertical-line;
+
+        height: calc(100% - 124px);
+        left: -15px;
+        top: 38px;
+
+        @media (min-width: $breakpoint-phablet) {
+          left: 0;
+        }
+      }
+
+      .back {
+        position: relative;
+
+        button {
+          background: $theme-color-brand-primary-base;
+          color: $theme-color-palette-white;
+          display: block;
+          margin: 0 0 0 122px;
+          max-width: 36px;
+
+          @media (min-width: $breakpoint-slim) {
+            margin: 0 auto;
+          }
+
+          svg {
+            fill: $theme-color-palette-white;
+          }
+        }
+      }
+
+      .back-container {
+        display: flex;
+
+        .back {
+          left: -10px;
+          top: 20px;
+        }
+
+        button {
+          margin: 0;
+        }
+
+        @media (max-width: $breakpoint-phablet) {
+          margin-left: -35px;
+        }
+
+        @media (max-width: $breakpoint-slim) {
+          margin-left: 0;
+        }
+      }
+
+      .root {
+        overflow: visible;
+        position: relative;
+
+        &::after {
+          background: $hierarchy-line-color;
+          content: '';
+          display: none;
+          height: $hierarchy-line-width;
+          left: 0;
+          position: absolute;
+          top: 50%;
+          width: 50%;
+          z-index: -1;
+
+          @media (min-width: $breakpoint-slim) {
+            display: block;
+          }
+        }
+      }
+
+      // Back button is displayed
+      &.has-back {
+        .root {
+          &::after {
+            left: -25px;
+          }
+        }
+
+        // Vertical line for child nodes
+        &::after {
+          left: 6px;
+        }
+
+        .child-nodes {
+          margin-left: 20px;
+        }
+
+        .child-nodes .leaf {
+          width: 280px;
+        }
+
+        @media (min-width: $breakpoint-phablet) {
+          .child-nodes {
+            margin-left: 45px;
+          }
+
+          &::after {
+            left: 45px;
+          }
+        }
+
+        @media (max-width: $breakpoint-slim) {
+          .child-nodes {
+            margin-left: 60px;
+          }
+
+          &::after {
+            height: calc(100% - 161px);
+            left: 45px;
+            top: 75px;
+          }
+        }
+
+        @media (max-width: $breakpoint-slim) {
+          .child-nodes {
+            margin-left: 60px;
+          }
+
+          &::after {
+            height: calc(100% - 161px);
+            left: 45px;
+            top: 75px;
+          }
+        }
+
+        // iPhone 5
+        @media (max-width: $breakpoint-phone) {
+          .back-container .leaf,
+          .child-nodes .leaf {
+            width: 220px;
+          }
+        }
+
+        // Galaxy S5
+        @media (min-width: $breakpoint-phone + 1) and (max-width: 360px) {
+          .back-container .leaf,
+          .child-nodes .leaf {
+            width: 260px;
+          }
+        }
+      }
+
+      // Back button is not displayed
+      @media (max-width: $breakpoint-slim) {
+        .child-nodes {
+          margin-left: 20px;
+        }
+
+        &::after {
+          left: 5px;
+        }
+      }
+
+      @media (max-width: $breakpoint-phone) {
+        .child-nodes .leaf {
+          width: 260px;
+        }
+      }
+    }
+  }
 }
 
 // Media Query for Mobile View
@@ -648,6 +745,10 @@ $hierarchy-line-width: 1.34px; //Fixes zoom somewhat
     }
   }
 
+  &.display-for-paging .container {
+    display: table;
+  }
+
   // Top of the Chain
   .root {
     margin: 0;
@@ -678,16 +779,6 @@ $hierarchy-line-width: 1.34px; //Fixes zoom somewhat
         left: 20px;
         width: 300px;
         z-index: -1;
-      }
-    }
-  }
-
-  .display-for-paging {
-    left: 20px;
-
-    .root {
-      &::after {
-        background-color: $hierarchy-line-color;
       }
     }
   }

--- a/src/components/hierarchy/hierarchy.js
+++ b/src/components/hierarchy/hierarchy.js
@@ -660,13 +660,18 @@ Hierarchy.prototype = {
     const rootNodeHTML = [];
     const structure = {
       legend: '<legend><ul></ul></legend>',
-      chart: s.paging ? '<ul class="container"><li class="chart display-for-paging"></li></ul>' : '<ul class="container"><li class="chart"></li></ul>',
+      chart: '<ul class="container"><li class="chart"></li></ul>',
       toplevel: s.paging ? '<ul class="child-nodes"></ul>' : '<ul class="top-level"></ul>',
       sublevel: s.paging ? '' : '<ul class="sub-level"></ul>'
     };
 
     const chartContainer = this.element.append(structure.chart);
     const chart = $('.chart', chartContainer);
+
+    if (s.paging) {
+      this.element.addClass('display-for-paging');
+    }
+
 
     if (thisLegend.length !== 0) {
       this.element.prepend(structure.legend);
@@ -695,6 +700,9 @@ Hierarchy.prototype = {
 
       // Append back button to chart to go back to view previous level
       const backButton = $(backMarkup).appendTo(chart);
+
+      // Wrap back button and leaf after leaf has been rendered
+      setTimeout(() => backButton.next($('.leaf')).addBack($('.back')).wrapAll('<div class="back-container"></div>'));
 
       // Attach data reference to back button
       backButton.children('button').data(data);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fix for back button wrapping in mobile views on hierarchy chart.

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise/issues/1528

**Steps necessary to review your pull request (required)**:

1. Get new code from PR
2. http://localhost:4000/components/hierarchy/example-paging
3. Reduce screen to phone size via chrome emulator. Or use mobile device
4. Expand a leaf to display back button.
5. Back should not wrap

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
