### PR TITLE
1181 - Added support to get and set filter type with fieldfilter

### DIFF
--- a/app/views/components/field-filter/example-filtertype.html
+++ b/app/views/components/field-filter/example-filtertype.html
@@ -1,0 +1,132 @@
+<div class="row top-padding">
+  <div class="twelve columns">
+    <h2>FieldFilter &mdash; Filter Type</h2>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+    <button class="btn-secondary" type="button" id="btn-get">Get</button>
+    <span>Current filter: <strong class="output"></strong></span>
+    <br><br>
+    <button id="btn-set-by-index" class="btn-secondary btn-menu">
+      <span>Set (by Index)</span>
+    </button>
+    <ul id="popupmenu-by-index" class="popupmenu has-icons"></ul>
+    <button id="btn-set-by-value" class="btn-secondary btn-menu">
+      <span>Set (by Value)</span>
+    </button>
+    <ul id="popupmenu-by-value" class="popupmenu has-icons"></ul>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+
+    <div class="field">
+      <label for="filterable" class="label">Filterable</label>
+      <input id="filterable" name="filterable" type="text">
+    </div>
+
+  </div>
+</div>
+
+
+<script>
+  $('body').one('initialized', function () {
+
+    // Some Sample Data for Field Filter
+    var fieldfilterData = [
+      { value: 'equals', text: 'Equals', icon: 'filter-equals' },
+      { value: 'in-range', text: 'In Range', icon: 'filter-in-range' },
+      { value: 'does-not-equal', text: 'Does Not Equal', icon: 'filter-does-not-equal' },
+      { value: 'before', text: 'Before', icon: 'filter-less-than' },
+      { value: 'on-or-before', text: 'On Or Before', icon: 'filter-less-equals' },
+      { value: 'after', text: 'After', icon: 'filter-greater-than' },
+      { value: 'on-or-after', text: 'On Or After', icon: 'filter-greater-equals' },
+    ];
+
+    // Cache variable
+    var output = $('.output');
+    var elem = $('#filterable');
+    var btnGetFilter = $('#btn-get');
+    var btnSetFilterByIndex = $('#btn-set-by-index');
+    var btnSetFilterByValue = $('#btn-set-by-value');
+
+    // Build html for popupmenu
+    var popupmenuHtml = { byIndex: '', byValue: '' };
+    var buildPopupmenuHtml = function () {
+      var getIcon = function (icon) {
+        iconHtml = '<svg class="icon" focusable="false" aria-hidden="true" role="presentation"><use xlink:href="#icon-'+ icon +'"></use></svg>';
+        return iconHtml;
+      }
+      for (var i = 0, l = fieldfilterData.length; i < l; i++) {
+        var opt = fieldfilterData[i];
+        popupmenuHtml.byIndex += '<li><a href="#" data-idx="'+ i +'">'+ getIcon(opt.icon) +'<span>'+ i +'</span></a></li>';
+        popupmenuHtml.byValue += '<li><a href="#" data-value="'+ opt.value +'">'+ getIcon(opt.icon) +'<span>'+ opt.text +'</span></a></li>';
+      }
+    };
+    buildPopupmenuHtml();
+
+    // Invoke popupmenu for buttons
+    btnSetFilterByIndex.popupmenu({
+      menu: 'popupmenu-by-index',
+      beforeOpen: function (response, options) {
+        response(popupmenuHtml.byIndex);
+      }
+    });
+    btnSetFilterByValue.popupmenu({
+      menu: 'popupmenu-by-value',
+      beforeOpen: function (response, options) {
+        response(popupmenuHtml.byValue);
+      }
+    });
+
+
+    // Invoke fieldfilter
+    elem.fieldfilter({ dataset: fieldfilterData });
+    var fieldfilterApi = elem.data('fieldfilter');
+
+    // Get filter type
+    btnGetFilter.on('click', function () {
+      if (fieldfilterApi) {
+        var filterType = fieldfilterApi.getFilterType();
+
+        var data = filterType.data;
+        if (data) {
+          output.html(data.text);
+          console.log('Current filter:', data.text);
+        }
+      }
+    });
+
+    // Set initialized filtertype output value
+    btnGetFilter.trigger('click');
+
+    // Set filter type (by Index)
+    btnSetFilterByIndex.on('selected', function(e, anchor) {
+      if (fieldfilterApi) {
+        var idx = parseInt(anchor.attr('data-idx'), 10);
+        fieldfilterApi.setFilterType(idx);
+      }
+    });
+
+    // Set filter type (by Value)
+    btnSetFilterByValue.on('selected', function(e, anchor) {
+      if (fieldfilterApi) {
+        var value = anchor.attr('data-value');
+        fieldfilterApi.setFilterType(value);
+      }
+    });
+
+    // Bind filtered
+    elem.on('filtered', function (e, args) {
+      var data = args.data;
+      if (data) {
+        output.html(data.text);
+        console.log('Filtered:', data.text);
+      }
+    });
+
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### v4.16.0 Features
 
 - `[Busy Indicator]` Made a fix to make it possible to use a busy indicator on a modals. ([#827](https://github.com/infor-design/enterprise/issues/827))
+- `[Field Filter]` Added support to get and set filter type programmatically. ([#1181](https://github.com/infor-design/enterprise/issues/1181))
 
 ### v4.16.0 Fixes
 

--- a/src/components/field-filter/field-filter.js
+++ b/src/components/field-filter/field-filter.js
@@ -165,7 +165,7 @@ FieldFilter.prototype = {
   },
 
   /**
-   * Get currently filter type
+   * Get current filter type
    * @returns {object} The current filter type
    */
   getFilterType() {

--- a/src/components/field-filter/field-filter.js
+++ b/src/components/field-filter/field-filter.js
@@ -165,6 +165,51 @@ FieldFilter.prototype = {
   },
 
   /**
+   * Get currently filter type
+   * @returns {object} The current filter type
+   */
+  getFilterType() {
+    this.setFiltered();
+    return this.filtered;
+  },
+
+  /**
+   * Set filter type to given value
+   * @param {number|string} value to be set, index or value.
+   * @returns {void}
+   */
+  setFilterType(value) {
+    if (this.ddApi) {
+      let newIdx = -1;
+      const s = this.settings;
+      const dataset = s.dropdownOpts.source && this.ddApi ? this.ddApi.dataset : s.dataset;
+
+      if (typeof value === 'number' && value > -1 && value < dataset.length) {
+        newIdx = value;
+      } else if (typeof value === 'string') {
+        let option = this.ffdropdown.find(`option[value="${value}"]`);
+        if (!option.length) {
+          option = this.ffdropdown.find('option').filter(function () {
+            return $(this).text() === value;
+          });
+        }
+        if (option.length) {
+          newIdx = option.index();
+        }
+      }
+
+      // Make filtered
+      if (newIdx !== -1 && newIdx !== this.ffdropdown[0].selectedIndex) {
+        this.ffdropdown[0].selectedIndex = newIdx;
+        this.ddApi.updated();
+        this.ffdropdown.triggerHandler('change');
+        this.setFiltered();
+        this.element.triggerHandler('filtered', [this.filtered]);
+      }
+    }
+  },
+
+  /**
    * Attach Events used by the Control
    * @private
    * @returns {object} The api

--- a/test/components/field-filter/field-filter-api.func-spec.js
+++ b/test/components/field-filter/field-filter-api.func-spec.js
@@ -1,0 +1,98 @@
+import { FieldFilter } from '../../../src/components/field-filter/field-filter';
+
+const fieldfilterHTML = require('../../../app/views/components/field-filter/example-index.html');
+const svg = require('../../../src/components/icons/svg.html');
+
+const fieldfilterData = [
+  { value: 'equals', text: 'Equals', icon: 'filter-equals' },
+  { value: 'in-range', text: 'In Range', icon: 'filter-in-range' },
+  { value: 'does-not-equal', text: 'Does Not Equal', icon: 'filter-does-not-equal' },
+  { value: 'before', text: 'Before', icon: 'filter-less-than' },
+  { value: 'on-or-before', text: 'On Or Before', icon: 'filter-less-equals' },
+  { value: 'after', text: 'After', icon: 'filter-greater-than' },
+  { value: 'on-or-after', text: 'On Or After', icon: 'filter-greater-equals' },
+];
+
+let fieldfilterEl;
+let svgEl;
+let fieldfilterObj;
+
+describe('FieldFilter API', () => {
+  beforeEach(() => {
+    fieldfilterEl = null;
+    svgEl = null;
+    fieldfilterObj = null;
+    document.body.insertAdjacentHTML('afterbegin', svg);
+    document.body.insertAdjacentHTML('afterbegin', fieldfilterHTML);
+    fieldfilterEl = document.body.querySelector('.field-filter');
+    svgEl = document.body.querySelector('.svg-icons');
+    fieldfilterEl.classList.add('no-init');
+    fieldfilterObj = new FieldFilter(fieldfilterEl, { dataset: fieldfilterData });
+  });
+
+  afterEach(() => {
+    fieldfilterObj.destroy();
+    fieldfilterEl.parentNode.removeChild(fieldfilterEl);
+    svgEl.parentNode.removeChild(svgEl);
+  });
+
+  it('Should be defined on jQuery object', () => {
+    expect(fieldfilterObj).toEqual(jasmine.any(Object));
+  });
+
+  it('Should open fieldfilter', () => {
+    fieldfilterObj.ddApi.open();
+
+    expect(fieldfilterObj.ddApi.isOpen()).toBeTruthy();
+    expect(fieldfilterEl.parentNode.querySelector('.dropdown.is-open')).toBeTruthy();
+  });
+
+  it('Should destroy fieldfilter', () => {
+    fieldfilterObj.destroy();
+
+    expect(fieldfilterEl.parentNode.querySelector('.dropdown')).toBeFalsy();
+  });
+
+  it('Should disable fieldfilter', () => {
+    fieldfilterObj.disable();
+
+    expect(fieldfilterEl.parentNode.querySelector('.dropdown.is-disabled')).toBeTruthy();
+    expect(fieldfilterObj.ddApi.isDisabled()).toBeTruthy();
+  });
+
+  it('Should enable fieldfilter', () => {
+    fieldfilterObj.disable();
+
+    expect(fieldfilterEl.parentNode.querySelector('.dropdown.is-disabled')).toBeTruthy();
+    expect(fieldfilterObj.ddApi.isDisabled()).toBeTruthy();
+    fieldfilterObj.enable();
+
+    expect(fieldfilterEl.parentNode.querySelector('.dropdown.is-disabled')).toBeFalsy();
+    expect(fieldfilterObj.ddApi.isDisabled()).toBeFalsy();
+  });
+
+  it('Should render fieldfilter readonly', () => {
+    fieldfilterObj.readonly();
+
+    expect(fieldfilterEl.parentNode.querySelector('.dropdown.is-readonly')).toBeTruthy();
+    expect(fieldfilterObj.ddApi.isDisabled()).toBeFalsy();
+  });
+
+  it('Should get current filter type', () => {
+    expect(fieldfilterObj.getFilterType().data.value).toEqual('equals');
+  });
+
+  it('Should set filter type programmatically by string value', () => {
+    expect(fieldfilterObj.getFilterType().data.value).toEqual('equals');
+    fieldfilterObj.setFilterType('in-range');
+
+    expect(fieldfilterObj.getFilterType().data.value).toEqual('in-range');
+  });
+
+  it('Should set filter type programmatically by index', () => {
+    expect(fieldfilterObj.getFilterType().data.value).toEqual('equals');
+    fieldfilterObj.setFilterType(1);
+
+    expect(fieldfilterObj.getFilterType().data.value).toEqual('in-range');
+  });
+});

--- a/test/components/field-filter/field-filter.e2e-spec.js
+++ b/test/components/field-filter/field-filter.e2e-spec.js
@@ -1,0 +1,116 @@
+const { browserStackErrorReporter } = requireHelper('browserstack-error-reporter');
+const utils = requireHelper('e2e-utils');
+const config = requireHelper('e2e-config');
+requireHelper('rejection');
+
+jasmine.getEnv().addReporter(browserStackErrorReporter);
+
+const clickOnFieldFilter = async (id) => {
+  const ddStr = 'div[aria-controls="dropdown-list"]';
+  const triggerEl = element(by.css(id)).element(by.xpath('..')).element(by.css(ddStr));
+  await browser.driver.wait(protractor.ExpectedConditions.presenceOf(triggerEl), config.waitsFor);
+  await triggerEl.click();
+};
+
+describe('FieldFilter example-index tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/field-filter/example-index');
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should open fieldfilter list on click', async () => {
+    await clickOnFieldFilter('#example-textfield');
+
+    expect(await element(by.css('#example-textfield')).element(by.xpath('..')).element(by.className('is-open')).isDisplayed()).toBe(true);
+  });
+
+  it('Should be able to select next element', async () => {
+    const ddStr = 'div[aria-controls="dropdown-list"]';
+    const triggerEl = element(by.css('#example-textfield')).element(by.xpath('..')).element(by.css(ddStr));
+
+    await triggerEl.sendKeys(protractor.Key.ARROW_DOWN);
+
+    const ddList = await element(by.css('#dropdown-list'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(ddList), config.waitsFor);
+
+    await browser.switchTo().activeElement().sendKeys(protractor.Key.ARROW_DOWN);
+    await browser.switchTo().activeElement().sendKeys(protractor.Key.ENTER);
+    await browser.switchTo().activeElement().sendKeys(protractor.Key.TAB);
+
+    expect(await element(by.id('example-textfield-ff')).getAttribute('value')).toEqual('does-not-equal');
+  });
+
+  it('Should not contain search element', async () => {
+    await clickOnFieldFilter('#example-textfield');
+    const ddList = await element(by.css('#dropdown-list'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(ddList), config.waitsFor);
+
+    expect(await element(by.css('#example-textfield')).element(by.xpath('..')).element(by.className('is-open')).isDisplayed()).toBe(true);
+    expect(await element(by.css('#example-textfield')).element(by.xpath('..')).element(by.css('#dropdown-search')).isPresent()).toBe(false);
+  });
+});
+
+describe('FieldFilter filter type tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/field-filter/example-filtertype');
+  });
+
+  it('Should open fieldfilter on click', async () => {
+    await clickOnFieldFilter('#filterable');
+
+    expect(await element(by.css('#filterable')).element(by.xpath('..')).element(by.className('is-open')).isDisplayed()).toBe(true);
+  });
+
+  it('Should be able to get current filter type', async () => {
+    expect(await element(by.className('output')).getText()).toEqual('Equals');
+    const ddStr = 'div[aria-controls="dropdown-list"]';
+    const triggerEl = element(by.css('#filterable')).element(by.xpath('..')).element(by.css(ddStr));
+
+    await triggerEl.sendKeys(protractor.Key.ARROW_DOWN);
+
+    const ddList = await element(by.css('#dropdown-list'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(ddList), config.waitsFor);
+
+    await browser.switchTo().activeElement().sendKeys(protractor.Key.ARROW_DOWN);
+    await browser.switchTo().activeElement().sendKeys(protractor.Key.ENTER);
+    await browser.switchTo().activeElement().sendKeys(protractor.Key.TAB);
+    await element(by.id('btn-get')).click();
+
+    expect(await element(by.className('output')).getText()).toEqual('Does Not Equal');
+  });
+
+  it('Should be able to set filter type programmatically by string value', async () => {
+    expect(await element(by.className('output')).getText()).toEqual('Equals');
+    await element(by.id('btn-set-by-value')).click();
+    const popupmenu = await element(by.id('popupmenu-by-value'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(popupmenu), config.waitsFor);
+
+    await browser.switchTo().activeElement().sendKeys(protractor.Key.ARROW_DOWN);
+    await browser.switchTo().activeElement().sendKeys(protractor.Key.ARROW_DOWN);
+    await browser.switchTo().activeElement().sendKeys(protractor.Key.ENTER);
+    await element(by.id('btn-get')).click();
+
+    expect(await element(by.className('output')).getText()).toEqual('Does Not Equal');
+  });
+
+  it('Should be able to set filter type programmatically by index', async () => {
+    expect(await element(by.className('output')).getText()).toEqual('Equals');
+    await element(by.id('btn-set-by-index')).click();
+    const popupmenu = await element(by.id('popupmenu-by-index'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(popupmenu), config.waitsFor);
+
+    await browser.switchTo().activeElement().sendKeys(protractor.Key.ARROW_DOWN);
+    await browser.switchTo().activeElement().sendKeys(protractor.Key.ENTER);
+    await element(by.id('btn-get')).click();
+
+    expect(await element(by.className('output')).getText()).toEqual('In Range');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added support to getFilterType() and setFilterType() api methods with FieldFilter control.

**Related github/jira issue (required)**:
Closes #1181

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/field-filter/example-filtertype.html
- Open above link
- Open developer tools and watch for logs
- Click on buttons "Set(by Index), Set(by Value)" to change filter type
- Click on button "Get" to get current filter type
