### PR TITLE
1550 - Fixed ellipsis was not displaying with dropdown

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -111,7 +111,12 @@ Dropdown.prototype = {
    * @returns {boolean} whether or not the text inside the in-page pseudo element too big to fit
    */
   get overflowed() {
-    return this.pseudoElem.find('span').width() > this.pseudoElem.width();
+    const span = this.pseudoElem.find('span').css('max-width', '');
+    if (span.width() > this.pseudoElem.width()) {
+      span.css('max-width', '100%');
+      return true;
+    }
+    return false;
   },
 
   /**
@@ -1865,6 +1870,10 @@ Dropdown.prototype = {
       if (isSmaller && isToBottom) {
         self.listUl[0].style.height = `${listHeight - (searchInputHeight * 2)}px`;
         self.list[0].style.height = `${parseInt(self.list[0].style.height, 10) - 10}px`;
+      }
+
+      if (placementObj.wasFlipped) {
+        self.listUl[0].style.height = `${parseInt(self.listUl[0].style.height, 10) + (searchInputHeight - 5)}px`;
       }
 
       return placementObj;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Dropdown was not displaying ellipsis when long text selected for cross browsers. Also found flipped list was not calculated the right height so this PR will fix both issues.

**Related github/jira issue (required)**:
Closes #1550

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/dropdown/test-long-text.html
http://localhost:4000/components/dropdown/test-multiselect-with-tooltip
- Open above links (test cross browsers)
- Make sure it display ellipsis
- Make browser window height smaller til open dropdown flipped to top
- See the input and trigger icon should not misaligned
