### PR TITLE
#1770 - Add absolute position on error icons in field-short dropdowns…

### DIFF
--- a/app/views/components/dropdown/test-firefox-error-positioning.html
+++ b/app/views/components/dropdown/test-firefox-error-positioning.html
@@ -1,0 +1,41 @@
+<div class="row">
+  <div class="six columns">
+
+    <h2>Dropdown Test: Overlapping Firefox Error Icon</h2>
+
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="field-short">
+      <label class="label" for="validated-dd">LSF Dropdown</label>
+      <select id="validated-dd" class="dropdown">
+        <option value=""></option>
+        <option value="1">1</option>
+        <option value="2">2</option>
+        <option value="3">3</option>
+        <option value="4">4</option>
+      </select>
+    </div>
+
+    <br><br><br>
+
+    <button id="showError" class="btn-primary">Show error</button>
+    <button id="removeError" class="btn-primary">Remove error</button>
+  </div>
+</div>
+
+<script>
+  $('#showError').on('click', function() {
+    $('#validated-dd').removeError().addError({
+      message: 'Error message',
+      inline: false,
+      showTooltip: true
+    });
+  });
+  $('#removeError').on('click', function() {
+    $('#validated-dd').removeError();
+  });
+</script>

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -630,6 +630,7 @@ input.dropdown.error:focus {
 
     ~ .icon-error {
       margin-left: -38px;
+      position: absolute;
       right: auto;
       top: 0;
     }


### PR DESCRIPTION
… and add a test file.

**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Firefox requires that the error icon is absolutely positioned or it will take up space in the parent div. I found that the error icons in non field-short fields are positioned absolutely via _icons.scss, but field-short was not taken into account there. To minimize risk to other controls or scenarios, I added the position: absolute in _dropdown.scss, within the .field-short parent and only for .icon-error.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
This is a fix #1770.

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
View test here: app\views\components\dropdown\test-firefox-error-positioning.html
http://localhost:4000/components/dropdown/firefox-overlap-error.html

<!-- Please include the following in your PR:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.
-->

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
