### PR TITLE
1716 - Added QA fix for landscape stretch column and size columns equally [v4.17.x]

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4094,7 +4094,7 @@ Datagrid.prototype = {
     if (lastColumn && this.isInitialRender && !this.settings.spacerColumn) {
       const diff = this.elemWidth - this.totalWidths[container];
 
-      if (this.settings.stretchColumn === 'last') {
+      if (this.settings.stretchColumn === 'last' && !this.settings.sizeColumnsEqually) {
         if (diff > 0 && diff > colWidth && !this.widthPercent && !col.width) {
           colWidth = '';
           this.headerWidths[index] = {
@@ -4123,8 +4123,8 @@ Datagrid.prototype = {
         const stretchColumn = $.grep(this.headerWidths, e => e.id === this.settings.stretchColumn);
         if ((diff2 > 0) && !stretchColumn[0].widthPercent) {
           stretchColumn[0].width += diff2 - 2;
-          this.totalWidths[container] = '100%';
         }
+        this.totalWidths[container] = '100%';
       }
 
       if (this.widthPercent) {
@@ -4416,9 +4416,7 @@ Datagrid.prototype = {
       this.settings.columnGroups = columnGroups;
     }
 
-    this.clearHeaderCache();
-    this.renderRows();
-    this.renderHeader();
+    this.rerender();
     this.resetPager('updatecolumns');
 
     /**
@@ -5301,11 +5299,10 @@ Datagrid.prototype = {
   * Resize event handler.
   * @private
   */
-  handleResize() {
-    const self = this;
-    self.clearHeaderCache();
-    self.renderRows();
-    self.renderHeader();
+  rerender() {
+    this.clearHeaderCache();
+    this.renderRows();
+    this.renderHeader();
   },
 
   /**
@@ -5611,6 +5608,13 @@ Datagrid.prototype = {
         }, 0);
       }
     });
+
+    if (this.stretchColumn !== 'last') {
+      $(window).on('orientationchange.datagrid', () => {
+        console.log('oc');
+        this.rerender();
+      });
+    }
 
     /**
     * Fires after a row is double clicked.
@@ -8820,13 +8824,11 @@ Datagrid.prototype = {
 
   /**
    * For an internal row node, get the dataset row index.
-   * This method is slated to be removed in a future v4.22.0 or v5.0.0.
-   * @deprecated as of v4.16.0. Please use `rowNodes()` for frozen columns.
+   * @private
    * @param {number} row The row node.
    * @returns {object} The row index in the dataset.
    */
   actualRowIndex(row) {
-    warnAboutDeprecation(this.rowNodes, this.actualRowIndex);
     return row.attr('aria-rowindex') - 1;
   },
 
@@ -10066,6 +10068,7 @@ Datagrid.prototype = {
     $(document).off('touchstart.datagrid touchend.datagrid touchcancel.datagrid click.datagrid touchmove.datagrid');
     this.bodyContainer.off().remove();
     $('body').off('resize.vtable resize.datagrid');
+    $(window).off('orientationchange.datagrid');
     return this;
   },
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5611,7 +5611,6 @@ Datagrid.prototype = {
 
     if (this.stretchColumn !== 'last') {
       $(window).on('orientationchange.datagrid', () => {
-        console.log('oc');
         this.rerender();
       });
     }

--- a/test/components/blockgrid/blockgrid-api.func-spec.js
+++ b/test/components/blockgrid/blockgrid-api.func-spec.js
@@ -54,7 +54,7 @@ describe('Blockgrid API', () => {
 
   it('Should select block', (done) => {
     const firstBlock = $('.block').first();
-    blockgridObj.selectBlock(firstBlock);
+    blockgridObj.select(firstBlock);
 
     setTimeout(() => {
       expect(document.body.querySelector('.block').classList.contains('is-selected')).toBeTruthy();

--- a/test/components/blockgrid/blockgrid-events.func-spec.js
+++ b/test/components/blockgrid/blockgrid-events.func-spec.js
@@ -38,7 +38,7 @@ describe('Blockgrid Single Events', () => {
   it('Should trigger "selected" event', () => {
     const spyEvent = spyOnEvent('#blockgrid', 'selected');
     const firstBlock = $('.block').first();
-    blockgridObj.selectBlock(firstBlock);
+    blockgridObj.select(firstBlock);
 
     expect(spyEvent).toHaveBeenTriggered();
   });
@@ -104,7 +104,7 @@ describe('Blockgrid Mixed Selection Events', () => {
     const spyEvent = spyOnEvent('#blockgrid', 'activated');
     const firstBlock = $('.block').first();
 
-    blockgridObj.selectBlock(firstBlock);
+    blockgridObj.select(firstBlock);
     setTimeout(() => {
       expect(spyEvent).toHaveBeenTriggered();
       done();
@@ -114,8 +114,8 @@ describe('Blockgrid Mixed Selection Events', () => {
   it('Should trigger "deactivated" event', (done) => {
     const spyEvent = spyOnEvent('#blockgrid', 'deactivated');
     const firstBlock = $('.block').first();
-    blockgridObj.selectBlock(firstBlock);
-    blockgridObj.selectBlock(firstBlock);
+    blockgridObj.select(firstBlock);
+    blockgridObj.select(firstBlock);
 
     setTimeout(() => {
       expect(spyEvent).toHaveBeenTriggered();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Added fixes for noted QA issues on 1716. Some things were not working perfectly when changing to landscape mode and the sizeColumnsEqually feature was broken. Also fixed one deprecation warning in the tests. Also removed one deprecation in datagrid as the function is actually different so the comment is incorrect

**Related github/jira issue (required)**:
Fixes #1716 

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-columns-stretch-column.html
- open on an IOS device or browser stack
- turn the device to landscape mode (this should now work)

http://localhost:4000/components/datagrid/test-columns-equal.html
- all columns should be equal size with no horizontal scrollbar