### PR TITLE
1884 - Fix demoapp's handling of query parameters on component pages

### DIFF
--- a/app/src/js/routes/general.js
+++ b/app/src/js/routes/general.js
@@ -19,13 +19,14 @@ function generalRoute(req, res, next) {
     res.opts.appMenuOpen = true;
   }
   const viewsRoot = req.app.get('views');
-  const directoryURL = utils.getDirectory(path.join(viewsRoot, req.originalUrl), viewsRoot);
-  const filename = utils.getFileName(req.originalUrl);
+  const originalUrl = utils.getPathWithoutQuery(req.originalUrl);
+  const directoryURL = utils.getDirectory(path.join(viewsRoot, originalUrl), viewsRoot);
+  const filename = utils.getFileName(originalUrl);
   const directoryPath = path.join(viewsRoot, directoryURL);
   const fileOnPath = path.join(directoryPath, filename);
 
   // Return out on '/';
-  if (utils.isRoot(req.originalUrl)) {
+  if (utils.isRoot(originalUrl)) {
     res.render(path.join(viewsRoot, 'kitchen-sink.html'), res.opts);
     next();
     return;
@@ -54,7 +55,7 @@ function generalRoute(req, res, next) {
   }
 
   // Check a friendly URL for a matching `.html` file.
-  const friendlyURLFilepath = path.resolve(`${viewsRoot}${utils.getPathWithoutQuery(req.originalUrl)}.html`);
+  const friendlyURLFilepath = path.resolve(`${viewsRoot}${originalUrl}.html`);
   if (utils.hasFile(friendlyURLFilepath)) {
     res.render(utils.getTemplateUrl(friendlyURLFilepath.replace(viewsRoot, '')), res.opts);
     next();
@@ -71,8 +72,8 @@ function generalRoute(req, res, next) {
 
   // Return the directory listing if we're looking at a directory
   if (utils.isType('directory', directoryPath)) {
-    if (req.originalUrl.substring(req.originalUrl.length - 1) === '/') {
-      res.redirect(req.originalUrl.substring(0, req.originalUrl.length - 1));
+    if (originalUrl.substring(originalUrl.length - 1) === '/') {
+      res.redirect(originalUrl.substring(0, originalUrl.length - 1));
       return;
     }
     directoryListing(directoryPath, viewsRoot, req, res, next);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a bug in the demoapp where, on component pages (and basically any page using the general route), query parameter strings in a URL with a file extension (.html) would incorrectly be included in a filename while attempting to resolve a matching view template.

**Related github/jira issue (required)**:
Closes #1884 

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp
- Navigate to http://localhost:4000/components/form/example-forms?theme=uplift.  Everything should render properly.
- Next, navigate to http://localhost:4000/components/form/example-forms.html?theme=uplift.  Everything should render properly.
- Next, navigate to http://localhost:4000/components/form/example-forms?theme=uplift&mkt_tok=eyJpIjoiWldNMk4yVmhZVFkwTTJaaiIsInQiOiI0d3ZVandQV2Q0cmx0Q0xXRGwrQmo4K3hGczMwM1k2NUhLOVl4bTlsUkVmcFRqNjdVeHhnNkc5dHlpcDBIS1BleWNaRmg0alpHcmJvVU9tQW9IcTdPK3lIUENtc0ZcL2NZdng1RWRCQ2xaNjVqYkhhczhNUTljeHhEeXhXMUo5TG0ifQ%3D%3D.  Once again, everything should render properly.
- Finally, navigate to  http://localhost:4000/components/form/example-forms.html?theme=uplift&mkt_tok=eyJpIjoiWldNMk4yVmhZVFkwTTJaaiIsInQiOiI0d3ZVandQV2Q0cmx0Q0xXRGwrQmo4K3hGczMwM1k2NUhLOVl4bTlsUkVmcFRqNjdVeHhnNkc5dHlpcDBIS1BleWNaRmg0alpHcmJvVU9tQW9IcTdPK3lIUENtc0ZcL2NZdng1RWRCQ2xaNjVqYkhhczhNUTljeHhEeXhXMUo5TG0ifQ%3D%3D.  This should render exactly the same.
