### PR TITLE
e2e - Up the datepicker variance amount to 2 mins

### DIFF
--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -573,7 +573,7 @@ describe('Datepicker Timeformat Tests', () => {
     const valueDate = new Date(value);
 
     const testDate = new Date();
-    const allowedVariance = 60000; // milliseconds
+    const allowedVariance = 120000; // milliseconds
     const dateDiff = Math.abs(testDate - valueDate); // guarentee its a positive result
 
     expect(dateDiff).toBeLessThanOrEqual(allowedVariance);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The 1min variance was too small for testing the one datepicker test.

**Related github/jira issue (required)**:
n/a

**Steps necessary to review your pull request (required)**:
- CI passes

Please include the following in your PR:
- [x] An e2e or functional test for the bug or feature.
- 🔕 A note to the change log.