### PR TITLE
1815 - Remove some arrow syntax functions so examples work on IE11 [v4.16.x]

### DIFF
--- a/app/views/components/hierarchy/example-index.html
+++ b/app/views/components/hierarchy/example-index.html
@@ -28,9 +28,9 @@
       console.log(event, eventInfo);
     });
 
-    setTimeout(() => {
+    setTimeout(function() {
       $('#hierarchy').data('hierarchy').selectLeaf("1_3");
-    }, 100);
+    }, 300);
 
 </script>
 

--- a/app/views/components/lookup/test-single-select-serverside.html
+++ b/app/views/components/lookup/test-single-select-serverside.html
@@ -55,7 +55,7 @@
               req.grandTotal = res.grandTotal; // This is the total amount on the server
             }
             // Set a timeout to simulate time for server to respond
-            setTimeout(() => {
+            setTimeout(function() {
               response(res.data, req);
             }, 1000);
           });

--- a/app/views/components/popupmenu/test-multiple.html
+++ b/app/views/components/popupmenu/test-multiple.html
@@ -71,7 +71,7 @@
     popupMenu.popupmenu();
     const popupMenuApi = popupMenu.data('popupmenu');
 
-    $('#popdown-destroy').click(() => {
+    $('#popdown-destroy').click(function() {
       contextMenu.off();
       contextMenuApi.destroy();
       contextMenu.parent().remove();

--- a/app/views/components/tree/test-preserve-restore.html
+++ b/app/views/components/tree/test-preserve-restore.html
@@ -184,11 +184,11 @@
   const preserveBtn = document.getElementById('preserve');
   const restoreBtn = document.getElementById('restore');
 
-  preserveBtn.addEventListener('click', () => {
+  preserveBtn.addEventListener('click', function() {
     tree.preserveEnablementState();
   });
 
-  restoreBtn.addEventListener('click', () => {
+  restoreBtn.addEventListener('click', function() {
     tree.restoreEnablementState();
   });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Some examples wont load on IE , in particular the Hierarchy one as noted. Removed the arrow functions so this will work. This probably doesnt need a new build as it was just an example page but thats debatable.

**Related github/jira issue (required)**:
Closes #1815

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/hierarchy/example-index.html
- load page in IE 11