### PR TITLE
1377 - Fixed deploy docs script async fn timing [v4.15.x]

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
     "stylelint": "^9.5.0",
     "stylelint-order": "^1.0.0",
     "uglify-es": "^3.3.10",
-    "vinyl-contents-tostring": "^1.0.0",
     "webpack": "4.20.2",
     "yargs": "^11.0.0"
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The `documentJsToHtml()` in the `deploy-documentation.js` script wasn't returning a promise to parse the documentation comments in the proper order of events leading to missing `api` data.

Note this doesn't require a v4.15.x patch, but I wanted it to be in the branch in case we ever have to redeploy the documentation for it.

**Related github/jira issue (required)**:
#1377 

**Steps necessary to review your pull request (required)**:
1. Checkout branch `4.15.x`
1. Run `npm run documentation -- --test-mode --dry-run --site=prod`
1. You should see `docs/ids-website/dist/docs/button.json` file now has a populated `"api"` property.
