### PR TITLE
1878 - `[Radios]` Fixed the last item being secected when clicking on…

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### v4.18.0 Fixes
 
+- `[Radios]` Fixed the last item being secected when clicking on the first when displayed horizontal. ([#1878](https://github.com/infor-design/enterprise/issues/1878))
 - `[Tabs-Module]` Fixed an issue where the close icon was outside the searchfield. ([#1704](https://github.com/infor-design/enterprise/issues/1704))
 
 ### v4.18.0 Chore & Maintenance

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -2,7 +2,7 @@
 //================================================== //
 
 .radio {
-  left: 0;
+  left: -9999px;
   opacity: 0;
   position: absolute;
   width: 0;


### PR DESCRIPTION
… the first when displayed horizontal

**Explain the _details_ for making this change. What existing problem does the pull request solve?**
When the radio buttons are displayed inline, horizontal, clicking on the first items radio button will select the last ite,

**Related github/jira issue (required)**:
Closes #1878 

**Steps necessary to review your pull request (required)**:
1. Go to 'http://master-enterprise.demo.design.infor.com/components/radios/example-horizontal.html'
2. Click on the first option (not the label but the radio button icon)
