### PR TITLE
1545 - Fixed server side selected rows with datagrid [v4.15.x]

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -6329,12 +6329,14 @@ Datagrid.prototype = {
 
     // Unselect it
     const unselectNode = function (elem, index) {
-      const removeSelected = function (node) {
+      const removeSelected = function (node, selIdx) {
         delete node._selected;
         self.selectedRowCount--;
-
+        if (typeof selIdx === 'undefined') {
+          selIdx = index;
+        }
         for (let i = 0; i < self._selectedRows.length; i++) {
-          if (self._selectedRows[i].idx === index) {
+          if (self._selectedRows[i].idx === selIdx) {
             self._selectedRows.splice(i, 1);
             break;
           }
@@ -6363,15 +6365,19 @@ Datagrid.prototype = {
         let rowData;
 
         if (selIdx !== undefined && selIdx > -1) {
-          rowData = self.settings.dataset[selIdx];
+          rowData = s.dataset[selIdx];
         }
         if (s.groupable) {
           const row = self.actualPagingRowIndex(self.actualRowIndex(rowNode));
           const gData = self.groupArray[row];
-          rowData = self.settings.dataset[gData.group].values[gData.node];
+          rowData = s.dataset[gData.group].values[gData.node];
         }
         if (rowData !== undefined) {
-          removeSelected(rowData);
+          if (s.paging && s.source) {
+            removeSelected(rowData, selIdx);
+          } else {
+            removeSelected(rowData);
+          }
         }
       }
     };

--- a/test/components/area/area-api.func-spec.js
+++ b/test/components/area/area-api.func-spec.js
@@ -114,7 +114,7 @@ describe('Area Chart API', () => {
   it('Should show on page', () => {
     expect(document.body.querySelectorAll('.dot').length).toEqual(9);
     expect(document.body.querySelectorAll('.line-group').length).toEqual(3);
-    expect(document.body.querySelectorAll('.chart-legend')[0].innerText).toEqual('Component AComponent BComponent C');
+    expect(document.body.querySelectorAll('.chart-legend')[0].innerText.replace(/[\r\n]+/g, '')).toEqual('Component AComponent BComponent C');
   });
 
   it('Should render selected dot', () => {

--- a/test/components/blockgrid/blockgrid-api.func-spec.js
+++ b/test/components/blockgrid/blockgrid-api.func-spec.js
@@ -68,16 +68,16 @@ describe('Blockgrid API', () => {
   });
 
   it('Should support updating text', () => {
-    expect(document.querySelectorAll('.block.is-selectable p')[0].innerText.replace(/[\r\n]+/g, '')).toEqual('Neyo Taylor Infor, Developer');
-    expect(document.querySelectorAll('.block.is-selectable p')[1].innerText.replace(/[\r\n]+/g, '')).toEqual('Jane Taylor Infor, Developer');
+    expect(document.querySelectorAll('.block.is-selectable p')[0].innerText.replace(/[\s\r\n]+/g, '')).toEqual('NeyoTaylorInfor,Developer');
+    expect(document.querySelectorAll('.block.is-selectable p')[1].innerText.replace(/[\s\r\n]+/g, '')).toEqual('JaneTaylorInfor,Developer');
 
     settings.dataset[0].maintxt = 'Updated';
     settings.dataset[1].title = 'Updated';
     blockgridObj.settings.dataset = settings.dataset;
     blockgridObj.updated();
 
-    expect(document.querySelectorAll('.block.is-selectable p')[0].innerText.replace(/[\r\n]+/g, '')).toEqual('Updated Infor, Developer');
-    expect(document.querySelectorAll('.block.is-selectable p')[1].innerText.replace(/[\r\n]+/g, '')).toEqual('Updated Infor, Developer');
+    expect(document.querySelectorAll('.block.is-selectable p')[0].innerText.replace(/[\s\r\n]+/g, '')).toEqual('UpdatedInfor,Developer');
+    expect(document.querySelectorAll('.block.is-selectable p')[1].innerText.replace(/[\s\r\n]+/g, '')).toEqual('UpdatedInfor,Developer');
   });
 
   it('Should have block', () => {

--- a/test/components/blockgrid/blockgrid-api.func-spec.js
+++ b/test/components/blockgrid/blockgrid-api.func-spec.js
@@ -68,16 +68,16 @@ describe('Blockgrid API', () => {
   });
 
   it('Should support updating text', () => {
-    expect(document.querySelectorAll('.block.is-selectable p')[0].innerText.replace(/\r?\n|\r/, '')).toEqual('Neyo Taylor Infor, Developer');
-    expect(document.querySelectorAll('.block.is-selectable p')[1].innerText.replace(/\r?\n|\r/, '')).toEqual('Jane Taylor Infor, Developer');
+    expect(document.querySelectorAll('.block.is-selectable p')[0].innerText.replace(/[\r\n]+/g, '')).toEqual('Neyo Taylor Infor, Developer');
+    expect(document.querySelectorAll('.block.is-selectable p')[1].innerText.replace(/[\r\n]+/g, '')).toEqual('Jane Taylor Infor, Developer');
 
     settings.dataset[0].maintxt = 'Updated';
     settings.dataset[1].title = 'Updated';
     blockgridObj.settings.dataset = settings.dataset;
     blockgridObj.updated();
 
-    expect(document.querySelectorAll('.block.is-selectable p')[0].innerText.replace(/\r?\n|\r/, '')).toEqual('Updated Infor, Developer');
-    expect(document.querySelectorAll('.block.is-selectable p')[1].innerText.replace(/\r?\n|\r/, '')).toEqual('Updated Infor, Developer');
+    expect(document.querySelectorAll('.block.is-selectable p')[0].innerText.replace(/[\r\n]+/g, '')).toEqual('Updated Infor, Developer');
+    expect(document.querySelectorAll('.block.is-selectable p')[1].innerText.replace(/[\r\n]+/g, '')).toEqual('Updated Infor, Developer');
   });
 
   it('Should have block', () => {

--- a/test/components/bubble/bubble-api.func-spec.js
+++ b/test/components/bubble/bubble-api.func-spec.js
@@ -222,7 +222,7 @@ describe('Bubble Chart API', () => {
   it('Should show on page', () => {
     expect(document.body.querySelectorAll('.dot').length).toEqual(24);
     expect(document.body.querySelectorAll('.line-group').length).toEqual(2);
-    expect(document.body.querySelectorAll('.chart-legend')[0].innerText).toEqual('Series 01Series 02');
+    expect(document.body.querySelectorAll('.chart-legend')[0].innerText.replace(/[\r\n]+/g, '')).toEqual('Series 01Series 02');
   });
 
   it('Should render selected dot', () => {

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -972,21 +972,28 @@ describe('Datagrid paging serverside multi select tests 2nd page', () => {
     await utils.checkForErrors();
   });
 
-  it('Should be able to select and have selections clear when paging 2nd page', async () => {
-    /*
-      STEPS TODO
-      - Go to 2nd page
-      - Click on checkbox in header row to Select All (10 rows)
-      - Unselect some of them
-      - See the number of selected items should change
-      - The "Select All" icon should change from tick to "-“ icon
-    */
-    await element(await by.css('.pager-next')).click();
+  it('Should be able to select and have selections clear when paging on 2nd page', async () => {
+    await element(await by.css('.pager-next a')).click();
     await browser.driver.sleep(config.sleep);
 
     expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(0);
 
-    await element(by.css('#datagrid .datagrid-header th .datagrid-checkbox')).click();
+    const checkboxTd = await element(by.css('#datagrid .datagrid-header th .datagrid-checkbox-wrapper'));
+    await browser.actions().mouseMove(checkboxTd).perform();
+    await browser.actions().click(checkboxTd).perform();
+
+    expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(10);
+    expect(await element.all(by.css('.contextual-toolbar .title.selection-count')).getText()).toEqual(['10 Selected']);
+    expect(await element(by.css('#datagrid .datagrid-header th .datagrid-checkbox.is-checked.is-partial')).isPresent()).toBeFalsy();
+    expect(await element(by.css('#datagrid .datagrid-header th .datagrid-checkbox.is-checked')).isPresent()).toBeTruthy();
+
+    await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1)')).click();
+    await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(2) td:nth-child(1)')).click();
+
+    expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(8);
+    expect(await element.all(by.css('.contextual-toolbar .title.selection-count')).getText()).toEqual(['8 Selected']);
+    expect(await element(by.css('#datagrid .datagrid-header th .datagrid-checkbox.is-checked.is-partial')).isPresent()).toBeTruthy();
+    expect(await element(by.css('#datagrid .datagrid-header th .datagrid-checkbox.is-checked')).isPresent()).toBeTruthy();
   });
 });
 

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -959,6 +959,37 @@ describe('Datagrid paging serverside multi select tests', () => {
   });
 });
 
+describe('Datagrid paging serverside multi select tests 2nd page', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/example-paging');
+
+    const datagridEl = await element(by.id('datagrid'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should be able to select and have selections clear when paging 2nd page', async () => {
+    /*
+      STEPS TODO
+      - Go to 2nd page
+      - Click on checkbox in header row to Select All (10 rows)
+      - Unselect some of them
+      - See the number of selected items should change
+      - The "Select All" icon should change from tick to "-“ icon
+    */
+    await element(await by.css('.pager-next')).click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(0);
+
+    await element(by.css('#datagrid .datagrid-header th .datagrid-checkbox')).click();
+  });
+});
+
 describe('Datagrid paging serverside single select tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-paging-select-serverside-single');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Selected rows was not working as expected after second page with server side paging and datagrid.

**Related github/jira issue (required)**:
Closes #1545

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/example-paging.html
- Open above link
- Go to 2nd page
- Click on checkbox in header row to Select All (10 rows)
- Deselect some of them
- See the number of selected items should change
- The "Select All" icon should change from tick to "-“ icon