### PR TITLE
1556 - Added a fix from remove error on inline errors

### DIFF
--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -60,8 +60,8 @@ select.dropdown-xs {
   .icon-alert,
   .icon-info,
   .icon-pending {
-    right: 25px;
-    top: 1px;
+    right: 20px;
+    top: -5px;
   }
 
   .badge {
@@ -631,6 +631,7 @@ input.dropdown.error:focus {
     ~ .icon-error {
       margin-left: -38px;
       right: auto;
+      top: 0;
     }
 
   }

--- a/src/components/validation/validator.js
+++ b/src/components/validation/validator.js
@@ -1015,7 +1015,7 @@ Validator.prototype = {
     }
 
     // Remove tooltip style message and tooltip
-    if (loc.attr(`data-${rule.type}-type`) === 'tooltip') {
+    if (field.attr(`data-${rule.type}-type`) === 'tooltip') {
       const errorIcon = field.closest('.field, .field-short').find('.icon-error');
       const tooltipAPI = errorIcon.data('tooltip');
       // Destroy tooltip

--- a/test/components/applicationmenu/applicationmenu.e2e-spec.js
+++ b/test/components/applicationmenu/applicationmenu.e2e-spec.js
@@ -13,8 +13,7 @@ describe('Applicationmenu index tests', () => {
   it('Should show the app menu', async () => {
     const button = await element(by.css('.application-menu-trigger'));
     await button.click();
-    await browser.driver
-      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('application-menu'))), config.waitsFor);
+    await browser.driver.sleep(config.sleep);
 
     expect(await element(by.id('application-menu')).isDisplayed()).toBeTruthy();
   });
@@ -102,8 +101,7 @@ describe('Applicationmenu container tests', () => {
   it('Should show the app menu', async () => {
     const button = await element(by.css('.application-menu-trigger'));
     await button.click();
-    await browser.driver
-      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('application-menu'))), config.waitsFor);
+    await browser.driver.sleep(config.sleep);
 
     expect(await element(by.id('application-menu')).isDisplayed()).toBeTruthy();
     expect(await element.all(by.css('.accordion-header')).count()).toEqual(17);

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -175,7 +175,7 @@ describe('Datagrid Client Side Filter and Sort Tests', () => {
     await element(by.css('#datagrid thead th:nth-child(2) input')).sendKeys('22');
 
     expect(await element(by.css('#datagrid thead th:nth-child(2) input')).getAttribute('value')).toEqual('22');
-    await browser.driver.sleep(300);
+    await browser.driver.sleep(500);
 
     expect(await element(by.css('#datagrid thead th:nth-child(2) input')).getAttribute('value')).toEqual('22');
   });

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -437,7 +437,6 @@ describe('Datepicker disabled date tests', () => {
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(elem), config.waitsFor);
 
-    expect(await element(by.css('.error-message')).isPresent()).toBe(true);
     expect(await element(by.css('.error-message')).getText()).toEqual('Unavailable Date');
   });
 });

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -627,7 +627,7 @@ describe('Datepicker Month Year Picker Tests', () => {
 
   it('Should be able to function as month/year picker', async () => {
     const datepickerEl = await element(by.id('month-year'));
-    await datepickerEl.sendKeys('10/2018');
+    await datepickerEl.sendKeys('01/2018');
     await datepickerEl.sendKeys(protractor.Key.ARROW_DOWN);
 
     let dropdownEl = await element(by.css('#year-dropdown + .dropdown-wrapper div[aria-controls="dropdown-list"]'));
@@ -640,7 +640,7 @@ describe('Datepicker Month Year Picker Tests', () => {
     const buttonEl = await element(by.css('.select-month.btn-tertiary'));
     await buttonEl.click();
 
-    expect(await element(by.id('month-year')).getAttribute('value')).toEqual('10/2020');
+    expect(await element(by.id('month-year')).getAttribute('value')).toEqual('01/2020');
   });
 
   it('Should be able to function as month/year picker long', async () => {

--- a/test/components/dropdown/dropdown-updates-events.func-spec.js
+++ b/test/components/dropdown/dropdown-updates-events.func-spec.js
@@ -143,7 +143,7 @@ describe('Dropdown updates, events', () => {
 
   it('should trigger change event on click', (done) => {
     setTimeout(() => {
-      const spyEvent = spyOnEvent('select.dropdown', 'change');
+      const spyEvent = spyOnEvent('#states', 'change');
       dropdownObj.open();
       setTimeout(() => {
         document.body.querySelectorAll('.dropdown-option')[0].click();

--- a/test/components/dropdown/dropdown-updates-events.func-spec.js
+++ b/test/components/dropdown/dropdown-updates-events.func-spec.js
@@ -145,9 +145,9 @@ describe('Dropdown updates, events', () => {
     setTimeout(() => {
       const spyEvent = spyOnEvent('select.dropdown', 'change');
       dropdownObj.open();
-      document.body.querySelectorAll('.dropdown-option')[0].click();
-
       setTimeout(() => {
+        document.body.querySelectorAll('.dropdown-option')[0].click();
+
         expect(spyEvent).toHaveBeenTriggered();
         done();
       }, 100);

--- a/test/components/dropdown/dropdown-updates-events.func-spec.js
+++ b/test/components/dropdown/dropdown-updates-events.func-spec.js
@@ -147,9 +147,11 @@ describe('Dropdown updates, events', () => {
       dropdownObj.open();
       document.body.querySelectorAll('.dropdown-option')[0].click();
 
-      expect(spyEvent).toHaveBeenTriggered();
-      done();
-    }, 1);
+      setTimeout(() => {
+        expect(spyEvent).toHaveBeenTriggered();
+        done();
+      }, 100);
+    }, 100);
   });
 
   it('should trigger change event on duplicate label', () => {

--- a/test/components/validation/validation.e2e-spec.js
+++ b/test/components/validation/validation.e2e-spec.js
@@ -79,6 +79,20 @@ describe('Validation multiple error tests', () => {
 
     expect(list.count()).toBe(3);
   });
+
+  it('Should be able to call removeError after addError', async () => {
+    await browser.executeScript('$("select.dropdown").removeError().addError({ message: "Dropdown error.", inline: false })');
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('.icon-error'))), config.waitsFor);
+
+    expect(await element(by.css('.icon-error'))).toBeTruthy();
+
+    await browser.executeScript('$("select.dropdown").removeError()');
+    await browser.driver
+      .wait(protractor.ExpectedConditions.stalenessOf(await element(by.css('.icon-error'))), config.waitsFor);
+
+    expect(await element(by.css('.icon-error'))).toBeTruthy();
+  });
 });
 
 describe('Validation submit error tests', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

**Related github/jira issue (required)**:
Fixes #1556 

**Steps necessary to review your pull request (required)**:
- the added e2e test covers this but
- go to http://localhost:4000/components/validation/example-multiple-errors.html
- in the console type `$('select.dropdown').removeError().addError({ message: 'Dropdown error.', inline: false });` and an error should show
- in the console type `$('select.dropdown').removeError();` and an error should go away

Extra Credit: Edit the page so the dropdown has `field-short` instead of `field` and rerun the steps. I noticed the alignment was off so fixed that too.
