### PR TITLE
NG411 - Fixes unintentional removal of custom validation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[App Menu]` Fixed some accessibility issues on the nav menu. ([#1721](https://github.com/infor-design/enterprise/issues/1721))
 - `[Css/Sass]` Fixed an issue where the High Contrast theme and Uplift theme were not using the right tokens.
 - `[Colors]` Fixed the color palette demo page to showcase the correct hex values based on the current theme ([#1801](https://github.com/infor-design/enterprise/issues/1801))
+- `[Datepicker]` Fixed an issue in NG where the custom validation is removed during the teardown of a datepicker.([NG #411](https://github.com/infor-design/enterprise-ng/issues/411))
 - `[Dropdown]` Changed the way dropdowns work with screen readers to be a collapsible listbox.([#404](https://github.com/infor-design/enterprise/issues/404))
 - `[MenuButton]` Approved the way menu buttons work with screen readers.([#404](https://github.com/infor-design/enterprise/issues/404))
 - `[Signin]` Fixed accessibility issues. ([#421](https://github.com/infor-design/enterprise/issues/421))

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -405,8 +405,10 @@ DatePicker.prototype = {
       this.element.mask(maskOptions);
     }
 
+    this.addedValidation = false;
     if (this.element[0] && this.element[0].getAttribute &&
       !this.element[0].getAttribute('data-validate')) {
+      this.addedValidation = true;
       this.element.attr({
         'data-validate': validation,
         'data-validation-events': JSON.stringify(events)
@@ -1529,7 +1531,9 @@ DatePicker.prototype = {
 
     this.element.off('keydown.datepicker blur.validate change.validate keyup.validate focus.validate');
 
-    this.element.removeAttr('data-validate').removeData('validate validationEvents');
+    if (this.addedValidation) {
+      this.element.removeAttr('data-validate').removeData('validate validationEvents');
+    }
 
     return this;
   },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Doing triage on #411 i found the solution was very simple so included a fix. For this to work we will need to merge and bump versions in the NG pr https://github.com/infor-design/enterprise-ng/pull/417

**Related github/jira issue (required)**:
Fixes NG 411 

**Steps necessary to review your pull request (required)**:
http://localhost:4200/ids-enterprise-ng-demo/datepicker
- go to the custom validation field at the bottom
- tab out 
- error should show no matter what you type

(or take my word for it since they depend on each other) https://github.com/infor-design/enterprise-ng/pull/417