### PR TITLE
1532 - Ensure that the passed in editorOptions are used when the datepicker gets recreated with a change in filter type

### DIFF
--- a/app/views/components/datagrid/example-filter.html
+++ b/app/views/components/datagrid/example-filter.html
@@ -66,7 +66,7 @@
       columns.push({ id: 'productName', name: 'Product Name', field: 'productName',  formatter: Formatters.Hyperlink, filterType: 'text', click: function(e, args){ console.log(e, args);} , mask: '*****************'});
       columns.push({ id: 'activity', name: 'Activity', field: 'activity', formatter: Formatters.Dropdown, filterType: 'multiselect', options: activities, editorOptions: {showSelectAll: true}});
       columns.push({ id: 'quantity', name: 'Qty', field: 'quantity', align: 'right', filterType: 'integer'});
-      columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'MM/dd/yyyy', filterType: 'date'});
+      columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'MM/dd/yyyy', filterType: 'date', editorOptions: {showMonthYearPicker: true}});
       columns.push({ id: 'inStock', name: 'In Stock', field: 'inStock', formatter: Formatters.Checkbox, align: 'center', filterType: 'checkbox'});
       columns.push({ id: 'status', name: 'Status', align: 'center', field: 'status', formatter: Formatters.Alert, filterType: 'select', editorOptions: {clearable: true}, options: statuses, ranges: [{'value':'Confirmed', 'classes': 'success', text: 'Confirmed'}, {'value':'Error', 'classes': 'error', text: 'Error'}]});
       columns.push({ id: 'price',  name: 'Price', field: 'price', formatter: Formatters.Decimal, filterType: 'decimal', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###,####.000'});

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1103,6 +1103,7 @@ Datagrid.prototype = {
       options.range = { useRange: true };
       initDatepicker();
     } else if ((!datepickerApi || isRange) && operator !== 'in-range') {
+      options.range = { useRange: false };
       input.removeData('is-range');
       initDatepicker();
     }
@@ -1284,7 +1285,7 @@ Datagrid.prototype = {
               const input = rowElem.find('input');
               const svg = rowElem.find('.btn-filter .icon-dropdown:first');
               const operator = svg.getIconName().replace('filter-', '');
-              self.filterSetDatepicker(input, operator);
+              self.filterSetDatepicker(input, operator, col.editorOptions);
             }
             self.applyFilter(null, 'selected');
           })


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Passing in the editorOptions for a datepicker when the filter type is changed.

**Related github/jira issue (required)**:
"Closes #1532 "

**Steps necessary to review your pull request (required)**:
To test:
1. Pull in the change
2. Navgiate to http://localhost:4000/components/datagrid/example-filter.html
3. Open the datepicker for Order Date, without changing the filter type.
4. The month and year should be dropdowns.
5. Close the datepicker and change it's filter type to 'in range'. Then reopen the datepicker
6 . The month and year should be dropdowns.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
