### PR TITLE
1586 - Datagrid: Equals filter on multi-select filters like a contain…

### DIFF
--- a/app/views/components/datagrid/example-filter.html
+++ b/app/views/components/datagrid/example-filter.html
@@ -13,7 +13,7 @@
         data = [];
 
       // Define Some Sample Data
-      data.push({ id: 1, productId: undefined, productName: 'Compressor', inStock: true, activity:  'Assemble Paint', quantity: 1, price: 410.99, orderDate: new Date(2014, 12, 8), action: 'Action', status: 'Error'});
+      data.push({ id: 1, productId: undefined, productName: 'Compressor', inStock: true, activity:  'Assemble', quantity: 1, price: 410.99, orderDate: new Date(2014, 12, 8), action: 'Action', status: 'Error'});
       data.push({ id: 2, productId: 2241202, productName: '1 Different Compressor', inStock: true, activity:  'Inspect and Repair', quantity: 2, price: 310.99, orderDate: new Date(2015, 7, 3), action: 'On Hold', status: 'Error'});
       data.push({ id: 3, productId: 2342203, productName: 'Compressor', inStock: true, activity:  'Inspect and Repair', quantity: 1, price: 620.99, orderDate: new Date(2014, 6, 3), action: 'Action', status: 'Error'});
       data.push({ id: 4, productId: 2445204, productName: undefined, inStock: false, activity:  'Assemble Paint', quantity: 3, price: 1210.99, orderDate: new Date(2015, 3, 3), action: 'Action', status: 'Confirmed'});
@@ -28,6 +28,7 @@
                       {id:'Error', value:'Error', label:'Error'}];
 
       var activities = [{id: 'Assemble Paint', value:'Assemble Paint', label: 'Assemble Paint'},
+                         {id: 'Assemble', value:'Assemble', label: 'Assemble'},
                          {id: '', value: '', label: 'Default Activity'},
                          {id: 'Inspect and Repair', value:'Inspect and Repair', label: 'Inspect and Repair'}];
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1725,7 +1725,7 @@ Datagrid.prototype = {
               isMatch = false;
 
               for (let k = 0; k < conditions[i].value.length; k++) {
-                const match = conditions[i].value[k].toLowerCase().indexOf(rowValue) >= 0 && (rowValue.toString() !== '' || conditions[i].value[k] === '');
+                const match = conditions[i].value[k].toLowerCase() === rowValue && (rowValue.toString() !== '' || conditions[i].value[k] === '');
                 if (match) {
                   isMatch = true;
                 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
For a multi-select filter the values are placed within an array, but similar values like "Assemble" and "Assemble Paint". If you select "Assemble Paint" then also the "Assemble" rows will display

This requires that the example-filter.html file is altered so that there is an "Assemble" activity available and that at least one row is set to "Assemble"

**Related github/jira issue (required)**:
Closes #1586 

**Steps necessary to review your pull request (required)**:
* Go to 'http://localhost:4000/components/datagrid/example-filter.html'
* Click on 'Activity filter ' and set it to "Assemble Paint"

