### PR TITLE
1893 - Fix Notifications example to work on common element in all layouts [v4.17.x]

### DIFF
--- a/app/views/components/notification/example-index.html
+++ b/app/views/components/notification/example-index.html
@@ -1,16 +1,22 @@
+<div id="parent">
+  <div id="fake-header"></div>
+</div>
+
 <script>
-  $('#maincontent').notification({
+  $('#fake-header').notification({
     type: 'error',
     message: 'DTO rejcted by your manager for Sept 30, 2018.',
+    parent: '#fake-header',
     link: '#',
     linkText: 'Click to view'
   });
 </script>
 
 <script>
-  $('#maincontent').notification({
+  $('#fake-header').notification({
     type: 'info',
     message: 'DTO rejcted by your manager for Sept 30, 2018.',
+    parent: '#fake-header',
     link: '#',
     linkText: 'Click to view'
   });
@@ -18,9 +24,10 @@
 
 
 <script>
-  $('#maincontent').notification({
+  $('#fake-header').notification({
     type: 'alert',
     message: 'DTO rejcted by your manager for Sept 30, 2018.',
+    parent: '#fake-header',
     link: '#',
     linkText: 'Click to view'
   });
@@ -28,9 +35,10 @@
 
 
 <script>
-  $('#maincontent').notification({
+  $('#fake-header').notification({
     type: 'success',
     message: 'DTO rejcted by your manager for Sept 30, 2018.',
+    parent: '#fake-header',
     link: '#',
     linkText: 'Click to view'
   });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes the main Notification sample page to work against HTML markup that will be the same among the demoapp's layouts.  Previously, the main example was broken on the IDS website because it was targeting the wrong element with an `.insertBefore()` statement.

Changing the above also fixed an additional problem on the sample where some of the Header's elements weren't able to be clicked.

**Related github/jira issue (required)**:
Fixes #1893 
Fixes #1639 

**Steps necessary to review your pull request (required)**:
Pull this branch and run the demoapp, then...

_To test the layout problem:_
- Navigate to http://localhost:4000/components/notification/example-index.html.  The four notifications should render properly.
- Navigate to http://localhost:4000/components/notification/example-index.html?layout=embedded. The four notifications should render properly.

Not needed:
- 🚫 An e2e or functional test for the bug or feature.
- 🚫 A note to the change log.
