### PR TITLE
1677- Hierarchy stacked layout needs ability to support multi root data structure [4.16.x]

### DIFF
--- a/app/data/hc-john-randolph-multi-root.json
+++ b/app/data/hc-john-randolph-multi-root.json
@@ -1,0 +1,28 @@
+{
+  "ancestorPath": null,
+  "centeredNode": {
+  "id": "1",
+  "name": "John Randolph",
+  "position": "CEO",
+  "employmentType": "FT",
+  "picture": "/images/4.jpg"
+},
+"children": [
+    {
+      "id": "2",
+      "name": "Barb Wire",
+      "position": "COO",
+      "employmentType": "FT",
+      "avatarInitials": "BW",
+      "isLeaf": true
+    },
+    {
+      "id": "3",
+      "name": "Greg Ford",
+      "position": "CTO",
+      "employmentType": "FT",
+      "avatarInitials": "GF",
+      "isLeaf": true
+    }
+  ]
+}

--- a/app/data/hc-multi-root.json
+++ b/app/data/hc-multi-root.json
@@ -1,0 +1,30 @@
+{
+  "ancestorPath": null,
+  "centeredNode": null,
+  "children": [
+    {
+      "id": "1",
+      "name": "John Randolph",
+      "position": "CEO",
+      "employmentType": "FT",
+      "picture": "/images/4.jpg",
+      "childrenUrl": "hc-john-randolph-multi-root.json"
+    },
+    {
+      "id": "2",
+      "name": "Barb Wire",
+      "position": "COO",
+      "employmentType": "FT",
+      "avatarInitials": "BW",
+      "isLeaf": true
+    },
+    {
+      "id": "3",
+      "name": "Greg Ford",
+      "position": "CTO",
+      "employmentType": "FT",
+      "avatarInitials": "GF",
+      "isLeaf": true
+    }
+  ]
+}

