### PR TITLE
1564 - Hierarchy Browser Issues [v4.15.x]

### DIFF
--- a/app/views/components/hierarchy/example-lazy-load.html
+++ b/app/views/components/hierarchy/example-lazy-load.html
@@ -23,7 +23,7 @@
     var hierarchyControl = $('#hierarchy').data('hierarchy');
 
     if (eventInfo.allowLazyLoad) {
-      $.getJSON('{{basepath}}api/orgstructure-children', function(data) {
+      $.getJSON('{{basepath}}api/orgstructure-children', {_: new Date().getTime()}, function(data) {
         hierarchyControl.add(eventInfo.data.id, eventInfo.data, data);
       });
     }

--- a/app/views/components/hierarchy/example-single.html
+++ b/app/views/components/hierarchy/example-single.html
@@ -38,12 +38,14 @@
     });
 
     var hierarchyControl = $('#hierarchy').data('hierarchy');
+    var idCount = 0;
 
     $('#hierarchy').on('selected', function (event, eventInfo) {
       var hierarchyControl = $('#hierarchy').data('hierarchy');
       if (eventInfo.allowLazyLoad) {
-        $.getJSON('{{basepath}}api/orgstructure-children', function(data) {
-          hierarchyControl.add(eventInfo.data.id, eventInfo.data, data);
+        $.getJSON('{{basepath}}api/orgstructure-children', {_: new Date().getTime()}, function(data) {
+          hierarchyControl.add(eventInfo.data.id + idCount, eventInfo.data, data);
+          idCount++;
         });
       }
     });

--- a/app/views/components/hierarchy/test-infor-org.html
+++ b/app/views/components/hierarchy/test-infor-org.html
@@ -26,7 +26,7 @@
     var hierarchyControl = $('#hierarchy').data('hierarchy');
 
     if (eventInfo.allowLazyLoad) {
-      $.getJSON('{{basepath}}api/orgstructure-children', function(data) {
+      $.getJSON('{{basepath}}api/orgstructure-children', {_: new Date().getTime()}, function(data) {
         hierarchyControl.add(eventInfo.data.id, eventInfo.data, data);
       });
     }

--- a/src/components/hierarchy/_hierarchy.scss
+++ b/src/components/hierarchy/_hierarchy.scss
@@ -17,6 +17,7 @@ $hierarchy-line-width: 1.34px; //Fixes zoom somewhat
 
 .hierarchy {
   margin: 0;
+  overflow: inherit;
   padding: 20px;
 
   .branch-collapsed {

--- a/src/components/hierarchy/hierarchy.js
+++ b/src/components/hierarchy/hierarchy.js
@@ -672,7 +672,6 @@ Hierarchy.prototype = {
       this.element.addClass('display-for-paging');
     }
 
-
     if (thisLegend.length !== 0) {
       this.element.prepend(structure.legend);
       const element = $('legend', chartContainer);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixed hierarchy issues in IE and IOS. These were not totally last regressions as initially thought.
#1564 - Was regressed in 4.11
#1565 - Seemed to never work
(If that matters)

**Related github/jira issue (required)**:
Closes #1564 
Closes #1565 

**Steps necessary to review your pull request (required)**:

#1565 
Was an issue because the getJSON command cached the ajax request so the ID's were the same in subsequent ajax calls. This caused the rows to not load since the ID's where not unique since the request is cached.

- launch IE 11 (browserstack or VM)
- open http://localhost:4000/components/hierarchy/example-single.html 
- open Richard Fairbanks
- open Kaylee Edwards -> should now open
Note that for purposes of this test the data is the same.

#1564 
- launch IOS Phone X (safari) on  browserstack or x code sim)
- http://localhost:4000/components/hierarchy/example-paging.html
- drill in to Kaylee Edwards
- go back
- drill in to Jason Ayers
- go back (should show up)

For some reason the overflow needs to inherit or the rows will hide.