### PR TITLE
1882 - Fixed selected all was not working with dropdown

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `[Datagrid]` Fixed an issue where lookup filterConditions were not rendering. ([#1873](https://github.com/infor-design/enterprise/issues/1873))
 - `[Datagrid]` Fixed an issue where filtering was missing translation. ([#1900](https://github.com/infor-design/enterprise/issues/1900))
 - `[Dropdown]` Changed the way dropdowns work with screen readers to be a collapsible listbox.([#404](https://github.com/infor-design/enterprise/issues/404))
+- `[Dropdown]` Fixed an issue where multiselect dropdown unchecking "Select All" was not getting clear after close list with Safari browser.([#1882](https://github.com/infor-design/enterprise/issues/1882))
 - `[Listbuilder]` Fixed an issue where the text was not sanitizing. ([#1692](https://github.com/infor-design/enterprise/issues/1692))
 - `[Locale]` Fixed trailing zeros were getting ignored when displaying thousands values. ([#404](https://github.com/infor-design/enterprise/issues/1840))
 - `[MenuButton]` Approved the way menu buttons work with screen readers.([#404](https://github.com/infor-design/enterprise/issues/404))

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -98,8 +98,8 @@ div.multiselect {
   }
 
   > span {
-    display: inline-block;
-    // max-width: 100%;
+    display: block;
+    min-height: 16px;
     overflow: hidden;
     text-overflow: ellipsis;
     vertical-align: top;

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -2232,7 +2232,6 @@ Dropdown.prototype = {
       // Select all
       items.forEach(node => node.classList.add('is-selected'));
       options.forEach((node) => {
-        node.selected = true;
         node.setAttribute('selected', true);
       });
 
@@ -2245,8 +2244,10 @@ Dropdown.prototype = {
       // Clear all
       items.forEach(node => node.classList.remove('is-selected'));
       options.forEach((node) => {
-        node.selected = false;
-        node.setAttribute('selected', true);
+        // Fix for ie-edge
+        // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12087679/
+        node.setAttribute('selected', false);
+        node.removeAttribute('selected');
       });
     }
     this.previousActiveDescendant = last.value || '';


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed multiselect dropdown unchecking "Select All" was not getting clear after close dropdown with Safari browser.

**Related github/jira issue (required)**:
Closes #1882

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/multiselect/test-select-all.html
- Open above link with safari
- Click on dropdown to open list
- Click on "Select All" option to select all items
- Click somewhere else to make dropdown close its list
- Click again on dropdown to open list
- Click on "Select All" option to unselect all items
- Click on any item in dropdown list
- Should toggle select/unselect with one click
