### PR TITLE
609 - Added fix for line chart responsive issue on Mobile

### DIFF
--- a/app/views/components/line/example-index.html
+++ b/app/views/components/line/example-index.html
@@ -36,7 +36,9 @@ $('body').on('initialized', function () {
           name: 'Jun',
           value: 8111
       }],
-      name: 'Component A'
+      name: 'Component A',
+      legendShortName: 'Comp A',
+      legendAbbrName: 'A'
     }, {
       data: [{
           name: 'Jan',
@@ -57,7 +59,9 @@ $('body').on('initialized', function () {
           name: 'Jun',
           value: 2811
       }],
-      name: 'Component B'
+      name: 'Component B',
+      legendShortName: 'Comp B',
+      legendAbbrName: 'A'
     }, {
       data: [{
           name: 'Jan',
@@ -78,7 +82,9 @@ $('body').on('initialized', function () {
           name: 'Jun',
           value: 3811
       }],
-      name: 'Component C'
+      name: 'Component C',
+      legendShortName: 'Comp C',
+      legendAbbrName: 'C'
     }];
 
   $('#line-example').chart({type: 'line', dataset: dataset, yAxis: {ticks: {number: 10, format: 's'} } });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -83,6 +83,7 @@
 - `[Tabs Multi]` Improved the experience on mobile by collapsing the menus a bit. ([#971](https://github.com/infor-design/enterprise/issues/971))
 - `[Lookup]` Fixed missing ellipsis menu on mobile devices. ([#1068](https://github.com/infor-design/enterprise/issues/1068))
 - `[Accordion]` Fixed incorrect font size on p tags in the accordion. ([#1116](https://github.com/infor-design/enterprise/issues/1116))
+- `[Line Chart]` Fixed and improved the legend text on mobile viewport. ([#609](https://github.com/infor-design/enterprise/issues/609))
 
 ### v4.15.0 Chore & Maintenance
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Missing the legend 'Component C' on Mobile view.

Added abbreviation and short name and display it depends on the width (481px to 768px viewport = abbreviation, then 480 and below = short name).

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/609

**Steps necessary to review your pull request (required)**:

- Pull this branch
- Run http://localhost:4000/components/line/example-index
- Test it on mobile viewport and tablet viewport, or just resize the browser down to 320px
- Comp A, Comp B, Comp C should display on 481px to 768px viewport
- A, B, C legend should display on mobile viewport (480px and below)

<!-- Please include the following in your PR:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.
-->

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
