### PR TITLE
1014/1568 - Removed z-index changes on radios

### DIFF
--- a/app/views/patterns/stepprocess.html
+++ b/app/views/patterns/stepprocess.html
@@ -128,6 +128,23 @@
           </div>
 
           <div class="field">
+            <fieldset class="radio-group">
+              <legend>Select an Option</legend>
+              <input type="radio" class="radio" name="options" id="option1" value="option1" />
+              <label for="option1" class="radio-label">Option one</label>
+              <br/>
+              <input type="radio" class="radio" name="options" id="option2" value="option1" checked="true" />
+              <label for="option2"  class="radio-label">Option two</label>
+              <br/>
+              <input type="radio" class="radio" name="options" id="option3" value="option3" />
+              <label for="option3" class="radio-label">Option three</label>
+              <br/>
+              <input type="radio" class="radio" name="options" id="option4" value="delivery" disabled="true" />
+              <label for="option4" class="radio-label">Option four</label>
+            </fieldset>
+          </div>
+
+          <div class="field">
             <label for="point-of-origin" class="label">Point of Origin</label>
             <input id="point-of-origin" name="point-of-origin" type="text">
           </div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,8 @@
 - `[Datagrid]` :Stretch column not working in Edge browser. ([#1716](https://github.com/infor-design/enterprise/issues/1716))
 - `[Datagrid]` Fixed a bug where filtering Order Date with `is-not-empty` on a null value would not correctly filter out results. ([#1718](https://github.com/infor-design/enterprise/issues/1718))
 - `[Datagrid]` Fixed a bug where when using the `disableClientSideFilter` setting the filtered event would not be called correctly. ([#1689](https://github.com/infor-design/enterprise/issues/1689))
+- `[Radio Button]` Fixed a rendering problem on the selected state of Radio Buttons used inside of Accordion components. ([#1568](https://github.com/infor-design/enterprise/issues/1568))
+- `[Radio Button]` Fixed a z-index issue that was causing radio buttons to sometimes display over top of page sections where they should have instead scrolled beneath. ([#1014](https://github.com/infor-design/enterprise/issues/1014))
 
 ### v4.17.0 Chore & Maintenance
 

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -6,7 +6,6 @@
   opacity: 0;
   position: absolute;
   width: 0;
-  z-index: 1;
 }
 
 .inline-radio {
@@ -55,7 +54,6 @@
 .radio-label {
   display: inline-block;
   line-height: 20px;
-  z-index: 5;
 
   &.radio-label:first-of-type {
     margin-top: 4px;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR removes some z-index values that were previously applied to Radio Buttons.  This change was causing some visual bugs where radio buttons would often appear "in front" of elements that they should sit "behind", in terms of z-order.  This was especially present on the Stepprocess pattern, but was also causing a rendering problem on Accordion components.

This PR also adds some radio buttons to the step process example for testing purposes.

**Related github/jira issue (required)**:
Closes #1014 
Closes #1568 

**Steps necessary to review your pull request (required)**:
Firstly, pull this branch and run the demoapp.

_To test the Stepprocess (#1014):_
- Go to http://localhost:4000/patterns/stepprocess
- Shrink the browser viewport down to a size that displays the "tablet" functionality, with the steps collapsing, and only the contents of the current step displayed in the viewport.
- Scroll down to put the radios just above the top boundary of the viewport.  Scrolling down will cause the sticky header to roll offscreen.
- Scroll back up to show the sticky header.  No radio buttons should be displayed over top of the sticky header.

_To test the Accordion (#1568):_
- Go to http://localhost:4000/components/accordion/example-index.html
- Expand the accordion header labeled "Sort By"
- Observe that the currently selected radio button is rendered correctly (blue ring surrounding a white circle)

paging @krishollenbeck @volante007
