### PR TITLE
1685 - Added fix for extra space [v4.16.x]

### DIFF
--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -296,6 +296,9 @@ Pager.prototype = {
    * @private
    */
   createPagerBar() {
+    if (this.pagerBar) {
+      return;
+    }
     this.pagerBar = this.element.prev('.pager-toolbar');
 
     if (this.pagerBar.length === 0) {

--- a/src/components/pager/readme.md
+++ b/src/components/pager/readme.md
@@ -12,6 +12,8 @@ demo:
     slug: example-paging
   - name: Paging on the Circle Pager Component
     slug: example-index
+  - name: Standalone Pager (Just uses events and settings)
+    slug: example-standalone
 ---
 
 ## Code Example


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When sorting the pager is recreated leaving a div in the page that adds extra space.
NOTE: This fix was pushed to master by mistake on https://github.com/infor-design/enterprise/pull/1695 so this just pushes the fix to 4.16.

CC @clepore in case you bump into it merging to master at all.

**Related github/jira issue (required)**:
Closes #1685

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/example-fixed-header.html
- sort several times
- page should not increase in size anymore
