### PR TITLE
Mark uplift theme as beta

### DIFF
--- a/app/src/js/middleware/option-handler.js
+++ b/app/src/js/middleware/option-handler.js
@@ -31,7 +31,7 @@ module.exports = function (app, defaults) {
       res.opts.theme = req.query.theme;
       logger('info', `Setting Theme to ${res.opts.theme}`);
 
-      if (res.opts.theme === 'uplift-alpha') {
+      if (res.opts.theme === 'uplift') {
         res.opts.isUpliftTheme = true;
       }
     } else {

--- a/app/src/js/routes/custom-icons.js
+++ b/app/src/js/routes/custom-icons.js
@@ -14,7 +14,7 @@ const themeToIcons = {
   'light'   : 'soho',
   'dark': 'soho',
   'high-contrast' : 'soho',
-  'uplift-alpha': 'uplift'
+  'uplift': 'uplift'
 }
 
 const hbsTemplate = `

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -105,7 +105,7 @@ const filePaths = {
         'dark-theme': path.join(SRC_DIR, 'themes', 'dark-theme.scss'),
         'high-contrast-theme': path.join(SRC_DIR, 'themes', 'high-contrast-theme.scss'),
         'light-theme': path.join(SRC_DIR, 'themes', 'light-theme.scss'),
-        'uplift-alpha-theme': path.join(SRC_DIR, 'themes', 'uplift-alpha-theme.scss'),
+        'uplift-theme': path.join(SRC_DIR, 'themes', 'uplift-theme.scss'),
       }
     }
   },
@@ -131,7 +131,7 @@ const filePaths = {
         'dark-theme': path.join(TEMP_DIR, 'dark-theme.scss'),
         'high-contrast-theme': path.join(TEMP_DIR, 'high-contrast-theme.scss'),
         'light-theme': path.join(TEMP_DIR, 'light-theme.scss'),
-        'uplift-alpha-theme': path.join(TEMP_DIR, 'uplift-alpha-theme.scss')
+        'uplift-theme': path.join(TEMP_DIR, 'uplift-theme.scss')
       }
     },
     log: {

--- a/scripts/configs/cssmin.js
+++ b/scripts/configs/cssmin.js
@@ -10,7 +10,7 @@ module.exports = {
         'dist/css/high-contrast-theme.min.css': ['dist/css/high-contrast-theme.css'],
         'dist/css/dark-theme.min.css': ['dist/css/dark-theme.css'],
         'dist/css/light-theme.min.css': ['dist/css/light-theme.css'],
-        'dist/css/uplift-alpha-theme.min.css': ['dist/css/uplift-alpha-theme.css'],
+        'dist/css/uplift-theme.min.css': ['dist/css/uplift-theme.css'],
       }
     },
   }

--- a/scripts/configs/sass.js
+++ b/scripts/configs/sass.js
@@ -10,7 +10,7 @@ module.exports = {
         'dist/css/light-theme.css': 'temp/light-theme.scss',
         'dist/css/dark-theme.css': 'temp/dark-theme.scss',
         'dist/css/high-contrast-theme.css': 'temp/high-contrast-theme.scss',
-        'dist/css/uplift-alpha-theme.css': 'temp/uplift-alpha-theme.scss'
+        'dist/css/uplift-theme.css': 'temp/uplift-theme.scss'
       }
     },
 
@@ -20,7 +20,7 @@ module.exports = {
         'dist/css/light-theme.css': 'temp/light-theme.scss',
         'dist/css/dark-theme.css': 'temp/dark-theme.scss',
         'dist/css/high-contrast-theme.css': 'temp/high-contrast-theme.scss',
-        'dist/css/uplift-alpha-theme.css': 'temp/uplift-alpha-theme.scss'
+        'dist/css/uplift-theme.css': 'temp/uplift-theme.scss'
       }
     },
 

--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -49,7 +49,7 @@ Personalize.prototype = {
       'light',
       'dark',
       'high-contrast',
-      'uplift-alpha'
+      'uplift'
     ];
 
     // Set the default theme, or grab the theme from an external CSS stylesheet.

--- a/src/themes/uplift-theme.scss
+++ b/src/themes/uplift-theme.scss
@@ -6,7 +6,7 @@
 @import '../core/mixins';
 
 // ids-identity token vars
-@import '../../node_modules/ids-identity/dist/tokens/web/theme-uplift';
+@import '../../node_modules/ids-identity/dist/theme-uplift/tokens/web/theme-uplift';
 
 // Enterprise colors
 @import '../components/colors/colorpalette';
@@ -17,12 +17,12 @@
 // Core Controls
 @import '../core/controls';
 
-// Temporary Banner - Remove this when not alpha.
+// Temporary Banner - Remove this when not beta.
 body::before {
-  background: $theme-color-status-warning;
+  background: $theme-color-status-base;
   bottom: 12px;
   color: $theme-color-palette-white;
-  content: 'alpha';
+  content: 'beta';
   font-size: 13px;
   font-weight: 900;
   height: 25px;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Seeing that we've got the fundamentals of color, typography, and iconography working in the components, I feel we can now mark it as `beta`.

- Updates references to `uplift-alpha` theme to be just `uplift`
- Renames theme file
- Updates banner to be `beta`

**Related github/jira issue (required)**:
Depends on merging #1795

**Steps necessary to review your pull request (required)**:
- `npm start` and got to http://localhost:4000/?theme=uplift
- You should see the uplift theme and an updated banner in the bottom

<!-- Please include the following in your PR:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.
-->

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
