### PR TITLE
Fix horizontal scroll bar display with medium rows

### DIFF
--- a/app/views/components/datagrid/test-horizontal-scroll.html
+++ b/app/views/components/datagrid/test-horizontal-scroll.html
@@ -1,0 +1,291 @@
+<div class="row">
+  <div class="six columns" style="max-width: 900px; height: 250px;">
+    <div id="datagrid"></div>
+  </div>
+  <div class="six columns" style="max-width: 900px; height: 250px;">
+    <div id="datagrid-filters"></div>
+  </div>
+</div>
+
+<div class="row" style="margin-top: 60px;">
+  <div class="six columns" style="max-width: 900px; height: 250px;">
+    <div id="datagrid-groups"></div>
+  </div>
+  <div class="six columns" style="max-width: 900px; height: 250px;">
+    <div id="datagrid-both"></div>
+  </div>
+</div>
+
+<div class="row" style="margin-top: 60px;">
+  <div class="six columns" style="max-width: 900px; height: 250px;">
+    <div id="datagrid-paging"></div>
+  </div>
+  <div class="six columns" style="max-width: 900px; height: 250px;">
+    <div id="datagrid-paging-filters"></div>
+  </div>
+</div>
+
+<div class="row" style="margin-top: 60px;">
+  <div class="six columns" style="max-width: 900px; height: 250px;">
+    <div id="datagrid-paging-groups"></div>
+  </div>
+  <div class="six columns" style="max-width: 900px; height: 250px;">
+    <div id="datagrid-paging-both"></div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function() {
+    var grid,
+      columns = [],
+      data = [];
+
+    // Some Sample Data
+    data.push({
+      id: 1,
+      productId: 2142201,
+      productName: 'Compressor',
+      activity: 'Assemble Paint',
+      quantity: 1,
+      price: '500',
+      status: 'OK',
+      orderDate: new Date(2014, 12, 8),
+      action: 'Action'
+    });
+    data.push({
+      id: 2,
+      productId: 2241202,
+      productName: 'Different Compressor',
+      activity: 'Inspect and Repair',
+      quantity: '2',
+      price: 210.99,
+      status: '',
+      orderDate: new Date(2015, 7, 3),
+      action: 'On Hold'
+    });
+    data.push({
+      id: 3,
+      productId: 2342203,
+      productName: 'Compressor',
+      activity: 'Inspect and Repair',
+      quantity: 1,
+      price: '120.99',
+      status: null,
+      orderDate: new Date(2014, 6, 3),
+      action: 'Action'
+    });
+    data.push({
+      id: 4,
+      productId: 2445204,
+      productName: 'Another Compressor',
+      activity: 'Assemble Paint',
+      quantity: 3,
+      price: '2345',
+      status: 'OK',
+      orderDate: new Date(2015, 3, 3),
+      action: 'Action'
+    });
+    data.push({
+      id: 5,
+      productId: 2542205,
+      productName: 'I Love Compressors',
+      activity: 'Inspect and Repair',
+      quantity: 4,
+      price: '210.99',
+      status: 'OK',
+      orderDate: new Date(2015, 5, 5),
+      action: 'On Hold'
+    });
+    data.push({
+      id: 5,
+      productId: 2642205,
+      productName: 'Air Compressors',
+      activity: 'Inspect and Repair',
+      quantity: 41,
+      price: '120.99',
+      status: 'OK',
+      orderDate: new Date(2014, 6, 9),
+      action: 'On Hold'
+    });
+    data.push({
+      id: 6,
+      productId: 2642206,
+      productName: 'Some Compressor',
+      activity: 'inspect and Repair',
+      quantity: 41,
+      price: '123.99',
+      status: 'OK',
+      orderDate: null,
+      action: 'On Hold'
+    });
+
+    // Define Columns for the Grid.
+    columns.push({
+      id: 'selectionCheckbox',
+      sortable: false,
+      resizable: false,
+      formatter: Formatters.SelectionCheckbox,
+      align: 'center'
+    });
+    columns.push({
+      id: 'productId',
+      name: 'Product Id',
+      field: 'productId',
+      formatter: Formatters.Readonly
+    });
+    columns.push({
+      id: 'productName',
+      name: 'Product Name',
+      sortable: false,
+      field: 'productName',
+      filterType: 'text',
+      formatter: Formatters.Text
+    });
+    columns.push({
+      id: 'activity',
+      hidden: true,
+      name: 'Activity',
+      field: 'activity',
+      filterType: 'text'
+    });
+    columns.push({
+      id: 'quantity',
+      name: 'Quantity',
+      field: 'quantity',
+      filterType: 'text'
+    });
+    columns.push({
+      id: 'price',
+      name: 'Price',
+      field: 'price',
+      formatter: Formatters.Decimal
+    });
+    columns.push({
+      id: 'orderDate',
+      name: 'Order Date',
+      field: 'orderDate',
+      formatter: Formatters.Date,
+      dateFormat: 'M/d/yyyy'
+    });
+    columns.push({
+      id: 'status',
+      name: 'Status',
+      field: 'status',
+      formatter: Formatters.Text
+    });
+    columns.push({ id: 'action', name: 'Action Item', field: 'action' });
+
+    // Init and get the api for the grid
+    $('#datagrid').datagrid({
+      columns: columns,
+      dataset: data,
+      toolbar: {
+        title: 'No extras',
+        actions: true,
+        rowHeight: true
+      }
+    });
+
+    $('#datagrid-filters').datagrid({
+      columns: columns,
+      dataset: data,
+      filterable: true,
+      toolbar: {
+        title: 'Filters',
+        actions: true,
+        rowHeight: true
+      }
+    });
+
+    $('#datagrid-groups').datagrid({
+      columns: columns,
+      columnGroups: [
+        { colspan: 3, id: 'group1', name: 'Column Group One' },
+        { colspan: 1, id: 'group2', name: 'Column Group Two' },
+        { colspan: 2, id: 'group3', name: 'Column Group Three' },
+        { colspan: 3, id: 'group4', name: 'Column Group four' }
+      ],
+      dataset: data,
+      toolbar: {
+        title: 'Groups',
+        actions: true,
+        rowHeight: true
+      }
+    });
+
+    $('#datagrid-both').datagrid({
+      columns: columns,
+      columnGroups: [
+        { colspan: 3, id: 'group1', name: 'Column Group One' },
+        { colspan: 1, id: 'group2', name: 'Column Group Two' },
+        { colspan: 2, id: 'group3', name: 'Column Group Three' },
+        { colspan: 3, id: 'group4', name: 'Column Group four' }
+      ],
+      dataset: data,
+      filterable: true,
+      toolbar: {
+        title: 'Both',
+        actions: true,
+        rowHeight: true
+      }
+    });
+
+    $('#datagrid-paging').datagrid({
+      columns: columns,
+      dataset: data,
+      paging: true,
+      toolbar: {
+        title: 'No extras',
+        actions: true,
+        rowHeight: true
+      }
+    });
+
+    $('#datagrid-paging-filters').datagrid({
+      columns: columns,
+      dataset: data,
+      paging: true,
+      filterable: true,
+      toolbar: {
+        title: 'Filters',
+        actions: true,
+        rowHeight: true
+      }
+    });
+
+    $('#datagrid-paging-groups').datagrid({
+      columns: columns,
+      columnGroups: [
+        { colspan: 3, id: 'group1', name: 'Column Group One' },
+        { colspan: 1, id: 'group2', name: 'Column Group Two' },
+        { colspan: 2, id: 'group3', name: 'Column Group Three' },
+        { colspan: 3, id: 'group4', name: 'Column Group four' }
+      ],
+      dataset: data,
+      paging: true,
+      toolbar: {
+        title: 'Groups',
+        actions: true,
+        rowHeight: true
+      }
+    });
+
+    $('#datagrid-paging-both').datagrid({
+      columns: columns,
+      columnGroups: [
+        { colspan: 3, id: 'group1', name: 'Column Group One' },
+        { colspan: 1, id: 'group2', name: 'Column Group Two' },
+        { colspan: 2, id: 'group3', name: 'Column Group Three' },
+        { colspan: 3, id: 'group4', name: 'Column Group four' }
+      ],
+      dataset: data,
+      paging: true,
+      filterable: true,
+      toolbar: {
+        title: 'Both',
+        actions: true,
+        rowHeight: true
+      }
+    });
+  });
+</script>

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -177,6 +177,18 @@ $datagrid-short-row-height: 23px;
     }
   }
 
