### PR TITLE
Travis CI: Use logic to exclude deploy stage for specific conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,3 +48,10 @@ jobs:
           skip_cleanup: true
           on:
             condition: $TRAVIS_EVENT_TYPE = cron
+
+# Specify stage(s) order and conditionals per stage
+stages:
+  - name: deploy
+    # do not run the deploy stage for Pull Request checks
+    # and require the branch name to be master (note for PRs this is the base branch name)
+    if: NOT type IN (pull_request) AND branch = master


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Travis is running the deploy unnecessarily on PR and custom branches.

**Related github/jira issue (required)**:
n/a

**Steps necessary to review your pull request (required)**:
1. Examine the tests/results from this branch/PR.
1. See that neither check has the "deploy" stage included
1. Make sure that commits to `master` still "deploy"
