### PR TITLE
1684 - Calendar: Disable the new event modal when no template is defined

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### v4.16.0 Fixes
 
 - `[Application Menu]` Fixed the truncation of long text in an accordion element in the application menu by adding a tooltip to truncated elements. ([#457](https://github.com/infor-design/enterprise/issues/457))
+- `[Calendar]` Disable the new event modal when no template is defined. ([#1700](https://github.com/infor-design/enterprise/issues/1700))
 - `[Dropdown]` Fixed a bug where the ellipsis was not showing on long text in some browsers. ([#1550](https://github.com/infor-design/enterprise/issues/1550))
 - `[Datagrid]` Fixed a bug in equals filter on multiselect filters. ([#1586](https://github.com/infor-design/enterprise/issues/1586))
 - `[Datagrid]` Fixed a bug where incorrect data is shown in the events in tree grid. ([#315](https://github.com/infor-design/enterprise-ng/issues/315))

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -883,6 +883,10 @@ Calendar.prototype = {
    * @param {function} done The callback for when the modal closes.
    */
   showEventModal(event, done) {
+    if (!this.settings.modalTemplate) {
+      return;
+    }
+    
     this.modalContents = document.querySelector('.calendar-event-modal');
     if (!this.modalContents) {
       this.modalContents = document.createElement('div');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
No modal should be defined as there is no template for the controls to allow the user to add the event.
This should either only show when a template exists, or have a way to disable to modal, eg a read-only calendar.

**Related github/jira issue (required)**:
Closes #1684 

**Steps necessary to review your pull request (required)**:
1. Go to '/components/calendar/test-ajax-events.html'
2. Double Click on a date


<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
