### PR TITLE
1500 - Different fix for long search items [v4.15.x]

### DIFF
--- a/src/components/autocomplete/autocomplete.js
+++ b/src/components/autocomplete/autocomplete.js
@@ -333,6 +333,16 @@ Autocomplete.prototype = {
         self.closeList(true);
       });
 
+    // Adjust the widths of the LIs to the longest
+    const lis = self.list.find('li');
+    const width = $(lis[0]).find('span').outerWidth() + 20;
+    if (width > parseInt(this.element.outerWidth(), 10)) {
+      for (let i = 0; i < lis.length; i++) {
+        lis.width(width + 'px');
+      }
+      this.maxWidth = width;
+    }
+
     // Optionally select the first item in the list
     if (self.settings.autoSelectFirstItem) {
       self.list.children().filter(':not(.separator):not(.hidden):not(.heading):not(.group):not(.is-disabled)').first()

--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -426,9 +426,7 @@
   // separator
   .separator {
     border-bottom: 1px solid $popupmenu-border-color;
-    left: 0;
     margin: 5px 0;
-    position: sticky;
 
     &:first-child {
       border: medium none;

--- a/src/components/searchfield/searchfield.js
+++ b/src/components/searchfield/searchfield.js
@@ -1893,11 +1893,15 @@ SearchField.prototype = {
       return;
     }
 
-    $('<li class="separator" role="presentation"></li>').appendTo(list);
+    const separator = $('<li class="separator" role="presentation"></li>').appendTo(list);
     const more = $('<li role="presentation"></li>').appendTo(list);
     this.moreLink = $('<a href="#" class="more-results" tabindex="-1" role="menuitem"></a>')
       .html(`<span>${Locale.translate('AllResults')} "${xssUtils.ensureAlphaNumeric(val)}"</span>`)
       .appendTo(more);
+
+    if (this.autocomplete.maxWidth) {
+      separator.width(`${this.autocomplete.maxWidth}px`);
+    }
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Reverted the fix using position: sticky as this didnt work on Safari, IE. Use a JS solution instead.

**Related github/jira issue (required)**:
Closes #1500 

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/searchfield/test-long-options.html
- Click on searchfield and type in "item" and a dropdown with long item names should popup
- Scroll the dropdown to the right to see the long item names
- The separator should now be in place and not being scrolled
- also the hover state and selected start should extend

![screen shot 2019-01-28 at 10 49 08 am](https://user-images.githubusercontent.com/814283/51852907-18357800-22f5-11e9-9689-70599a6cf33f.png)
