### PR TITLE
1688 - Ensure that fn Datagrid.settings.source is called

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -2076,20 +2076,20 @@ Datagrid.prototype = {
 
     if (this.restoreFilterClientSide) {
       this.restoreFilterClientSide = false;
-      return;
+    } else {
+      /**
+      * Fires after a filter action ocurs
+      * @event filtered
+      * @memberof Datagrid
+      * @property {object} event The jquery event object
+      * @property {object} args Object with the arguments
+      * @property {number} args.op The filter operation, this can be 'apply', 'clear'
+      * @property {object} args.conditions An object with all the condition data.
+      * @property {string} args.trigger Info on what was the triggering action. May be render, select or key
+      */
+      this.element.trigger('filtered', { op: 'apply', conditions, trigger });
     }
 
-    /**
-    * Fires after a filter action ocurs
-    * @event filtered
-    * @memberof Datagrid
-    * @property {object} event The jquery event object
-    * @property {object} args Object with the arguments
-    * @property {number} args.op The filter operation, this can be 'apply', 'clear'
-    * @property {object} args.conditions An object with all the condition data.
-    * @property {string} args.trigger Info on what was the triggering action. May be render, select or key
-    */
-    this.element.trigger('filtered', { op: 'apply', conditions, trigger });
     this.setSearchActivePage({
       trigger,
       type: 'filtered'


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
I want to ensure that function Datagrid.settings.source is called in all cases, so server side code can act on any change done by user.

**Related github/jira issue (required)**:
#1688

**Steps necessary to review your pull request (required)**:
- Check that hhttp://localhost:4000/components/datagrid/example-paging was enriched by all types of column filters (multi select, single select)
- Check why text filters work even without this fix + Check why sorting is not experiencing same problem,
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

<!-- Please include the following in your PR:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.
-->

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
