### PR TITLE
1948 - Fixes datagrid checkboxes when string  '1' and '0 is used as the source

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "marked": "^0.3.17",
     "mmm": "^0.2.2",
     "moment": "^2.19.2",
-    "node-sass": "^4.9.2",
+    "node-sass": "4.11.0",
     "protractor": "^5.4.1",
     "protractor-image-comparison": "^2.0.1",
     "pygmentize-bundled": "^2.3.0",

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -244,7 +244,7 @@ const formatters = {
       isChecked = col.isChecked(value);
     } else {
       // treat 1, true or '1' as checked
-      isChecked = (value === undefined ? false : value === true);
+      isChecked = (value === undefined ? false : (value === true || parseInt(value, 10) === 1));
     }
 
     // We add hidden Yes/No text so that the exported excel spreadsheet shows


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes the check on 1, '1'

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise/issues/1948

**Steps necessary to review your pull request (required)**:
Add a data grid component, with some data.
Add a column which use Soho.Formatters.Checkbox

Column should be checked if data contains either true, 1, or '1'