### PR TITLE
Update the jsdoc template for website visuals [4.17.x]

### DIFF
--- a/docs/templates/documentationjs/theme-ids-website/section._
+++ b/docs/templates/documentationjs/theme-ids-website/section._
@@ -41,44 +41,46 @@
   <% if (section.since) { %><div>Since: <%- section.since %></div><% }%>
 
   <% if (section.params.length) { %>
-    <table class="jsdoc-parameters">
-      <caption class="jsdoc-section--heading">Parameters</caption>
-      <colgroup>
-        <col width='30%' />
-        <col width='20%' />
-        <col width='50%' />
-      </colgroup>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Type</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% section.params.forEach(function(param) { %>
+    <div class="table-container">
+      <table class="jsdoc-parameters">
+        <caption class="jsdoc-section--heading">Parameters</caption>
+        <colgroup>
+          <col width='30%' />
+          <col width='20%' />
+          <col width='50%' />
+        </colgroup>
+        <thead>
           <tr>
-            <td class="jsdoc-prop--name">
-              <%- param.name %>
-            </td>
-            <td>
-              <code><%= formatType(param.type) %><% if (param.default) { %>= <%- param.default %><% } %></code>
-            </td>
-            <td class="jsdoc-prop--desc">
-              <%= md(param.description, true) %>
-            </td>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
           </tr>
-          <% if (param.properties && param.properties.length) { %>
-            <% param.properties.forEach(function(property) { %>
-              <%= renderParamProperty({
-                property: property,
-                renderParamProperty: renderParamProperty
-              }) %>
-            <% }) %>
-          <% } %>
-        <% }) %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          <% section.params.forEach(function(param) { %>
+            <tr>
+              <td class="jsdoc-prop--name">
+                <%- param.name %>
+              </td>
+              <td>
+                <code><%= formatType(param.type) %><% if (param.default) { %>= <%- param.default %><% } %></code>
+              </td>
+              <td class="jsdoc-prop--desc">
+                <%= md(param.description, true) %>
+              </td>
+            </tr>
+            <% if (param.properties && param.properties.length) { %>
+              <% param.properties.forEach(function(property) { %>
+                <%= renderParamProperty({
+                  property: property,
+                  renderParamProperty: renderParamProperty
+                }) %>
+              <% }) %>
+            <% } %>
+          <% }) %>
+        </tbody>
+      </table>
+    </div>
   <% } %>
 
   <% if (section.properties.length) { %>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
We needed to update the template to match the IDS website. I did this into `4.17.x` because it doesn't touch any consumer code and doesn't need QAd.

**Related github/jira issue (required)**:
See pull request infor-design/website#773 for details

**Steps necessary to review your pull request (required)**:
1. Test a documentation deploy to staging

---
Also reviewing the code change is easier to see with "hide whitespace" option on the diff:
<img width="372" alt="Screen Shot 2019-03-25 at 2 56 58 PM" src="https://user-images.githubusercontent.com/742319/54946362-4d81cf00-4f0e-11e9-9bf7-657ca992306f.png">
