### PR TITLE
1802 - Datagrid hide column display issues

### DIFF
--- a/app/views/components/datagrid/example-modal-datagrid.html
+++ b/app/views/components/datagrid/example-modal-datagrid.html
@@ -1,0 +1,118 @@
+<div class="row">
+  <div class="twelve columns">
+    <button class="btn-secondary" type="button" id="open-modal">Open Modal</button><br><br>
+
+    <!-- "Context" Example -->
+    <div id="modal-content" style="display: none;">
+      <div id="datagrid">
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    //Locale.set('en-US').done(function () {
+    var grid,
+    columns = [],
+    data = [];
+
+    // Some Sample Data
+    data.push({ id: 1, productId: 'T100', productName: 'Compressor', phone: '191/2004', activity:  'Assemble Paint', quantity: 1, price: '800.9905673502324', percent: .10, status: 'OK', orderDate: '00000000', action: 'Action'});
+    data.push({ id: 2, productId: '200', productName: 'Different Compressor', phone: '(888) 888-8888', activity:  'Inspect and Repair', quantity: '2', percent: .10, price: null, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+    data.push({ id: 3, productId: '300', productName: 'Compressor', phone: '(888) 888-8888', activity:  'Inspect and Repair', quantity: 1, price: '120.99', percent: .10, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+    data.push({ id: 4, productId: 'Z400', productName: 'Another Compressor', phone: '(888) 888-8888', activity:  'Assemble Paint', quantity: 3, price: '2345', percent: .10, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+    data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: '2345', percent: .10, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+    data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: '210.99', percent: .10, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+    data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: '120.99', percent: .10, status: 'OK', orderDate:new Date(2017, 5, 5), action: 'On Hold'});
+    data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '123.99', percent: .10, status: 'OK', orderDate: null, action: 'On Hold'});
+
+    //Define Columns for the Grid.
+    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
+    columns.push({ id: 'productId', name: 'Id', field: 'productId', formatter: Formatters.Text});
+    columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink});
+    columns.push({ id: 'activity', name: 'Activity', field: 'activity'});
+//    columns.push({ id: 'hidden', hidden: true, name: 'Hidden', field: 'hidden'});
+    columns.push({ id: 'price', align: 'right', name: 'Actual Price', field: 'price', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'currency', currencySign: '$'}});
+    columns.push({ id: 'percent', align: 'right', name: 'Actual %', field: 'percent', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'percent'}});
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+//    columns.push({ id: 'phone', name: 'Phone', field: 'phone', formatter: Formatters.Text});
+    columns.push({ id: 'field1', name: 'Field1', field: 'field1', formatter: Formatters.Text });
+    columns.push({ id: 'field2', name: 'Field2', field: 'field2', formatter: Formatters.Text });
+    columns.push({ id: 'field3', name: 'Field3', field: 'field3', formatter: Formatters.Text });
+    columns.push({ id: 'field4', name: 'Field4', field: 'field4', formatter: Formatters.Text });
+    columns.push({ id: 'field5', name: 'Field5', field: 'field5', formatter: Formatters.Text });
+    columns.push({ id: 'field6', name: 'Field6', field: 'field6', formatter: Formatters.Text });
+    columns.push({ id: 'field7', name: 'Field7', field: 'field7', formatter: Formatters.Text });
+    columns.push({ id: 'field8', name: 'Field8', field: 'field8', formatter: Formatters.Text });
+    columns.push({ id: 'field9', name: 'Field9', field: 'field9', formatter: Formatters.Text });
+    columns.push({ id: 'field10', name: 'Field10', field: 'field10', formatter: Formatters.Text });
+    columns.push({ id: 'field11', name: 'Field11', field: 'field11', formatter: Formatters.Text });
+    columns.push({ id: 'field12', name: 'Field12', field: 'field12', formatter: Formatters.Text });
+
+    //Init and get the api for the grid
+    grid = $('#datagrid').datagrid({
+      columns: columns,
+      dataset: data,
+      saveColumns: false,
+      paging: true,
+      pagesize: 5,
+      actionableMode: true,
+      cellNavigation: true,
+      editable: false,
+      enableTooltips: true,
+      filterWhenTyping: false,
+      redrawOnResize: false,
+      rowHeight: 'short',
+      selectable: 'single',
+      showDirty: false
+      // toolbar: {title: 'Compressors', actions: true, rowHeight: true, personalize: true}
+    }).data('datagrid');
+
+    // Hide 10 of the columns to expose the issue
+    grid.hideColumn('field1');
+    grid.hideColumn('field2');
+    grid.hideColumn('field3');
+    grid.hideColumn('field4');
+    grid.hideColumn('field5');
+    grid.hideColumn('field6');
+    grid.hideColumn('field7');
+    grid.hideColumn('field8');
+    grid.hideColumn('field9');
+    grid.hideColumn('field10');
+
+    var modals = {
+      'open-modal': {
+        'title': 'Open Modal',
+        'content': $('#modal-content')
+      }
+    },
+
+    setModal = function (opt) {
+      opt = $.extend({
+        buttons: [{
+          text: 'Cancel',
+          id: 'modal-button-1',
+          click: function(e, modal) {
+            modal.close();
+          }
+        }, {
+          text: 'Save',
+          id: 'modal-button-2',
+          click: function(e, modal) {
+            modal.close();
+          },
+          validate: false,
+          isDefault: true
+        }],
+        maxWidth: 1000
+      }, opt);
+
+      $('body').modal(opt);
+    };
+
+    $('#open-modal').on('click', function () {
+      setModal(modals[this.id]);
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `[Locale]` Added for having a different language that the locale. This is done by calling the new `setLanguage` function. ([#1552](https://github.com/infor-design/enterprise/issues//1552))
 - `[Locale / Mask]` Added limited initial support for some unicode languages. This means you can convert to and from numbers typed in Devangari, Arabic, and Chinese (Financial and Simplified). ([#439](https://github.com/infor-design/enterprise/issues/439))
 - `[Mask]` It is now possible to type numbers in unicode such as Devangari, Arabic, and Chinese (Financial and Simplified) into the the masks that involve numbers. ([#439](https://github.com/infor-design/enterprise/issues/439))
+- `[Modal]` Added an option to dictate the maximum width of the modal. ([#1802](https://github.com/infor-design/enterprise/issues/1802))
 - `[Icons]` Add support for creating an svg file for the Uplift theme's (alpha) new icons from ids-identity@2.4.0 assets. ([#1759](https://github.com/infor-design/enterprise/issues/1759))
 
 ### v4.17.0 Fixes
@@ -37,6 +38,7 @@
 - `[Datagrid]` Fixed a bug where filtering Order Date with `is-not-empty` on a null value would not correctly filter out results. ([#1718](https://github.com/infor-design/enterprise/issues/1718))
 - `[Datagrid]` Fixed a bug where when using the `disableClientSideFilter` setting the filtered event would not be called correctly. ([#1689](https://github.com/infor-design/enterprise/issues/1689))
 - `[Datagrid]` Fixed a bug where hidden columns inside a colspan were aligning incorrectly. ([#1764](https://github.com/infor-design/enterprise/issues/1764))
+- `[Modal]` Fixed a bug where the modal can overflow the page. ([#1802](https://github.com/infor-design/enterprise/issues/1802))
 - `[Radio Button]` Fixed a rendering problem on the selected state of Radio Buttons used inside of Accordion components. ([#1568](https://github.com/infor-design/enterprise/issues/1568))
 - `[Radio Button]` Fixed a z-index issue that was causing radio buttons to sometimes display over top of page sections where they should have instead scrolled beneath. ([#1014](https://github.com/infor-design/enterprise/issues/1014))
 

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -26,6 +26,7 @@ const COMPONENT_NAME = 'modal';
 * @param {function} [settings.beforeShow=null] A call back function that can be used to return data for the modal.
 * @param {boolean} [settings.useFlexToolbar] If true the new flex toolbar will be used (For CAP)
 * @param {boolean} [settings.showCloseBtn] If true, show a close icon button on the top right of the modal.
+* @param {number} [settings.maxWidth=null] Optional max width to add in pixels.
 * return the markup in the response and this will be shown in the modal. The busy indicator will be shown while waiting for a response.
 */
 const MODAL_DEFAULTS = {
@@ -40,7 +41,8 @@ const MODAL_DEFAULTS = {
   frameWidth: 46,
   beforeShow: null,
   useFlexToolbar: false,
-  showCloseBtn: false
+  showCloseBtn: false,
+  maxWidth: null
 };
 
 function Modal(element, settings) {
@@ -169,7 +171,7 @@ Modal.prototype = {
     let isAppended = false;
 
     this.element = $(`${'<div class="modal">' +
-        '<div class="modal-content">' +
+        '<div class="modal-content" style="max-width: '}${this.settings.maxWidth ? this.settings.maxWidth : ''}px${'">' +
           '<div class="modal-header"><h1 class="modal-title">'}${this.settings.title}</h1></div>` +
           '<div class="modal-body-wrapper">' +
             '<div class="modal-body"></div>' +
@@ -759,7 +761,7 @@ Modal.prototype = {
   resize() {
     // 90% -(180 :extra elements-height)
     let calcHeight = ($(window).height() * 0.9) - this.settings.frameHeight;
-    const calcWidth = ($(window).width() * 1.05) - this.settings.frameWidth;
+    const calcWidth = ($(window).width() * 1) - this.settings.frameWidth;
 
     const wrapper = this.element.find('.modal-body-wrapper');
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Modal overflows the width of the page at larger breakpoints.
There was no option for manipulating the max-width of the modal.
Reverted the `calcWidth` multiplier back to 1 from 1.05 which was added here and created the bug: #393. I retested #393 and it looks fine.
Added an option to dictate max-width of the modal. Defaults to `null`.

**Related github/jira issue (required)**:
Closes #1802.
Related to #393.

**Steps necessary to review your pull request (required)**:
- Pull branch
- Run app
- Browse to new page: http://localhost:4000/components/datagrid/example-modal-datagrid
  - Observe there is no overflow of the modal
  - Play around with changing the maxWidth option in the example page