### PR TITLE
1553 - Fixed more small size cutoff radar [v4.17.x]

### DIFF
--- a/src/components/radar/radar.js
+++ b/src/components/radar/radar.js
@@ -184,7 +184,7 @@ Radar.prototype = {
     const angleSlice = Math.PI * 2 / total; // The width in radians of each 'slice'
 
     if (dims.w <= 328) {
-      const extra = 50; // Reduce the size of the radar
+      const extra = dims.w < 225 ? 75 : 50; // Reduce the size of the radar
       radius = Math.min((dims.w - extra) / 2, (dims.h - extra) / 2);
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed radar labels were cut off on very small view ports.

**Related github/jira issue (required)**:
Closes #1553

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/radar/test-long-text.html
- Open above link with Win10 Firefox
- Resize the browser window to all the way smaller 
- See labels should not cut off
