### PR TITLE
Step Process Control folder should not be selectable #1633

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,8 @@
 - `[Hierarchy]` Add print media styles to decrease ink usage and increase presentability for print format. Note that you may need to enable the setting to print background images, both Mac and PC have a setting for this. ([#456](https://github.com/infor-design/enterprise/issues/456))
 
 ### v4.16.0 Fixes
-- `[Stepprocess]` Fixed bug where step folder was selected when it was collapsed or expanded ([#1633](https://github.com/infor-design/enterprise/issues/1633))
+
+- `[Stepprocess]` Fixed a bug where the step folder was still selected when it was collapsed or expanded. ([#1633](https://github.com/infor-design/enterprise/issues/1633))
 - `[Dropdown]` Fixed a bug where the ellipsis was not showing on long text in some browsers. ([#1550](https://github.com/infor-design/enterprise/issues/1550))
 - `[Datagrid]` Fixed a bug in equals filter on multiselect filters. ([#1586](https://github.com/infor-design/enterprise/issues/1586))
 - `[Datagrid]` Fixed a bug where incorrect data is shown in the events in tree grid. ([#315](https://github.com/infor-design/enterprise-ng/issues/315))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@
 - `[Hierarchy]` Add print media styles to decrease ink usage and increase presentability for print format. Note that you may need to enable the setting to print background images, both Mac and PC have a setting for this. ([#456](https://github.com/infor-design/enterprise/issues/456))
 
 ### v4.16.0 Fixes
-- '[Stepprocess]' Fixed bug where step folder was selected when it was collapsed or expanded
+- `[Stepprocess]` Fixed bug where step folder was selected when it was collapsed or expanded ([#1633](https://github.com/infor-design/enterprise/issues/1633))
 - `[Dropdown]` Fixed a bug where the ellipsis was not showing on long text in some browsers. ([#1550](https://github.com/infor-design/enterprise/issues/1550))
 - `[Datagrid]` Fixed a bug in equals filter on multiselect filters. ([#1586](https://github.com/infor-design/enterprise/issues/1586))
 - `[Datagrid]` Fixed a bug where incorrect data is shown in the events in tree grid. ([#315](https://github.com/infor-design/enterprise-ng/issues/315))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@
 - `[Hierarchy]` Add print media styles to decrease ink usage and increase presentability for print format. Note that you may need to enable the setting to print background images, both Mac and PC have a setting for this. ([#456](https://github.com/infor-design/enterprise/issues/456))
 
 ### v4.16.0 Fixes
-
+- '[Stepprocess]' Fixed bug where step folder was selected when it was collapsed or expanded
 - `[Dropdown]` Fixed a bug where the ellipsis was not showing on long text in some browsers. ([#1550](https://github.com/infor-design/enterprise/issues/1550))
 - `[Datagrid]` Fixed a bug in equals filter on multiselect filters. ([#1586](https://github.com/infor-design/enterprise/issues/1586))
 - `[Datagrid]` Fixed a bug where incorrect data is shown in the events in tree grid. ([#315](https://github.com/infor-design/enterprise-ng/issues/315))
@@ -20,6 +20,7 @@
 - `[Validation]` Fixed a bug in removeError where the icon is sometimes not removed. ([#1556](https://github.com/infor-design/enterprise/issues/1556))
 - `[Datepicker]` Fixed the range picker to clear when changing months in a filter. ([#1537](https://github.com/infor-design/enterprise/issues/1537))
 - `[Datepicker]` Fixed disabled dates example to validate again on disabled dates. ([#1445](https://github.com/infor-design/enterprise/issues/1445))
+- `[Dategrid]` Fixed a Date Editor bug when passing a series of zeroes to a datagrid cell with an editable date. ([#1020](https://github.com/infor-design/enterprise/issues/1020))
 - `[Dategrid]` Fixed a Date Editor bug when passing a series of zeroes to a datagrid cell with an editable date. ([#1020](https://github.com/infor-design/enterprise/issues/1020))
 
 ### v4.16.0 Chore & Maintenance

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,7 +21,6 @@
 - `[Datepicker]` Fixed the range picker to clear when changing months in a filter. ([#1537](https://github.com/infor-design/enterprise/issues/1537))
 - `[Datepicker]` Fixed disabled dates example to validate again on disabled dates. ([#1445](https://github.com/infor-design/enterprise/issues/1445))
 - `[Dategrid]` Fixed a Date Editor bug when passing a series of zeroes to a datagrid cell with an editable date. ([#1020](https://github.com/infor-design/enterprise/issues/1020))
-- `[Dategrid]` Fixed a Date Editor bug when passing a series of zeroes to a datagrid cell with an editable date. ([#1020](https://github.com/infor-design/enterprise/issues/1020))
 
 ### v4.16.0 Chore & Maintenance
 

--- a/src/patterns/stepprocess/stepprocess.js
+++ b/src/patterns/stepprocess/stepprocess.js
@@ -644,19 +644,21 @@ Stepprocess.prototype = {
     const allStepLinksJq = $(this.settings.stepLink, this.stepListJq);
     const stepJq = stepLink.closest(this.settings.stepLi);
 
-    allStepLinksJq
-      .attr({
-        tabindex: '-1',
-        'aria-selected': 'false'
-      })
-      .parent().removeClass('is-selected');
+    if (!this.isFolder(stepJq)) {
+      allStepLinksJq
+        .attr({
+          tabindex: '-1',
+          'aria-selected': 'false'
+        })
+        .parent().removeClass('is-selected');
 
-    stepLink.attr({
-      tabindex: '0',
-      'aria-selected': 'true'
-    });
+      stepLink.attr({
+        tabindex: '0',
+        'aria-selected': 'true'
+      });
 
-    stepJq.addClass('is-selected');
+      stepJq.addClass('is-selected');
+    }
 
     if (this.isFolder(stepJq)) {
       // It is a folder


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Stepprocess expanding or collapsing a folder show the step as being selected, this leaves a disconnect with the end user on what step is selected and what is showing in the step panel frame.

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise/issues/1633

**Steps necessary to review your pull request (required)**:
Include:
* Go to http://localhost:4000/patterns/stepprocess-markup.html#profile
* Expand/collapse folder