### PR TITLE
1674 - Fix x-axis label not showing on line graphs with one value

### DIFF
--- a/app/views/components/line/test-one-entry.html
+++ b/app/views/components/line/test-one-entry.html
@@ -1,0 +1,47 @@
+<div class="row">
+  <div class="two-thirds column">
+    <h2 class="widget-title">Line Chart - One Entry</h2>
+  </div>
+</div>
+
+<div class="row">
+  <div class="two-thirds column">
+    <div class="widget">
+      <div class="widget-header">
+        <h2 class="widget-title">Line Chart Title</h2>
+      </div>
+      <div class="widget-content">
+        <div id="line-example" class="chart-container">
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').on('initialized', function () {
+
+    var dataset = [{
+      data: [{
+        name: 'Jan',
+        value: 12,
+        depth: 4
+      }],
+      name: 'Component A'
+    }, {
+      data: [{
+        name: 'Jan',
+        value: 22
+      }],
+      name: 'Component B'
+    }, {
+      data: [{
+        name: 'Jan',
+        value: 32
+      }],
+      name: 'Component C'
+    }];
+
+    $('#line-example').chart({ type: 'line', dataset: dataset, animate: false });
+  });
+</script>

--- a/src/components/line/line.js
+++ b/src/components/line/line.js
@@ -272,7 +272,13 @@ Line.prototype = {
       maxes = dataset.map(function (d) { return getMaxes(d); });
     }
 
-    const entries = d3.max(dataset.map(function (d) { return d.data.length; })) - 1;
+    let entries;
+    if (d3.max(dataset.map(function (d) { return d.data.length; })) <= 1) {
+      entries = d3.max(dataset.map(function (d) { return d.data.length; }));
+    } else {
+      entries = d3.max(dataset.map(function (d) { return d.data.length; })) - 1;
+    }
+
     const xScale = x.domain(!!self.settings.xAxis && !!self.settings.xAxis.domain ?
       (self.settings.xAxis.domain) :
       ([0, self.settings.isBubble || self.settings.isScatterPlot ? d3.max(maxes.x) : entries]));


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
x-axis labels were not showing on line graphs with only one value. This PR adds a check for the data length and does not remove the last entry if <= 1

**Related github/jira issue (required)**:
closes #1674 

**Steps necessary to review your pull request (required)**:
- Pull branch
- Check http://localhost:4000/components/line/test-one-entry.html
- make sure x-axis label is visible

