### PR TITLE
970 - Renamed advance months setting for [v5.0.x]

### DIFF
--- a/app/views/components/datepicker/example-month-year-format.html
+++ b/app/views/components/datepicker/example-month-year-format.html
@@ -4,12 +4,12 @@
 
     <div class="field">
       <label for="month-year" class="label">Month / Year Together (more clicks)</label>
-      <input id="month-year" class="datepicker" name="month-year" data-options="{'showMonthYearPicker': 'true', 'hideDays': 'true', 'dateFormat': 'MM/yyyy'}" type="text">
+      <input id="month-year" class="datepicker" name="month-year" data-options="{'showMonthYearPicker': 'true', 'hideDays': 'true', 'dateFormat': 'MM/yyyy'}" type="text"/>
     </div>
 
     <div class="field">
       <label for="month-year-long" class="label">Month / Year Together - Long Version (more clicks)</label>
-      <input id="month-year-long" class="datepicker" name="month-year" data-options="{'showMonthYearPicker': 'true', 'hideDays': 'true', 'dateFormat': 'MMM yyyy'}" type="text">
+      <input id="month-year-long" class="datepicker" name="month-year" data-options="{'showMonthYearPicker': 'true', 'hideDays': 'true', 'dateFormat': 'MMM yyyy'}" type="text"/>
     </div>
 
     <div class="field">
@@ -60,13 +60,13 @@
     $('#together-month').append(months).trigger('updated');
 
     //Dynamically populate the month with an advance month range
-    var advanceMonths = 5, years= [], yearDropdown='', year = new Date().getFullYear();
+    var displayedYearsAhead = 5, years= [], yearDropdown='', year = new Date().getFullYear();
 
-    for (var i = advanceMonths; i >= 1; i--) {
+    for (var i = displayedYearsAhead; i >= 1; i--) {
       years.push(parseInt(year) - i);
     }
     years.push(year);
-    for (var j = 1; j <= advanceMonths; j++) {
+    for (var j = 1; j <= displayedYearsAhead; j++) {
       years.push(parseInt(year) + j);
     }
 
@@ -76,7 +76,6 @@
 
     $('#year-only').append(yearDropdown).trigger('updated');
     $('#together-year').append(yearDropdown).trigger('updated');
-
 
   });
 </script>

--- a/app/views/components/datepicker/example-month-year-picker.html
+++ b/app/views/components/datepicker/example-month-year-picker.html
@@ -4,7 +4,7 @@
 
     <div class="field">
       <label for="date-field-normal" class="label">Date Field</label>
-      <input id="date-field-normal" class="datepicker" name="date-field" data-options="{'showMonthYearPicker': 'true'}" type="text">
+      <input id="date-field-normal" class="datepicker" name="date-field" data-options="{'showMonthYearPicker': 'true', 'displayedYearsAhead': '8' , 'displayedYearsBehind': '1'}" type="text"/>
     </div>
 
   </div>

--- a/docs/CHANGELOG.50.md
+++ b/docs/CHANGELOG.50.md
@@ -9,6 +9,8 @@
 
 - `[Datepicker]` Renamed the setting `advanceMonths` to `displayedYearsAhead` because it  works on the year dropdown so it was incorrectly named. Also added a new setting `displayedYearsBehind` so that you can change both the number of years shown forward and backwards. This might be used for example if you only work with forward years and not that far backwards.
 
