### PR TITLE
1641 - selectRow and unselectRow can alter a checkbox that is not the…

### DIFF
--- a/app/views/components/datagrid/example-singleselect.html
+++ b/app/views/components/datagrid/example-singleselect.html
@@ -15,13 +15,13 @@
         data = [];
 
       // Some Sample Data
-      data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
-      data.push({ id: 2, productId: 2241202, productName: '1 Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
-      data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
-      data.push({ id: 4, productId: 2445204, productName: '1 Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
-      data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
-      data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
-      data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+      data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action', checked: false});
+      data.push({ id: 2, productId: 2241202, productName: '1 Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold', checked: false});
+      data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action', checked: false});
+      data.push({ id: 4, productId: 2445204, productName: '1 Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action', checked: false});
+      data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold', checked: false});
+      data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', checked: false});
+      data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', checked: false});
 
       //Define Columns for the Grid.
       columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Readonly});
@@ -31,6 +31,7 @@
       columns.push({ id: 'price', name: 'Status', field: 'price', formatter: Formatters.Alert, ranges: [{'min': 0, 'max': 150, 'classes': 'success', text: 'Confirmed'}, {'min': 151, 'max': 9999, 'classes': 'error', text: 'Error'}]});
       columns.push({ id: 'quantity', name: 'Badge', field: 'quantity', align: 'center', formatter: Formatters.Badge, sortable: false, ranges: [{'min': 0, 'max': 2, 'classes': 'error'}, {'value': 41, 'classes': 'good'}]});
       columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+      columns.push({ id: 'checked', name: 'Checked', field: 'checked', formatter: Formatters.Checkbox});
 
       //Init and get the api for the grid
       $('#datagrid').datagrid({

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5774,11 +5774,12 @@ Datagrid.prototype = {
     if ((!data || self.isRowSelected(data)) && !force) {
       return;
     }
-    checkbox = self.cellNode(elem, self.columnIdxById('selectionCheckbox'));
+    
     elem.addClass(`is-selected${self.settings.selectable === 'mixed' ? ' hide-selected-color' : ''}`).attr('aria-selected', 'true')
       .find('td').attr('aria-selected', 'true');
 
-    if (checkbox.length > 0) {
+    if (self.columnIdxById('selectionCheckbox') !== -1) {
+      checkbox = self.cellNode(elem, self.columnIdxById('selectionCheckbox'));
       checkbox.find('.datagrid-cell-wrapper .datagrid-checkbox')
         .addClass('is-checked').attr('aria-checked', 'true');
     }
@@ -6344,11 +6345,15 @@ Datagrid.prototype = {
           }
         }
       };
-      checkbox = self.cellNode(elem, self.columnIdxById('selectionCheckbox'));
+      
       elem.removeClass('is-selected hide-selected-color').removeAttr('aria-selected')
         .find('td').removeAttr('aria-selected');
-      checkbox.find('.datagrid-cell-wrapper .datagrid-checkbox')
-        .removeClass('is-checked no-animate').attr('aria-checked', 'false');
+
+      if (self.columnIdxById('selectionCheckbox') !== -1) {
+        checkbox = self.cellNode(elem, self.columnIdxById('selectionCheckbox'));
+        checkbox.find('.datagrid-cell-wrapper .datagrid-checkbox')
+          .removeClass('is-checked no-animate').attr('aria-checked', 'false');
+      }
 
       if (s.treeGrid) {
         for (let i = 0; i < s.treeDepth.length; i++) {


### PR DESCRIPTION
… selectionCheckbox

**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The method to find the selectionCheckbox can result in a cellnode that is not the selection checkbox from being selected and then altered.

If there is no selectionCheckbox columns then, self.columnIdxById('selectionCheckbox') will return -1, but the cellNode method will return the last column node for the row. If this is a checkbox then the checkbox will change.

self.cellNode(elem, self.columnIdxById('selectionCheckbox'));

**Related github/jira issue (required)**:
Closes #1641 

**Steps necessary to review your pull request (required)**:
* Go to 'http://localhost:4000/components/datagrid/example-singleselect.html'
* Click on any row to select the row


<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
