### PR TITLE
1413 - Added support to preview mode with editor

### DIFF
--- a/app/views/components/editor/example-preview.html
+++ b/app/views/components/editor/example-preview.html
@@ -1,0 +1,18 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <div class="field">
+      <label class="label" for="title">Title</label>
+      <input type="text" id="title" value="The Page Title"/>
+    </div>
+
+    <div class="field">
+      <span class="label">Comments</span>
+      <div class="editor" id="editor1" role="textbox" aria-multiline="true" aria-label="Comments" data-options="{preview: true}">
+        <p>Embrace <a href="http://en.wikipedia.org/wiki/e-commerce" class="hyperlink">e-commerce action-items</a>, reintermediate, ecologies paradigms wireless share life-hacks create innovative harness. Evolve solutions rich-clientAPIs synergies harness relationships virtual vertical facilitate end-to-end, wireless, evolve synergistic synergies.</p>
+        <p>Cross-platform, evolve, ROI scale cultivate eyeballs addelivery, e-services content cross-platform leverage extensible viral incentivize integrateAJAX-enabled sticky evolve magnetic cultivate leverage; cutting-edge. Innovate, end-to-end podcasting, whiteboard streamline e-business social; compelling, "cross-media exploit infomediaries innovative integrate integrateAJAX-enabled." Killer interactive reinvent, cultivate widgets leverage morph.</p>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/app/views/components/editor/example-preview.html
+++ b/app/views/components/editor/example-preview.html
@@ -1,5 +1,10 @@
+<div class="row top-padding">
+  <div class="twelve columns">
+    <button class="btn-secondary" type="button" id="btn-toggle"></button>
+  </div>
+</div>
 
-<div class="row">
+<div class="row top-padding">
   <div class="twelve columns">
     <div class="field">
       <label class="label" for="title">Title</label>
@@ -17,3 +22,31 @@
 
   </div>
 </div>
+
+<script>
+  $('body').one('initialized', function () {
+    // Cache variable
+    var btnToggle = $('#btn-toggle');
+    var editorApi = $('#editor1').data('editor');
+    var textEditable = 'Change to Editable Mode';
+    var textPreview = 'Change to Preview Mode';
+
+    // Initialy set button text
+    if (editorApi) {
+      btnToggle.text(editorApi.isPreview() ? textEditable : textPreview);
+    }
+
+    // Bind toggle
+    btnToggle.on('click', function () {
+      if (editorApi) {
+        if (editorApi.isPreview()) {
+          editorApi.editable();
+          btnToggle.text(textPreview);
+        } else {
+          editorApi.preview();
+          btnToggle.text(textEditable);
+        }
+      }
+    });
+  });
+</script>

--- a/app/views/components/editor/example-preview.html
+++ b/app/views/components/editor/example-preview.html
@@ -9,8 +9,9 @@
     <div class="field">
       <span class="label">Comments</span>
       <div class="editor" id="editor1" role="textbox" aria-multiline="true" aria-label="Comments" data-options="{preview: true}">
