### PR TITLE
NG354 - Fixes tooltip in code block

### DIFF
--- a/app/views/components/datagrid/test-custom-tooltip-dynamic.html
+++ b/app/views/components/datagrid/test-custom-tooltip-dynamic.html
@@ -23,10 +23,10 @@
     //Define Columns for the Grid.
     columns.push({ id: 'productId', hidden: true, name: 'Product Id', field: 'productId', formatter: Formatters.Readonly });
     columns.push({ id: 'productDesc', name: 'Product Desc', sortable: false, field: 'productName', width: 240, formatter: Formatters.Hyperlink });
-    columns.push({ id: 'activity', name: 'Activity', field: 'activity', width: 160 });
-    columns.push({ id: 'status', name: 'Exception', field: 'status', formatter: Formatters.Editor, contentTooltip: true,
+    columns.push({ id: 'activity', name: 'Activity', field: 'activity', width: 160, tooltip: 'Testing' });
+    columns.push({ id: 'status', name: 'Exception', field: 'status',
       tooltip: function(cell, value) {
-        return '<p>Test:' + value + '</p>';
+        return 'Test: ' + value;
       },
       width: 100 }
     );

--- a/app/views/components/datagrid/test-custom-tooltip-dynamic.html
+++ b/app/views/components/datagrid/test-custom-tooltip-dynamic.html
@@ -11,24 +11,6 @@
     var columns = [],
       data = [];
 
-    var myCustom = function (row, cell, value, col) {
-
-      var message = 'Info on the Status',
-        bar1Color = '#BDBDBD',
-        bar2Color = value === 'Error' ? '#E84F4F' : '#FD9437',
-        bar3Color = value === 'Error' ? '#E84F4F' : '#FD9437',
-        bar4Color = value === 'Error' ? '#E84F4F' : '#FD9437'; //alert
-
-      return '<div class="list-exceptions" title="' + message + '" style="position:relative; top: 10px; left: 25px; width: 18px;">' +
-        '<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" >' +
-        '<polygon fill="white" points="0 16 16 16 16 0 0 0"></polygon>' +
-        '<path d="M13.7142857,16 L2.28571429,16 C1.02285714,16 0,14.9771429 0,13.7142857 L0,13.7142857 L16,13.7142857 L16,13.7142857 C16,14.9771429 14.9771429,16 13.7142857,16" id="bar-4" fill="' + bar4Color + '"></path>' +
-        '<polygon id="bar-3" fill="' + bar3Color + '" points="0 11.4285714 16 11.4285714 16 9.14285714 0 9.14285714"></polygon>' +
-        '<polygon id="bar-2" fill="' + bar2Color + '" points="0 6.85714286 16 6.85714286 16 4.57142857 0 4.57142857"></polygon>' +
-        '<path d="M16,2.28571429 L0,2.28571429 C0,1.02285714 1.02285714,0 2.28571429,0 L13.7142857,0 C14.9771429,0 16,1.02285714 16,2.28571429 Z" id="bar-1" fill="' + bar1Color + '"></path>' +
-        '</svg></div>';
-    };
-
     // Some Sample Data
     data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity: 'Assemble Paint', quantity: 1, price: 210.99, status: 'Error', orderDate: new Date(2014, 12, 8), action: 'Action' });
     data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity: 'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold', ordered: true });
@@ -42,13 +24,19 @@
     columns.push({ id: 'productId', hidden: true, name: 'Product Id', field: 'productId', formatter: Formatters.Readonly });
     columns.push({ id: 'productDesc', name: 'Product Desc', sortable: false, field: 'productName', width: 240, formatter: Formatters.Hyperlink });
     columns.push({ id: 'activity', name: 'Activity', field: 'activity', width: 160 });
