### PR TITLE
971 - Added solution so pages can run on safari <=9 [v4.15.x]

### DIFF
--- a/app/src/js/middleware/csp-handler.js
+++ b/app/src/js/middleware/csp-handler.js
@@ -1,3 +1,5 @@
+const browser = require('browser-detect');
+
 // Adds a stored "nonce" attribute to all script tags to conform with security policy.
 function addNonceToScript(html, nonce) {
   if (!html || !html.length) {
@@ -26,17 +28,29 @@ module.exports = function () {
       res.opts.nonce = Math.random().toString(12).replace(/[^a-z0-9]+/g, '').substr(0, 8);
     }
 
+    const bs = browser(req.headers['user-agent']);
+    let includeUnsafe = false;
+
+    if (bs.name === 'safari' && bs.versionNumber <= 9) {
+      includeUnsafe = true;
+    }
+    const scriptSrc = ['self',
+      `nonce-${res.opts.nonce}`,
+      'http://squizlabs.github.io',
+      'http://myserver.com'
+    ];
+
+    if (includeUnsafe) {
+      scriptSrc.push('unsafe-inline');
+    }
+
     res.setPolicy({
       policy: {
         directives: {
           'default-src': ['self',
             'https://*.infor.com'
           ],
-          'script-src': ['self',
-            `nonce-${res.opts.nonce}`,
-            'http://squizlabs.github.io',
-            'http://myserver.com'
-          ],
+          'script-src': scriptSrc,
           'connect-src': [
             'self',
             'http://myserver.com',

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "babel-loader": "^7.1.4",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-env": "^1.6.1",
+    "browser-detect": "^0.2.28",
     "browserstack-local": "^1.3.3",
     "chai-jquery": "^2.0.0",
     "chalk": "^2.3.2",

--- a/test/components/dropdown/dropdown-updates-events.func-spec.js
+++ b/test/components/dropdown/dropdown-updates-events.func-spec.js
@@ -142,17 +142,14 @@ describe('Dropdown updates, events', () => {
   });
 
   it('should trigger change event on click', (done) => {
-    const spyEvent = spyOnEvent('select.dropdown', 'change');
-    dropdownObj.open();
-
     setTimeout(() => {
+      const spyEvent = spyOnEvent('select.dropdown', 'change');
+      dropdownObj.open();
       document.body.querySelectorAll('.dropdown-option')[0].click();
 
-      setTimeout(() => {
-        expect(spyEvent).toHaveBeenTriggered();
-        done();
-      }, 300);
-    }, 300);
+      expect(spyEvent).toHaveBeenTriggered();
+      done();
+    }, 1);
   });
 
   it('should trigger change event on duplicate label', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

We found that CSP is not support for nonce values on Safari <=9 (iphone 6s or lower).
This fixes this by allowing the unsafe-inline for just those cases.

**Related github/jira issue (required)**:
#971 

**Steps necessary to review your pull request (required)**:
- pull branch
- restart server
- open any page at all like http://localhost:4000/components/datagrid/example-index.html
- do that on Iphone 6s and then on any newer browser plus chrome desktop
