### PR TITLE
1686 - Added a fix for extra scroll bars [v4.16.x]

### DIFF
--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -3590,6 +3590,13 @@ html[dir='rtl'] {
   }
 }
 
+.is-mac.is-firefox,
+.is-mac.is-safari {
+  .has-visible-scrollbars .datagrid-body.right table {
+    margin-right: 15px;
+  }
+}
+
 //Contextual toolbar
 .datagrid-contextual-toolbar.contextual-toolbar {
   &.toolbar {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3801,7 +3801,7 @@ Datagrid.prototype = {
       return '100%';
     } else if (!isNaN(this.totalWidths[container])) {
       if (hasVisibleScrollbars) {
-        return `${parseFloat(this.totalWidths[container]) + 14}px`;
+        return `${parseFloat(this.totalWidths[container]) + 15}px`;
       }
       return `${parseFloat(this.totalWidths[container])}px`;
     }
@@ -3846,6 +3846,10 @@ Datagrid.prototype = {
 
     if (this.hasRightPane) {
       this.element.addClass('has-frozen-right-columns');
+
+      if (utils.getScrollbarWidth() > 0) {
+        this.element.addClass('has-visible-scrollbars');
+      }
     }
   },
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1035,4 +1035,27 @@ utils.getArrayFromList = function (listObj) {
   return Function.prototype.call.bind(unboundSlice)(listObj);
 };
 
+/**
+ * Gets the OS scollbar width in pixels.
+ * @returns {number} The width as a number.
+ */
+utils.getScrollbarWidth = function () {
+  const outer = document.createElement('div');
+  outer.style.visibility = 'hidden';
+  outer.style.width = '100px';
+  document.body.appendChild(outer);
+
+  const widthNoScroll = outer.offsetWidth;
+  outer.style.overflow = 'scroll';
+
+  const inner = document.createElement('div');
+  inner.style.width = '100%';
+  outer.appendChild(inner);
+
+  const widthWithScroll = inner.offsetWidth;
+  outer.parentNode.removeChild(outer);
+
+  return widthNoScroll - widthWithScroll;
+};
+
 export { utils, math };


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes a followup issue on #1686 where an extra scrollbar occurred. Also added a util that can be used if the scrollbar size is needed elsewhere.

**Related github/jira issue (required)**:
Fixes  #1686

**Steps necessary to review your pull request (required)**:
- Try for each of the three options in  Mac -> System Preferences -> General -> Show Scrollbars 
- Load http://localhost:4000/components/datagrid/example-frozen-columns page in Mac- Safari, Chrome and FF, reloading the page each time changing the setting.

Should now not see the extra scroll bar on the right column and the scrollbars should appear in order.
