### PR TITLE
Changes z-index on dropdown popupmenu

### DIFF
--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -210,7 +210,7 @@ div.multiselect {
   position: absolute;
   white-space: nowrap;
   width: auto;
-  z-index: 4501;
+  z-index: 24501;
 
   &.text-align-reverse {
     text-align: right;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Infor Mongoose has a setting which turns open tabs into floating elements which what I could see sets the z-index into 19000. Because of that the dropdown popup is hidden.

**Related github/jira issue (required)**:
https://jira.infor.com/browse/MUPS-2117

**Steps necessary to review your pull request (required)**:
Put dropdown component in a positioned element and give that element a high z-index above 4501