### PR TITLE
1672 - Added test and example for filter mask [v4.16.x]

### DIFF
--- a/app/views/components/datagrid/example-custom-filter-conditions.html
+++ b/app/views/components/datagrid/example-custom-filter-conditions.html
@@ -26,7 +26,7 @@
       // Define Columns for the Grid.
       columns.push({ id: 'id', name: 'Id', field: 'id', formatter: Formatters.Readonly, filterConditions: ['contains', 'equals'], filterType: 'text'});
       columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Readonly, filterConditions: ['contains', 'equals'], filterType: 'text'});
-      columns.push({ id: 'productName', name: 'Product Name', field: 'productName',  formatter: Formatters.Hyperlink, filterConditions: ['contains', 'equals'], filterType: 'text', click: function(e, args){ console.log(e, args);} , mask: '*****************'});
+      columns.push({ id: 'productName', name: 'Product Name', field: 'productName',  formatter: Formatters.Hyperlink, filterConditions: ['contains', 'equals'], filterType: 'text'});
 
       // Init and get the api for the grid
       $('#datagrid').datagrid({

--- a/app/views/components/datagrid/test-filter-lookup-click-function.html
+++ b/app/views/components/datagrid/test-filter-lookup-click-function.html
@@ -62,7 +62,7 @@
     // Define Columns for the Grid.
     columns.push({ id: 'id', name: 'Id', field: 'id', formatter: Formatters.Readonly, filterType: 'text'});
     columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, validate: 'required', editorOptions: lookupOptions, width: 170, filterType: 'lookup' });
-    columns.push({ id: 'productName', name: 'Product Name', field: 'productName',  formatter: Formatters.Hyperlink, filterType: 'text', click: function(e, args){ console.log(e, args);} , mask: '*****************'});
+    columns.push({ id: 'productName', name: 'Product Name', field: 'productName',  formatter: Formatters.Hyperlink, filterType: 'text'});
     columns.push({ id: 'activity', name: 'Activity', field: 'activity', formatter: Formatters.Dropdown, filterType: 'multiselect', options: activities, editorOptions: {showSelectAll: true}});
     columns.push({ id: 'quantity', name: 'Qty', field: 'quantity', align: 'right', filterType: 'integer'});
     columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'MM/dd/yyyy', filterType: 'date', width: 250});

--- a/app/views/components/datagrid/test-filter-mask.html
+++ b/app/views/components/datagrid/test-filter-mask.html
@@ -54,9 +54,9 @@
       // Define Columns for the Grid.
       columns.push({ id: 'id', name: 'Id', field: 'id', formatter: Formatters.Readonly, filterType: 'text'});
       columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editorOptions: lookupOptions, width: 120, filterType: 'lookup' });
-      columns.push({ id: 'productName', name: 'Product Name', field: 'productName',  formatter: Formatters.Hyperlink, filterType: 'text'});
+      columns.push({ id: 'productName', name: 'Product Name', field: 'productName',  formatter: Formatters.Hyperlink, filterType: 'text', mask: '*****'});
       columns.push({ id: 'activity', name: 'Activity', field: 'activity', formatter: Formatters.Dropdown, filterType: 'multiselect', options: activities, editorOptions: {showSelectAll: true}});
-      columns.push({ id: 'quantity', name: 'Qty', field: 'quantity', align: 'right', filterType: 'integer'});
+      columns.push({ id: 'quantity', name: 'Qty', field: 'quantity', align: 'right', filterType: 'integer', mask: '###'});
       columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'MM/dd/yyyy', filterType: 'date', editorOptions: {showMonthYearPicker: true}});
       columns.push({ id: 'inStock', name: 'In Stock', field: 'inStock', formatter: Formatters.Checkbox, align: 'center', filterType: 'checkbox'});
       columns.push({ id: 'status', name: 'Status', field: 'status', formatter: Formatters.Alert, filterType: 'select', editorOptions: {clearable: true}, options: statuses, ranges: [{'value':'Confirmed', 'classes': 'success', text: 'Confirmed'}, {'value':'Error', 'classes': 'error', text: 'Error'}]});

--- a/app/views/components/datagrid/test-filter-with-tooltip.html
+++ b/app/views/components/datagrid/test-filter-with-tooltip.html
@@ -34,7 +34,7 @@
       // Define Columns for the Grid.
       columns.push({ id: 'id', name: 'Id', field: 'id', formatter: Formatters.Readonly, filterType: 'text'});
       columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Readonly, filterType: 'text'});
-      columns.push({ id: 'productName', name: 'Product Name', field: 'productName',  formatter: Formatters.Hyperlink, filterType: 'text', click: function(e, args){ console.log(e, args);} , mask: '*****************'});
+      columns.push({ id: 'productName', name: 'Product Name', field: 'productName',  formatter: Formatters.Hyperlink, filterType: 'text'});
       columns.push({ id: 'activity', name: 'Activity', field: 'activity', formatter: Formatters.Dropdown, filterType: 'multiselect', options: activities, editorOptions: {showSelectAll: true}});
       columns.push({ id: 'quantity', name: 'Qty', field: 'quantity', align: 'right', filterType: 'integer'});
       columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'MM/dd/yyyy', filterType: 'date', width: 250});

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -906,6 +906,30 @@ describe('Datagrid filter lookup custom click function tests', () => {
   });
 });
 
+describe('Datagrid filter masks', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/test-filter-mask');
+
+    const datagridEl = await element(by.id('datagrid'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should mask on text filters', async () => {
+    await element(by.id('test-filter-mask-datagrid-1-header-filter-2')).sendKeys('Compressor');
+    await element(by.id('test-filter-mask-datagrid-1-header-filter-2')).sendKeys(protractor.Key.ENTER);
+    await element(by.id('test-filter-mask-datagrid-1-header-filter-4')).sendKeys('999999');
+    await element(by.id('test-filter-mask-datagrid-1-header-filter-2')).sendKeys(protractor.Key.ENTER);
+
+    expect(await element(by.id('test-filter-mask-datagrid-1-header-filter-2')).getAttribute('value')).toEqual('Compr');
+    expect(await element(by.id('test-filter-mask-datagrid-1-header-filter-4')).getAttribute('value')).toEqual('999');
+  });
+});
+
 describe('Datagrid grouping multiselect tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-grouping-multiselect');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

While not really a bug the behavior was confusing and flagged by QA so added a quick fix and made a test for the actual feature of having a mask on the filter row input fields.

**Related github/jira issue (required)**:
Closes #1672

**Steps necessary to review your pull request (required)**:
- new test should run fine
- http://localhost:4000/components/datagrid/test-filter-mask - qty and product name are constrained by a mask
- http://localhost:4000/components/datagrid/example-filter  product name allows spaces (now has no mask)