### PR TITLE
1747 - Demoapp: remove `font` query parameter

### DIFF
--- a/app/src/js/middleware/option-handler.js
+++ b/app/src/js/middleware/option-handler.js
@@ -50,15 +50,6 @@ module.exports = function (app, defaults) {
       logger('info', 'Using the minified version of "sohoxi.js"');
     }
 
-    if ((req.query.font && req.query.font.length > 0) || res.opts.theme === 'uplift-alpha') {
-      res.opts.font = req.query.font;
-      logger('info', `Using the ${req.query.font} font`);
-    }
-
-    if (res.opts.theme === 'uplift-alpha') {
-      res.opts.font = true;
-    }
-
     let useLiveReload = false;
     process.argv.forEach((val) => {
       if (val === '--livereload') {

--- a/app/views/includes/head.html
+++ b/app/views/includes/head.html
@@ -42,7 +42,6 @@
   <script>
     var colors;
     var theme;
-    var font = '';
     var blockUI = '{{layout}}'.indexOf('embedded') > -1 ? false : true;
 
     {{#colors}}
@@ -61,12 +60,9 @@
     {{#theme}}
     theme = '{{theme}}';
     {{/theme}}
-    {{#font}}
-    font = '{{font}}';
-    {{/font}}
 
     // If Initialize isnt called need to defer this
-    $('html').personalize({colors: colors, theme: theme, font: font, blockUI: blockUI});
+    $('html').personalize({colors: colors, theme: theme, blockUI: blockUI});
   </script>
 
   <link rel="stylesheet" id="sohoxi-stylesheet" href="{{basepath}}css/{{theme}}-theme.css" type="text/css"/>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@
 ### v4.17.0 Chore & Maintenance
 
 - `[Css/Sass]` Replaced font-size numerical declarations with their ids-identity token counterpart. ([#1640](https://github.com/infor-design/enterprise/issues/1640))
+- `[Demoapp]` Removed query parameter for changing fonts. ([#1747](https://github.com/infor-design/enterprise/issues/1747))
 
 (n Issues Solved this release, Backlog Enterprise n, Backlog Ng n, n Functional Tests, n e2e Test)
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR removes the ability to change the font in the demoapp view query parameters (fx: http://localhost:4000?font=source-sans).  This was necessary for some initial testing on new IDS themes, but is no longer necessary since the decision was made that multiple fonts on a theme will not be supported.

**Related github/jira issue (required)**:
Closes #1747 

**Steps necessary to review your pull request (required)**:
- Pull this branch
- Run the demoapp in verbose mode with `node --inspect-brk ./app/server.js --verbose`
- Open any page with the font query param (fx: http://localhost:4000?font=source-sans)
- Ensure that there are no messages about fonts changing present in the Node.js console, and that there is no change in font on the page itself.
