### PR TITLE
1890 - Fixed resize 2nd last column was not working with datagrid [v4.17.x]

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5077,7 +5077,7 @@ Datagrid.prototype = {
     let columnStartWidth;
     let column;
 
-    this.resizeHandle.drag({ axis: 'x', containment: 'parent' })
+    this.resizeHandle.drag({ axis: 'x', containment: this.element })
       .on('dragstart.datagrid', () => {
         if (!self.currentHeader) {
           return;

--- a/src/components/drag/drag.js
+++ b/src/components/drag/drag.js
@@ -129,7 +129,9 @@ Drag.prototype = {
     }
 
     if (this.settings.containment) {
-      if (this.settings.containment === 'parent') {
+      if (this.settings.containment instanceof jQuery) {
+        this.container = this.settings.containment;
+      } else if (this.settings.containment === 'parent') {
         this.container = this.element.parent();
       } else if (this.settings.containment === 'window') {
         this.container = $(window);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed resize 2nd last column was not working with datagrid.

**Related github/jira issue (required)**:
Closes #1890

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/example-filter
- Open above link
- Resize the "Status" column
- Should be working fine
