### PR TITLE
1685 - Added fix for extra space [v4.16.x]

### DIFF
--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -3590,6 +3590,13 @@ html[dir='rtl'] {
   }
 }
 
+.is-mac.is-firefox,
+.is-mac.is-safari {
+  .has-visible-scrollbars .datagrid-body.right table {
+    margin-right: 15px;
+  }
+}
+
 //Contextual toolbar
 .datagrid-contextual-toolbar.contextual-toolbar {
   &.toolbar {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3801,7 +3801,7 @@ Datagrid.prototype = {
       return '100%';
     } else if (!isNaN(this.totalWidths[container])) {
       if (hasVisibleScrollbars) {
-        return `${parseFloat(this.totalWidths[container]) + 14}px`;
+        return `${parseFloat(this.totalWidths[container]) + 15}px`;
       }
       return `${parseFloat(this.totalWidths[container])}px`;
     }
@@ -3846,6 +3846,10 @@ Datagrid.prototype = {
 
     if (this.hasRightPane) {
       this.element.addClass('has-frozen-right-columns');
+
+      if (utils.getScrollbarWidth() > 0) {
+        this.element.addClass('has-visible-scrollbars');
+      }
     }
   },
 

--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -296,6 +296,10 @@ Pager.prototype = {
    * @private
    */
   createPagerBar() {
+    if (this.pagerBar) {
+      return;
+    }
+
     this.pagerBar = this.element.prev('.pager-toolbar');
 
     if (this.pagerBar.length === 0) {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1035,4 +1035,31 @@ utils.getArrayFromList = function (listObj) {
   return Function.prototype.call.bind(unboundSlice)(listObj);
 };
 
+/**
+ * Gets the OS scollbar width in pixels.
+ * @returns {number} The width as a number in pixels.
+ */
+utils.getScrollbarWidth = function () {
+  const outer = document.createElement('div');
+  outer.style.visibility = 'hidden';
+  outer.style.width = '100px';
+  document.body.appendChild(outer);
+
+  const widthNoScroll = outer.offsetWidth;
+  // force scrollbars
+  outer.style.overflow = 'scroll';
+
+  // add innerdiv
+  const inner = document.createElement('div');
+  inner.style.width = '100%';
+  outer.appendChild(inner);
+
+  const widthWithScroll = inner.offsetWidth;
+
+  // remove divs
+  outer.parentNode.removeChild(outer);
+
+  return widthNoScroll - widthWithScroll;
+};
+
 export { utils, math };

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1046,17 +1046,13 @@ utils.getScrollbarWidth = function () {
   document.body.appendChild(outer);
 
   const widthNoScroll = outer.offsetWidth;
-  // force scrollbars
   outer.style.overflow = 'scroll';
 
-  // add innerdiv
   const inner = document.createElement('div');
   inner.style.width = '100%';
   outer.appendChild(inner);
 
   const widthWithScroll = inner.offsetWidth;
-
-  // remove divs
   outer.parentNode.removeChild(outer);
 
   return widthNoScroll - widthWithScroll;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When sorting the pager is recreated leaving a div in the page that adds extra space.
NOTE: This fix was pushed to master by mistake on https://github.com/infor-design/enterprise/pull/1695 so this just pushes the fix to 4.16.

CC @clepore in case you bump into it merging to master at all.

**Related github/jira issue (required)**:
Closes #1685

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/example-fixed-header.html
- sort several times
- page should not increase in size anymore