-        <p>Embrace <a href="http://en.wikipedia.org/wiki/e-commerce" class="hyperlink">e-commerce action-items</a>, reintermediate, ecologies paradigms wireless share life-hacks create innovative harness. Evolve solutions rich-clientAPIs synergies harness relationships virtual vertical facilitate end-to-end, wireless, evolve synergistic synergies.</p>
-        <p>Cross-platform, evolve, ROI scale cultivate eyeballs addelivery, e-services content cross-platform leverage extensible viral incentivize integrateAJAX-enabled sticky evolve magnetic cultivate leverage; cutting-edge. Innovate, end-to-end podcasting, whiteboard streamline e-business social; compelling, "cross-media exploit infomediaries innovative integrate integrateAJAX-enabled." Killer interactive reinvent, cultivate widgets leverage morph.</p>
+        <p>Embrace <a href="http://en.wikipedia.org/wiki/e-commerce" class="hyperlink hide-focus">e-commerce action-items</a>, reintermediate, ecologies paradigms wireless share life-hacks create innovative harness. <b>Evolve solutions rich-clientAPIs</b> synergies harness relationships <i>virtual vertical facilitate end-to-end</i>, wireless, evolve synergistic synergies.</p>
+        <p>Cross-platform, <font color="#de7223">evolve, ROI scale cultivate eyeballs</font> <font color="#56932e">addelivery</font>, e-services content cross-platform l<strike>everage extensible viral incentivize</strike> integrateAJAX-enabled sticky evolve magnetic cultivate leverage; cutting-edge.</p><blockquote>Innovate, end-to-end podcasting, whiteboard streamline e-business social; compelling, cross-media exploit infomediaries innovative integrate integrateAJAX-enabled.</blockquote>
+        <p>Killer interactive reinvent, cultivate widgets leverage morph.</p><ul><li>Item One</li><li>Item Two</li><li>Item Three</li></ul>
       </div>
     </div>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### v4.16.0 Features
 
 - `[Busy Indicator]` Made a fix to make it possible to use a busy indicator on a modals. ([#827](https://github.com/infor-design/enterprise/issues/827))
+- `[Editor]` Added new state called "preview" a non editable mode to editor. Where it only shows the HTML with no toolbar, borders etc. ([#1413](https://github.com/infor-design/enterprise/issues/1413))
 - `[Field Filter]` Added support to get and set filter type programmatically. ([#1181](https://github.com/infor-design/enterprise/issues/1181))
 - `[Hierarchy]` Add print media styles to decrease ink usage and increase presentability for print format. Note that you may need to enable the setting to print background images, both Mac and PC have a setting for this. ([#456](https://github.com/infor-design/enterprise/issues/456))
 

--- a/src/components/editor/_editor.scss
+++ b/src/components/editor/_editor.scss
@@ -100,6 +100,32 @@
     top: 54px;
   }
 
+  &.is-preview {
+    .editor-toolbar {
+      display: none;
+    }
+
+    .hyperlink {
+      cursor: pointer;
+    }
+
+    .editor {
+      background-color: transparent;
+      border: none;
+      box-shadow: none;
+      height: auto;
+      min-height: auto;
+      padding: 0;
+    }
+
+    &.is-active,
+    &.is-active:hover {
+      .editor {
+        box-shadow: none;
+      }
+    }
+  }
+
 }
 
 .editor {

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -2324,6 +2324,14 @@ Editor.prototype = {
   },
 
   /**
+   * Check for the editor is in preview mode.
+   * @returns {boolean} true if editor in preview mode
+   */
+  isPreview() {
+    return this.container[0] ? this.container[0].classList.contains('is-preview') : false;
+  },
+
+  /**
    * Check for the editor is in editable mode.
    * @returns {boolean} true if editor is editabled
    */

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -33,7 +33,7 @@ const COMPONENT_NAME = 'editor';
 * @param {string} [settings.image = { url: 'https://imgplaceholder.com/250x250/368AC0/ffffff/fa-image' }] Info object to populate the image dialog defaulting to ` {url: 'http://lorempixel.com/output/cats-q-c-300-200-3.jpg'}`
 * @param {function} [settings.onLinkClick = null] Call back for clicking on links to control link behavior.
 * @param {function} [settings.showHtmlView = false] If set to true, editor should be displayed in HTML view initialy.
-* @param {function} [settings.preview = false] If set to true, editor should be displayed in preview mode non editable content.
+* @param {function} [settings.preview = false] If set to true, editor should be displayed in preview mode with noneditable content.
 */
 const EDITOR_DEFAULTS = {
   buttons: {

--- a/test/components/editor/editor-api.func-spec.js
+++ b/test/components/editor/editor-api.func-spec.js
@@ -50,4 +50,49 @@ describe('Editor API', () => {
 
     expect(editorObj.getCleanedHtml(startHtml)).toEqual(endHtml);
   });
+
+  it('Should render preview mode', () => {
+    editorObj.destroy();
+    editorObj = new Editor(editorEl, { preview: true });
+
+    expect(editorEl.parentNode.classList.contains('is-preview')).toBeTruthy();
+    expect(editorEl.parentNode.classList.contains('is-disabled')).toBeFalsy();
+    expect(editorEl.parentNode.classList.contains('is-readonly')).toBeFalsy();
+    expect(editorEl.classList.contains('is-preview')).toBeFalsy();
+    expect(editorEl.classList.contains('is-disabled')).toBeFalsy();
+    expect(editorEl.classList.contains('is-readonly')).toBeFalsy();
+    expect(editorEl.getAttribute('contenteditable')).toBe('false');
+    expect(editorEl.parentNode.querySelector('.editor-toolbar')).not.toBeVisible();
+  });
+
+  it('Should switch to preview mode', () => {
+    editorObj.preview();
+
+    expect(editorEl.parentNode.classList.contains('is-preview')).toBeTruthy();
+    expect(editorEl.parentNode.classList.contains('is-disabled')).toBeFalsy();
+    expect(editorEl.parentNode.classList.contains('is-readonly')).toBeFalsy();
+    expect(editorEl.classList.contains('is-preview')).toBeFalsy();
+    expect(editorEl.classList.contains('is-disabled')).toBeFalsy();
+    expect(editorEl.classList.contains('is-readonly')).toBeFalsy();
+    expect(editorEl.getAttribute('contenteditable')).toBe('false');
+    expect(editorEl.parentNode.querySelector('.editor-toolbar')).not.toBeVisible();
+  });
+
+  it('Should switch to preview and editable modes', () => {
+    editorObj.preview();
+
+    expect(editorEl.parentNode.classList.contains('is-preview')).toBeTruthy();
+    expect(editorEl.parentNode.classList.contains('is-disabled')).toBeFalsy();
+    expect(editorEl.parentNode.classList.contains('is-readonly')).toBeFalsy();
+    expect(editorEl.classList.contains('is-preview')).toBeFalsy();
+    expect(editorEl.classList.contains('is-disabled')).toBeFalsy();
+    expect(editorEl.classList.contains('is-readonly')).toBeFalsy();
+    expect(editorEl.getAttribute('contenteditable')).toBe('false');
+    expect(editorEl.parentNode.querySelector('.editor-toolbar')).not.toBeVisible();
+    editorObj.enable();
+
+    expect(editorEl.parentNode.classList.contains('is-preview')).toBeFalsy();
+    expect(editorEl.getAttribute('contenteditable')).toBe('true');
+    expect(editorEl.parentNode.querySelector('.editor-toolbar')).toBeVisible();
+  });
 });

--- a/test/components/editor/editor.e2e-spec.js
+++ b/test/components/editor/editor.e2e-spec.js
@@ -62,3 +62,28 @@ describe('Editor example-index tests', () => {
     });
   }
 });
+
+describe('Editor preview mode tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/editor/example-preview?layout=nofrills');
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should render editor in preview mode', async () => {
+    const container = await element(by.css('.editor-container'));
+    const elem = await element(by.css('.editor'));
+
+    expect(await container.getAttribute('class')).toContain('is-preview');
+    expect(await container.getAttribute('class')).not.toContain('is-disabled');
+    expect(await container.getAttribute('class')).not.toContain('is-readonly');
+    expect(await elem.getAttribute('class')).not.toContain('is-preview');
+    expect(await elem.getAttribute('class')).not.toContain('is-disabled');
+    expect(await elem.getAttribute('class')).not.toContain('is-readonly');
+    expect(await elem.isDisplayed()).toBeTruthy();
+    expect(await elem.getAttribute('contenteditable')).toBe('false');
+    expect(await element(by.css('.editor-toolbar')).isPresent()).toBeFalsy();
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added new state called “preview” a non editable mode to editor. Where it only shows the HTML with no toolbar, borders etc.

**Related github/jira issue (required)**:
Closes #1413

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/editor/example-preview.html
- Open above link
- See the editor it should be not editable
- Click top button "Change to Editable Mode"
- Apply any changes to editor content (text color, bold, block quote etc.)
- Click top button "Change to Preview Mode"
