### PR TITLE
1900 - Fixed datagrid filtering was missing translation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[Css/Sass]` Fixed an issue where the High Contrast theme and Uplift theme were not using the right tokens.
 - `[Colors]` Fixed the color palette demo page to showcase the correct hex values based on the current theme ([#1801](https://github.com/infor-design/enterprise/issues/1801))
 - `[Datagrid]` Fixed an issue where lookup filterConditions were not rendering. ([#1873](https://github.com/infor-design/enterprise/issues/1873))
+- `[Datagrid]` Fixed an issue where filtering was missing translation. ([#1900](https://github.com/infor-design/enterprise/issues/1900))
 - `[Dropdown]` Changed the way dropdowns work with screen readers to be a collapsible listbox.([#404](https://github.com/infor-design/enterprise/issues/404))
 - `[Locale]` Fixed trailing zeros were getting ignored when displaying thousands values. ([#404](https://github.com/infor-design/enterprise/issues/1840))
 - `[MenuButton]` Approved the way menu buttons work with screen readers.([#404](https://github.com/infor-design/enterprise/issues/404))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5170,11 +5170,15 @@ Datagrid.prototype = {
       count = this.lastCount;
     }
 
+    const formatInteger = v => Locale.formatNumber(v, { style: 'integer' });
     let countText;
     if (self.settings.showFilterTotal && self.filteredCount > 0) {
-      countText = `(${Locale.formatNumber(count - self.filteredCount, { style: 'integer' })} of ${Locale.formatNumber(count, { style: 'integer' })} ${Locale.translate(count === 1 ? 'Result' : 'Results')})`;
+      countText = `(${Locale.translate(count === 1 ? 'ResultOf' : 'ResultsOf')})`;
+      countText = countText.replace('{0}', formatInteger(count - self.filteredCount));
+      countText = countText.replace('{1}', formatInteger(count));
     } else {
-      countText = `(${Locale.formatNumber(count, { style: 'integer' })} ${Locale.translate(count === 1 ? 'Result' : 'Results')})`;
+      countText = `({0} ${Locale.translate(count === 1 ? 'Result' : 'Results')})`;
+      countText = countText.replace('{0}', formatInteger(count));
     }
 
     if (self.settings.resultsText) {

--- a/src/components/locale/cultures/en-US.js
+++ b/src/components/locale/cultures/en-US.js
@@ -298,6 +298,8 @@ Soho.Locale.addCulture('en-US', {
     ResetDefault: { id: 'ResetDefault', value: 'Reset to Default', comment: 'Reset Datagrid Columns, Filter and other Layout' },
     Result: { id: 'Result', value: 'Result', comment: 'Showing a single result in a List' },
     Results: { id: 'Results', value: 'Results', comment: 'As in showing N Results (plural) in a List' },
+    ResultOf: { id: 'ResultOf', value: '{0} of {1} Result', comment: 'Text Showing current and total number of Result' },
+    ResultsOf: { id: 'ResultsOf', value: '{0} of {1} Results', comment: 'Text Showing current and total number of Results' },
     RightAlign: { id: 'RightAlign', value: 'Align Right', comment: 'Right Align tooltip' },
     RightAlignText: { id: 'RightAlignText', value: 'Align Right', comment: 'Right Align Text tooltip' },
     Right: { id: 'Right', value: 'Right', comment: 'Right' },

--- a/src/components/locale/cultures/es-US.js
+++ b/src/components/locale/cultures/es-US.js
@@ -290,6 +290,8 @@ Soho.Locale.addCulture('es-US', {
     ResetDefault: { id: 'ResetDefault', value: 'Restablecer valores predeterminados', comment: 'Reset Datagrid Columns, Filter and other Layout' },
     Result: { id: 'Result', value: 'Resultado', comment: 'Showing a single result in a List' },
     Results: { id: 'Results', value: 'Resultados', comment: 'As in showing N Results (plural) in a List' },
+    ResultOf: { id: 'ResultOf', value: '{0} de {1} Resultado', comment: 'Text Showing current and total number of Result' },
+    ResultsOf: { id: 'ResultsOf', value: '{0} de {1} Resultados', comment: 'Text Showing current and total number of Results' },
     RightAlign: { id: 'RightAlign', value: 'Alinear a la derecha', comment: 'Right Align tooltip' },
     RightAlignText: { id: 'RightAlignText', value: 'Alinear a la derecha', comment: 'Right Align Text tooltip' },
     Right: { id: 'Right', value: 'Derecha', comment: 'Right' },

--- a/src/components/locale/cultures/fr-FR.js
+++ b/src/components/locale/cultures/fr-FR.js
@@ -289,6 +289,8 @@ Soho.Locale.addCulture('fr-FR', {
     ResetDefault: { id: 'ResetDefault', value: 'Réinitialiser à valeur par défaut', comment: 'Reset Datagrid Columns, Filter and other Layout' },
     Result: { id: 'Result', value: 'Résultat', comment: 'Showing a single result in a List' },
     Results: { id: 'Results', value: 'Résultats', comment: 'As in showing N Results (plural) in a List' },
+    ResultOf: { id: 'ResultOf', value: '{0} de {1} Résultat', comment: 'Text Showing current and total number of Result' },
+    ResultsOf: { id: 'ResultsOf', value: '{0} de {1} Résultats', comment: 'Text Showing current and total number of Results' },
     RightAlign: { id: 'RightAlign', value: 'Alignement à droite', comment: 'Right Align tooltip' },
     RightAlignText: { id: 'RightAlignText', value: 'Alignement à droite', comment: 'Right Align Text tooltip' },
     Right: { id: 'Right', value: 'Droite', comment: 'Right' },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the english word "of" in (x of y results) was not translating when switching Locale.

**Related github/jira issue (required)**:
Closes #1900

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/example-filter.html?locale=fr-FR
- Open above link
- Open developer tools
- Type "1" in the filter for column "Qty"
- The title should be written as: Filterable Datagrid (2 de 9 Résultats)
