### PR TITLE
1021 - Fixed rowactivated for ie11 with datagrid [v4.17.x]

### DIFF
--- a/app/views/components/datagrid/test-before-row-activated.html
+++ b/app/views/components/datagrid/test-before-row-activated.html
@@ -80,20 +80,20 @@
       var delay = 3000;
       toast('Begin: Before Row Activated', delay);
 
-      var response = new Promise((resolve, reject) => {
-        setTimeout(function() {
-          var shouldGoAhead = true;
-          if (shouldGoAhead) {
-            resolve();
-          } else {
-            reject();
-            message({ type: 'error', msg: 'Row Not Activated (row: '+ args.row +')' });
-          }
-          console.log('Complete: Before Row Activated');
-        }, delay);
-      });
+      var deferred = $.Deferred();
 
-      return response;
+      setTimeout(function() {
+        var shouldGoAhead = true;
+        if (shouldGoAhead) {
+          deferred.resolve();
+        } else {
+          deferred.reject();
+          message({ type: 'error', msg: 'Row Not Activated (row: '+ args.row +')' });
+        }
+        console.log('Complete: Before Row Activated');
+      }, delay);
+
+      return deferred.promise();
     });
 
   });

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -6218,13 +6218,13 @@ Datagrid.prototype = {
     const findInRows = (rowNodes) => {
       let found = false;
       rowNodes.toArray().forEach((row) => {
-        row.querySelectorAll('td').forEach((cell) => {
+        [].slice.call(row.querySelectorAll('td')).forEach((cell) => {
           const cellText = cell.innerText.toLowerCase();
           const isSearchExpandableRow = self.settings.searchExpandableRow ? true : !DOM.hasClass(this, 'datagrid-expandable-row');
 
           if (cellText.indexOf(term) > -1 && isSearchExpandableRow) {
             found = true;
-            cell.querySelectorAll('*').forEach((node) => {
+            [].slice.call(cell.querySelectorAll('*')).forEach((node) => {
               if (xssUtils.unescapeHTML(node.innerHTML) === node.textContent) {
                 const contents = node.textContent;
                 const exp = new RegExp(`(${stringUtils.escapeRegExp(term)})`, 'gi');
@@ -6851,7 +6851,7 @@ Datagrid.prototype = {
     }
 
     // Deselect activated row
-    const activated = this.bodyContainer[0].querySelectorAll('tr.is-rowactivated');
+    const activated = [].slice.call(this.bodyContainer[0].querySelectorAll('tr.is-rowactivated'));
     if (activated.length > 0) {
       activated.forEach((row) => {
         row.classList.remove('is-rowactivated');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Example page for rowactivated was not working with IE11.

**Related github/jira issue (required)**:
Closes #1021

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-before-row-activated.html
- Open above link with IE11
- Click on any row to make it activated
- See `beforerowactivated` is triggered
- Then `rowactivated` is triggered
