### PR TITLE
1840 - Fixed trailing zeros were getting ignored with german locale

### DIFF
--- a/app/views/components/datagrid/test-custom-number-formats.html
+++ b/app/views/components/datagrid/test-custom-number-formats.html
@@ -17,6 +17,8 @@
       columns.push({ id: 'price1', name: 'Price', field: 'price', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '####,00'});
       columns.push({ id: 'price2', name: 'Price ($)', field: 'price', formatter: Formatters.Decimal, numberFormat: {style: 'currency'}});
       columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', formatter: Formatters.Decimal, numberFormat: {style: 'percent'}});
+      columns.push({ id: 'quantity', name: 'Integer', field: 'quantity', formatter: Formatters.Integer});
+      columns.push({ id: 'quantity', name: 'Decimal', field: 'quantity', formatter: Formatters.Decimal});
 
       //Init and get the api for the grid
       grid = $('#datagrid').datagrid({
@@ -28,6 +30,12 @@
       //Pass data in
       $.get('{{basepath}}api/compressors?pageNum=1&sort=productId&pageSize=10', function(data) {
         grid = grid.data('datagrid');
+        if (data.data && data.data.length > 1) {
+          var clone = JSON.parse(JSON.stringify(data.data));;
+          clone[0].quantity = 145000;
+          clone[1].quantity = 283423;
+          data.data.splice(0, 0, clone[0], clone[1]);
+        }
         grid.loadData(data.data);
       });
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Css/Sass]` Fixed an issue where the High Contrast theme and Uplift theme were not using the right tokens.
 - `[Colors]` Fixed the color palette demo page to showcase the correct hex values based on the current theme ([#1801](https://github.com/infor-design/enterprise/issues/1801))
 - `[Dropdown]` Changed the way dropdowns work with screen readers to be a collapsible listbox.([#404](https://github.com/infor-design/enterprise/issues/404))
+- `[Locale]` Fixed trailing zeros were getting ignored when displaying thousands values.([#404](https://github.com/infor-design/enterprise/issues/1840))
 - `[MenuButton]` Approved the way menu buttons work with screen readers.([#404](https://github.com/infor-design/enterprise/issues/404))
 - `[Signin]` Fixed accessibility issues. ([#421](https://github.com/infor-design/enterprise/issues/421))
 - `[Skiplink]` Fixed an zindex issue on skip links over the nav menu. ([#1721](https://github.com/infor-design/enterprise/issues/1721))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@
 - `[Css/Sass]` Fixed an issue where the High Contrast theme and Uplift theme were not using the right tokens.
 - `[Colors]` Fixed the color palette demo page to showcase the correct hex values based on the current theme ([#1801](https://github.com/infor-design/enterprise/issues/1801))
 - `[Dropdown]` Changed the way dropdowns work with screen readers to be a collapsible listbox.([#404](https://github.com/infor-design/enterprise/issues/404))
-- `[Locale]` Fixed trailing zeros were getting ignored when displaying thousands values.([#404](https://github.com/infor-design/enterprise/issues/1840))
+- `[Locale]` Fixed trailing zeros were getting ignored when displaying thousands values. ([#404](https://github.com/infor-design/enterprise/issues/1840))
 - `[MenuButton]` Approved the way menu buttons work with screen readers.([#404](https://github.com/infor-design/enterprise/issues/404))
 - `[Signin]` Fixed accessibility issues. ([#421](https://github.com/infor-design/enterprise/issues/421))
 - `[Skiplink]` Fixed an zindex issue on skip links over the nav menu. ([#1721](https://github.com/infor-design/enterprise/issues/1721))

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -1209,21 +1209,21 @@ const Locale = {  // eslint-disable-line
     const isNegative = (formattedNum.indexOf(minusSign) > -1);
     formattedNum = formattedNum.replace(minusSign, '');
 
-    if (minimumFractionDigits === 0) { // Not default
-      formattedNum = formattedNum.replace(/(\.[0-9]*?)0+$/, '$1'); // remove trailing zeros
-      formattedNum = formattedNum.replace(/\.$/, ''); // remove trailing dot
-    }
+    const escape = str => str.replace(/([.?*+^$[\]\\(){}|-])/g, '\\$1');
+    let expr = '';
 
-    if (minimumFractionDigits === 0 && decimal !== '.') { // Not default
-      formattedNum = formattedNum.replace(/(\,[0-9]*?)0+$/, '$1'); // remove trailing zeros
-      formattedNum = formattedNum.replace(/\,$/, ''); // remove trailing dot
+    if (minimumFractionDigits === 0) { // Not default
+      expr = new RegExp(`(${escape(decimal)}[0-9]*?)0+$`);
+      formattedNum = formattedNum.replace(expr, '$1'); // remove trailing zeros
     }
 
     if (minimumFractionDigits > 0) {
-      const expr = new RegExp(`(\\..{${minimumFractionDigits}}[0-9]*?)0+$`);
+      expr = new RegExp(`(${escape(decimal)}.{${minimumFractionDigits}}[0-9]*?)0+$`);
       formattedNum = formattedNum.replace(expr, '$1'); // remove trailing zeros
-      formattedNum = formattedNum.replace(/\.$/, ''); // remove trailing dot
     }
+
+    expr = new RegExp(`${escape(decimal)}$`);
+    formattedNum = formattedNum.replace(expr, ''); // remove trailing decimal
 
     if (options && options.style === 'currency') {
       formattedNum = curFormat.replace('###', formattedNum);

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -554,6 +554,8 @@ describe('Locale API', () => {
   it('Should format decimals', () => {
     Locale.set('en-US');
 
+    expect(Locale.formatNumber(145000)).toEqual('145,000.00');
+    expect(Locale.formatNumber(283423)).toEqual('283,423.00');
     expect(Locale.formatNumber(12345.1234)).toEqual('12,345.123');
     expect(Locale.formatNumber(12345.123, { style: 'decimal', maximumFractionDigits: 2 })).toEqual('12,345.12');
     expect(Locale.formatNumber(12345.123456, { style: 'decimal', maximumFractionDigits: 3 })).toEqual('12,345.123');
@@ -563,12 +565,16 @@ describe('Locale API', () => {
     expect(Locale.formatNumber('12,345.123')).toEqual('12,345.123');
     expect(Locale.formatNumber(12345.1234, { group: '' })).toEqual('12345.123');
     expect(Locale.formatNumber(5.1, { minimumFractionDigits: 2, maximumFractionDigits: 2 })).toEqual('5.10');
+    expect(Locale.formatNumber(145000, { style: 'decimal', minimumFractionDigits: 5, maximumFractionDigits: 7 })).toEqual('145,000.00000');
 
     Locale.set('de-DE');
 
+    expect(Locale.formatNumber(145000)).toEqual('145.000,00');
+    expect(Locale.formatNumber(283423)).toEqual('283.423,00');
     expect(Locale.formatNumber(12345.1)).toEqual('12.345,10');
     expect(Locale.formatNumber(0.0000004, { style: 'decimal', maximumFractionDigits: 7 })).toEqual('0,0000004');
     expect(Locale.formatNumber(0.000004, { style: 'decimal', maximumFractionDigits: 7 })).toEqual('0,000004');
+    expect(Locale.formatNumber(145000, { style: 'decimal', minimumFractionDigits: 5, maximumFractionDigits: 7 })).toEqual('145.000,00000');
 
     Locale.set('ar-EG');
 
@@ -602,6 +608,8 @@ describe('Locale API', () => {
 
     Locale.set('de-DE');
 
+    expect(Locale.formatNumber(145000, { style: 'integer' })).toEqual('145.000');
+    expect(Locale.formatNumber(283423, { style: 'integer' })).toEqual('283.423');
     expect(Locale.formatNumber(12345.123, { style: 'integer' })).toEqual('12.345');
   });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed trailing zeros were getting ignored when displaying thousands values with German Locale.

**Related github/jira issue (required)**:
Closes #1840

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-custom-number-formats.html?locale=de-DE
- All functional tests related to the Locale API should pass
- Open above link
- Review last two columns (Integer, Decimal)
- See 1st row should be (Integer:145.000, Decimal:145.000,00)
- And 2nd row should be (Integer:283.423, Decimal:283.423,00)
