### PR TITLE
## - Updating Datagrid column hardcoded 0 value issue

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4096,7 +4096,7 @@ Datagrid.prototype = {
       if (orgColumn) {
         isHidden = columns[i].hidden;
 
-        $.extend(columns[i], orgColumn[0]);
+        $.extend(columns[i], orgColumn[i]);
 
         if (isHidden !== undefined) {
           columns[i].hidden = isHidden;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
The ColumnsFromString function has hadcoded column value "0" instead dynamic value.
This causes the issue when we revert the datagrid changes

When you call the function resetColumns() of the dataGrid, the function is using the variable "originalColumns" which reads the columns from Settings of the datagrid.

 ```this.originalColumns = this.columnsFromString(JSON.stringify(this.settings.columns));```

columnsFromString function loops through the columns present in given string and saves as an object value. this process saves oth Column Id in ith Column object.

```$.extend(columns[i], orgColumn[0]);```


**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
1. Set a default row into the grid on page load
1. Add a new row into the grid by adding "New" button which will call "addRow()" function
1. Call Undo function to remove added row by calling resetColumns() function
    - Result:
    The grid will be restored with first(0th) Column value in all columns
    - Expected Result:
    The grid should be restored with default column values (not by first column values)


<!-- Please include the following in your PR:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.
-->

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
