### PR TITLE
1689 - Ensure filtered event is called on disableClientSideFilter

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Datagrid]` Added a fix to allow the commit of a cell edit after tabbing into a cell once having clicked into a previous cell.([#1608](https://github.com/infor-design/enterprise/issues/1608))
 - `[Datagrid]` :Stretch column not working in Edge browser. ([#1716](https://github.com/infor-design/enterprise/issues/1716))
 - `[Datagrid]` Fixed a bug where filtering Order Date with `is-not-empty` on a null value would not correctly filter out results. ([#1718](https://github.com/infor-design/enterprise/issues/1718))
+- `[Datagrid]` Fixed a bug where when using the `disableClientSideFilter` setting the filtered event would not be called correctly. ([#1689](https://github.com/infor-design/enterprise/issues/1689))
 
 ### v4.17.0 Chore & Maintenance
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -2080,20 +2080,20 @@ Datagrid.prototype = {
 
     if (this.restoreFilterClientSide) {
       this.restoreFilterClientSide = false;
-      return;
+    } else {
+      /**
+      * Fires after a filter action ocurs
+      * @event filtered
+      * @memberof Datagrid
+      * @property {object} event The jquery event object
+      * @property {object} args Object with the arguments
+      * @property {number} args.op The filter operation, this can be 'apply', 'clear'
+      * @property {object} args.conditions An object with all the condition data.
+      * @property {string} args.trigger Info on what was the triggering action. May be render, select or key
+      */
+      this.element.trigger('filtered', { op: 'apply', conditions, trigger });
     }
 
-    /**
-    * Fires after a filter action ocurs
-    * @event filtered
-    * @memberof Datagrid
-    * @property {object} event The jquery event object
-    * @property {object} args Object with the arguments
-    * @property {number} args.op The filter operation, this can be 'apply', 'clear'
-    * @property {object} args.conditions An object with all the condition data.
-    * @property {string} args.trigger Info on what was the triggering action. May be render, select or key
-    */
-    this.element.trigger('filtered', { op: 'apply', conditions, trigger });
     this.setSearchActivePage({
       trigger,
       type: 'filtered'

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -2309,6 +2309,10 @@ Editor.prototype = {
    * @returns {void}
    */
   destroyPreviewMode() {
+    if (!this.container[0]) {
+      return;
+    }
+
     const classList = this.container[0].classList;
     if (classList.contains('is-preview')) {
       classList.remove('is-preview');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

After some changes the `filtered` event no longer fires on disableClientSideFilter. The result of this is that you cant get notification to trigger your backend anymore when disableClientSideFilter: true.

CC @Mincol

**Related github/jira issue (required)**:
Fixes #1689 

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-disable-client-filter-and-sort.html
- sort on any column -> only the visual indicator should stay, nothing happens because its disabled otherwise , the end user would then do this server side
- type 22 in any filter column -> only the filter condition should stay -> nothing happens because its disabled otherwise , the end user would then do this server side
- look at the console and you should now see a filtered event