+  &.has-group-headers {
+    .datagrid-body {
+      height: calc(100% - 78px);
+    }
+  }
+
+  &.has-group-headers.has-filterable-columns {
+    .datagrid-body {
+      height: calc(100% - 100px);
+    }
+  }
+
   &.has-filterable-columns {
     .datagrid-body {
       height: calc(100% - 60px);
@@ -408,23 +420,15 @@ $datagrid-short-row-height: 23px;
     }
 
     &.has-group-headers .datagrid-body {
-      height: calc(100% - 50px);
+      height: calc(100% - 51px);
     }
 
     &.has-filterable-columns .datagrid-body {
       height: calc(100% - 49px);
     }
 
-    &.has-toolbar {
-      height: calc(100% - 45px);
-
-      &.paginated {
-        height: calc(100% - 103px);
-      }
-    }
-
-    &.paginated {
-      height: calc(100% - 58px);
+    &.has-group-headers.has-filterable-columns .datagrid-body {
+      height: calc(100% - 76px);
     }
 
     //Resize Drag Arrows
@@ -525,6 +529,18 @@ $datagrid-short-row-height: 23px;
     //Set Container Heights for scrolling
     .datagrid-body {
       height: calc(100% - 30px);
+    }
+
+    &.has-group-headers .datagrid-body {
+      height: calc(100% - 61px);
+    }
+
+    &.has-filterable-columns .datagrid-body {
+      height: calc(100% - 55px);
+    }
+
+    &.has-group-headers.has-filterable-columns .datagrid-body {
+      height: calc(100% - 86px);
     }
 
     .drag-target-arrows {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Solves issue #1618. `.datagrid-body` height calculation was not being properly adjusted for medium and short row heights when filter rows and/or column groups were present. This fix adjusts _datagrid.scss and adds test-horizontal-scroll.html.

**Related github/jira issue (required)**:
Closes #1618 

**Steps necessary to review your pull request (required)**:
- Open http://localhost:4000/components/datagrid/test-horizontal-scroll.
- Change the row heights.
- Witness the horizontal scroll bar remain in place for each example
- make sure the bottom row isnt cut off.