### PR TITLE
1738 - Allow updated to refresh with no settings [v4.16.x]

### DIFF
--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -1162,9 +1162,10 @@ ListView.prototype = {
       if (settings && settings.dataset) {
         this.settings.dataset = settings.dataset;
       }
-      this.updateSearch();
-      this.refresh(settings.dataset || null);
     }
+
+    this.updateSearch();
+    this.refresh(settings && settings.dataset ? settings.dataset : null);
     return this;
   },
 

--- a/test/components/listview/listview-events.func-spec.js
+++ b/test/components/listview/listview-events.func-spec.js
@@ -74,4 +74,22 @@ describe('Listview Events', () => {
     listviewAPI.deselect($(liEl));
     listviewAPI.deselect($(liEl2));
   });
+
+  it('Should be fire rendered on updated with no params', () => {
+    listviewAPI = new ListView(listviewEl, { dataset: data, template: 'period-end-tmpl', selectable: 'multiple' });
+
+    const spyEvent = spyOnEvent($(listviewEl), 'rendered');
+    listviewAPI.updated();
+
+    expect(spyEvent).toHaveBeenTriggered();
+  });
+
+  it('Should be fire rendered on updated with new settings', () => {
+    listviewAPI = new ListView(listviewEl, { dataset: data, template: 'period-end-tmpl', selectable: 'multiple' });
+
+    const spyEvent = spyOnEvent($(listviewEl), 'rendered');
+    listviewAPI.updated({ dataset: data });
+
+    expect(spyEvent).toHaveBeenTriggered();
+  });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Recent list view changes will now cancel out listview rendering when calling `updated()` with no new settings. The problem with this is in angular thats how it works as the settings are outside in the wrapper. I adjusted the updated function so it has the same logic but still renders with no settings.

Please review and give your opinion @EdwardCoyle in case im missing a reason behind this.
@pwpatton Please verify on your end.

**Related github/jira issue (required)**:
Closes #1738 

**Steps necessary to review your pull request (required)**:

- Added a test for this that shows that render is happening because the event `rendered` is called in both cases when calling the `updated` both with and without the settings.
- you could manually open a page like http://localhost:4000/components/listview/test-listview-performance-paging.html and call `$('.listview').data('listview').updated()` and see that the DOM updated as well for a manual test
- verify on your end @pwpatton and @tobywicksinfor
