### PR TITLE
e2e - Use a date variance vs enum array for testing

### DIFF
--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -568,16 +568,15 @@ describe('Datepicker Timeformat Tests', () => {
     await datepickerEl.sendKeys(protractor.Key.ARROW_DOWN);
 
     const todayEl = await element(by.css('button.is-today'));
-    const testDate = new Date();
-    testDate.setSeconds(0);
-    testDate.setMilliseconds(0);
     await todayEl.click();
     const value = await element(by.id('dp3')).getAttribute('value');
+    const valueDate = new Date(value);
 
-    const dateVariances = [-2, -1, 0, 1, 2]
-      .map(amt => testDate.setSeconds(testDate.getSeconds() + amt));
+    const testDate = new Date();
+    const allowedVariance = 60000; // milliseconds
+    const dateDiff = Math.abs(testDate - valueDate); // guarentee its a positive result
 
-    expect(dateVariances).toContain(new Date(value).getTime());
+    expect(dateDiff).toBeLessThanOrEqual(allowedVariance);
   });
 });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
One datepicker test keeps failing in the cron job.

**Related github/jira issue (required)**:
n/a

**Steps necessary to review your pull request (required)**:
- [x] Watch CI tests
- [x] Test locally
    1. go to `datepicker.e2e-spec.js`
    1. Mark the right `it` test to be `fit` (get the test from the files changed tab for this PR) 
    1. `npm run start && npm run e2e:local:debug`

---
- [x] An e2e or functional test for the bug or feature.
- 🚫 A note to the change log.