### PR TITLE
1822 & 1829- DataGrid tabbing and validation messages

### DIFF
--- a/app/views/components/datagrid/test-addrow-tabbing.html
+++ b/app/views/components/datagrid/test-addrow-tabbing.html
@@ -1,0 +1,120 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <div role="toolbar" class="toolbar">
+
+      <div class="title">
+        Example illustrates the tabbing issue with added row.
+       </div>
+
+      <div class="buttonset">
+        <button type="button" id="addRow" class="btn">
+          <span>Add Row</span>
+        </button>
+      </div>
+    </div>
+
+    <div id="datagrid">
+
+    </div>
+  </div>
+</div>
+
+<script>
+  var gridApi = null;
+
+  $('body').one('initialized', function () {
+
+    Locale.set('en-US').done(function () {
+        var grid,
+          data = [],
+          columns = [],
+
+          //lookup data
+          lookupOptions,
+          lookupData = [],
+          lookupColumns = [];
+
+          // Some Sample Data for Lookup
+          lookupData.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+          lookupData.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+          lookupData.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+          lookupData.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+          lookupData.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+          lookupData.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+          lookupData.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+
+          //Define Columns for the Lookup Grid.
+          lookupColumns.push({ id: 'productId', name: 'Product Id', field: 'productId', width: 140});
+          lookupColumns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', width: 250, formatter: Formatters.Hyperlink});
+          lookupColumns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', width: 125});
+          lookupColumns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', width: 125});
+          lookupColumns.push({ id: 'price', name: 'Price', field: 'price', width: 125, formatter: Formatters.Decimal});
+          lookupColumns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+
+          lookupOptions = {
+            // field: 'productId',
+            field: function (row, field, grid) {
+              return row.productId;
+            },
+            match: function (value, row, field, grid) {
+              return (row.productId) === value;
+            },
+            options: {
+              columns: lookupColumns,
+              dataset: lookupData,
+              selectable: 'single', //multiselect or single
+              toolbar: {title: 'Products', results: true, dateFilter: false ,keywordFilter: false, advancedFilter: true, actions: true, views: true , rowHeight: true}
+            }
+          };
+
+
+        // Some Sample Data
+        data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  '<svg/onload=alert(1)>', quantity: 1, price: 210.99, status: 'OK', orderDate:  new Date(2016, 2, 15, 12, 30, 36), portable: false, action: 'ac', description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning'});
+        data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, status: '', orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false, action: 'oh', description: 'The kit has an air blow gun that can be used for cleaning'});
+        data.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity:  'Inspect and Repair', portable: true, quantity: 1, price: 120.992, status: null, orderDate: new Date(2014, 6, 3), action: 'ac'});
+        data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', portable: true, quantity: 3, price: null, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'ac', description: 'Compressor comes with with air tool kit'});
+        data.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'oh'});
+        data.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', portable: false, quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'oh'});
+        data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'oh'});
+
+        //Define Columns for the Grid.
+        columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
+        columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Ellipsis, editor: Editors.Input });
+        columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, editorOptions: lookupOptions });
+        columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, align: 'right', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###.000'});
+        columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date5});
+
+        //Init and get the api for the grid
+        grid = $('#datagrid').datagrid({
+          columns: columns,
+          dataset: data,
+          editable: true,
+          toolbar: {keywordFilter: true, results: true},
+          showDirty: true,
+          clickToSelect: false,
+          actionableMode: true,
+          cellNavigation: true,
+          enableTooltips: true,
+          selectable: 'mixed',
+          rowHeight: 'short'
+        }).on('cellchange', function (e, args) {
+          console.log(e, args);
+        }).on('rowadd', function (e, args) {
+          console.log(e, args);
+        }).on('rowremove', function (e, args) {
+          console.log(e, args);
+        }).on('exiteditmode', function (e, args) {
+          console.log('exiteditmode');
+          console.log(e, args);
+        });
+
+        gridApi = $('#datagrid').data('datagrid');
+
+        $('#addRow').on('click', function () {
+          gridApi.addRow({ productName: '', productId: '0' });
+        });
+    });
+  });
+
+</script>

