### PR TITLE
1772 - Fixed two regression datagrid bugs [v4.16.x]

### DIFF
--- a/app/views/components/datagrid/example-editable.html
+++ b/app/views/components/datagrid/example-editable.html
@@ -111,10 +111,7 @@
       toolbar: {title: 'Data Grid Header Title', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: true,  collapsibleFilter: true},
       paging: true,
       pagesize: 5,
-      pagesizes: [2, 5, 6],
-      frozenColumns: {
-        left: ['rowStatus', 'selectionCheckbox', 'id', 'productName']
-      },
+      pagesizes: [2, 5, 6]
     }).on('cellchange', function (e, args) {
       console.log('cellchange', args);
     }).on('rowadd', function (e, args) {

--- a/app/views/components/datagrid/test-editable-colorpicker.html
+++ b/app/views/components/datagrid/test-editable-colorpicker.html
@@ -13,14 +13,13 @@
         data = [];
 
     // Some Sample Data
-    data.push({ id: 1, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold', ordered: true, setting: {optionOne: 'One', optionTwo: 'One'}, color: '#66A140'});
-    data.push({ id: 2, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 9, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action', ordered: true, color: '#7BBFB5'});
+    data.push({ id: 1, productId: 2241202, productName: 'Different Compressor', comment: 'Some comments about the item', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold', ordered: true, setting: {optionOne: 'One', optionTwo: 'One'}, color: '#66A140'});
+    data.push({ id: 2, productId: 2445204, productName: 'Another Compressor', comment: 'Some comments about the item', activity:  'Assemble Paint', quantity: 9, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action', ordered: true, color: '#7BBFB5'});
 
     //Define Columns for the Grid.
     columns.push({ id: 'productDesc', resizable: false, name: 'Product Desc', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, width: 200});
-    columns.push({ id: 'comment', name: 'Comment', field: 'comment', formatter: Formatters.Editor, editor: Editors.Editor, width: '60%' });
+    columns.push({ id: 'comment', name: 'Comment', field: 'comment', width: '60%' });
     columns.push({ id: 'productId', name: 'Product Id', field: 'productId', width: 160 });
-
     columns.push({ id: 'colorpickerId', name: 'Colorpicker', field: 'color', formatter: Formatters.Colorpicker, editor: Editors.Colorpicker, width: 190});
 
     //Init and get the api for the grid

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1958,6 +1958,11 @@ $datagrid-short-row-height: 23px;
         visibility: visible;
       }
 
+      .colorpicker-container .icon {
+        margin-left: 8px;
+        top: 10px;
+      }
+
       //Date Picker
       .datepicker {
         border: 0;

--- a/src/components/datagrid/datagrid.editors.js
+++ b/src/components/datagrid/datagrid.editors.js
@@ -310,6 +310,8 @@ const editors = {
       const self = this;
 
       this.input.trigger('openlist');
+      const rowNodes = grid.rowNodes(row);
+      rowNodes.removeClass('is-hover-row');
       this.input.focus().select();
 
       this.input.off('listclosed').on('listclosed', () => {
@@ -448,6 +450,8 @@ const editors = {
       // Check if isClick or cell touch and just open the list
       if (event.type === 'click') {
         this.input.trigger('openlist');
+        const rowNodes = grid.rowNodes(row);
+        rowNodes.removeClass('is-hover-row');
         $('#dropdown-list input').focus();
       } else {
         this.input[0].parentNode.querySelector('div.dropdown').focus();

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3397,7 +3397,7 @@ Datagrid.prototype = {
     const isActivated = rowData._rowactivated;
     const rowStatus = { class: '', svg: '' };
 
-    if (rowData && rowData.rowStatus && self.settings.showNewRowIndicator) {
+    if (rowData && rowData.rowStatus && (rowData.rowStatus.icon === 'new' ? self.settings.showNewRowIndicator : true)) {
       rowStatus.show = true;
       rowStatus.class = ` rowstatus-row-${rowData.rowStatus.icon}`;
       rowStatus.icon = (rowData.rowStatus.icon === 'success') ? '#icon-check' : '#icon-exclamation';
@@ -5256,12 +5256,10 @@ Datagrid.prototype = {
     if (self.settings.showHoverState) {
       self.bodyContainer
         .off('mouseenter.datagrid, mouseleave.datagrid')
-        .on('mouseenter.datagrid', 'tbody > tr', function (e) {
-          console.log('mouseenter', this, e);
+        .on('mouseenter.datagrid', 'tbody > tr', function () {
           const rowNodes = self.rowNodes($(this));
           rowNodes.addClass('is-hover-row');
-        }).on('mouseleave.datagrid', 'tbody > tr', function (e) {
-          console.log('mouseleave', this, e);
+        }).on('mouseleave.datagrid', 'tbody > tr', function () {
           const rowNodes = self.rowNodes($(this));
           rowNodes.removeClass('is-hover-row');
         });

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5256,10 +5256,12 @@ Datagrid.prototype = {
     if (self.settings.showHoverState) {
       self.bodyContainer
         .off('mouseenter.datagrid, mouseleave.datagrid')
-        .on('mouseenter.datagrid', 'tbody > tr', function () {
+        .on('mouseenter.datagrid', 'tbody > tr', function (e) {
+          console.log('mouseenter', this, e);
           const rowNodes = self.rowNodes($(this));
           rowNodes.addClass('is-hover-row');
-        }).on('mouseleave.datagrid', 'tbody > tr', function () {
+        }).on('mouseleave.datagrid', 'tbody > tr', function (e) {
+          console.log('mouseleave', this, e);
           const rowNodes = self.rowNodes($(this));
           rowNodes.removeClass('is-hover-row');
         });

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -97,6 +97,59 @@ describe('Datagrid Custom Filter Option Tests', () => {
   });
 });
 
+describe('Datagrid Editable Tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/example-editable?layout=nofrills');
+
+    const datagridEl = await element(by.id('datagrid'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should render row statuses', async () => {
+    await element(await by.id('toggle-row-status')).click();
+
+    expect(await element.all(by.css('#datagrid .rowstatus-row-error')).count()).toEqual(1);
+    expect(await element.all(by.css('#datagrid .rowstatus-row-alert')).count()).toEqual(1);
+    expect(await element.all(by.css('#datagrid .rowstatus-row-info')).count()).toEqual(1);
+    expect(await element.all(by.css('#datagrid .rowstatus-row-in-progress')).count()).toEqual(1);
+    expect(await element.all(by.css('#datagrid .rowstatus-row-success')).count()).toEqual(1);
+  });
+
+  it('Should render row statuses across page', async () => {
+    await element(await by.id('toggle-row-status')).click();
+    await element(await by.css('.pager-next a')).click();
+    await browser.driver.sleep(300);
+    await element(await by.css('.pager-prev a')).click();
+    await browser.driver.sleep(300);
+
+    expect(await element.all(by.css('#datagrid .rowstatus-row-error')).count()).toEqual(1);
+    expect(await element.all(by.css('#datagrid .rowstatus-row-alert')).count()).toEqual(1);
+    expect(await element.all(by.css('#datagrid .rowstatus-row-info')).count()).toEqual(1);
+    expect(await element.all(by.css('#datagrid .rowstatus-row-in-progress')).count()).toEqual(1);
+    expect(await element.all(by.css('#datagrid .rowstatus-row-success')).count()).toEqual(1);
+  });
+
+  it('Should not show indicator on showNewRowIndicator false', async () => {
+    await element(await by.id('toggle-row-status')).click();
+    await element.all(await by.css('.toolbar .btn-actions')).get(0).click();
+    await browser.driver.sleep(300);
+    await element(await by.cssContainingText('li a', 'Add')).click();
+    await browser.driver.sleep(300);
+
+    expect(await element.all(by.css('#datagrid .rowstatus-row-new')).count()).toEqual(0);
+    expect(await element.all(by.css('#datagrid .rowstatus-row-error')).count()).toEqual(1);
+    expect(await element.all(by.css('#datagrid .rowstatus-row-alert')).count()).toEqual(1);
+    expect(await element.all(by.css('#datagrid .rowstatus-row-info')).count()).toEqual(1);
+    expect(await element.all(by.css('#datagrid .rowstatus-row-in-progress')).count()).toEqual(1);
+    expect(await element.all(by.css('#datagrid .rowstatus-row-success')).count()).toEqual(0);
+  });
+});
+
 describe('Datagrid Empty Message Tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/example-empty-message?layout=nofrills');

--- a/test/components/tree/tree.e2e-spec.js
+++ b/test/components/tree/tree.e2e-spec.js
@@ -55,7 +55,7 @@ describe('Tree example-index tests', () => {
       const containerEl = await element(by.id('maincontent'));
       await browser.driver.sleep(config.sleep);
 
-      expect(await browser.protractorImageComparison.checkElement(containerEl, 'tree-index')).toEqual(0);
+      expect(await browser.protractorImageComparison.checkElement(containerEl, 'tree-index')).toBeLessThan(1);
     });
   }
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixed two regressions for 4.16 as noted on the test steps.

**Related github/jira issue (required)**:
Fixes #1771
Fixes #1772

**Steps necessary to review your pull request (required)**:
Testing #1771 
http://localhost:4000/components/datagrid/example-editable.html
- press add row status
- press  go back one page and then back to the first page -> status should stay around
- reload
- press add row status
- press add under the .. menu -> status should sty around but the new indicator is not shown as there is a setting around it

Testing #1772 
http://localhost:4000/components/datagrid/example-editable.html
- select an item in the last columns dropdown list moving down from top to bottom
- should no longer have a hover state showing up
