### PR TITLE
1685 - Added fix for extra space [v4.16.x]

### DIFF
--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -296,11 +296,11 @@ Pager.prototype = {
    * @private
    */
   createPagerBar() {
-    this.pagerBar = this.element.prev('.pager-toolbar');
-
-    if (this.pagerBar.length === 0) {
-      this.pagerBar = $('<ul class="pager-toolbar"></ul>');
+    if (this.pagerBar) {
+      return;
     }
+
+    this.pagerBar = $('<ul class="pager-toolbar"></ul>');
 
     if (this.settings.type === 'standalone') {
       if (this.isListView) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When sorting the pager is recreated leaving a div in the page that adds extra space.

**Related github/jira issue (required)**:
Closes #1685

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/example-fixed-header.html
- sort several times
- page should not increase in size anymore