+- `[Icons]` Icons with the word `confirm` have been changed to `success`. Example: `icon-confirm` to `icon-success`. ([#1417](https://github.com/infor-design/enterprise/issues/1417))
+
 ### v5.0.0 Features
 
 ### v5.0.0 Fixes

--- a/docs/CHANGELOG.50.md
+++ b/docs/CHANGELOG.50.md
@@ -1,0 +1,18 @@
+# What's New with Enterprise
+
+## v5.0.0
+
+- [Npm Package](https://www.npmjs.com/package/ids-enterprise)
+- [IDS Enterprise Angular Change Log](https://github.com/infor-design/enterprise-ng/blob/master/docs/CHANGELOG.md)
+
+### v5.0.0 Breaking Changes
+
+- `[Datepicker]` Renamed the setting `advanceMonths` to `displayedYearsAhead` because it  works on the year dropdown so it was incorrectly named. Also added a new setting `displayedYearsBehind` so that you can change both the number of years shown forward and backwards. This might be used for example if you only work with forward years and not that far backwards.
+
+### v5.0.0 Features
+
+### v5.0.0 Fixes
+
+### v5.0.0 Chore & Maintenance
+
+(? Issues Solved this release, Backlog Enterprise ?, Backlog Ng ?, ? Functional Tests, ? e2e Test)

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -56,7 +56,8 @@ const COMPONENT_NAME = 'datepicker';
  * @param {boolean} [settings.showMonthYearPicker=false] If true the month and year will render as dropdowns.
  * @param {boolean} [settings.hideDays=false] If true the days portion of the calendar will be hidden.
  *  Usefull for Month/Year only formats.
- * @param {number} [settings.advanceMonths=5] The number of months in each direction to show in
+ * @param {number} [settings.displayedYearsAhead=5] The number of years forward to show in the year dropdown.
+ * @param {number} [settings.displayedYearsBehind=5] he number of years backwards to show in the year dropdown.
  *  the dropdown for months (when initially opening)
  * @param {array} [settings.legend]  Legend Build up
  * for example `[{name: 'Public Holiday', color: '#76B051', dates: []},
@@ -101,7 +102,8 @@ const DATEPICKER_DEFAULTS = {
   showLegend: false,
   showMonthYearPicker: false,
   hideDays: false,
-  advanceMonths: 5,
+  displayedYearsAhead: 5,
+  displayedYearsBehind: 5,
   legend: [
     // Legend Build up example
     // Color in level 6 - http://usmvvwdev53:424/controls/colors

--- a/src/components/monthview/monthview.js
+++ b/src/components/monthview/monthview.js
@@ -28,7 +28,8 @@ const COMPONENT_NAME_DEFAULTS = {
   ],
   hideDays: false,
   showMonthYearPicker: false,
-  advanceMonths: 5,
+  displayedYearsAhead: 5,
+  displayedYearsBehind: 5,
   range: {
     useRange: false, // true - if datepicker using range dates
     start: '', // Start date '03/05/2018'
@@ -85,8 +86,8 @@ const COMPONENT_NAME_DEFAULTS = {
  * @param {boolean} [settings.range.includeDisabled=false] Include disable dates in range of dates.
  * @param {boolean} [settings.hideDays=false] If true the days portion of the calendar will be hidden. Usefull for Month/Year only formats.
  * @param {boolean} [settings.showMonthYearPicker=false] If true the month and year will render as dropdowns.
- * @param {number} [settings.advanceMonths=5] The number of months in each direction to show in
- *  the dropdown for months (when initially opening)
+ * @param {number} [settings.displayedYearsAhead=5] The number of years forward to show in the year dropdown.
+ * @param {number} [settings.displayedYearsBehind=5] he number of years backwards to show in the year dropdown.
  * @param {array} [settings.legend]  Legend Build up
  * for example `[{name: 'Public Holiday', color: '#76B051', dates: []},
  * {name: 'Weekends', color: '#EFA836', dayOfWeek: []}]`
@@ -533,12 +534,11 @@ MonthView.prototype = {
       <select id="year-dropdown" class="dropdown year">`;
 
     const years = [];
-
-    for (let i = this.settings.advanceMonths; i >= 1; i--) {
+    for (let i = parseInt(this.settings.displayedYearsBehind, 10); i >= 1; i--) {
       years.push(parseInt(year, 10) - i);
     }
     years.push(year);
-    for (let j = 1; j <= this.settings.advanceMonths; j++) {
+    for (let j = 1; j <= parseInt(this.settings.displayedYearsAhead, 10); j++) {
       years.push(parseInt(year, 10) + j);
     }
 

--- a/test/components/datepicker/datepicker-api.func-spec.js
+++ b/test/components/datepicker/datepicker-api.func-spec.js
@@ -433,4 +433,36 @@ describe('DatePicker API', () => {
 
     expect($(datepickerEl).siblings('svg.icon').css('visibility')).toEqual('hidden');
   });
+
+  it('Should be able to control displayedYearsAhead and displayedYearsBehind', (done) => {
+    datepickerAPI.destroy();
+
+    datepickerAPI = new DatePicker(datepickerEl, {
+      showMonthYearPicker: true,
+      displayedYearsAhead: 8,
+      displayedYearsBehind: 1
+    });
+
+    datepickerAPI.openCalendar();
+    setTimeout(() => {
+      const allYears = document.querySelectorAll('#year-dropdown option');
+
+      expect(allYears.length).toEqual(10);
+      const currentYear = new Date().getFullYear();
+
+      expect(allYears[0].innerText).toEqual((currentYear - 1).toString());
+      expect(allYears[1].innerText).toEqual((currentYear).toString());
+      expect(allYears[2].innerText).toEqual((currentYear + 1).toString());
+      expect(allYears[3].innerText).toEqual((currentYear + 2).toString());
+      expect(allYears[4].innerText).toEqual((currentYear + 3).toString());
+      expect(allYears[5].innerText).toEqual((currentYear + 4).toString());
+      expect(allYears[6].innerText).toEqual((currentYear + 5).toString());
+      expect(allYears[7].innerText).toEqual((currentYear + 6).toString());
+      expect(allYears[8].innerText).toEqual((currentYear + 7).toString());
+      expect(allYears[9].innerText).toEqual((currentYear + 8).toString());
+
+      datepickerAPI.closeCalendar();
+      done();
+    }, 300);
+  });
 });

--- a/test/components/datepicker/datepicker-settings.func-spec.js
+++ b/test/components/datepicker/datepicker-settings.func-spec.js
@@ -50,7 +50,8 @@ describe('DatePicker Settings', () => {
       showLegend: false,
       showMonthYearPicker: false,
       hideDays: false,
-      advanceMonths: 5,
+      displayedYearsAhead: 5,
+      displayedYearsBehind: 5,
       legend: [
         // Legend Build up example
         // Color in level 6 - http://usmvvwdev53:424/controls/colors


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The datepicker advanceMonths setting was wrongly named as it worked on years. Made a new setting so you can choose how far back and forward you want to go.

Established CHANGELOG.50.md for notes on breaking changes (we will merge this when minor release is done back to CHANGELOG).

**Related github/jira issue (required)**:
Closes #970 

**Steps necessary to review your pull request (required)**:

http://localhost:4000/components/datepicker/example-month-year-picker.html
- open picker
- open year picker (this example shows one year back and 8 ahead now)
