### PR TITLE
1907 - Fix for incorrect groupSize definition on US Locale [v4.17.x]

### DIFF
--- a/src/components/locale/cultures/en-US.js
+++ b/src/components/locale/cultures/en-US.js
@@ -53,7 +53,7 @@ Soho.Locale.addCulture('en-US', {
     minusSign: '-',
     decimal: '.',
     group: ',',
-    groupSizes: [3, 0]
+    groupSizes: [3, 3]
   },
   // Resx - Provided By Translation Team
   messages: {

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -739,7 +739,7 @@ describe('Locale API', () => {
   it('Should format negative numbers', () => {
     Locale.set('en-US');
 
-    expect(Locale.formatNumber(-1000000, { style: 'currency' })).toEqual('-$1000,000.00');
+    expect(Locale.formatNumber(-1000000, { style: 'currency' })).toEqual('-$1,000,000.00');
 
     Locale.set('de-DE');
 
@@ -1062,11 +1062,11 @@ describe('Locale API', () => {
     expect(Locale.formatNumber(1234.1234)).toEqual('1,234.123');
     expect(Locale.formatNumber(12345.1234)).toEqual('12,345.123');
     expect(Locale.formatNumber(123456.1234)).toEqual('123,456.123');
-    expect(Locale.formatNumber(1234567.1234)).toEqual('1234,567.123');
-    expect(Locale.formatNumber(12345678.1234)).toEqual('12345,678.123');
-    expect(Locale.formatNumber(123456789.1234)).toEqual('123456,789.123');
-    expect(Locale.formatNumber(1234567890.1234)).toEqual('1234567,890.123');
-    expect(Locale.formatNumber(123456789.1234, { style: 'currency' })).toEqual('$123456,789.12');
+    expect(Locale.formatNumber(1234567.1234)).toEqual('1,234,567.123');
+    expect(Locale.formatNumber(12345678.1234)).toEqual('12,345,678.123');
+    expect(Locale.formatNumber(123456789.1234)).toEqual('123,456,789.123');
+    expect(Locale.formatNumber(1234567890.1234)).toEqual('1,234,567,890.123');
+    expect(Locale.formatNumber(123456789.1234, { style: 'currency' })).toEqual('$123,456,789.12');
     expect(Locale.formatNumber(100, { style: 'percent' })).toEqual('10,000 %');
 
     Locale.set('nl-NL'); // 3, 3
@@ -1244,8 +1244,8 @@ describe('Locale API', () => {
     Locale.getLocale('nl-NL').done(() => {
       expect(Locale.currentLocale.name).toEqual('en-US');
 
-      expect(Locale.formatNumber(123456789.1234, { locale: 'en-US' })).toEqual('123456,789.123');
-      expect(Locale.formatNumber(123456789.1234)).toEqual('123456,789.123');
+      expect(Locale.formatNumber(123456789.1234, { locale: 'en-US' })).toEqual('123,456,789.123');
+      expect(Locale.formatNumber(123456789.1234)).toEqual('123,456,789.123');
       expect(Locale.formatNumber(123456789.1234, { locale: 'nl-NL' })).toEqual('123.456.789,123');
       expect(Locale.currentLocale.name).toEqual('en-US');
     });
@@ -1253,8 +1253,8 @@ describe('Locale API', () => {
     Locale.getLocale('hi-IN').done(() => {
       expect(Locale.currentLocale.name).toEqual('en-US');
 
-      expect(Locale.formatNumber(123456789.1234, { locale: 'en-US' })).toEqual('123456,789.123');
-      expect(Locale.formatNumber(123456789.1234)).toEqual('123456,789.123');
+      expect(Locale.formatNumber(123456789.1234, { locale: 'en-US' })).toEqual('123,456,789.123');
+      expect(Locale.formatNumber(123456789.1234)).toEqual('123,456,789.123');
       expect(Locale.formatNumber(123456789.1234, { locale: 'hi-IN' })).toEqual('12,34,56,789.123');
       expect(Locale.currentLocale.name).toEqual('en-US');
       done();

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -1053,7 +1053,7 @@ describe('Locale API', () => {
   });
 
   it('Should handle group size', () => {
-    Locale.set('en-US'); // 3, 0
+    Locale.set('en-US'); // 3, 3
 
     expect(Locale.formatNumber(-2.53, { style: 'percent', minimumFractionDigits: 2 })).toEqual('-253.00 %');
     expect(Locale.formatNumber(1.1234)).toEqual('1.123');
@@ -1103,7 +1103,7 @@ describe('Locale API', () => {
   });
 
   it('Should parse group size', () => {
-    Locale.set('en-US'); // 3, 0
+    Locale.set('en-US'); // 3, 3
 
     expect(Locale.parseNumber('-253.00 %')).toEqual(-253);
     expect(Locale.parseNumber('1.123')).toEqual(1.123);
@@ -1153,7 +1153,7 @@ describe('Locale API', () => {
   });
 
   it('Should be able to not show the group size', () => {
-    Locale.set('en-US'); // 3, 0
+    Locale.set('en-US'); // 3, 3
 
     expect(Locale.formatNumber(1234567.1234, { group: '' })).toEqual('1234567.123');
     expect(Locale.formatNumber(12345678.1234, { group: '' })).toEqual('12345678.123');
@@ -1170,7 +1170,7 @@ describe('Locale API', () => {
   });
 
   it('Should be able to set the group size', () => {
-    Locale.set('en-US'); // 3, 0
+    Locale.set('en-US'); // 3, 3
 
     expect(Locale.formatNumber(1234567.1234, { groupSizes: [3, 0] })).toEqual('1234,567.123');
     expect(Locale.formatNumber(12345678.1234, { groupSizes: [3, 0] })).toEqual('12345,678.123');
@@ -1187,7 +1187,7 @@ describe('Locale API', () => {
   });
 
   it('Should be able to set zero group size', () => {
-    Locale.set('en-US'); // 3, 0
+    Locale.set('en-US'); // 3, 3
 
     expect(Locale.formatNumber(1234567.1234, { groupSizes: [0, 0] })).toEqual('1234567.123');
     expect(Locale.formatNumber(12345678.1234, { groupSizes: [0, 0] })).toEqual('12345678.123');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a bug in the IDS `en-US` culture file that was causing incorrect number formatting due to an incorrect `groupSize` definition.  It was previously set to `[3,0]`, where it needed to be `[3,3]`.

Additionally, some functional tests were altered to reflect the correctly formatted values with a `[3,3] groupSize.

**Related github/jira issue (required)**:
Closes #1907

**Steps necessary to review your pull request (required)**:
All functional tests related to the `Locale` API, specifically the ones that test `Locale.formatNumber()` against `en-US`, should all pass.

----
paging @pwpatton @fitzorama
