### PR TITLE
1549 - Better support for Windows paths

### DIFF
--- a/app/src/js/routes/directory-list.js
+++ b/app/src/js/routes/directory-list.js
@@ -58,20 +58,21 @@ module.exports = function directoryList(directory, viewsRoot, req, res, next) {
       let icon = '#icon-document';
       let type = 'file';
       let tempDir = `${directory}`;
+      const sep = path.sep;
 
       function hasNoTrailingSlash(dir) {
-        return dir.lastIndexOf('/') !== (dir.length - 1);
+        return dir.lastIndexOf(sep) !== (dir.length - 1);
       }
       const hasExplicitList = req.url.lastIndexOf('/list') !== -1;
 
       // handle "list"
       if (hasExplicitList) {
-        tempDir = tempDir.substr(0, tempDir.lastIndexOf('/') + 1);
+        tempDir = tempDir.substr(0, tempDir.lastIndexOf(sep) + 1);
         href = link;
       } else if (hasNoTrailingSlash(tempDir)) {
       // Correct for a missing slash at the end of the URL
-        const subDir = tempDir.substring(tempDir.lastIndexOf('/') + 1);
-        tempDir = `${tempDir}/`;
+        const subDir = tempDir.substring(tempDir.lastIndexOf(sep) + 1);
+        tempDir = `${tempDir}${sep}`;
         href = `${subDir}/${link}`;
       }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes an issue in the demoapp that was causing bad hyperlinks to be created when running on a Windows system.  The problem was due to some incorrect detection of unix path separators in Windows.

**Related github/jira issue (required)**:
Closes #1549 

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp on a Windows VM
- Navigate to http://localhost:4000/components/dropdown
- Click any example link in the list.  All of these links should be relative URL paths, and should all be working correctly.

Paging @fitzorama 