### PR TITLE
1749 - Fix non firing click event [v4.16.x]

### DIFF
--- a/app/views/components/datagrid/test-icon-buttons.html
+++ b/app/views/components/datagrid/test-icon-buttons.html
@@ -32,17 +32,17 @@
       data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', ordered: 0});
       data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '100.99', status: 'OK', orderDate: new Date(2014, 6, 9, 12, 12, 12), action: 'On Hold', ordered: 0});
 
-      //Define Columns for the Grid.
-
+      // Define Columns for the Grid.
       columns.push({ id: 'id', hidden: true, name: ' Id', field: 'id', formatter: Formatters.Readonly });
       columns.push({ id: 'productDesc', name: 'Product Desc', field: 'productName', formatter: Formatters.Hyperlink});
       columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity'});
+      columns.push({ id: 'quantity2', name: 'Quantity2', hidden: true, field: 'quantity2'});
       columns.push({ id: 'actionLink', name: 'As Link', sortable: false, align: 'center', width: 80, formatter: Formatters.Hyperlink, icon: 'reset', tooltip: 'Reset', click: function (e, args) {console.log(args[0].cell, args[0].row, args[0].item.id);}});
       columns.push({ id: 'action', name: 'Active', sortable: false, align: 'center', width: 80, formatter: Formatters.Button, icon: 'reset', tooltip: 'Reset', click: function (e, args) {console.log(args[0].cell, args[0].row, args[0].item.id);},
         contentVisible: function (row, cell, data, col, item) { return (item.status === 'OK');} });
       columns.push({ id: 'activity', name: 'Activity', field: 'activity'});
 
-      //Init and get the api for the grid
+      // Init and get the api for the grid
       grid = $('#readonly-datagrid').datagrid({
         columns: columns,
         enableTooltips: true,

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5446,7 +5446,7 @@ Datagrid.prototype = {
       // Handle Cell Click Event
       const elem = $(this).closest('td');
       const cell = elem.attr('aria-colindex') - 1;
-      const col = self.columnSettings(cell, true);
+      const col = self.columnSettings(cell);
 
       if (col.click && typeof col.click === 'function' && target.is('button, input[checkbox], a') || target.parent().is('button')) {   //eslint-disable-line
         const rowElem = $(this).closest('tr');
@@ -8345,16 +8345,10 @@ Datagrid.prototype = {
   /**
    * Get the settings for a column by index.
    * @param  {number} idx The column index.
-   * @param  {boolean} onlyVisible If only the visible columns should be included.
    * @returns {array} The settings array
    */
-  columnSettings(idx, onlyVisible) {
-    let foundColumn = this.settings.columns[idx];
-
-    if (onlyVisible) {
-      foundColumn = this.visibleColumns()[idx];
-    }
-
+  columnSettings(idx) {
+    const foundColumn = this.settings.columns[idx];
     return foundColumn || {};
   },
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -8344,6 +8344,7 @@ Datagrid.prototype = {
 
   /**
    * Get the settings for a column by index.
+   * @private
    * @param  {number} idx The column index.
    * @returns {array} The settings array
    */

--- a/test/components/datagrid/datagrid-columns.func-spec.js
+++ b/test/components/datagrid/datagrid-columns.func-spec.js
@@ -76,4 +76,39 @@ describe('Datagrid Columns API', () => {
 
     expect(datagridObj.visibleColumns().length).toEqual(8);
   });
+
+  it('Should fire the column click event on button and link columns', (done) => {
+    const newColumns = [];
+    // One Hidden column to try to trip it up
+    newColumns.push({ id: 'quantity2', name: 'Quantity2', hidden: true, field: 'quantity2' });
+    newColumns.push({
+      id: 'actionLink',
+      name: 'As Link',
+      formatter: Formatters.Hyperlink,
+      icon: 'reset',
+      click: (e, args) => {
+        expect(args[0].cell).toEqual(1);
+        expect(args[0].row).toEqual(1);
+        expect(args[0].item.id).toEqual('2');
+        expect(args[0].item.productId).toEqual('200');
+      }
+    });
+    newColumns.push({
+      id: 'action',
+      name: 'Active',
+      formatter: Formatters.Button,
+      icon: 'reset',
+      click: (e, args) => {
+        expect(args[0].cell).toEqual(2);
+        expect(args[0].row).toEqual(2);
+        expect(args[0].item.id).toEqual('3');
+        expect(args[0].item.productId).toEqual('300');
+        done();
+      }
+    });
+    newColumns.push({ id: 'activity', name: 'Activity', field: 'activity' });
+    datagridObj.updateColumns(newColumns);
+    document.querySelector('.datagrid tr:nth-child(2) td:nth-child(2) a').click();
+    document.querySelector('.datagrid tr:nth-child(3) td:nth-child(3) button').click();
+  });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The frozen columns code had the effect of making click events not fire on columns when either:
- there is a hidden column
- there is more than one click function per column set

**Related github/jira issue (required)**:
Fixes #1749 

**Steps necessary to review your pull request (required)**:
- make sure the new test works
- go to http://localhost:4000/components/datagrid/test-icon-buttons.html
- click each of the two buttons and watch the console. There should be data for both of these columns