### PR TITLE
1709 - Toolbar Flex: fixing menu button selected event

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,7 @@
 - `[Tree]` Fixed a bug when calling the disable or enable methods of the tree. This was not working with ie11. ([PR#1600](https://github.com/infor-design/enterprise/issues/1600))
 - `[Stepprocess]` Fixed a bug where the step folder was still selected when it was collapsed or expanded. ([#1633](https://github.com/infor-design/enterprise/issues/1633))
 - `[Toolbar Flex]` Added the ability to pass in a `beforeOpen` callback to the More Actions menu (fixes a bug where it wasn't possible to dynamically add content to the More Actions menu in same way that was possible on the original Toolbar component)
+- `[Toolbar Flex]` Fixed a bug where selected events were not bubbling up for a menu button on a flex toolbar. ([#1709](https://github.com/infor-design/enterprise/issues/1709)) 
 
 ### v4.16.0 Chore & Maintenance
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,7 +43,7 @@
 - `[Tree]` Fixed a bug when calling the disable or enable methods of the tree. This was not working with ie11. ([PR#1600](https://github.com/infor-design/enterprise/issues/1600))
 - `[Stepprocess]` Fixed a bug where the step folder was still selected when it was collapsed or expanded. ([#1633](https://github.com/infor-design/enterprise/issues/1633))
 - `[Toolbar Flex]` Added the ability to pass in a `beforeOpen` callback to the More Actions menu (fixes a bug where it wasn't possible to dynamically add content to the More Actions menu in same way that was possible on the original Toolbar component)
-- `[Toolbar Flex]` Fixed a bug where selected events were not bubbling up for a menu button on a flex toolbar. ([#1709](https://github.com/infor-design/enterprise/issues/1709)) 
+- `[Toolbar Flex]` Fixed a bug where selected events were not bubbling up for a menu button on a flex toolbar. ([#1709](https://github.com/infor-design/enterprise/issues/1709))
 
 ### v4.16.0 Chore & Maintenance
 

--- a/src/components/toolbar-flex/toolbar-flex.item.js
+++ b/src/components/toolbar-flex/toolbar-flex.item.js
@@ -428,7 +428,7 @@ ToolbarFlexItem.prototype = {
               itemLinkAPI.selectedAnchor = $(elementLink).children('a');
             } else {
               // case of a menu button overflowed into more actions
-              // itemLinkAPI.selectedAnchor = anchor;
+              itemLinkAPI.selectedAnchor = anchor;
             }
             itemLinkAPI.selected = true;
             return;
@@ -504,12 +504,10 @@ ToolbarFlexItem.prototype = {
     }
 
     // Action Buttons need more stuff
-    if (this.type !== 'actionbutton') {
-      return;
+    if (this.type === 'actionbutton') {
+      this.renderMoreActionsMenu();
+      this.refreshMoreActionsMenu();
     }
-
-    this.renderMoreActionsMenu();
-    this.refreshMoreActionsMenu();
 
     this.handleEvents();
   },

--- a/src/components/toolbar-flex/toolbar-flex.item.js
+++ b/src/components/toolbar-flex/toolbar-flex.item.js
@@ -426,6 +426,9 @@ ToolbarFlexItem.prototype = {
             if (elementLink) {
               e.preventDefault();
               itemLinkAPI.selectedAnchor = $(elementLink).children('a');
+            } else {
+              // case of a menu button overflowed into more actions
+              // itemLinkAPI.selectedAnchor = anchor;
             }
             itemLinkAPI.selected = true;
             return;
@@ -504,6 +507,7 @@ ToolbarFlexItem.prototype = {
     if (this.type !== 'actionbutton') {
       return;
     }
+
     this.renderMoreActionsMenu();
     this.refreshMoreActionsMenu();
 

--- a/test/components/toolbar-flex/toolbar-flex-api.func-spec.js
+++ b/test/components/toolbar-flex/toolbar-flex-api.func-spec.js
@@ -335,4 +335,48 @@ describe('Flex Toolbar', () => {
       expect(secondIconButton.overflowed).toBeTruthy();
     });
   });
+
+  describe('Item selected events', () => {
+    it('Should trigger "selected" event for a normal button', () => {
+      const button = toolbarAPI.items[0].element;
+      const buttonSpyEvent = spyOnEvent('div.buttonset button:first-child', 'selected');
+
+      button.click();
+      expect(buttonSpyEvent).toHaveBeenTriggered();
+    });
+
+    it('Should trigger "selected" event for a menu button', () => {
+      const menuButton = toolbarAPI.items[1];
+      const menuButtonSpyEvent = spyOnEvent('button#menu-button', 'selected');
+      const firstMenuEntry = document.body.querySelector('button#menu-button + div ul li a');
+
+      menuButton.componentAPI.open();
+      firstMenuEntry.click();
+      expect(menuButtonSpyEvent).toHaveBeenTriggered();
+    });
+
+    it('Should trigger "selected" event for overflow menu', () => {
+      const moreMenuButton = toolbarAPI.items[5];
+      const moreActionsSpyEvent = spyOnEvent('button.btn-actions', 'selected');
+      const firstMoreMenuEntry = document.body.querySelector('button.btn-actions + div ul li:nth-child(5) a');
+
+      moreMenuButton.componentAPI.open();
+      firstMoreMenuEntry.click();
+      expect(moreActionsSpyEvent).toHaveBeenTriggered();
+    });
+
+    it('Should trigger "selected" event for menu button in the overflow menu', () => {
+      rowEl.style.width = '700px';
+      const moreMenuButton = toolbarAPI.items[5];
+      const moreActionsSpyEvent = spyOnEvent('button.btn-actions', 'selected');
+      const overflowedMenuButton = document.body.querySelector('button.btn-actions + div ul li:nth-child(2)');
+      const firstMoreMenuEntry = document.body.querySelector('button.btn-actions + div ul li:nth-child(2) a#item-one');
+
+      moreMenuButton.componentAPI.open();
+      $(overflowedMenuButton).trigger('mouseover');
+
+      firstMoreMenuEntry.click();
+      expect(moreActionsSpyEvent).toHaveBeenTriggered();
+    });
+  });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixing the issue of the events not being handled for menu buttons in toolbar-flex.item.js. This reconnects the selected events again.

**Related github/jira issue (required)**:
"Closes #1709"

**Steps necessary to review your pull request (required)**:
1. Go to '/components/toolbar-flex/example-more-actions-ajax'
2. Click on Menu Button, and then select Menu Button Option 1
3. The toast message appears with "Select Menu Item: Menu Button Option 1"
4. Shrink the window so the Menu Button is overflowed into the More Menu.
5. Open the more menu, hover over the Menu Button, and in the submenu select Menu Button Option 1
6. The toast message appears with "Select Menu Item: Menu Button Option 1"

![nomenubuttoneventsfixed](https://user-images.githubusercontent.com/22107636/53595407-ca659700-3b62-11e9-85ed-68e27ac966b6.gif)

<!-- Please include the following in your PR:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.
-->

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
