### PR TITLE
1814 - Fix ellipsis on header for IE11

### DIFF
--- a/app/views/patterns/builder-subtitle-test.html
+++ b/app/views/patterns/builder-subtitle-test.html
@@ -46,7 +46,7 @@
           <div class="title">
             <h2>
               <span class="panel-title">Builder Panel Title - Test a really really really really really really really really long title</span><br>
-              <span class="panel-subhead">Builder Panel Subheader - Test also a really really really really really really really really long subtitle</span>
+              <div class="panel-subhead">Builder Panel Subheader - Test also a really really really really really really really really long subtitle</div>
             </h2>
           </div>
           <div class="buttonset">

--- a/src/components/datagrid/datagrid.editors.js
+++ b/src/components/datagrid/datagrid.editors.js
@@ -794,7 +794,6 @@ const editors = {
       self.input.on('change', () => {
         setTimeout(() => {
           container.parent().focus();
-          grid.setNextActiveCell(event);
           grid.quickEditMode = false;
         }, 1);
       });

--- a/src/patterns/_builder.scss
+++ b/src/patterns/_builder.scss
@@ -91,6 +91,8 @@
 
   .panel-subhead {
     margin-top: 3px;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .panel-title {


### PR DESCRIPTION
**Related github/jira issue (required)**:
Closes #1814 

**Steps necessary to review your pull request (required)**:
1. Open  http://localhost:4000/patterns/builder-subtitle-test.html on IE 11
2. ensure the the sub-header is not cropped and has an ellipsis