--- a/app/views/components/datagrid/test-editable-validation.html
+++ b/app/views/components/datagrid/test-editable-validation.html
@@ -54,7 +54,7 @@
               async: true
             });
           },
-          message: 'Async Error',
+          message: 'Both the Next Action Date and the corresponding Test function must be selected.',
 		      type: 'error',
           async: true
         };

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@
 - `[Datagrid]` Added support for ellipsis to header text. ([#842](https://github.com/infor-design/enterprise/issues/842))
 - `[Datagrid]` Added support to cancel `rowactivated` event. Now it will trigger the new event `beforerowactivated` which will wait/sync to cancel or proceed to do `rowactivated` event. ([#1021](https://github.com/infor-design/enterprise/issues/1021))
 - `[Datagrid]` Added option to align grouped headers text. ([#1714](https://github.com/infor-design/enterprise/issues/1714))
+- `[Datagrid]` Tabbing through a new row moves focus to next line for a lookup column. ([#1822](https://github.com/infor-design/enterprise/issues/1822))
+- `[Datagrid]` Validation tooltip does not wrap words correctly across multiple lines. ([#1829](https://github.com/infor-design/enterprise/issues/1829))
 - `[Dropdown]` Added support to make dropdown readonly fields optionally not tab-able. ([#1591](https://github.com/infor-design/enterprise/issues/1591))
 - `[Form Compact]` Implemented design for field-heavy forms. This design is experimental, likely not production ready, and subject to change without notice. ([#1699](https://github.com/infor-design/enterprise/issues/1699))
 - `[Locale]` Added support for passing in `locale` or `language` to the `parse` and `format` and `translation` functions so they will work without changing the current locale or language. ([#462](https://github.com/infor-design/enterprise/issues/462))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9046,7 +9046,7 @@ Datagrid.prototype = {
     const self = this;
     if (e.type === 'keydown') {
       if (this.settings.actionableMode) {
-        const keyCode = (e.keyCode === 13) ? 40: e.keyCode;
+        const keyCode = (e.keyCode === 13) ? 40 : e.keyCode;
         setTimeout(() => {
           const evt = $.Event('keydown.datagrid');
           evt.keyCode = keyCode;

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9046,9 +9046,11 @@ Datagrid.prototype = {
     const self = this;
     if (e.type === 'keydown') {
       if (this.settings.actionableMode) {
+        const keyCode = (e.keyCode === 13) ? 40: e.keyCode;
         setTimeout(() => {
           const evt = $.Event('keydown.datagrid');
-          evt.keyCode = 40; // move down
+          evt.keyCode = keyCode;
+          
           self.activeCell.node.trigger(evt);
         }, 0);
       } else {

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -345,6 +345,7 @@
 
 .tooltip-content {
   padding: 7px 10px 5px;
+  word-break: normal;
 
   // Error Tooltip Styling
   li {


### PR DESCRIPTION
1822 - DataGrid: Tabbing through a new row moves focus to next line for a lookup column
1829 - DataGrid: Validation tooltip does not wrap words correctly across multiple lines

**Explain the _details_ for making this change. What existing problem does the pull request solve?**
1822 
A datagrid with actionableMode: true and cellNavigation: true is setting focus to the next cell in the next row when tabbing from a lookup column where the user has typed in a value.

1829
If a validation rule has a long message than the words may not wrap correctly. This required a change to the validation message for the rule.

**Related github/jira issue (required)**:
Closes #1822 
Closes #1829 


**Steps necessary to review your pull request (required)**:
1822
1. Goto 'http://localhost:4000/components/datagrid/test-addrow-tabbing.htm'
2. Click on the 'Add Row' button
3. Use the tab key to tab across to the Product Id column
4. Enter a Product Id value of 1
5. Hit the tab key

1829
1. Go to 'http://localhost:4000/components/datagrid/test-editable-validation.html'
2. set the Product Id to "1" to display the validation message
3. See error
