### PR TITLE
N/A - E2E change autosave option to true for debug configs

### DIFF
--- a/test/protractor.ci.debug.conf.js
+++ b/test/protractor.ci.debug.conf.js
@@ -39,7 +39,7 @@ exports.config = {
       browser.protractorImageComparison = new protractorImageComparison({
         baselineFolder: `${basePath}/baseline`,
         screenshotPath: `${basePath}/.tmp/`,
-        autoSaveBaseline: false,
+        autoSaveBaseline: true,
         ignoreAntialiasing: true,
         disableCSSAnimation: true,
         debug: false


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
When doing e2e testing and resetting the baseline images, the cli returns: `Failed: Image not found, saving current image as new baseline.` but it never creates the baseline.

**Related github/jira issue (required)**:
n/a

**Steps necessary to review your pull request (required)**:
none
