### PR TITLE
1914 - Replace opacity property from buttons disabled state css

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### v4.18.0 Chore & Maintenance
 
+- `[Buttons]` Updated button disabled states with corresponding ids-identity tokens. ([1914](https://github.com/infor-design/enterprise/issues/1914)
 - `[Docs]` Added a statement on supporting accessibility. ([#1540](https://github.com/infor-design/enterprise/issues/1540))
 - `[Docs]` Added the supported screen readers and some notes on accessibility. ([#1722](https://github.com/infor-design/enterprise/issues/1722))
 

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "handlebars-registrar": "^1.5.2",
     "html-loader": "^0.5.5",
     "ids-css": "^1.3.0",
-    "ids-identity": "^2.4.0",
+    "ids-identity": "^2.5.0",
     "jasmine-core": "^3.2.1",
     "jasmine-jquery": "^2.1.1",
     "jasmine-spec-reporter": "^4.2.1",

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -176,12 +176,11 @@ button {
     background-color: $button-color-primary-disabled-background;
     border-color: $button-color-primary-disabled-border;
     box-shadow: none;
-    color: $button-color-primary-initial-font;
+    color: $button-color-primary-disabled-font;
     cursor: default;
-    opacity: $button-color-secondary-disabled-opacity;
 
     .icon {
-      color: $theme-color-palette-white;
+      color: $button-color-primary-disabled-icon;
     }
   }
 
@@ -308,7 +307,10 @@ a.btn-close {
     box-shadow: none;
     color: $button-color-secondary-disabled-font;
     cursor: default;
-    opacity: $button-color-secondary-disabled-opacity;
+
+    .icon {
+      color: $button-color-secondary-disabled-icon;
+    }
   }
 
   .ripple-effect {
@@ -372,7 +374,6 @@ a.btn-close {
   &[disabled]:hover {
     color: $button-color-tertiary-disabled-font;
     cursor: default;
-    opacity: $button-color-secondary-disabled-opacity;
 
     .icon {
       color: $button-color-tertiary-disabled-font;

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -461,7 +461,6 @@ $toolbarsearchfield-category-empty-width: 51px;
         box-shadow: none;
         color: $button-color-secondary-disabled-font;
         cursor: default;
-        opacity: $button-color-secondary-disabled-opacity;
       }
 
       .ripple-effect {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
We were seeing issues with using opacity in button disabled state styles, so we adapted the tokens and are now using those. Yes there will be slight visual changes, but nothing drastic.

You can read more about it in the following design-system pull requests:
- https://github.com/infor-design/design-system/pull/361
- https://github.com/infor-design/design-system/pull/366

**Related github/jira issue (required)**:
#1914 

**Steps necessary to review your pull request (required)**:
1. `npm i && npm run start`
1. Compare the following links and make sure the buttons look disabled
    - Sscreenshot here: https://github.com/infor-design/design-system/pull/361#pullrequestreview-225246269)
    - Screenshot here: https://github.com/infor-design/design-system/pull/366#pullrequestreview-225605286

| Localhost | v4.17.1 |
| --------- | ------- |
| [Light Theme](http://localhost:4000/) | [Light Theme](https://4171-enterprise.demo.design.infor.com) |
| [Dark Theme](http://localhost:4000/?theme=dark) | [Dark Theme](https://4171-enterprise.demo.design.infor.com?theme=dark) |
| [High Contrast Theme](http://localhost:4000/?theme=high-contrast) | [High Contrast Theme](https://4171-enterprise.demo.design.infor.com?theme=high-contrast) |
| [Uplift Theme](http://localhost:4000/?theme=uplift) | [Uplift Theme](https://4171-enterprise.demo.design.infor.com?theme=uplift) |


---


Please include the following in your PR:
- 🚫 An e2e or functional test for the bug or feature.
- ✅ A note to the change log.


<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
