### PR TITLE
1768 - Tabs IE11 mobile overflow QA FAIL

### DIFF
--- a/app/views/components/tabs/example-composite-form.html
+++ b/app/views/components/tabs/example-composite-form.html
@@ -58,7 +58,7 @@
       </div>
       <div class="expandable-footer">
         <button id="composite-form-expander" class="btn-tertiary expandable-expander">
-          <span>Show Summary</span>
+          <span>Hide Summary</span>
         </button>
       </div>
     </section>
@@ -133,3 +133,12 @@
   </section>
 
 </div>
+
+<script>
+  $('#composite-form-expander').on('click', function (e, args) {
+    var span = $(this).find('span');
+    var text = span.text();
+
+    span.text(text === 'Hide Summary' ? 'Show Summary' : 'Hide Summary');
+  });
+</script>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ids-enterprise",
   "slug": "ids-enterprise",
-  "version": "4.17.0-beta.0",
+  "version": "4.18.0-dev",
   "description": "Infor Design System (IDS) Enterprise Components for the web",
   "repository": {
     "type": "git",

--- a/src/components/expandablearea/expandablearea.js
+++ b/src/components/expandablearea/expandablearea.js
@@ -141,6 +141,8 @@ ExpandableArea.prototype = {
       this.close();
     }
 
+    this.resize();
+
     return this;
   },
 
@@ -338,6 +340,18 @@ ExpandableArea.prototype = {
         self.element.css('min-height', 'auto');
       }
     }, 300); // equal to transition time
+  },
+
+  /**
+  * Determines if the the body has resized and fires the applyIE11Fix.
+  * @private
+  * @returns {void}
+  */
+  resize() {
+    const self = this;
+    $('body').on('resize.expandablearea', () => {
+      self.applyIE11Fix();
+    });
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
When user resizes the browser with the expandablearea `is-expanded`, the applyIE11Fix does not take effect.

**Related github/jira issue (required)**:
Relates to #1768.

**Steps necessary to review your pull request (required)**:
- Pull branch
- Run app
- In IE11
  - Expand browser window to desktop size
  - Ensure expandablearea `is-expanded`
  - Browse to http://localhost:4000/components/compositeform/example-index.html
  - Collapse browser window to mobile size
  - Ensure there is no overflow
  - Expand back out to desktop size
- Follow above IE11 steps but use http://localhost:4000/components/tabs/example-composite-form.html