### PR TITLE
1021 - Added support to cancel rowactivated with datagrid

### DIFF
--- a/app/views/components/datagrid/test-before-row-activated.html
+++ b/app/views/components/datagrid/test-before-row-activated.html
@@ -1,0 +1,100 @@
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    var elem = $('#datagrid'),
+      data = [],
+      columns = [];
+
+    // Create Some Sample Data
+    data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 0, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+    data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+    data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+    data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+    data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+    data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+    data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+
+    // Define Columns for the Grid.
+    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
+    columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Readonly});
+    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink});
+    columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity'});
+    columns.push({ id: 'price', name: 'Price', field: 'price', formatter: Formatters.Decimal});
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+
+    // Toast message
+    var toast = function (message, timeout) {
+      $('body').toast({
+        title: '',
+        message: message || '',
+        timeout: timeout || 1000
+      });
+    };
+
+    // Message (Success or Error)
+    var message = function(options) {
+      var isError = options.type === 'error';
+      $('body').message({
+        title: '<span>'+ (isError ? 'Error' : 'Success') +'</span>',
+        status: isError ? 'error' : 'success',
+        returnFocus: $(this),
+        message: options.msg || '',
+        buttons: [{
+          text: 'Ok',
+          click: function() {
+            $(this).data('modal').close();
+          },
+          isDefault: true
+        }]
+      });
+    };
+
+    // Init the grid
+    elem.datagrid({
+      columns: columns,
+      dataset: data,
+      selectable: 'mixed',
+      toolbar: {title: 'Tasks (Hierarchical)', results: true, personalize: true}
+    })
+
+    // Selected
+    elem.on('selected', function (e, args, action) {
+      console.log('selected', args, action);
+    });
+
+    // Row Activated
+    elem.on('rowactivated', function (e, args) {
+      console.log('rowactivated', args);
+      message({ type: 'success', msg: 'Row Activated (row: '+ args.row +')' });
+    })
+
+    // Before Row Activated
+    elem.on('beforerowactivated', function (e, args) {
+      console.log('Begin: Before Row Activated');
+      var delay = 3000;
+      toast('Begin: Before Row Activated', delay);
+
+      var response = new Promise((resolve, reject) => {
+        setTimeout(function() {
+          var shouldGoAhead = true;
+          if (shouldGoAhead) {
+            resolve();
+          } else {
+            reject();
+            message({ type: 'error', msg: 'Row Not Activated (row: '+ args.row +')' });
+          }
+          console.log('Complete: Before Row Activated');
+        }, delay);
+      });
+
+      return response;
+    });
+
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### v4.17.0 Features
 
+- `[Datagrid]` Added support to cancel `rowactivated` event. Now it will trigger the new event `beforerowactivated` which will wait/sync to cancel or proceed to do `rowactivated` event. ([#1021](https://github.com/infor-design/enterprise/issues/1021))
 - `[Locale]` Added support for showing timezones in the current language with a fall back for IE 11. ([#592](https://github.com/infor-design/enterprise/issues/592))
 
 ### v4.17.0 Fixes

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -6643,12 +6643,15 @@ Datagrid.prototype = {
       dataset = s.treeGrid ? s.treeDepth : s.dataset;
     }
 
-    if (dataset[idx]) {
+    let args = [{ row: idx, item: dataset[idx] }];
+
+    const doRowactivated = () => {
       const rowNodes = this.rowNodes(idx).toArray();
       rowNodes.forEach((rowElem) => {
         rowElem.classList.add('is-rowactivated');
       });
       dataset[idx]._rowactivated = true;
+      args = [{ row: idx, item: dataset[idx] }];
 
       /**
        * Fires after a row is activated in mixed selection mode.
@@ -6659,7 +6662,18 @@ Datagrid.prototype = {
        * @property {array} args.row An array of selected rows.
        * @property {object} args.item The current sort column.
        */
-      this.element.triggerHandler('rowactivated', [{ row: idx, item: dataset[idx] }]);
+      this.element.triggerHandler('rowactivated', args);
+    };
+
+    if (dataset[idx]) {
+      $.when(this.element.triggerHandler('beforerowactivated', args)).done((response) => {
+        const isFalse = v => ((typeof v === 'string' && v.toLowerCase() === 'false') ||
+          (typeof v === 'boolean' && v === false) ||
+          (typeof v === 'number' && v === 0));
+        if (!isFalse(response)) {
+          doRowactivated();
+        }
+      });
     }
   },
 

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -934,7 +934,7 @@ describe('Locale API', () => {
     expect(Locale.parseDate('22-03-2000 20:11 Eastern-standaardtijd', { pattern: 'dd-MM-yyyy HH:mm zzzz' }).getTime()).toEqual(new Date(2000, 2, 22, 20, 11).getTime());
   });
 
-  fit('Should be able to display dates into another timezone', () => { //eslint-disable-line
+  it('Should be able to display dates into another timezone', () => {
     Locale.set('en-US');
 
     expect(Locale.dateToTimeZone(new Date(2018, 2, 26), 'Australia/Brisbane')).toEqual('3/26/2018, 2:00:00 PM');
@@ -947,7 +947,7 @@ describe('Locale API', () => {
     expect(Locale.dateToTimeZone(new Date(2018, 2, 26), 'America/New_York')).toEqual('26-3-2018 00:00:00');
   });
 
-  fit('Should be able to display dates into another timezone including short timezone name', () => { //eslint-disable-line
+  it('Should be able to display dates into another timezone including short timezone name', () => {
     Locale.set('en-US');
 
     expect(Locale.dateToTimeZone(new Date(2018, 2, 26), 'Australia/Brisbane', 'short')).toEqual('3/26/2018, 2:00:00 PM GMT+10');
@@ -960,7 +960,7 @@ describe('Locale API', () => {
     expect(Locale.dateToTimeZone(new Date(2018, 2, 26), 'America/New_York', 'short')).toEqual('26-3-2018 00:00:00 GMT-4');
   });
 
-  fit('Should be able to display dates into another timezone including long timezone name', () => { //eslint-disable-line
+  it('Should be able to display dates into another timezone including long timezone name', () => {
     Locale.set('en-US');
 
     expect(Locale.dateToTimeZone(new Date(2018, 2, 26), 'Australia/Brisbane', 'long')).toEqual('3/26/2018, 2:00:00 PM Australian Eastern Standard Time');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added support to cancel `rowactivated` event with datagrid. Now datagrid will trigger the new event `beforerowactivated` which will wait/sync to cancel or proceed to do `rowactivated` event.

**Related github/jira issue (required)**:
Closes #1021

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-before-row-activated.html
- Open above link
- Click on any row to make it activated
- See `beforerowactivated` is triggered
- Then `rowactivated` is triggered
