### PR TITLE
Fix padding issue for embedded layouts in website [v4.16.x]

### DIFF
--- a/app/src/sass/layouts/_embedded.scss
+++ b/app/src/sass/layouts/_embedded.scss
@@ -7,6 +7,7 @@
   .custom-header {
     background-color: $theme-color-palette-white;
     height: 38px;
+    margin-bottom: 20px;
     width: 100%;
     z-index: 100;
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
In the embedded demos on design.infor.com, there's often little to no margin between the theme switching tab bar and the component content.

**Related github/jira issue (required)**:
n/a

**Steps necessary to review your pull request (required)**:

**Before:**

![image](https://user-images.githubusercontent.com/1012017/54295894-48299980-458a-11e9-8eae-912d6372aa95.png)

**After:**

![image](https://user-images.githubusercontent.com/1012017/54295946-5ecff080-458a-11e9-8129-88ba9aa4d6c6.png)

