### PR TITLE
Fixes #1731 - Refactor for escape and tab key handling with noSearch …

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1348,10 +1348,6 @@ Dropdown.prototype = {
         this.open();
       }
 
-      if (key === 'Tab' && this.isOpen()) {
-        this.closeList('tab');
-      }
-
       // TODO: refactor this out so that `handleKeyDown` is no longer necessary.
       // This is necessary here because in `noSearch` mode, there is no actionable searchInput.
       if (this.settings.noSearch && !e.ctrlKey) {
@@ -1375,16 +1371,14 @@ Dropdown.prototype = {
       return true;
     }
 
-    // In nosearch mode, bypass the typeahead autocomplete and pass keydown events
-    // along to the list elements
-    if (this.settings.noSearch && isEscapeKey) {
-      if (this.isOpen()) {
+    if (isEscapeKey || key === 'Tab') {
+      // In nosearch mode, bypass the typeahead autocomplete and pass keydown events
+      // along to the list elements
+      if (this.settings.noSearch && this.isOpen()) {
         return this.handleKeyDown(target, e);
       }
-    }
 
-    // Allow some keys to pass through with no changes in functionality
-    if (isEscapeKey || key === 'Tab') {
+      // Allow some keys to pass through with no changes in functionality
       return true;
     }
 


### PR DESCRIPTION
…option to close an open dropdown menu

**Explain the _details_ for making this change. What existing problem does the pull request solve?**
When using noSearch: true on a dropdown control, tab does not close the list.

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise/issues/1731

**Steps necessary to review your pull request (required)**:
Opening a standard dropdown (noSearch: false) and a noSearch:true dropdown and pressing tab should close the menu and focus the next element. Escape, arrow keys, and normal searching keys should all behave the same.

<!-- Please include the following in your PR:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.
-->

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