--- a/app/views/components/hierarchy/test-multi-root.html
+++ b/app/views/components/hierarchy/test-multi-root.html
@@ -1,0 +1,79 @@
+<figure class="hierarchy" id="hierarchy"></figure>
+
+<script id="hierarchyInit">
+  const options = {
+    templateId: 'hierarchyChartTemplate',
+    legendKey: 'employmentType',
+    legend: [
+      { 'value' : 'FT', 'label' : 'Full Time'     },
+      { 'value' : 'PT', 'label' : 'Part Time'     },
+      { 'value' : 'C',  'label' : 'Contractor'    },
+      { 'value' : 'O',  'label' : 'Open Position' }
+    ],
+    dataset: [],
+    layout: 'stacked'
+  };
+  // Initial load
+  $.getJSON('{{basepath}}api/hc-multi-root', function(data) {
+    options.dataset = [data];
+    $('#hierarchy').hierarchy(options);
+  });
+  $('#hierarchy').on('selected', function(event, eventInfo) {
+    const hierarchyControl = $('#hierarchy').data('hierarchy');
+    console.log(event, eventInfo);
+    if (eventInfo.eventType === 'expand' || eventInfo.eventType === 'back') {
+      $.getJSON(`{{basepath}}api/${eventInfo.data.childrenUrl}`, function(newData) {
+        reload(eventInfo, hierarchyControl, newData);
+      });
+    }
+  });
+  function reload(eventInfo, hierarchyControl, newData) {
+    eventInfo.data.children = newData;
+    options.dataset = [eventInfo.data.children];
+    hierarchyControl.reload(options);
+  }
+</script>
+
+
+{{={{{ }}}=}}
+<script type="text/html" id="hierarchyChartTemplate">
+  <div class="leaf {{colorClass}}" id="{{id}}">
+
+    {{#picture}}
+    <img src="{{picture}}" class="image" alt="Image of {{name}}"/>
+    {{/picture}}
+    {{^picture}}
+
+    {{#avatarInitials}}
+    <div class="image-initials">{{avatarInitials}}</div>
+    {{/avatarInitials}}
+    {{^avatarInitials}}
+    <span class="image-placeholder"></span>
+    {{/avatarInitials}}
+
+    {{/picture}}
+
+    <div class="detail">
+      <p class="heading">{{name}}</p>
+      <p class="subheading">{{position}}</p>
+      <p class="micro">{{employmentType}}</p>
+    </div>
+
+    {{#menu}}
+    <button class="btn-actions btn-icon" type="button" data-init="false" id="btn-{{id}}">
+      <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
+        <use xlink:href="#icon-more"></use>
+      </svg>
+      <span class="audible">More Info & Additional Actions</span>
+    </button>
+    <ul class="popupmenu"></ul>
+    {{/menu}}
+
+    <button class="btn btn-icon" type="button">
+      <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
+        <use xlink:href="#icon-caret-up"></use>
+      </svg>
+      <span class="audible">Expand/Collapse</span>
+    </button>
+  </div>
+</script>

--- a/src/components/hierarchy/_hierarchy-stacked.scss
+++ b/src/components/hierarchy/_hierarchy-stacked.scss
@@ -27,6 +27,11 @@
     padding-left: 0;
   }
 
+  .chart > .sub-level:first-child {
+    border-top: none;
+    margin-top: 0;
+  }
+
   .chart .root:first-child::after {
     display: none;
   }

--- a/src/components/hierarchy/hierarchy.js
+++ b/src/components/hierarchy/hierarchy.js
@@ -788,13 +788,22 @@ Hierarchy.prototype = {
       });
     } else {
       const centeredNode = data.centeredNode;
-      let leaf = this.isStackedLayout() ? this.getTemplate(centeredNode) : this.getTemplate(data);
-      leaf = xssUtils.sanitizeHTML(leaf);
-      rootNodeHTML.push(leaf);
-      $(rootNodeHTML[0]).addClass('root is-selected').appendTo(chart);
+      let leaf;
 
-      if (data.centeredNode) {
-        this.updateState($('.leaf.root'), true, data.centeredNode, undefined);
+      if (this.isStackedLayout() && centeredNode !== null) {
+        leaf = this.getTemplate(centeredNode);
+      } else if (!this.isStackedLayout()) {
+        leaf = this.getTemplate(data);
+      }
+
+      if (leaf) {
+        leaf = xssUtils.sanitizeHTML(leaf);
+        rootNodeHTML.push(leaf);
+        $(rootNodeHTML[0]).addClass('root is-selected').appendTo(chart);
+      }
+
+      if (centeredNode && centeredNode !== null) {
+        this.updateState($('.leaf.root'), true, centeredNode, undefined);
       } else {
         this.updateState($('.leaf.root'), true, data, undefined);
       }
@@ -1005,7 +1014,8 @@ Hierarchy.prototype = {
 
         let childLength = thisNodeData.children.length;
         while (childLength--) {
-          self.updateState($(`#${thisNodeData.children[childLength].id}`), false, thisNodeData.children[childLength], undefined);
+          const lf = $(`#${thisNodeData.children[childLength].id}`);
+          self.updateState(lf, false, thisNodeData.children[childLength], undefined);
         }
       }
     }
@@ -1039,7 +1049,7 @@ Hierarchy.prototype = {
         });
       }
 
-      if (data.centeredNode) {
+      if (data.centeredNode && data.centeredNode !== null) {
         this.setRootColor(data.centeredNode);
       }
     }
@@ -1115,8 +1125,12 @@ Hierarchy.prototype = {
 
     const s = this.settings;
     const btn = $(leaf).find('.btn');
-    const data = $(leaf).data();
     const expandCaret = s.paging ? 'caret-right' : 'caret-up';
+    let data = $(leaf).data();
+
+    if (data === undefined && nodeData !== undefined) {
+      data = nodeData;
+    }
 
     // data has been loaded if it has children
     if ((data.children && data.children.length !== 0) || eventType === 'add') {


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Cherry picked changes from https://github.com/infor-design/enterprise/issues/1677 for this PR.

Need a way to render multiple roots. For example.
```
{
  "ancestorPath": null,
  "centeredNode": null
  "children":  [{..childrenUrl}, {..childrenUrl}, {...childrenUrl}]
}
```

**Describe the solution you'd like**
Cards will display as one level if there are multiple roots on the initial data load (see attached screenshot).

**Additional context**
    ![multi-root](https://user-images.githubusercontent.com/1056684/53431682-9d748100-39b6-11e9-9adf-cd45234309a6.png)
