### PR TITLE
1704 - Tabs-module searchfield x icon

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # What's New with Enterprise
 
+## v4.18.0
+
+### v4.18.0 Future Deprecation
+
+### v4.18.0 Features
+
+### v4.18.0 Fixes
+
+- `[Tabs-Module]` Fixed an issue where the close icon was outside the searchfield. ([#1704](https://github.com/infor-design/enterprise/issues/1704))
+
+### v4.18.0 Chore & Maintenance
+
 ## v4.17.0
 
 - [Npm Package](https://www.npmjs.com/package/ids-enterprise)

--- a/src/components/breakpoints/_breakpoints.scss
+++ b/src/components/breakpoints/_breakpoints.scss
@@ -2,7 +2,7 @@
 //================================================== //
 
 // NOTE:
-// See the @mixin "respond-to" in `/sass/_mixins.scss` to see what the actual
+// See the @mixin "respond-to" in `/core/_mixins.scss` to see what the actual
 // media queries are (Sass compiler doesn't like that mixin residing in this file).
 $breakpoints: phone, phonedown, tablet, desktop, extralarge;
 

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -717,7 +717,8 @@ html[dir='rtl'] {
 
       &.show-category {
         .searchfield {
-          padding-right: 10px;
+          padding-left: 22px;
+          padding-right: 5px;
         }
       }
     }
@@ -808,6 +809,22 @@ html[dir='rtl'] {
 
         .go-button {
           right: 17px;
+        }
+      }
+    }
+  }
+
+  html[dir='rtl'] {
+    .toolbar-searchfield-wrapper {
+      &.has-categories {
+        &.has-go-button {
+          > .icon.close {
+            left: 40px;
+          }
+
+          .go-button {
+            right: 0;
+          }
         }
       }
     }

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -47,8 +47,6 @@ $toolbarsearchfield-category-empty-width: 51px;
   }
 
   &.has-go-button {
-    text-align: right;
-
     .searchfield {
       border-bottom-right-radius: 0;
       border-top-right-radius: 0;
@@ -58,7 +56,6 @@ $toolbarsearchfield-category-empty-width: 51px;
     .go-button {
       border-bottom-left-radius: 0;
       border-top-left-radius: 0;
-      position: relative;
     }
 
     > .icon {
@@ -312,6 +309,8 @@ $toolbarsearchfield-category-empty-width: 51px;
       .go-button {
         border-bottom-left-radius: 0;
         border-top-left-radius: 0;
+        position: relative;
+        right: 0;
       }
     }
 
@@ -323,10 +322,8 @@ $toolbarsearchfield-category-empty-width: 51px;
   }
 
   &.has-go-button {
-    &.has-text {
-      .searchfield {
-        width: 100%;
-      }
+    .searchfield {
+      width: auto !important;
     }
   }
 
@@ -581,6 +578,14 @@ $toolbarsearchfield-category-empty-width: 51px;
   }
 }
 
+.header {
+  .toolbar {
+    .toolbar-searchfield-wrapper {
+      text-align: right;
+    }
+  }
+}
+
 // For non-collapsible searchfields:  Only be non-collapsible on larger breakpoints.
 @media (min-width: $breakpoint-phone-to-tablet) {
   .toolbar-searchfield-wrapper.non-collapsible {
@@ -684,10 +689,6 @@ html[dir='rtl'] {
   .toolbar-searchfield-wrapper {
     text-align: right;
 
-    &.has-go-button {
-      text-align: left;
-    }
-
     &.has-text {
       &:not(.is-open) {
         .searchfield {
@@ -765,17 +766,39 @@ html[dir='rtl'] {
     }
 
     &.has-go-button {
+      .searchfield {
+        // width: auto;
+      }
+
       > .icon.close {
         color: $searchfield-header-icon-color;
-        right: 44px;
+        right: 45px;
       }
     }
   }
 
   html[dir='rtl'] {
     .toolbar-searchfield-wrapper.has-go-button > .icon.close {
-      left: 35px;
+      left: 45px;
       right: auto;
+    }
+  }
+}
+
+@include respond-to(phonedown) {
+  .toolbar-searchfield-wrapper {
+    &.has-categories {
+      &.show-category {
+        .btn {
+          padding-right: 5px;
+        }
+      }
+
+      &.has-go-button {
+        .go-button {
+          right: 17px;
+        }
+      }
     }
   }
 }

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -47,8 +47,8 @@ $toolbarsearchfield-category-empty-width: 51px;
   }
 
   &.has-go-button {
-
     text-align: right;
+
     .searchfield {
       border-bottom-right-radius: 0;
       border-top-right-radius: 0;

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -766,13 +766,13 @@ html[dir='rtl'] {
     }
 
     &.has-go-button {
-      .searchfield {
-        // width: auto;
-      }
+      width: auto !important;
 
-      > .icon.close {
-        color: $searchfield-header-icon-color;
-        right: 45px;
+      > .icon {
+        &.close {
+          color: $searchfield-header-icon-color;
+          right: 45px;
+        }
       }
     }
   }
@@ -795,6 +795,17 @@ html[dir='rtl'] {
       }
 
       &.has-go-button {
+        > .icon {
+          &.close {
+            right: 60px;
+          }
+        }
+
+        .searchfield {
+          padding-right: 40px;
+          width: auto !important;
+        }
+
         .go-button {
           right: 17px;
         }

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -237,12 +237,6 @@ $toolbarsearchfield-category-empty-width: 51px;
     }
   }
 
-  &:not(.is-open) {
-    .icon.close {
-      display: none !important;
-    }
-  }
-
   &.has-focus {
     .searchfield {
       border-color: transparent;
@@ -690,6 +684,10 @@ html[dir='rtl'] {
   .toolbar-searchfield-wrapper {
     text-align: right;
 
+    &.has-go-button {
+      text-align: left;
+    }
+
     &.has-text {
       &:not(.is-open) {
         .searchfield {
@@ -768,7 +766,7 @@ html[dir='rtl'] {
 
     &.has-go-button {
       > .icon.close {
-        right: 35px;
+        right: 44px;
       }
     }
   }

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -47,6 +47,8 @@ $toolbarsearchfield-category-empty-width: 51px;
   }
 
   &.has-go-button {
+
+    text-align: right;
     .searchfield {
       border-bottom-right-radius: 0;
       border-top-right-radius: 0;
@@ -56,6 +58,7 @@ $toolbarsearchfield-category-empty-width: 51px;
     .go-button {
       border-bottom-left-radius: 0;
       border-top-left-radius: 0;
+      position: relative;
     }
 
     > .icon {

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -766,6 +766,7 @@ html[dir='rtl'] {
 
     &.has-go-button {
       > .icon.close {
+        color: $searchfield-header-icon-color;
         right: 44px;
       }
     }

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -686,9 +686,15 @@ $toolbarsearchfield-category-empty-width: 51px;
 }
 
 html[dir='rtl'] {
-  .toolbar-searchfield-wrapper {
-    text-align: right;
+  .header {
+    .toolbar {
+      .toolbar-searchfield-wrapper {
+        text-align: left;
+      }
+    }
+  }
 
+  .toolbar-searchfield-wrapper {
     &.has-text {
       &:not(.is-open) {
         .searchfield {

--- a/src/components/tabs-module/_tabs-module.scss
+++ b/src/components/tabs-module/_tabs-module.scss
@@ -693,6 +693,14 @@ html[dir='rtl'] {
       }
     }
 
+    .toolbar-searchfield-wrapper {
+      text-align: left;
+
+      .searchfield {
+        padding-left: 30px;
+      }
+    }
+
     // Change state when the spillover button is necessary
     &.has-more-button {
       .tab-more {
@@ -770,6 +778,18 @@ html[dir='rtl'] {
         margin-left: 0;
         visibility: hidden;
         width: 0;
+      }
+    }
+  }
+
+  html[dir='rtl'] {
+    .tab-container {
+      &.module-tabs {
+        .toolbar-searchfield-wrapper {
+          .searchfield {
+            padding-left: 60px;
+          }
+        }
       }
     }
   }

--- a/src/components/tabs-module/_tabs-module.scss
+++ b/src/components/tabs-module/_tabs-module.scss
@@ -351,6 +351,7 @@
 
   .toolbar-searchfield-wrapper {
     color: $module-tabs-active-text-color;
+    text-align: right;
 
     .icon:not(.error) {
       color: $module-tabs-inactive-text-color;
@@ -361,6 +362,7 @@
       border-bottom-color: rgba($searchfield-moduletabs-border-color, 0);
       border-top-color: rgba($searchfield-moduletabs-bg-color, 0);
       color: $module-tabs-inactive-text-color;
+      width: auto !important;
 
       &::-webkit-input-placeholder { // Chrome/Opera/Safari */
         color: $module-tabs-inactive-text-color;
@@ -431,7 +433,6 @@
 
       .icon:not(.error) {
         color: $module-tabs-active-text-color;
-        right: 44px;
       }
     }
 

--- a/src/components/tabs-module/_tabs-module.scss
+++ b/src/components/tabs-module/_tabs-module.scss
@@ -431,7 +431,7 @@
 
       .icon:not(.error) {
         color: $module-tabs-active-text-color;
-        right: 40px;
+        right: 44px;
       }
     }
 

--- a/src/components/tabs-module/_tabs-module.scss
+++ b/src/components/tabs-module/_tabs-module.scss
@@ -431,6 +431,7 @@
 
       .icon:not(.error) {
         color: $module-tabs-active-text-color;
+        right: 40px;
       }
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Close icon (x) appears outside of searchfield input.

**Related github/jira issue (required)**:
Closes #1704.

**Steps necessary to review your pull request (required)**:
Pull branch and run app.
- Browse to the three pages noted in the issue by QA:
  - http://localhost:4000/components/tabs-module/example-category-searchfield-go-button-home.html
  - http://localhost:4000/components/tabs-module/example-category-searchfield.html
  - http://localhost:4000/components/tabs-module/example-category-searchfield-go-button.html
- Notice the close icon is now appearing in the searchfield input.

This may need some tweaking as I'm not 100% on the placement of some of these items. Happy to take suggestions.