### PR TITLE
1731 - Added additional fix for IE, Tab focus [v4.17.x]

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1462,7 +1462,6 @@ Dropdown.prototype = {
    * Focus the input element. Since the select is hidden this is needed over normal focus()
    * @private
    * @param  {boolean} [useSearchInput] If true the search is used.
-   * @param {boolean} [noFocus] if true, does not attempt to focus the input
    * @returns {void}
    */
   activate(useSearchInput) {
@@ -1492,13 +1491,7 @@ Dropdown.prototype = {
     selectText();
 
     // Set focus back to the element
-    if (env.browser.isIE10() || env.browser.isIE11()) {
-      setTimeout(() => {
-        input[0].focus();
-      }, 0);
-    } else {
-      input[0].focus();
-    }
+    input[0].focus();
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Made additional fix so that #1731 was solved for IE 11. Did this by removing old code with a timeout.
Tested back old stuff and could not reproduce any issues.

**Related github/jira issue (required)**:
Closes #1731 

**Steps necessary to review your pull request (required)**:
- Retest steps on https://github.com/infor-design/enterprise/pull/97
- open IE 11
- go to http://localhost:4000/components/dropdown/example-no-search-lsf.html
- click on the first Dropdown to open it
- hit tab
- should close the list and go to the next field.
