### PR TITLE
1466 - Add Custom Tooltip tests, improved some pager tests

### DIFF
--- a/app/views/components/pager/example-standalone.html
+++ b/app/views/components/pager/example-standalone.html
@@ -1,7 +1,6 @@
 <div class="row">
   <div class="six columns">
-      <div class="pager-container">
-      </div>
+    <div class="pager-container"></div>
   </div>
   <div class="six columns">
     <div class="field">
@@ -40,10 +39,29 @@
       <input type="checkbox" class="checkbox" name="disable-last-button" id="disable-last-button"/>
       <label for="disable-last-button" class="checkbox-label">Disable Last Button</label>
     </div>
+
+    <div class="field">
+      <label for="firstPageButtonTooltip">First Pager Button Tooltip</label>
+      <input type="text" id="firstPageButtonTooltip" value="Custom First Tooltip"/>
+    </div>
+    <div class="field">
+      <label for="firstPageButtonTooltip">Previous Pager Button Tooltip</label>
+      <input type="text" id="previousPageButtonTooltip" value="Custom Previous Tooltip"/>
+    </div>
+    <div class="field">
+      <label for="firstPageButtonTooltip">Next Pager Button Tooltip</label>
+      <input type="text" id="nextPageButtonTooltip" value="Custom Next Tooltip"/>
+    </div>
+    <div class="field">
+      <label for="firstPageButtonTooltip">Last Pager Button Tooltip</label>
+      <input type="text" id="lastPageButtonTooltip" value="Custom Last Tooltip"/>
+    </div>
+
+    <button class="btn-primary" type="button" id="reset-tooltips">Reset Tooltips</button>
   </div>
 </div>
 
