### PR TITLE
1716 - Datagrid: stretch column not working in Edge browser

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### v4.17.0 Fixes
 
-- `[Component Name]` An explanation and description. ([#123](https://github.com/infor-design/enterprise/issues/12))
+- `[Datagrid]` :Stretch column not working in Edge browser. ([#1716](https://github.com/infor-design/enterprise/issues/1716))
 
 ### v4.17.0 Chore & Maintenance
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4044,7 +4044,6 @@ Datagrid.prototype = {
 
       if (this.settings.stretchColumn !== 'last') {
         this.headerWidths[index] = { id: col.id, width: colWidth, widthPercent: this.widthPercent };
-        this.totalWidths[container] += col.hidden ? 0 : colWidth;
         const diff2 = this.elemWidth - this.totalWidths[container];
         const stretchColumn = $.grep(this.headerWidths, e => e.id === this.settings.stretchColumn);
         if ((diff2 > 0) && !stretchColumn[0].widthPercent) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The stretch column does not work correctly and within the Edge browser a space can be seen.


**Related github/jira issue (required)**:
Closes #1716 

**Steps necessary to review your pull request (required)**:
Go to 'http://localhost:4000/components/datagrid/test-columns-stretch-column.html'

The grid column's should fill the grid 

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
