### PR TITLE
1459 - Fix page size selector bugs on responsive List/Detail view [v4.17.x]

### DIFF
--- a/src/components/pager/_pager.scss
+++ b/src/components/pager/_pager.scss
@@ -242,9 +242,3 @@ html[dir='rtl'] {
     }
   }
 }
-
-@include respond-to(phone) {
-  .pager-pagesize {
-    display: none !important;
-  }
-}

--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -726,6 +726,7 @@ Pager.prototype = {
 
     const disableFirstIndeterminate = this.settings.indeterminate && this.firstPage === true;
     const disableLastIndeterminate = this.settings.indeterminate && this.lastPage === true;
+    const hasDataset = (this.settings.dataset && this.settings.dataset.length);
 
     // If this is a filtered dataset, use the `filteredTotal` instead
     if (this.state.filteredPages) {
@@ -782,7 +783,7 @@ Pager.prototype = {
     }
 
     // Disable first/last if we can display all available page numbers
-    if (!this.isTable && this.settings.type !== 'standalone' && maxNumberButtons >= totalPages) {
+    if (!this.isTable && this.settings.type !== 'standalone' && hasDataset && maxNumberButtons >= totalPages) {
       disableFirstButton = true;
       disableLastButton = true;
     }
@@ -861,7 +862,7 @@ Pager.prototype = {
 
     // Draw all relevant page numbers, if applicable
     // Page Number Buttons are only rendered if there is visible space available to fit them.
-    if (!this.isTable && (this.settings.dataset && this.settings.dataset.length)) {
+    if (!this.isTable && hasDataset) {
       let numberButtonHTML = '';
       buttonsToRender.forEach((i) => {
         if (i === (activePage || 1)) {

--- a/src/layouts/_layouts.scss
+++ b/src/layouts/_layouts.scss
@@ -356,7 +356,23 @@ body.no-scroll {
       }
     }
   }
+}
 
+// on iOS landscape mode, fix the height of the listview to actually show the pager.
+@media (max-width: $breakpoint-phone-to-tablet - 1px) and (orientation: landscape) {
+  .ios {
+    .two-column {
+      > .sidebar {
+        .listview-search {
+          + .listview {
+            &.paginated {
+              height: calc(100% - 190px);
+            }
+          }
+        }
+      }
+    }
+  }
 }
 
 @media (max-width: $breakpoint-phone-to-tablet - 1) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds an additional patch as a follow up to #1691, specifically for fixing some mobile-layout related problems on the Pager and its page-size selector button.  The issues are documented [in this comment](https://github.com/infor-design/enterprise/issues/1459#issuecomment-475228968)

**Related github/jira issue (required)**:
Closes #1459

**Steps necessary to review your pull request (required)**:
Pull this branch and run the demoapp.

_Test the landscape orientation bug and visibility of page size selector (**NOTE**: To test these issues, you need to be using an iPhone, or running an iPhone simulator on a Mac)_
- Open Safari and navigate to http://localhost:4000/patterns/list-detail-paging-pagesize-selector
- Rotate the device left or right to get to Landscape orientation
- The responsive view should have activated. There should be a pager bar present and usable at the bottom of the device.  The pager bar should correctly display the "compact" page size selector button.
- If the device has the iOS "black bar" that allows the window to be dragged, the buttons on the pager bar should still be usable if pressed correctly.

_Test incorrectly-disabled buttons_
- Open a desktop browser to http://localhost:4000/patterns/list-detail-paging-pagesize-selector
- Shrink the viewport width so that the responsive view is shown.
- Observe that the Last pager button should not be disabled.
- Click the "next" button until there are no more pages left to navigate.
- Observe that the First pager button should not be disabled.