-<script>
+<script id="test-script">
   $('body').one('initialized', function () {
     var api = $('.pager-container').pager({
       type: 'standalone',
@@ -77,13 +95,13 @@
       nextPageTooltip: 'Custom Next Tooltip',
       lastPageTooltip: 'Custom Last Tooltip'
     }).on('firstpage', function (e, args) {
-      console.log('First Page:', args);
+      console.log(args);
     }).on('previouspage', function (e, args) {
-      console.log('Previous Page:', args);
+      console.log(args);
     }).on('nextpage', function (e, args) {
-      console.log('Next Page:', args);
+      console.log(args);
     }).on('lastpage', function (e, args) {
-      console.log('Last Page:', args);
+      console.log(args);
     }).data('pager');
 
     //TODO: Make func tests for these (api.updated calls)
@@ -134,6 +152,51 @@
     $('#disable-last-button').on('change.test', function() {
       var isChecked = !this.checked;
       api.updated({enableLastButton: isChecked});
+    });
+
+    var startingFirstVal = $('#firstPageButtonTooltip').val();
+    var startingPreviousVal = $('#previousPageButtonTooltip').val();
+    var startingNextVal = $('#nextPageButtonTooltip').val();
+    var startingLastVal = $('#lastPageButtonTooltip').val();
+    var doUpdate = true;
+
+    $('#firstPageButtonTooltip').on('change.test', function () {
+      var val = Soho.xss.stripTags($(this).val());
+      if (!val.length) val = startingFirstVal;
+      if (doUpdate) api.updated({ firstPageTooltip: val });
+    });
+
+    $('#previousPageButtonTooltip').on('change.test', function () {
+      var val = Soho.xss.stripTags($(this).val());
+      if (!val.length) val = startingPreviousVal;
+      if (doUpdate) api.updated({ previousPageTooltip: val });
+    });
+
+    $('#nextPageButtonTooltip').on('change.test', function () {
+      var val = Soho.xss.stripTags($(this).val());
+      if (!val.length) val = startingNextVal;
+      if (doUpdate) api.updated({ nextPageTooltip: val });
+    });
+
+    $('#lastPageButtonTooltip').on('change.test', function () {
+      var val = Soho.xss.stripTags($(this).val());
+      if (!val.length) val = startingLastVal;
+      if (doUpdate) api.updated({ lastPageTooltip: val });
+    });
+
+    $('#reset-tooltips').on('click', function() {
+      doUpdate = false;
+      $('#firstPageButtonTooltip').val(startingFirstVal);
+      $('#previousPageButtonTooltip').val(startingPreviousVal);
+      $('#nextPageButtonTooltip').val(startingNextVal);
+      $('#lastPageButtonTooltip').val(startingLastVal);
+      api.updated({
+        firstPageTooltip: startingFirstVal,
+        previousPageTooltip: startingPreviousVal,
+        nextPageTooltip: startingNextVal,
+        lastPageTooltip: startingLastVal
+      });
+      doUpdate = true;
     });
 
     // Add functionality to trigger the pager events of the items

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,8 +37,7 @@
 - `[Icons]` Established missing icon sourcing and sizing consistency from ids-identity icon/svg assets. ([PR#1628](https://github.com/infor-design/enterprise/pull/1628))
 - `[Listview]` Addressed performance issues with paging on all platforms, especially Windows and IE/Edge browsers. As part of this, reworked all components that integrate with the Pager component to render their contents based on a dataset, as opposed to DOM elements. ([#922](https://github.com/infor-design/enterprise/issues/922))
 - `[Lookup]` Fixed a bug with settings: async, server-side, and single select modes.  The grid was not deselecting the previously selected value when a new row was clicked.  If the value is preselected in the markup, the lookup modal will no longer close prematurely. ([PR#1654](https://github.com/infor-design/enterprise/issues/1654))
-- `[Pager]` Made it possible to set and persist custom tooltips on first, previous, next and last pager buttons.
-([#922](https://github.com/infor-design/enterprise/issues/922))
+- `[Pager]` Made it possible to set and persist custom tooltips on first, previous, next and last pager buttons. ([#922](https://github.com/infor-design/enterprise/issues/922))
 - `[Pager]` Fixed propagation of the `pagesizes` setting when using `updated()`. Previously, the array was deep extended, instead of being replaced outright. ([PR#1466](https://github.com/infor-design/enterprise/issues/1466))
 - `[Tree]` Fixed a bug when calling the disable or enable methods of the tree. This was not working with ie11. ([PR#1600](https://github.com/infor-design/enterprise/issues/1600))
 - `[Stepprocess]` Fixed a bug where the step folder was still selected when it was collapsed or expanded. ([#1633](https://github.com/infor-design/enterprise/issues/1633))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,9 @@
 - `[Icons]` Established missing icon sourcing and sizing consistency from ids-identity icon/svg assets. ([PR#1628](https://github.com/infor-design/enterprise/pull/1628))
 - `[Listview]` Addressed performance issues with paging on all platforms, especially Windows and IE/Edge browsers. As part of this, reworked all components that integrate with the Pager component to render their contents based on a dataset, as opposed to DOM elements. ([#922](https://github.com/infor-design/enterprise/issues/922))
 - `[Lookup]` Fixed a bug with settings: async, server-side, and single select modes.  The grid was not deselecting the previously selected value when a new row was clicked.  If the value is preselected in the markup, the lookup modal will no longer close prematurely. ([PR#1654](https://github.com/infor-design/enterprise/issues/1654))
+- `[Pager]` Made it possible to set and persist custom tooltips on first, previous, next and last pager buttons.
+([#922](https://github.com/infor-design/enterprise/issues/922))
+- `[Pager]` Fixed propagation of the `pagesizes` setting when using `updated()`. Previously, the array was deep extended, instead of being replaced outright. ([PR#1466](https://github.com/infor-design/enterprise/issues/1466))
 - `[Tree]` Fixed a bug when calling the disable or enable methods of the tree. This was not working with ie11. ([PR#1600](https://github.com/infor-design/enterprise/issues/1600))
 - `[Stepprocess]` Fixed a bug where the step folder was still selected when it was collapsed or expanded. ([#1633](https://github.com/infor-design/enterprise/issues/1633))
 

--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -1196,6 +1196,9 @@ Pager.prototype = {
     if (settings) {
       this.settings = utils.mergeSettings(this.element, settings, this.settings);
     }
+    if (Array.isArray(settings.pagesizes) && settings.pagesizes.length) {
+      this.settings.pagesizes = settings.pagesizes;
+    }
 
     // Limit updated paging info to a specific subset
     const pagingInfo = {

--- a/test/components/pager/pager-api.func-spec.js
+++ b/test/components/pager/pager-api.func-spec.js
@@ -1,39 +1,47 @@
 import { Pager } from '../../../src/components/pager/pager';
+import { cleanup } from '../../helpers/func-utils';
 
 const pagerHTML = require('../../../app/views/components/pager/example-standalone.html');
 const svg = require('../../../src/components/icons/svg.html');
 
+// Custom tooltip settings
+const firstContent = 'In The Beginning...';
+const previousContent = 'Before Long...';
+const nextContent = 'The Next Day...';
+const lastContent = 'In Closing...';
+
 let pagerEl;
-let svgEl;
 let pagerObj;
 
 describe('Pager API (Standalone)', () => {
   beforeEach(() => {
     pagerEl = null;
-    svgEl = null;
     pagerObj = null;
+
     document.body.insertAdjacentHTML('afterbegin', svg);
     document.body.insertAdjacentHTML('afterbegin', pagerHTML);
     pagerEl = document.body.querySelector('.pager-container');
-    svgEl = document.body.querySelector('.svg-icons');
-    pagerObj = new Pager(pagerEl, { type: 'standalone' });
   });
 
   afterEach(() => {
-    pagerObj.updated({ type: 'standalone' });
     pagerObj.destroy();
-    pagerEl.parentNode.removeChild(pagerEl);
-    svgEl.parentNode.removeChild(svgEl);
-
-    const rowEl = document.body.querySelector('.row');
-    rowEl.parentNode.removeChild(rowEl);
+    cleanup([
+      '.pager-container',
+      '.svg-icons',
+      '.row',
+      '#test-script'
+    ]);
   });
 
   it('Should be defined on jQuery object', () => {
+    pagerObj = new Pager(pagerEl, { type: 'standalone' });
+
     expect(pagerObj).toEqual(jasmine.any(Object));
   });
 
   it('Should render', () => {
+    pagerObj = new Pager(pagerEl, { type: 'standalone' });
+
     expect(document.body.querySelector('.pager-toolbar')).toBeTruthy();
     expect(document.body.querySelector('.pager-first')).toBeTruthy();
     expect(document.body.querySelector('.pager-prev')).toBeTruthy();
@@ -42,20 +50,19 @@ describe('Pager API (Standalone)', () => {
   });
 
   it('Should destroy pager', () => {
+    pagerObj = new Pager(pagerEl, { type: 'standalone' });
     pagerObj.destroy();
 
     expect(document.body.querySelector('.pager-toolbar')).toBeFalsy();
   });
 
   it('Should be show page size selector', () => {
-    pagerObj.destroy();
     pagerObj = new Pager(pagerEl, { type: 'standalone', showPageSizeSelector: true });
 
     expect(document.body.querySelector('.pager-pagesize')).toBeTruthy();
   });
 
   it('Should hide first button', () => {
-    pagerObj.destroy();
     pagerObj = new Pager(pagerEl, { type: 'standalone', showFirstButton: false });
 
     expect(document.body.querySelector('.pager-first a')).not.toExist();
@@ -67,7 +74,6 @@ describe('Pager API (Standalone)', () => {
   });
 
   it('Should disable first button', () => {
-    pagerObj.destroy();
     pagerObj = new Pager(pagerEl, { type: 'standalone', enableFirstButton: false });
 
     expect(document.body.querySelector('.pager-first a[disabled]')).toBeTruthy();
@@ -79,7 +85,6 @@ describe('Pager API (Standalone)', () => {
   });
 
   it('Should hide previous button', () => {
-    pagerObj.destroy();
     pagerObj = new Pager(pagerEl, { type: 'standalone', showPreviousButton: false });
 
     expect(document.body.querySelector('.pager-first a')).toBeVisible();
@@ -89,7 +94,6 @@ describe('Pager API (Standalone)', () => {
   });
 
   it('Should disable previous button', () => {
-    pagerObj.destroy();
     pagerObj = new Pager(pagerEl, { type: 'standalone', enablePreviousButton: false });
 
     expect(document.body.querySelector('.pager-first a[disabled]')).toBeFalsy();
@@ -99,7 +103,6 @@ describe('Pager API (Standalone)', () => {
   });
 
   it('Should hide next button', () => {
-    pagerObj.destroy();
     pagerObj = new Pager(pagerEl, { type: 'standalone', showNextButton: false });
 
     expect(document.body.querySelector('.pager-first a')).toBeVisible();
@@ -109,7 +112,6 @@ describe('Pager API (Standalone)', () => {
   });
 
   it('Should disable next button', () => {
-    pagerObj.destroy();
     pagerObj = new Pager(pagerEl, { type: 'standalone', enableNextButton: false });
 
     expect(document.body.querySelector('.pager-first a[disabled]')).toBeFalsy();
@@ -119,7 +121,6 @@ describe('Pager API (Standalone)', () => {
   });
 
   it('Should hide last button', () => {
-    pagerObj.destroy();
     pagerObj = new Pager(pagerEl, { type: 'standalone', showLastButton: false });
 
     expect(document.body.querySelector('.pager-first a')).toBeVisible();
@@ -131,7 +132,6 @@ describe('Pager API (Standalone)', () => {
   });
 
   it('Should disable last button', () => {
-    pagerObj.destroy();
     pagerObj = new Pager(pagerEl, { type: 'standalone', enableLastButton: false });
 
     expect(document.body.querySelector('.pager-first a[disabled]')).toBeFalsy();
@@ -140,5 +140,81 @@ describe('Pager API (Standalone)', () => {
     expect(document.body.querySelector('.pager-last a[disabled]')).toBeTruthy();
 
     pagerObj.updated({ enableLastButton: true });
+  });
+
+  it('Can have custom tooltips on the first, previous, next, and last buttons', () => {
+    pagerObj = new Pager(pagerEl, {
+      type: 'standalone',
+      firstPageTooltip: firstContent,
+      previousPageTooltip: previousContent,
+      nextPageTooltip: nextContent,
+      lastPageTooltip: lastContent
+    });
+
+    const firstBtnTooltipAPI = $(document.body.querySelector('.pager-first a')).data('tooltip');
+    const previousBtnTooltipAPI = $(document.body.querySelector('.pager-prev a')).data('tooltip');
+    const nextBtnTooltipAPI = $(document.body.querySelector('.pager-next a')).data('tooltip');
+    const lastBtnTooltipAPI = $(document.body.querySelector('.pager-last a')).data('tooltip');
+
+    expect(firstBtnTooltipAPI.settings.content).toEqual(firstContent);
+    expect(previousBtnTooltipAPI.settings.content).toEqual(previousContent);
+    expect(nextBtnTooltipAPI.settings.content).toEqual(nextContent);
+    expect(lastBtnTooltipAPI.settings.content).toEqual(lastContent);
+  });
+
+  it('Can be updated with new settings', () => {
+    pagerObj = new Pager(pagerEl, { type: 'standalone' });
+
+    function updateJunk(api, state) {
+      console.log(`This function is junk! ${state}`);
+    }
+
+    const newSettings = {
+      firstPageTooltip: firstContent,
+      previousPageTooltip: previousContent,
+      nextPageTooltip: nextContent,
+      lastPageTooltip: lastContent,
+      enableFirstButton: false,
+      enablePreviousButton: false,
+      enableNextButton: false,
+      enableLastButton: false,
+      showPageSizeSelector: false,
+      showFirstButton: false,
+      showPreviousButton: false,
+      showNextButton: false,
+      showLastButton: false,
+      indeterminate: true,
+      onFirstPage: updateJunk,
+      onPreviousPage: updateJunk,
+      onNextPage: updateJunk,
+      onLastPage: updateJunk,
+      pagesize: 16,
+      pagesizes: [16, 32, 64]
+    };
+
+    pagerObj.updated(newSettings);
+
+    expect(pagerObj.settings.firstPageTooltip).toEqual(firstContent);
+    expect(pagerObj.settings.previousPageTooltip).toEqual(previousContent);
+    expect(pagerObj.settings.nextPageTooltip).toEqual(nextContent);
+    expect(pagerObj.settings.lastPageTooltip).toEqual(lastContent);
+    expect(pagerObj.settings.enableFirstButton).toBeFalsy();
+    expect(pagerObj.settings.enablePreviousButton).toBeFalsy();
+    expect(pagerObj.settings.enableNextButton).toBeFalsy();
+    expect(pagerObj.settings.enableLastButton).toBeFalsy();
+    expect(pagerObj.settings.showPageSizeSelector).toBeFalsy();
+    expect(pagerObj.settings.showFirstButton).toBeFalsy();
+    expect(pagerObj.settings.showPreviousButton).toBeFalsy();
+    expect(pagerObj.settings.showNextButton).toBeFalsy();
+    expect(pagerObj.settings.showLastButton).toBeFalsy();
+    expect(typeof pagerObj.settings.onFirstPage).toEqual('function');
+    expect(typeof pagerObj.settings.onPreviousPage).toEqual('function');
+    expect(typeof pagerObj.settings.onNextPage).toEqual('function');
+    expect(typeof pagerObj.settings.onLastPage).toEqual('function');
+    expect(pagerObj.settings.indeterminate).toBeTruthy();
+    expect(pagerObj.settings.pagesize).toEqual(16);
+
+    debugger;
+    expect(pagerObj.settings.pagesizes.length).toEqual(3);
   });
 });

--- a/test/components/pager/pager-api.func-spec.js
+++ b/test/components/pager/pager-api.func-spec.js
@@ -213,8 +213,6 @@ describe('Pager API (Standalone)', () => {
     expect(typeof pagerObj.settings.onLastPage).toEqual('function');
     expect(pagerObj.settings.indeterminate).toBeTruthy();
     expect(pagerObj.settings.pagesize).toEqual(16);
-
-    debugger;
     expect(pagerObj.settings.pagesizes.length).toEqual(3);
   });
 });

--- a/test/components/pager/pager-events.func-spec.js
+++ b/test/components/pager/pager-events.func-spec.js
@@ -1,35 +1,31 @@
 import { Pager } from '../../../src/components/pager/pager';
+import { cleanup } from '../../helpers/func-utils';
 
 const pagerHTML = require('../../../app/views/components/pager/example-standalone.html');
 const svg = require('../../../src/components/icons/svg.html');
 
 let pagerEl;
-let svgEl;
 let pagerObj;
 
 describe('Pager Event Test', () => {
   beforeEach(() => {
     pagerEl = null;
-    svgEl = null;
     pagerObj = null;
     document.body.insertAdjacentHTML('afterbegin', svg);
     document.body.insertAdjacentHTML('afterbegin', pagerHTML);
     pagerEl = document.body.querySelector('.pager-container');
-    svgEl = document.body.querySelector('.svg-icons');
-    pagerObj = new Pager(pagerEl, { type: 'standalone' });
   });
 
   afterEach(() => {
     pagerObj.destroy();
-    pagerEl.parentNode.removeChild(pagerEl);
-    svgEl.parentNode.removeChild(svgEl);
-
-    const rowEl = document.body.querySelector('.row');
-    rowEl.parentNode.removeChild(rowEl);
+    cleanup([
+      '.pager-container',
+      '.svg-icons',
+      '.row',
+    ]);
   });
 
   it('Should trigger "firstpage" event when first page is clicked', (done) => {
-    pagerObj.destroy();
     pagerObj = new Pager(pagerEl, {
       type: 'standalone',
       onFirstPage: () => {
@@ -46,7 +42,6 @@ describe('Pager Event Test', () => {
   });
 
   it('Should trigger "previouspage" event when prev page is clicked', (done) => {
-    pagerObj.destroy();
     pagerObj = new Pager(pagerEl, {
       type: 'standalone',
       onPreviousPage: () => {
@@ -63,7 +58,6 @@ describe('Pager Event Test', () => {
   });
 
   it('Should trigger "nextpage" event when next page is clicked', (done) => {
-    pagerObj.destroy();
     pagerObj = new Pager(pagerEl, {
       type: 'standalone',
       onNextPage: () => {
@@ -80,7 +74,6 @@ describe('Pager Event Test', () => {
   });
 
   it('Should trigger "lastpage" event when last page is clicked', (done) => {
-    pagerObj.destroy();
     pagerObj = new Pager(pagerEl, {
       type: 'standalone',
       onLastPage: () => {
@@ -94,21 +87,5 @@ describe('Pager Event Test', () => {
     expect(spyFunc).toHaveBeenCalled();
     expect(spyEvent).toHaveBeenTriggered();
     done();
-  });
-
-  it('Should support custom tooltips', () => {
-    pagerObj.destroy();
-    pagerObj = new Pager(pagerEl, {
-      type: 'standalone',
-      firstPageTooltip: 'Custom First',
-      previousPageTooltip: 'Custom Previous',
-      nextPageTooltip: 'Custom Next',
-      lastPageTooltip: 'Custom Last'
-    });
-
-    expect($('.pager-first a').data('tooltip').content).toEqual('<p>Custom First</p>');
-    expect($('.pager-prev a').data('tooltip').content).toEqual('<p>Custom Previous</p>');
-    expect($('.pager-next a').data('tooltip').content).toEqual('<p>Custom Next</p>');
-    expect($('.pager-last a').data('tooltip').content).toEqual('<p>Custom Last</p>');
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR:
- Adds the tooltip customization fields from @pwpatton's example on #1466 (I changed the fields to work off of a `change` event to make it more automatic, matchin our other gauntlet tests)
- Adds tests to the Pager functional test suite for setting custom tooltips through invoking, and updating existing tooltips.
- Fixed propagation of the `pagesizes` setting when using `PagerAPI.updated()` (was previously merging the array values, instead of replacing the array outright).
- Improved the pager test suite in general (using the `cleanup` method, changed lifecycle, etc)

Please note that the original issue described in #1466 was actually fixed in the Listview/Pager refactoring done in #922.

**Related github/jira issue (required)**:
Closes #1466 

**Steps necessary to review your pull request (required)**:
Pull this branch, then:
- Run the Pager functional test suite.  All should pass.
- Open http://localhost:4000/components/pager/example-standalone
- Change any of the custom tooltip text fields
- Hover/focus the corresponding pager button.  The tooltip that appears should contain your new text.
- Click the "reset" button
- Once again, hover/focus the corresponding pager button.  Its text contents should revert back.