-    columns.push({ id: 'status', name: 'Exception', field: 'status', formatter: myCustom, tooltip: 'Error Info', width: 100 });
+    columns.push({ id: 'status', name: 'Exception', field: 'status', formatter: Formatters.Editor, contentTooltip: true,
+      tooltip: function(cell, value) {
+        return '<p>Test:' + value + '</p>';
+      },
+      width: 100 }
+    );
     columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity' });
 
     //Init and get the api for the grid
     $('#readonly-datagrid').datagrid({
       columns: columns,
-      dataset: data
+      dataset: data,
+      enableTooltips: true
     }).on('afterrender', function () {
       $('.list-exceptions').tooltip();
     });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[Datepicker]` Fixed an issue in NG where the custom validation is removed during the teardown of a datepicker.([NG #411](https://github.com/infor-design/enterprise-ng/issues/411))
 - `[Datagrid]` Fixed an issue where lookup filterConditions were not rendering. ([#1873](https://github.com/infor-design/enterprise/issues/1873))
 - `[Datagrid]` Fixed an issue where filtering was missing translation. ([#1900](https://github.com/infor-design/enterprise/issues/1900))
+- `[Datagrid]` Added ability to pass a function to the tooltip option for custom formatting. ([#354](https://github.com/infor-design/enterprise-ng/issues/354))
 - `[Dropdown]` Changed the way dropdowns work with screen readers to be a collapsible listbox.([#404](https://github.com/infor-design/enterprise/issues/404))
 - `[Dropdown]` Fixed an issue where multiselect dropdown unchecking "Select All" was not getting clear after close list with Safari browser.([#1882](https://github.com/infor-design/enterprise/issues/1882))
 - `[Listbuilder]` Fixed an issue where the text was not sanitizing. ([#1692](https://github.com/infor-design/enterprise/issues/1692))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `[Dropdown]` Changed the way dropdowns work with screen readers to be a collapsible listbox.([#404](https://github.com/infor-design/enterprise/issues/404))
 - `[Dropdown]` Fixed an issue where multiselect dropdown unchecking "Select All" was not getting clear after close list with Safari browser.([#1882](https://github.com/infor-design/enterprise/issues/1882))
 - `[Listbuilder]` Fixed an issue where the text was not sanitizing. ([#1692](https://github.com/infor-design/enterprise/issues/1692))
+- `[Lookup]` Fixed an issue where the tooltip was using audible text in the code block component. ([#354](https://github.com/infor-design/enterprise-ng/issues/354))
 - `[Locale]` Fixed trailing zeros were getting ignored when displaying thousands values. ([#404](https://github.com/infor-design/enterprise/issues/1840))
 - `[MenuButton]` Approved the way menu buttons work with screen readers.([#404](https://github.com/infor-design/enterprise/issues/404))
 - `[Radios]` Fixed the last radio item was being selected when clicking on the first when displayed horizontal. ([#1878](https://github.com/infor-design/enterprise/issues/1878))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4302,7 +4302,6 @@ Datagrid.prototype = {
         const tooltip = $(elem).data('gridtooltip') || self.cacheTooltip(elem);
         const containerEl = isHeaderColumn ? elem.parentNode : elem;
         const width = self.getOuterWidth(containerEl);
-
         if (tooltip && (tooltip.forced || (tooltip.textwidth > (width - 35))) && !isPopup) {
           self.showTooltip(tooltip);
         }
@@ -9804,13 +9803,21 @@ Datagrid.prototype = {
         const width = col.editorOptions &&
           col.editorOptions.width ? this.setUnit(col.editorOptions.width) : false;
 
-        // Width for tooltip can be come from column options
-        contentTooltip.style.width = width || `${elem.offsetWidth}px`;
-        const wrapperHTML = tooltip.wrapper.innerHTML;
+        if (typeof col.tooltip === 'function') {
+          const rowNode = this.closest(elem, el => utils.hasClass(el, 'datagrid-row'));
+          const rowIdx = rowNode.getAttribute('data-index');
+          const value = this.fieldValue(this.settings.dataset[rowIdx], col.field);
+          tooltip.wrapper = elem.querySelector('.datagrid-cell-wrapper');
+          tooltip.content = col.tooltip(cell, value);
+        } else {
+          // Width for tooltip can be come from column options
+          contentTooltip.style.width = width || `${elem.offsetWidth}px`;
+          const wrapperHTML = tooltip.wrapper.innerHTML;
 
-        if (xssUtils.stripHTML(wrapperHTML) !== '') {
-          tooltip.content = wrapperHTML;
-          tooltip.extraClassList = ['popover', 'alternate', 'content-tooltip'];
+          if (xssUtils.stripHTML(wrapperHTML) !== '') {
+            tooltip.content = wrapperHTML;
+            tooltip.extraClassList = ['popover', 'alternate', 'content-tooltip'];
+          }
         }
       } else if (aTitle) {
         // Title attribute on links `a`

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9773,6 +9773,8 @@ Datagrid.prototype = {
       const isTh = elem.tagName.toLowerCase() === 'th';
       const isHeaderColumn = utils.hasClass(elem, 'datagrid-column-wrapper');
       const isHeaderFilter = utils.hasClass(elem.parentNode, 'datagrid-filter-wrapper');
+      const cell = elem.getAttribute('aria-colindex') - 1;
+      const col = this.columnSettings(cell);
       let title;
 
       tooltip = { content: '', wrapper: elem.querySelector('.datagrid-cell-wrapper') };
@@ -9803,21 +9805,13 @@ Datagrid.prototype = {
         const width = col.editorOptions &&
           col.editorOptions.width ? this.setUnit(col.editorOptions.width) : false;
 
-        if (typeof col.tooltip === 'function') {
-          const rowNode = this.closest(elem, el => utils.hasClass(el, 'datagrid-row'));
-          const rowIdx = rowNode.getAttribute('data-index');
-          const value = this.fieldValue(this.settings.dataset[rowIdx], col.field);
-          tooltip.wrapper = elem.querySelector('.datagrid-cell-wrapper');
-          tooltip.content = col.tooltip(cell, value);
-        } else {
-          // Width for tooltip can be come from column options
-          contentTooltip.style.width = width || `${elem.offsetWidth}px`;
-          const wrapperHTML = tooltip.wrapper.innerHTML;
+        // Width for tooltip can be come from column options
+        contentTooltip.style.width = width || `${elem.offsetWidth}px`;
+        const wrapperHTML = tooltip.wrapper.innerHTML;
 
-          if (xssUtils.stripHTML(wrapperHTML) !== '') {
-            tooltip.content = wrapperHTML;
-            tooltip.extraClassList = ['popover', 'alternate', 'content-tooltip'];
-          }
+        if (xssUtils.stripHTML(wrapperHTML) !== '') {
+          tooltip.content = wrapperHTML;
+          tooltip.extraClassList = ['popover', 'alternate', 'content-tooltip'];
         }
       } else if (aTitle) {
         // Title attribute on links `a`
@@ -9879,6 +9873,16 @@ Datagrid.prototype = {
         if (title || isHeaderFilter) {
           tooltip.forced = true;
         }
+      }
+
+      if (typeof col.tooltip === 'function') {
+        const isEllipsis = utils.hasClass((isHeaderColumn ? elem.parentNode : elem), 'text-ellipsis');
+        let extraWidth = isEllipsis ? 8 : 0;
+        const rowNode = this.closest(elem, el => utils.hasClass(el, 'datagrid-row'));
+        const rowIdx = rowNode.getAttribute('data-index');
+        const value = this.fieldValue(this.settings.dataset[rowIdx], col.field);
+        tooltip.content = col.tooltip(cell, value);
+        tooltip.textwidth = stringUtils.textWidth(tooltip.content) + extraWidth;
       }
     }
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9800,8 +9800,6 @@ Datagrid.prototype = {
 
       if (contentTooltip) {
         // Used with rich text editor
-        const cell = elem.getAttribute('aria-colindex') - 1;
-        const col = this.columnSettings(cell);
         const width = col.editorOptions &&
           col.editorOptions.width ? this.setUnit(col.editorOptions.width) : false;
 
@@ -9876,13 +9874,11 @@ Datagrid.prototype = {
       }
 
       if (typeof col.tooltip === 'function') {
-        const isEllipsis = utils.hasClass((isHeaderColumn ? elem.parentNode : elem), 'text-ellipsis');
-        let extraWidth = isEllipsis ? 8 : 0;
         const rowNode = this.closest(elem, el => utils.hasClass(el, 'datagrid-row'));
         const rowIdx = rowNode.getAttribute('data-index');
         const value = this.fieldValue(this.settings.dataset[rowIdx], col.field);
         tooltip.content = col.tooltip(cell, value);
-        tooltip.textwidth = stringUtils.textWidth(tooltip.content) + extraWidth;
+        tooltip.textwidth = stringUtils.textWidth(tooltip.content) + 20;
       }
     }
 

--- a/src/components/lookup/lookup.js
+++ b/src/components/lookup/lookup.js
@@ -172,10 +172,6 @@ Lookup.prototype = {
   addAria() {
     const self = this;
     self.label = self.isInlineLabel ? self.inlineLabelText : $(`label[for="${self.element.attr('id')}"]`);
-
-    if (self.label) {
-      self.label.append(`<span class="audible">${Locale.translate('UseEnter')}</span>`);
-    }
   },
 
   /**
@@ -811,10 +807,6 @@ Lookup.prototype = {
 
     this.icon.remove();
     this.element.unwrap();
-
-    if (this.label && this.label != null) {
-      this.label.find('.audible').remove();
-    }
   }
 };
 

--- a/test/components/toolbar-flex/toolbar-flex-api.func-spec.js
+++ b/test/components/toolbar-flex/toolbar-flex-api.func-spec.js
@@ -333,7 +333,7 @@ describe('Flex Toolbar', () => {
 
         expect(textButton.overflowed).toBeFalsy();
 
-        const secondIconButton = toolbarAPI.items[3];
+        const secondIconButton = toolbarAPI.items[2];
 
         expect(secondIconButton.overflowed).toBeTruthy();
         done();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Removes the `audible` span from the lookup label so that the code block does not use that text in the tooltip. Will need to revisit the screen reader implementation using `aria-haspopup` instead.

**Related github/jira issue (required)**:
related to ([#354](https://github.com/infor-design/enterprise-ng/issues/354))

**Steps necessary to review your pull request (required)**:
- `npm run build` and move the `dist` into enterprise-ng `node_modules` or `npm link` this branch to enterprise-ng.
- create test page in enterprise-ng with the attached example. [CodeBlockTooltip.zip](https://github.com/infor-design/enterprise/files/3069086/CodeBlockTooltip.zip)
- make sure the tooltip only displays the text in the cells.

<!-- Please include the following in your PR:
- ~[ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.
-->

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
