### PR TITLE
1591 - Added support for not tab-able to readonly dropdown

### DIFF
--- a/app/views/components/dropdown/example-readonly.html
+++ b/app/views/components/dropdown/example-readonly.html
@@ -29,6 +29,16 @@
     </div>
 
     <div class="field">
+      <label for="readonly2-dropdown">Readonly Dropdown (No Tab Stop)</label>
+      <select id="readonly2-dropdown" class="dropdown" readonly="true" tabindex="-1">
+        <option value="1">Item 1</option>
+        <option value="2">Item 2</option>
+        <option value="3">Item 3</option>
+        <option value="4">Item 4</option>
+      </select>
+    </div>
+
+    <div class="field">
       <label for="random-input-2">First Random Input</label>
       <input id="random-input-2" />
     </div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### v4.17.0 Features
 
 - `[Datagrid]` Added support to cancel `rowactivated` event. Now it will trigger the new event `beforerowactivated` which will wait/sync to cancel or proceed to do `rowactivated` event. ([#1021](https://github.com/infor-design/enterprise/issues/1021))
+- `[Dropdown]` Added support to make dropdown readonly fields optionally not tab-able. ([#1591](https://github.com/infor-design/enterprise/issues/1591))
 - `[Locale]` Added support for showing timezones in the current language with a fall back for IE 11. ([#592](https://github.com/infor-design/enterprise/issues/592))
 
 ### v4.17.0 Fixes

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -186,6 +186,11 @@ div.multiselect {
     color: $input-readonly-color;
     cursor: text;
     -webkit-text-fill-color: $input-readonly-color;
+
+    &[tabindex='-1']:focus {
+      border-color: $input-color-readonly-border !important;
+      box-shadow: none;
+    }
   }
 
   &:focus {

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1317,6 +1317,11 @@ Dropdown.prototype = {
     const target = $(e.target);
     const key = e.key;
 
+    // No need to execute if readonly
+    if (target.is('.is-readonly')) {
+      return true;
+    }
+
     // "Esc" is used by IE11
     const isEscapeKey = key === 'Esc' || key === 'Escape';
 
@@ -2811,7 +2816,7 @@ Dropdown.prototype = {
     this.pseudoElem
       .removeClass('is-disabled')
       .addClass('is-readonly')
-      .attr('tabindex', '0')
+      .attr('tabindex', this.element.attr('tabindex') || '0')
       .prop('disabled', false)
       .prop('readonly', true);
     this.closeList('cancel');

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -460,3 +460,21 @@ describe('Dropdown placeholder tests', () => {
     expect(await element(by.css('[data-placeholder-text]')).isDisplayed()).toBeTruthy();
   });
 });
+
+describe('Dropdown readonly tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/dropdown/example-readonly');
+  });
+
+  it('Should honor the tabindex', async () => {
+    await element(by.css('#random-input-1')).sendKeys(protractor.Key.TAB);
+
+    expect(await browser.driver.switchTo().activeElement().getAttribute('aria-label')).toEqual('Readonly Dropdown');
+
+    const dd = { id: 'readonly-dropdown', str: 'div[aria-controls="dropdown-list"]' };
+    dd.el = await element(by.id(dd.id)).element(by.xpath('..')).element(by.css(dd.str));
+    await dd.el.sendKeys(protractor.Key.TAB);
+
+    expect(await browser.driver.switchTo().activeElement().getAttribute('id')).toEqual('random-input-2');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added support to make dropdown readonly fields optionally not tab-able.

**Related github/jira issue (required)**:
Closes #1591

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/dropdown/example-readonly.html
- Open above link
- Tab thru each field on the page
- Field "Readonly Dropdown (No Tab Stop)"
- Should not be tab able
