### PR TITLE
1629 - Updating hierarchy control to make sure dataset is an array and not an object

### DIFF
--- a/app/views/components/hierarchy/example-minimal.html
+++ b/app/views/components/hierarchy/example-minimal.html
@@ -10,7 +10,7 @@
 
   // Initial load
   $.getJSON('{{basepath}}api/hc-john-randolph', function(data) {
-    options.dataset = data;
+    options.dataset = [data];
     $('#hierarchy').hierarchy(options);
   });
 
@@ -27,7 +27,7 @@
 
   function reload(eventInfo, hierarchyControl, newData) {
     eventInfo.data.children = newData;
-    options.dataset = eventInfo.data.children;
+    options.dataset = [eventInfo.data.children];
     hierarchyControl.reload(options);
   }
 </script>

--- a/app/views/components/hierarchy/example-stacked.html
+++ b/app/views/components/hierarchy/example-stacked.html
@@ -17,7 +17,7 @@
 
   // Initial load
   $.getJSON('{{basepath}}api/hc-john-randolph', function(data) {
-    options.dataset = data;
+    options.dataset = [data];
     $('#hierarchy').hierarchy(options);
   });
 
@@ -25,7 +25,7 @@
     const hierarchyControl = $('#hierarchy').data('hierarchy');
     console.log(event, eventInfo);
 
