### PR TITLE
1718 - Datagrid is-not-empty filter on null

### DIFF
--- a/app/views/components/datagrid/test-filter-editable.html
+++ b/app/views/components/datagrid/test-filter-editable.html
@@ -19,7 +19,7 @@
       data.push({ id: 4, productId: 2445204, productName: '1 Another Compressor', inStock: false, activity:  'Assemble Paint', order: { quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3)}, action: 'Action', status: 'Confirmed'});
       data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', inStock: true, activity:  'Inspect and Repair', order: { quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5)}, action: 'On Hold', status: 'Confirmed'});
       data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', inStock: false, activity:  'Inspect and Repair', order: { quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9)}, action: 'On Hold', status: 'Error'});
-      data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', inStock: true, activity:  'inspect and Repair', order: { quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9)}, action: 'On Hold', status: 'Confirmed'});
+      data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', inStock: true, activity:  'inspect and Repair', order: { quantity: 41, price: 123.99, status: 'OK', orderDate: ''}, action: 'On Hold', status: 'Confirmed'});
       data.push({ id: 7, productId: null, productName: null, activity:  null, order: { quantity: null, price: null, status: null, orderDate: null}, action: 'Blank Row', status: 'Confirmed'});
 
       var statuses = [{id:'Confirmed', value:'Confirmed', label:'Confirmed'},

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 - `[Component Name]` An explanation and description. ([#123](https://github.com/infor-design/enterprise/issues/12))
 
+- `[Datagrid]` Fixed a bug where filtering Order Date with `is-not-empty` on a null value would not correctly filter out results. ([#1718](https://github.com/infor-design/enterprise/issues/1718))
+
 ### v4.17.0 Chore & Maintenance
 
 - `[Component Name]` An explanation and description. ([#123](https://github.com/infor-design/enterprise/issues/12))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1957,7 +1957,11 @@ Datagrid.prototype = {
             isMatch = (rowValueStr === '');
             break;
           case 'is-not-empty':
-            isMatch = (rowValue !== '');
+            if (rowValue === '') {
+              isMatch = (rowValue !== '');
+              break;
+            }
+            isMatch = !(rowValue === null);
             break;
           case 'in-range':
             isMatch = false;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Datagrid was not filtering properly on a `null` value in Order Date.

**Related github/jira issue (required)**:
Closes #1718.

**Steps necessary to review your pull request (required)**:
- Pull branch
- Run app
- Goto: http://localhost:4000/components/datagrid/example-filter.html
- Filter on Order Date with `is-not-empty` filter (will show 7 results with id: 1, 2, 3, 4, 5, 5, 6)
- Should NOT show two results: one `''` and one `null`.
