### PR TITLE
1814 - Cropped Header for Builder Panel When Text is Long

### DIFF
--- a/app/views/patterns/builder-subtitle-test.html
+++ b/app/views/patterns/builder-subtitle-test.html
@@ -45,8 +45,8 @@
         <div class="toolbar no-actions-button">
           <div class="title">
             <h2>
-              <span class="panel-title">Builder Panel Title - Test a long title</span><br>
-              <span class="panel-subhead">Builder Panel Subheader - Test also a long subtitle</span>
+              <span class="panel-title">Builder Panel Title - Test a really really really really really really really really long title</span><br>
+              <span class="panel-subhead">Builder Panel Subheader - Test also a really really really really really really really really long subtitle</span>
             </h2>
           </div>
           <div class="buttonset">

--- a/app/views/patterns/builder-subtitle-test.html
+++ b/app/views/patterns/builder-subtitle-test.html
@@ -1,0 +1,170 @@
+<body class="no-scroll">
+  <a href="#maincontent" class="skip-link" data-translate="text">SkipToMain</a>
+  {{> includes/svg-inline-refs}}
+
+  <div class="page-container no-scroll builder two-column">
+
+    <div class="sidebar no-scroll" role="complementary">
+      <header class="header is-personalizable">
+        <div class="toolbar">
+          <div class="title">
+            <h1>Patterns</h1>
+          </div>
+
+          <div class="buttonset">
+            <input class="searchfield" placeholder="Search">
+          </div>
+        </div>
+      </header>
+
+      <div class="listview scrollable" id="task-listview" data-options="{'template': 'task-tmpl', 'source': '{{basepath}}api/inventory-tasks'}"></div>
+    </div>
+
+    <div id="maincontent" class="main no-scroll builder-pane" role="main">
+      <header class="header is-personalizable">
+        <div class="toolbar">
+          <div class="title">
+
+            <button class="btn-icon list-detail-back-button go-back" type="button">
+              <span class="audible">Show navigation</span>
+              <span class="icon app-header">
+                <span class="one"></span>
+                <span class="two"></span>
+                <span class="three"></span>
+              </span>
+            </button>
+
+            <h1>Builder</h1>
+          </div>
+
+          {{> includes/header-actionbutton}}
+        </div>
+      </header>
+
+      <div class="builder-header header subheader is-personalizable">
+        <div class="toolbar no-actions-button">
+          <div class="title">
+            <h2>
+              <span class="panel-title">Builder Panel Title - Test a long title</span><br>
+              <span class="panel-subhead">Builder Panel Subheader - Test also a long subtitle</span>
+            </h2>
+          </div>
+          <div class="buttonset">
+            <button type="button" id="sidebar-responsive-menu" class="btn-tertiary hidden-lg hidden-xl" data-popdown="builder-popdown-content">
+              <svg class="icon" focusable="false" aria-hidden="true">
+                <use xlink:href="#icon-settings"></use>
+              </svg>
+              <span>Sidebar Popup</span>
+            </button>
+
+          </div>
+        </div>
+        <div id="builder-popdown-content" class="popdown hidden">
+          <div class="widget">
+            <div class="widget-header">
+              <h2 class="widget-title">My Cart <span class="extra">(8 Items)</span></h2>
+            </div>
+            <div class="widget-content">
+              <p style="margin: 0 20px 20px;">
+                Tag aggregate, feeds rich weblogs user-centric user-centred mashups frictionless, interactive blogospheres e-enable visionary, solutions enable vertical target seamless remix seize folksonomies--vortals efficient. Integrate, metrics. Peer-to-peer weblogs mesh methodologies platforms citizen-media revolutionary podcasts enable communities, "folksonomies best-of-breed reinvent; rss-capable mindshare."
+              </p>
+              <p style="margin: 0 20px 20px;">
+                Syndicate share, synergies capture, value-added integrate B2C, integrate synthesize envisioneer podcasts orchestrate incentivize cross-platform networkeffects. Robust redefine ecologies, eyeballs, "A-list semantic," revolutionary bricks-and-clicks Cluetrain target syndicate integrate viral e-enable mindshare reintermediate whiteboard.
+              </p>
+            </div>
+            <div class="widget-footer modal-buttonset">
+              <button type="button" class="btn-modal-secondary" style="width: 50%;">Edit Cart</button>
+              <button type="button" class="btn-modal-primary" style="width: 50%;">Checkout</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="wizard-toolbar">
+        <a class="hyperlink" href="#">< Back to Order #627126128</a>
+        <div class="wizard">
+            <div class="wizard-header">
+              <div class="bar">
+                <div class="completed-range"></div>
+                <a href="#" class="tick complete">
+                  <span class="label">Edit Cart</span>
+                </a>
+                <a href="#" class="tick complete">
+                  <span class="label">Shipping</span>
+                </a>
+                <a href="#" class="tick current">
+                  <span class="label">Payment</span>
+                </a>
+                <a href="#" class="tick">
+                  <span class="label">Confirmation</span>
+                </a>
+              </div>
+            </div>
+        </div>
+      </div>
+
+      <div class="builder-content scrollable">
+        <div class="builder-actions">
+          <div class="builder-actions-header">
+            <h3>Main Panel Contents</h3>
+          </div>
+          <div class="builder-actions-content">
+            <p>
+              Web-enabled networks engage strategic bleeding-edge, e-services reinvent syndicate beta-test initiatives. Experiences optimize dynamic scalable dynamic mindshare communities dot-com reintermediate e-tailers deliverables, engage customized dynamic mission-critical.
+            </p>
+            <p>
+              A-list, social, citizen-media?" Real-time orchestrate ubiquitous addelivery A-list cutting-edge sexy innovate folksonomies: paradigms feeds. Platforms cross-platform. Wireless data-driven productize, cultivate web-readiness integrateAJAX-enabled, mashups? Embrace cultivate action-items, infrastructures authentic. Rss-capable weblogs whiteboard schemas embedded harness optimize disintermediate eyeballs morph peer-to-peer, networkeffects markets tagclouds semantic, customized ecologies channels, initiatives, scalable magnetic.
+            </p>
+          </div>
+        </div>
+        <div class="builder-sidebar my-cart scrollable">
+          <div class="builder-sidebar-header">
+            <h3>Sidebar Contents</h3>
+          </div>
+          <div class="builder-sidebar-content">
+            <p style="margin: 0 20px 20px;">
+              Tag aggregate, feeds rich weblogs user-centric user-centred mashups frictionless, interactive blogospheres e-enable visionary, solutions enable vertical target seamless remix seize folksonomies--vortals efficient. Integrate, metrics. Peer-to-peer weblogs mesh methodologies platforms citizen-media revolutionary podcasts enable communities, "folksonomies best-of-breed reinvent; rss-capable mindshare."
+            </p>
+            <p style="margin: 0 20px 20px;">
+              Syndicate share, synergies capture, value-added integrate B2C, integrate synthesize envisioneer podcasts orchestrate incentivize cross-platform networkeffects. Robust redefine ecologies, eyeballs, "A-list semantic," revolutionary bricks-and-clicks Cluetrain target syndicate integrate viral e-enable mindshare reintermediate whiteboard.
+            </p>
+          </div>
+          <div class="builder-sidebar-footer"></div>
+        </div>
+      </div>
+
+    </div>
+    <!-- #maincontent.main.scrollable.builder-pane -->
+
+  </div>
+  <!-- END Actual Layout Markup -->
+
+  <!-- Layout Template for Listview -->
+  {{={{{ }}}=}}
+  <script id="task-tmpl" type="text/html">
+    <ul>
+      {{#dataset}}
+        {{#disabled}}
+          <li class="is-disabled">
+        {{/disabled}}
+        {{^disabled}}
+          <li>
+        {{/disabled}}
+          <p class="listview-heading">Task #{{task}}</p>
+          <p class="listview-subheading">{{desc}}</p>
+          <p class="listview-micro">Due: {{date}}</p>
+        </li>
+      {{/dataset}}
+    </ul>
+  </script>
+
+  <!-- Change Colors -->
+  <script>
+    $('body').on('initialized', function() {
+      $(this).personalize({
+        startingColor: '#2578A9' // Azure07
+      });
+    });
+  </script>
+
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@
 ### v4.17.0 Fixes
 
 - `[Accordion]` Fixed a bug where some truncated text elements were not generating a tooltip. ([#1736](https://github.com/infor-design/enterprise/issues/1736))
+- `[Builder]` Cropped Header for Builder Panel When Text is Long. ([#1814](https://github.com/infor-design/enterprise/issues/1814))
 - `[Calendar]` Event model title color is not correct if the modal is opened and another event is selected. ([#1739](https://github.com/infor-design/enterprise/issues/1739))
 - `[Calendar]` Modal is still displayed after changing months. ([#1741](https://github.com/infor-design/enterprise/issues/1741))
 - `[Calendar]` Changing some event spans is causing missing dates on the dialogs. ([#1708](https://github.com/infor-design/enterprise/issues/1708))

--- a/src/patterns/_builder.scss
+++ b/src/patterns/_builder.scss
@@ -81,12 +81,12 @@
     color: $theme-color-palette-white;
     display: inline-block;
     margin-bottom: 0;
-    position: relative;
-    top: 10px;
-    vertical-align: top;
     max-width: 100%;
     overflow: hidden;
+    position: relative;
     text-overflow: ellipsis;
+    top: 10px;
+    vertical-align: top;
   }
 
   .panel-subhead {

--- a/src/patterns/_builder.scss
+++ b/src/patterns/_builder.scss
@@ -84,10 +84,12 @@
     position: relative;
     top: 10px;
     vertical-align: top;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .panel-subhead {
-    display: block;
     margin-top: 3px;
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
In the Builder Panel Header, when the text is very long, it is being cropped. This becomes an issue for us when app is viewed on mobile because space becomes limited and fewer characters can be shown.

**Related github/jira issue (required)**:
Closes #1814 

**Steps necessary to review your pull request (required)**:
Goto 'http://localhost:4000/patterns/builder-subtitle-test.html'