-    if (eventInfo.data.childrenUrl) {
+    if (eventInfo.eventType === 'expand' || eventInfo.eventType === 'back') {
       $.getJSON(`{{basepath}}api/${eventInfo.data.childrenUrl}`, function(newData) {
         reload(eventInfo, hierarchyControl, newData);
       });
@@ -34,7 +34,7 @@
 
   function reload(eventInfo, hierarchyControl, newData) {
     eventInfo.data.children = newData;
-    options.dataset = eventInfo.data.children;
+    options.dataset = [eventInfo.data.children];
     hierarchyControl.reload(options);
   }
 </script>
@@ -48,12 +48,14 @@
     <img src="{{picture}}" class="image" alt="Image of {{name}}"/>
     {{/picture}}
     {{^picture}}
-      {{#avatarInitials}}
-      <div class="image-initials {{imageInitialBackground}}">{{avatarInitials}}</div>
-      {{/avatarInitials}}
-      {{^avatarInitials}}
-      <span class="image-placeholder"></span>
-      {{/avatarInitials}}
+
+    {{#avatarInitials}}
+    <div class="image-initials">{{avatarInitials}}</div>
+    {{/avatarInitials}}
+    {{^avatarInitials}}
+    <span class="image-placeholder"></span>
+    {{/avatarInitials}}
+
     {{/picture}}
 
     <div class="detail">
@@ -62,12 +64,21 @@
       <p class="micro">{{employmentType}}</p>
     </div>
 
+    {{#menu}}
+    <button class="btn-actions btn-icon" type="button" data-init="false" id="btn-{{id}}">
+      <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
+        <use xlink:href="#icon-more"></use>
+      </svg>
+      <span class="audible">More Info & Additional Actions</span>
+    </button>
+    <ul class="popupmenu"></ul>
+    {{/menu}}
+
     <button class="btn btn-icon" type="button">
       <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
         <use xlink:href="#icon-caret-up"></use>
       </svg>
       <span class="audible">Expand/Collapse</span>
     </button>
-
   </div>
 </script>

--- a/app/views/examples/landmark/example-orgchart.html
+++ b/app/views/examples/landmark/example-orgchart.html
@@ -17,7 +17,7 @@
 
   // Initial load
   $.getJSON('{{basepath}}api/hc-john-randolph', function(data) {
-    options.dataset = data;
+    options.dataset = [data];
     $('#hierarchy').hierarchy(options);
   });
 
@@ -34,7 +34,7 @@
 
   function reload(eventInfo, hierarchyControl, newData) {
     eventInfo.data.children = newData;
-    options.dataset = eventInfo.data.children;
+    options.dataset = [eventInfo.data.children];
     hierarchyControl.reload(options);
   }
 </script>

--- a/src/components/hierarchy/hierarchy.js
+++ b/src/components/hierarchy/hierarchy.js
@@ -99,20 +99,12 @@ Hierarchy.prototype = {
 
     // Safety check, check for data
 
-    if (s.dataset === undefined) {
-      console.error('Hierarchy dataset is undefined.');
-      return;
-    }
-
-    if (!Array.isArray(s.dataset)) {
-      console.error('Hierarchy dataset must be an Array');
-      return;
-    }
-
-    if (s.dataset.length === 0) {
+    if (s.dataset === undefined || s.dataset.length === 0 || !Array.isArray(s.dataset)) {
       this.element.emptymessage(s.emptyMessage);
-      return;
-    } else if ((s.dataset[0] && s.dataset[0].children) &&
+      return this;
+    }
+
+    if ((s.dataset[0] && s.dataset[0].children) &&
       s.dataset[0].children.length > 0 || this.isStackedLayout()) {
       this.render(s.dataset[0]);
     } else if (s.dataset && s.dataset.children.length > 0) {

--- a/src/components/hierarchy/hierarchy.js
+++ b/src/components/hierarchy/hierarchy.js
@@ -11,34 +11,34 @@ import '../../utils/animations';
 const COMPONENT_NAME = 'hierarchy';
 
 /**
-* The displays customizable hierarchical data such as an org chart.
-*
-* @class Hierarchy
-* @param {string} element The component element.
-* @param {string} [settings] The component settings.
-* @param {string} [settings.legend] Pass in custom markdown for the legend structure.
-* @param {string} [settings.legendKey] Key to use for the legend matching
-* @param {string} [settings.dataset=[]] Hierarchical Data to display
-* @param {boolean} [settings.newData=[]] New data to be appended into dataset
-* @param {string} [settings.templateId] Additional product name information to display
-* @param {boolean} [settings.mobileView=false] If true will only show mobile view, default using device info.
-* @param {number} [settings.leafHeight=null] Set the height of the leaf
-* @param {number} [settings.leafWidth=null] Set the width of the leaf
-* @param {string} [settings.beforeExpand=null] A callback that fires before node expansion of a node.
-* @param {boolean} [settings.paging=false] If true show pagination.
-* @param {boolean} [settings.renderSubLevel=false] If true elements with no children will be rendered detached
-* @param {boolean} [settings.layout=string]
-* Which layout should be rendered {'horizontal', 'mobile-only', 'stacked', 'paging'}
-* @param {object} [settings.emptyMessage = { title: 'No Data', info: , icon: 'icon-empty-no-data' }]
-* An empty message will be displayed when there is no chart data. This accepts an object of the form
-* `emptyMessage: {
-*   title: 'No Data Available',
-*   info: 'Make a selection on the list above to see results',
-*   icon: 'icon-empty-no-data',
-*   button: {text: 'xxx', click: <function>
-*   }`
-* Set this to null for no message or will default to 'No Data Found with an icon.'
-*/
+ * The displays customizable hierarchical data such as an org chart.
+ *
+ * @class Hierarchy
+ * @param {string} element The component element.
+ * @param {string} [settings] The component settings.
+ * @param {string} [settings.legend] Pass in custom markdown for the legend structure.
+ * @param {string} [settings.legendKey] Key to use for the legend matching
+ * @param {array} [settings.dataset=[]] Hierarchical Data to display
+ * @param {boolean} [settings.newData=[]] New data to be appended into dataset
+ * @param {string} [settings.templateId] Additional product name information to display
+ * @param {boolean} [settings.mobileView=false] If true will only show mobile view, default using device info.
+ * @param {number} [settings.leafHeight=null] Set the height of the leaf
+ * @param {number} [settings.leafWidth=null] Set the width of the leaf
+ * @param {string} [settings.beforeExpand=null] A callback that fires before node expansion of a node.
+ * @param {boolean} [settings.paging=false] If true show pagination.
+ * @param {boolean} [settings.renderSubLevel=false] If true elements with no children will be rendered detached
+ * @param {boolean} [settings.layout=string]
+ * Which layout should be rendered {'horizontal', 'mobile-only', 'stacked', 'paging'}
+ * @param {object} [settings.emptyMessage = { title: 'No Data', info: , icon: 'icon-empty-no-data' }]
+ * An empty message will be displayed when there is no chart data. This accepts an object of the form
+ * `emptyMessage: {
+ *   title: 'No Data Available',
+ *   info: 'Make a selection on the list above to see results',
+ *   icon: 'icon-empty-no-data',
+ *   button: {text: 'xxx', click: <function>
+ *   }`
+ * Set this to null for no message or will default to 'No Data Found with an icon.'
+ */
 const HIERARCHY_DEFAULTS = {
   legend: [],
   legendKey: '',
@@ -101,22 +101,22 @@ Hierarchy.prototype = {
 
     if (s.dataset === undefined) {
       console.error('Hierarchy dataset is undefined.');
+      return;
     }
 
-    if (s.layout === 'horizontal' || s.layout === 'paging' || s.layout === 'mobile-only') {
-      if (s.dataset.length === 0) {
-        this.element.emptymessage(s.emptyMessage);
-        return;
-      } else if (s.dataset[0] && s.dataset[0].children.length > 0) {
-        this.render(s.dataset[0]);
-      } else if (s.dataset && s.dataset.children.length > 0) {
-        this.render(s.dataset);
-      }
+    if (!Array.isArray(s.dataset)) {
+      console.error('Hierarchy dataset must be an Array');
+      return;
     }
 
-    if (s.layout === 'stacked') {
-      const data = [s.dataset][0];
-      this.render(data);
+    if (s.dataset.length === 0) {
+      this.element.emptymessage(s.emptyMessage);
+      return;
+    } else if ((s.dataset[0] && s.dataset[0].children) &&
+      s.dataset[0].children.length > 0 || this.isStackedLayout()) {
+      this.render(s.dataset[0]);
+    } else if (s.dataset && s.dataset.children.length > 0) {
+      this.render(s.dataset);
     }
 
     if (s.leafHeight !== null && s.leafWidth !== null) {
@@ -174,7 +174,7 @@ Hierarchy.prototype = {
     // Expand or Collapse
     self.element.off('click.hierarchy').on('click.hierarchy', '.btn', function (e) {
       // Stacked layout doesn't expand/collapse
-      if (s.layout === 'stacked') {
+      if (self.isStackedLayout()) {
         return;
       }
 
@@ -220,12 +220,12 @@ Hierarchy.prototype = {
     });
 
     /**
-    * Fires when node is selected
-    * @event selected
-    * @memberof Hierarchy
-    * @param {object} event - The jquery event object
-    * @param {object} eventInfo - More info to identify the node.
-    */
+     * Fires when node is selected
+     * @event selected
+     * @memberof Hierarchy
+     * @param {object} event - The jquery event object
+     * @param {object} eventInfo - More info to identify the node.
+     */
     self.element.on('mouseup', '.leaf, .back button', function (e) {
       const leaf = $(this);
       const target = $(e.target);
@@ -661,14 +661,14 @@ Hierarchy.prototype = {
 
     nodeTopLevel.animateOpen();
     /**
-    * Fires when leaf expanded.
-    *
-    * @event expanded
-    * @memberof Hierarchy
-    * @type {object}
-    * @param {object} event - The jquery event object
-    * @param {array} args [nodeData, dataset]
-    */
+     * Fires when leaf expanded.
+     *
+     * @event expanded
+     * @memberof Hierarchy
+     * @type {object}
+     * @param {object} event - The jquery event object
+     * @param {array} args [nodeData, dataset]
+     */
     this.element.trigger('expanded', [nodeData, s.dataset]);
 
     if (node.hasClass('root')) {
@@ -698,14 +698,14 @@ Hierarchy.prototype = {
 
     nodeTopLevel.animateClosed().on('animateclosedcomplete', () => {
       /**
-      * Fires when leaf collapsed.
-      *
-      * @event collapsed
-      * @memberof Hierarchy
-      * @type {object}
-      * @param {object} event - The jquery event object
-      * @param {array} args [nodeData, dataset]
-      */
+       * Fires when leaf collapsed.
+       *
+       * @event collapsed
+       * @memberof Hierarchy
+       * @type {object}
+       * @param {object} event - The jquery event object
+       * @param {array} args [nodeData, dataset]
+       */
       this.element.trigger('collapsed', [nodeData, s.dataset]);
     });
 
@@ -719,11 +719,11 @@ Hierarchy.prototype = {
   },
 
   /**
-  * Main render method
-  * @private
-  * @param {object} data info.
-  * @returns {void}
-  */
+   * Main render method
+   * @private
+   * @param {object} data info.
+   * @returns {void}
+   */
   render(data) {
     /* eslint-disable no-use-before-define */
     const s = this.settings;
@@ -757,12 +757,12 @@ Hierarchy.prototype = {
     if (s.paging && data.parentDataSet) {
       const backMarkup = '' +
         '<div class="back">' +
-          '<button type="button" class="btn-icon hide-focus btn-back">' +
-            '<svg class="icon" focusable="false" aria-hidden="true" role="presentation">' +
-              '<use xlink:href="#icon-caret-left"></use>' +
-            '</svg>' +
-            '<span>Back</span>' +
-          '</button>' +
+        '<button type="button" class="btn-icon hide-focus btn-back">' +
+        '<svg class="icon" focusable="false" aria-hidden="true" role="presentation">' +
+        '<use xlink:href="#icon-caret-left"></use>' +
+        '</svg>' +
+        '<span>Back</span>' +
+        '</button>' +
         '</div>';
 
       // Append back button to chart to go back to view previous level
@@ -800,7 +800,8 @@ Hierarchy.prototype = {
         }
       });
     } else {
-      let leaf = s.layout === 'stacked' ? this.getTemplate(data.centeredNode) : this.getTemplate(data);
+      const centeredNode = data.centeredNode;
+      let leaf = this.isStackedLayout() ? this.getTemplate(centeredNode) : this.getTemplate(data);
       leaf = xssUtils.sanitizeHTML(leaf);
       rootNodeHTML.push(leaf);
       $(rootNodeHTML[0]).addClass('root is-selected').appendTo(chart);
@@ -878,11 +879,23 @@ Hierarchy.prototype = {
   },
 
   /**
-  * Checks to see if children have children
-  * @private
-  * @returns {boolean} true if have children
-  */
+   * @private
+   * @returns {boolean} true if stacked layout
+   */
+  isStackedLayout() {
+    return this.settings.layout && this.settings.layout === 'stacked';
+  },
+
+  /**
+   * Checks to see if children have children
+   * @private
+   * @returns {boolean} true if have children
+   */
   isSingleChildWithChildren() {
+    if (this.isStackedLayout()) {
+      return false;
+    }
+
     const s = this.settings;
     if (s.dataset && (s.dataset[0] && s.dataset[0].children)) {
       let i = s.dataset[0].children.length;
@@ -920,11 +933,11 @@ Hierarchy.prototype = {
   },
 
   /**
-  * Add the legend from the Settings
-  * @private
-  * @param {object} element .
-  * @returns {void}
-  */
+   * Add the legend from the Settings
+   * @private
+   * @param {object} element .
+   * @returns {void}
+   */
   createLegend(element) {
     const s = this.settings;
     const mod = 4;
@@ -948,12 +961,12 @@ Hierarchy.prototype = {
   },
 
   /**
-  * Creates a leaf node under element for nodeData
-  * @private
-  * @param {object} nodeData contains info.
-  * @param {object} container .
-  * @returns {void}
-  */
+   * Creates a leaf node under element for nodeData
+   * @private
+   * @param {object} nodeData contains info.
+   * @param {object} container .
+   * @returns {void}
+   */
   createLeaf(nodeData, container) {
     const self = this;
     const chartClassName = self.settings.rootClass;
@@ -1023,16 +1036,16 @@ Hierarchy.prototype = {
   },
 
   /**
-  * Set leaf colors matching data to key in legend
-  * @private
-  * @param {object} data contains info.
-  * @returns {void}
-  */
+   * Set leaf colors matching data to key in legend
+   * @private
+   * @param {object} data contains info.
+   * @returns {void}
+   */
   setColor(data) {
     const s = this.settings;
     this.setRootColor(data);
 
-    if (s.layout === 'stacked') {
+    if (this.isStackedLayout()) {
       if (data.ancestorPath && data.ancestorPath !== null) {
         data.ancestorPath.forEach((d) => {
           this.setRootColor(d);

--- a/src/components/hierarchy/hierarchy.js
+++ b/src/components/hierarchy/hierarchy.js
@@ -98,10 +98,9 @@ Hierarchy.prototype = {
     }
 
     // Safety check, check for data
-
     if (s.dataset === undefined || s.dataset.length === 0 || !Array.isArray(s.dataset)) {
       this.element.emptymessage(s.emptyMessage);
-      return this;
+      return;
     }
 
     if ((s.dataset[0] && s.dataset[0].children) &&

--- a/test/components/hierarchy/hierarchy-stacked-api.func-spec.js
+++ b/test/components/hierarchy/hierarchy-stacked-api.func-spec.js
@@ -33,7 +33,7 @@ describe('Hierarchy Stacked API', () => {
       templateId: 'hierarchyChartTemplate',
       legendKey: 'employmentType',
       legend: legendData,
-      dataset: data,
+      dataset: [data],
       layout: 'stacked'
     });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
There are inconsistencies between the new stacked layout vs the current existing layouts. The stacked layout examples were passing in data as an object vs an array. Allowing an object causes issues with the Angular wrapper which expects the data set to be an array. To resolve this I am updating the control to make sure only an array is passed in as data.

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise/issues/1629

**Steps necessary to review your pull request (required)**:
Navigate through existing examples. http://localhost:4000/components/hierarchy/example-stacked.html Everything should still work as expected. All tests should pass.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
