### PR TITLE
355 - Added support for tab thru to multiple inputs in edit mode datagrid

### DIFF
--- a/app/views/components/datagrid/test-codeblock.html
+++ b/app/views/components/datagrid/test-codeblock.html
@@ -1,0 +1,625 @@
+<style>
+  .datagrid .code-block {
+    background: inherit;
+    border: none;
+    display: block;
+    font-family: inherit;
+    line-height: inherit;
+    margin: 0 0 -19px;
+    overflow: inherit;
+    position: relative;
+    text-overflow: inherit;
+  }
+
+  .datagrid .is-active .code-block {
+    display: inline-block;
+    line-height: inherit !important;
+    top: -3px;
+    width: calc(100% - 104px);
+  }
+
+  .datagrid .code-block label {
+    display: inline-block;
+    margin-bottom: 0;
+    overflow: hidden;
+    position: relative;
+    top: -1px;
+    vertical-align: middle;
+    white-space: nowrap;
+  }
+
+  .datagrid .code-block label::after {
+    content: ':';
+  }
+
+  .datagrid .code-block .data {
+    display: inline-block;
+    line-height: inherit;
+    margin-bottom: 0;
+    padding-left: 5px;
+    padding-right: 15px;
+    position: relative;
+    top: 0;
+    white-space: nowrap;
+  }
+
+  .datagrid .code-block .data:not(:last-of-type)::after,
+  .datagrid td.is-editing .code-block .data:not(:last-of-type)::after {
+    color: #5c5c5c;
+    content: '•';
+    font-size: 18px;
+    margin-right: 0;
+    padding-left: 15px;
+    position: relative;
+    top: 1px;
+  }
+
+  .datagrid td.is-editing .code-block input[type='text'] {
+    width: 60%;
+  }
+
+  .datagrid td.is-editing .code-block input.lookup {
+    border-color: transparent;
+    padding: 0 2px 0 0;
+    transition: margin 0.5s ease, left 0.5s ease, padding 0.5s ease, width 0.5s ease;
+    vertical-align: baseline;
+    width: auto; /* IE doesnt support initial */
+    width: initial;
+  }
+
+  .datagrid td.is-editing .code-block .lookup-wrapper {
+    padding-left: 0;
+    padding-top: 0;
+    vertical-align: baseline;
+  }
+
+  .datagrid td.is-editing .code-block .field {
+    margin-right: 0;
+  }
+
+  .datagrid td.is-editing .code-block .field::after {
+    content: '';
+  }
+
+  .datagrid td.is-editing .code-block input.lookup ~ .trigger .icon {
+    top: 8px;
+    width: 18px;
+  }
+
+  .datagrid td.is-editing .code-block input.lookup ~ .trigger {
+    margin-top: 0;
+  }
+
+  .datagrid td.is-editing .code-block .datagrid-cell-wrapper:focus {
+    outline: none;
+  }
+
+  .datagrid td.is-editing .code-block .lookup-wrapper .trigger {
+    margin-left: -33px;
+    margin-top: 0;
+  }
+
+  .field-options {
+    margin-right: 15px;
+  }
+
+  .code-block-container > button {
+    display: inline-block;
+  }
+
+  .code-block-actions {
+    left: -17px;
+    transform: rotate(90deg);
+    visibility: visible;
+  }
+
+  .code-block-buttons {
+    display: inline-block;
+    left: 5px;
+    position: relative;
+  }
+
+  /* --- */
+  .code-block.is-active {
+    border: 1px solid #368ac0;
+    box-shadow: 0 0 4px 3px rgba(54, 138, 192, 0.3);
+  }
+
+  .code-block.is-active input {
+    box-shadow: none !important;
+  }
+
+  .field.is-active {
+    border: 1px solid #368ac0;
+  }
+
+  .field.is-active .field-options:not([disabled]) {
+    border-color: transparent !important;
+    box-shadow: none !important;
+  }
+
+  /* Make Label and Input Inline */
+  .lookup-wrapper,
+  .label {
+    display: inline;
+  }
+
+  .field {
+    border: 1px solid transparent;
+    border-radius: 2px;
+    display: inline-block;
+    height: 34px;
+    line-height: 34px;
+    margin: -3px -12px -3px -3px;
+    padding: 0 0 0 12px;
+    vertical-align: middle;
+  }
+
+  .field:not(:last-of-type):not(.is-active)::after {
+    color: #5c5c5c;
+    content: '•';
+    font-size: 18px;
+    position: absolute;
+    right: 18px;
+    top: -1px;
+    width: 4px;
+  }
+
+  .field.is-active::after {
+    content: '';
+  }
+
+  .field.is-active:focus {
+    box-shadow: none !important;
+  }
+
+  /* Adjust labels and input styles */
+  .label {
+    position: relative;
+    top: -1px;
+  }
+
+  /* Add a : After the label */
+  .label::after {
+    content: ':';
+  }
+
+  input {
+    border-color: transparent;
+    padding-left: 0;
+    transition: margin 0.5s ease, left 0.5s ease, padding 0.5s ease, width 0.5s ease;
+    width: auto; /* IE doesnt support initial */
+    width: initial;
+  }
+
+  .is-number-mask {
+    text-align: left;
+  }
+
+  .lookup,
+  input {
+    padding: 0;
+  }
+
+  .lookup:focus {
+    box-shadow: none !important;
+  }
+
+  /* Other Input Types */
+  input[readonly] {
+    background-color: transparent;
+  }
+
+  /* Make Elements Sit Well Next to Each other */
+  .field .field-options:not([disabled]).lookup,
+  .field.is-active .field-options:not([disabled]).lookup,
+  .field .field-options:not([disabled]),
+  .field .field-options:not([disabled]).datepicker,
+  .field.is-active .field-options:not([disabled]).datepicker,
+  .field .dropdown-wrapper {
+    margin-left: 3px;
+    margin-right: 18px;
+  }
+
+  /* Support for IE, Edge and FF */
+  .ie .field .field-options:not([disabled]).lookup,
+  .is-firefox .field .field-options:not([disabled]).lookup,
+  .ie .field.is-active .field-options:not([disabled]).lookup,
+  .is-firefox .field.is-active .field-options:not([disabled]).lookup,
+  .ie .field .field-options:not([disabled]),
+  .is-firefox .field .field-options:not([disabled]),
+  .ie .field .field-options:not([disabled]).datepicker,
+  .is-firefox .field .field-options:not([disabled]).datepicker,
+  .ie .field.is-active .field-options:not([disabled]).datepicker,
+  .is-firefox .field.is-active .field-options:not([disabled]).datepicker {
+    margin-right: 0;
+  }
+
+  .field.is-active .field-options:not([disabled]) {
+    margin-right: 9px;
+  }
+
+  .field input.field-options:not([disabled]).lookup.is-active,
+  .field.is-active .field-options:not([disabled]).datepicker {
+    padding-right: 10px;
+  }
+
+  .field.is-active::before,
+  .datepicker + .icon {
+    visibility: hidden;
+  }
+
+  .datepicker.is-active + .icon {
+    visibility: visible;
+    z-index: 2;
+  }
+
+  .trigger {
+    margin-left: -33px;
+    visibility: hidden;
+  }
+
+  input.is-active + .trigger {
+    visibility: visible;
+  }
+
+  input.is-active + .trigger .icon {
+    fill: #5c5c5c !important;
+  }
+
+  .lookup-wrapper.is-active + .trigger {
+    visibility: visible;
+  }
+
+  /* Adjust the Field Options */
+  .btn-actions {
+    left: -15px;
+    margin-right: -22px;
+    top: 0;
+    visibility: hidden;
+    z-index: 1;
+  }
+
+  .field.is-fieldoptions .lookup-wrapper .btn-actions {
+    left: -15px;
+  }
+
+  .field-options.checkbox ~ .btn-actions,
+  .field-options.dropdown ~ .btn-actions {
+    top: 0;
+  }
+
+  input.is-active + .trigger + .btn-actions {
+    border: none;
+    box-shadow: none !important;
+    left: -15px;
+    margin-right: -18px;
+    visibility: visible;
+  }
+
+  /* Input Field with field options */
+  .btn-actions.is-active {
+    border: none;
+    box-shadow: none !important;
+    visibility: visible;
+  }
+
+  .field.is-active::before {
+    visibility: hidden;
+  }
+
+  /* Readonly Styles */
+  .data {
+    font-size: 1.4rem;
+    padding-left: 3px;
+    padding-right: 41px;
+  }
+
+  .input-style.is-readonly .field::after {
+    right: 20px;
+    top: -3px;
+  }
+
+  /* Style Datepicker alignment */
+  .field-options.datepicker {
+    width: auto; /* IE doesnt support initial */
+    width: initial;
+  }
+
+  /* Style Checkbox alignment */
+  .field .checkbox-label {
+    margin-right: 18px;
+  }
+
+  div.field + .field-checkbox {
+    margin-bottom: -3px !important;
+  }
+
+  /* Style Dropdown & alignment */
+  .dropdown {
+    border-width: 0;
+    height: 32px !important;
+    padding: 8px 0;
+    vertical-align: top;
+  }
+
+  .field .dropdown-sm {
+    max-width: 100px;
+    min-width: 61px;
+    padding-right: 0;
+    transition: padding 0.5s ease;
+    width: auto;
+  }
+
+  .field .dropdown-sm.is-open {
+    padding-right: 28px;
+    transition: padding 0.5s ease;
+  }
+
+  .dropdown + .icon {
+    right: 24px;
+    visibility: hidden;
+  }
+
+  .field.is-active div.dropdown:not(.is-open) {
+    border-width: 0;
+    box-shadow: none;
+  }
+</style>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+    $('body').on('initialized', function () {
+
+      var customFormatter = function (row, cell, value, col, rowData, api) {
+        // console.log({i: 'format', row, cell, value, col, rowData, api});
+        return '' +
+          '<span class="code-block">' +
+            '<label for="contact" class="label">Contact</label>' +
+            '<span class="data">'+ rowData.contact +'</span>' +
+            '<label for="phone" class="label">Phone</label>' +
+            '<span class="data">'+ rowData.phone +'</span>' +
+            '<label for="location" class="label">Location</label>' +
+            '<span class="data">'+ rowData.location +'</span>' +
+          '</span>';
+      };
+
+      var customEditor = function (row, cell, value, container, column, event, grid, rowData) {
+        // console.log({i: 'edit', row, cell, value, container, column, event, grid, rowData});
+        this.name = 'MyCustom';
+        this.originalValue = value;
+
+        this.init = function () {
+          const btnHtml = function (id) {
+            return '<button type="button" id="popupmenu-'+ id +'" class="btn-actions btn-menu">' +
+              $.createIcon({ icon: 'more' }) +
+              '<span class="audible">More Actions</span></button>' +
+              '<ul class="popupmenu">' +
+                '<li><a href="#">Show Field History</a></li>' +
+                '<li><a href="#">Show Pending Changes</a></li>' +
+                '<li>' +
+                  '<a href="#">Drill Around</a>' +
+                  '<ul class="popupmenu">' +
+                    '<li><a href="#">Sub Menu 1</a></li>' +
+                    '<li><a href="#">Sub Menu 2</a></li>' +
+                  '</ul>' +
+                '</li>' +
+              '</ul>';
+          };
+
+          const html = '' +
+            '<div class="code-block">' +
+              '<div class="field">' +
+                  '<label for="contact" class="label">Contact</label>' +
+                  '<input type="text" name="contact" id="contact" value="'+ rowData.contact +'"/>' +
+                  btnHtml('contact') +
+                '</div>' +
+              '<div class="field">' +
+                  '<label for="phone" class="label">Phone</label>' +
+                  '<input type="text" name="phone" id="phone" value="'+ rowData.phone +'"/>' +
+                  btnHtml('phone') +
+                '</div>' +
+              '<div class="field">' +
+                  '<label for="location" class="label">Location</label>' +
+                  '<input type="text" name="location" id="location" value="'+ rowData.location +'"/>' +
+                  btnHtml('location') +
+                '</div>' +
+            '</div>';
+
+          $(html).appendTo(container);
+          container.find('.btn-menu').button();
+        };
+
+        this.val = function (value) {
+          return '';
+        };
+
+        this.focus = function () {
+          container.find('[type="text"]:first').focus().select();
+        };
+
+        this.destroy = function () {
+        };
+
+        this.init();
+      };
+
+      var data = [
+        {
+          'id': 1,
+          'companyId': '101',
+          'companyName': 'Alexandar Gravel & Stone',
+          'phone': '414-821-0697',
+          'location': 'Terrencefort, TX',
+          'contact': 'Lida Snyder',
+          'customerSince': '04/25/2016',
+          'favorite': true
+        },
+        {
+          'id': 2,
+          'companyId': '102',
+          'companyName': 'Briar Valley Gravel',
+          'phone': '702-389-9973',
+          'location': 'Davontemouth, UT',
+          'contact': 'Bull Cunningham',
+          'customerSince': '05/02/2016'
+        },
+        {
+          'id': 3,
+          'companyId': '103',
+          'companyName': 'Riverhead Building Supply',
+          'phone': '929-769-3984',
+          'location': 'Hermistonhaven, AZ',
+          'contact': 'Johnny Fields',
+          'customerSince': '08/28/2016',
+          'favorite': true
+        },
+        {
+          'id': 4,
+          'companyId': '104',
+          'companyName': 'Gravel Corp',
+          'phone': '299-166-7016',
+          'location': 'North Beau, NV',
+          'contact': 'Nina Mendez',
+          'customerSince': '01/25/2015'
+        },
+        {
+          'id': 5,
+          'companyId': '105',
+          'companyName': 'United Construction',
+          'phone': '299-166-7016',
+          'location': 'New Abdul, TX',
+          'contact': 'Paul Strayer',
+          'customerSince': '04/21/2016'
+        },
+        {
+          'id': 6,
+          'companyId': '106',
+          'companyName': 'Gravel, Gravel, Gravel',
+          'phone': '299-166-7067',
+          'location': 'Smithsville, UT',
+          'contact': 'John Nasmith',
+          'customerSince': '06/25/2016'
+        },
+        {
+          'id': 7,
+          'companyId': '108',
+          'companyName': 'Stone Gravel Supply Company',
+          'phone': '202-504-5299',
+          'location': 'Ryesmith, AK',
+          'contact': 'Spring Adams',
+          'customerSince': '07/25/2015'
+        },
+        {
+          'id': 8,
+          'companyId': '109',
+          'companyName': 'Smith Gravel & Stone',
+          'phone': '411-821-0697',
+          'location': 'Lancaster, TX',
+          'contact': 'Mary Adams',
+          'customerSince': '04/25/2016',
+          'favorite': true
+        },
+        {
+          'id': 9,
+          'companyId': '110',
+          'companyName': 'Hidden Valley Gravel',
+          'phone': '202-389-9973',
+          'location': 'Shark City, UT',
+          'contact': 'Donald Cunningham',
+          'customerSince': '05/01/2016'
+        },
+        {
+          'id': 10,
+          'companyId': '111',
+          'companyName': 'Copperhead Building Supply',
+          'phone': '929-769-3984',
+          'location': 'Hermistonhaven, AZ',
+          'contact': 'Johnny Smith',
+          'customerSince': '08/21/2016',
+          'favorite': true
+        },
+        {
+          'id': 11,
+          'companyId': '112',
+          'companyName': 'Gravel Lovers Inc',
+          'phone': '299-166-7016',
+          'location': 'North Beau, NV',
+          'contact': 'Paulo Mendez',
+          'customerSince': '03/25/2014'
+        },
+        {
+          'id': 12,
+          'companyId': '113',
+          'companyName': 'United Gravel',
+          'phone': '299-126-7016',
+          'location': 'New Manilla, TX',
+          'contact': 'Paul Strayer',
+          'customerSince': '04/21/2016'
+        },
+        {
+          'id': 13,
+          'companyId': '114',
+          'companyName': 'Construction City',
+          'phone': '399-166-7067',
+          'location': 'Joanestown, UT',
+          'contact': 'Andy Nasmith',
+          'customerSince': '06/25/2015'
+        },
+        {
+          'id': 14,
+          'companyId': '115',
+          'companyName': 'Stone City Supply Company',
+          'phone': '202-504-5299',
+          'location': 'River Ridge, PA',
+          'contact': 'Winter Adams',
+          'customerSince': '01/25/2015'
+        }
+      ];
+
+      var columns = [
+        {
+          id: 'companyId',
+          name: 'Company',
+          field: 'companyId',
+          filterType: 'text',
+          width: 100,
+          editor: Editors.Input
+        },
+        {
+          id: 'companyName',
+          name: 'Name',
+          field: 'companyName',
+          filterType: 'text',
+          width: 140,
+          editor: Editors.Input
+        },
+        { id: 'codeBlock',
+          name: 'Code Block',
+          sortable: false,
+          formatter: customFormatter,
+          filterType: 'text',
+          expandOnActivate: true,
+          textOverflow: 'ellipsis',
+          editor: customEditor
+        }
+      ];
+
+      //Init and get the api for the grid
+      $('#datagrid').datagrid({
+        columns: columns,
+        dataset: data,
+        selectable: 'single',
+        idProperty: 'productId',
+        editable: true,
+        filterable: true
+      });
+    });
+
+</script>

--- a/app/views/components/datagrid/test-codeblock.html
+++ b/app/views/components/datagrid/test-codeblock.html
@@ -55,7 +55,17 @@
   }
 
   .datagrid td.is-editing .code-block input[type='text'] {
-    width: 60%;
+    padding: 8px 0;
+    width: 50%;
+  }
+
+  .datagrid td.is-editing .icon {
+    color: inherit;
+    top: auto;
+  }
+
+  .datagrid td.is-editing .code-block input[type='text']:focus {
+    /* border: 1px solid #999; */
   }
 
   .datagrid td.is-editing .code-block input.lookup {
@@ -383,10 +393,10 @@
           '<span class="code-block">' +
             '<label for="contact" class="label">Contact</label>' +
             '<span class="data">'+ rowData.contact +'</span>' +
-            '<label for="phone" class="label">Phone</label>' +
-            '<span class="data">'+ rowData.phone +'</span>' +
             '<label for="location" class="label">Location</label>' +
             '<span class="data">'+ rowData.location +'</span>' +
+            '<label for="customer-since" class="label">Customer Since</label>' +
+            '<span class="data">'+ rowData.customerSince +'</span>' +
           '</span>';
       };
 
@@ -397,9 +407,11 @@
 
         this.init = function () {
           const btnHtml = function (id) {
-            return '<button type="button" id="popupmenu-'+ id +'" class="btn-actions btn-menu">' +
-              $.createIcon({ icon: 'more' }) +
-              '<span class="audible">More Actions</span></button>' +
+            return '' +
+              '<button type="button" id="popupmenu-'+ id +'" class="btn-actions btn-menu">' +
+                '<span class="audible">More Actions</span>' +
+                $.createIcon({ icon: 'more' }) +
+              '</button>' +
               '<ul class="popupmenu">' +
                 '<li><a href="#">Show Field History</a></li>' +
                 '<li><a href="#">Show Pending Changes</a></li>' +
@@ -416,24 +428,25 @@
           const html = '' +
             '<div class="code-block">' +
               '<div class="field">' +
-                  '<label for="contact" class="label">Contact</label>' +
-                  '<input type="text" name="contact" id="contact" value="'+ rowData.contact +'"/>' +
-                  btnHtml('contact') +
-                '</div>' +
+                '<label for="contact" class="label">Contact</label>' +
+                '<input type="text" name="contact" id="contact" value="'+ rowData.contact +'"/>' +
+                btnHtml('contact') +
+              '</div>' +
               '<div class="field">' +
-                  '<label for="phone" class="label">Phone</label>' +
-                  '<input type="text" name="phone" id="phone" value="'+ rowData.phone +'"/>' +
-                  btnHtml('phone') +
-                '</div>' +
+                '<label for="location" class="label">Location</label>' +
+                '<input type="text" name="location" id="location" value="'+ rowData.location +'"/>' +
+                btnHtml('location') +
+              '</div>' +
               '<div class="field">' +
-                  '<label for="location" class="label">Location</label>' +
-                  '<input type="text" name="location" id="location" value="'+ rowData.location +'"/>' +
-                  btnHtml('location') +
-                '</div>' +
+                '<label for="customer-since" class="label">Customer Since</label>' +
+                '<input type="text" name="customer-since" id="customer-since" value="'+ rowData.customerSince +'"/>' +
+                btnHtml('customer-since') +
+              '</div>' +
             '</div>';
 
           $(html).appendTo(container);
-          container.find('.btn-menu').button();
+          container.find('#customer-since').datepicker();
+          container.find('[type="text"]').fieldoptions();
         };
 
         this.val = function (value) {

--- a/app/views/components/datagrid/test-codeblock.html
+++ b/app/views/components/datagrid/test-codeblock.html
@@ -1,380 +1,389 @@
 <style>
-  .datagrid .code-block {
-    background: inherit;
-    border: none;
-    display: block;
-    font-family: inherit;
-    line-height: inherit;
-    margin: 0 0 -19px;
-    overflow: inherit;
-    position: relative;
-    text-overflow: inherit;
-  }
+.datagrid .code-block {
+  background: inherit;
+  border: none;
+  display: block;
+  font-family: inherit;
+  line-height: inherit;
+  margin: 0 0 -19px;
+  overflow: inherit;
+  position: relative;
+  text-overflow: inherit;
+}
 
-  .datagrid .is-active .code-block {
-    display: inline-block;
-    line-height: inherit !important;
-    top: -3px;
-    width: calc(100% - 104px);
-  }
+.datagrid .is-active .code-block {
+  display: inline-block;
+  line-height: inherit !important;
+  top: -3px;
+  width: calc(100% - 104px);
+}
 
-  .datagrid .code-block label {
-    display: inline-block;
-    margin-bottom: 0;
-    overflow: hidden;
-    position: relative;
-    top: -1px;
-    vertical-align: middle;
-    white-space: nowrap;
-  }
+.datagrid .code-block label {
+  display: inline-block;
+  margin-bottom: 0;
+  overflow: hidden;
+  position: relative;
+  top: 1px;
+  vertical-align: middle;
+  white-space: nowrap;
+}
 
-  .datagrid .code-block label::after {
-    content: ':';
-  }
+.datagrid .code-block label::after {
+  content: ':';
+}
 
-  .datagrid .code-block .data {
-    display: inline-block;
-    line-height: inherit;
-    margin-bottom: 0;
-    padding-left: 5px;
-    padding-right: 15px;
-    position: relative;
-    top: 0;
-    white-space: nowrap;
-  }
+.datagrid .code-block .data {
+  display: inline-block;
+  line-height: inherit;
+  margin-bottom: 0;
+  padding-left: 5px;
+  padding-right: 15px;
+  position: relative;
+  top: 0;
+  white-space: nowrap;
+}
 
-  .datagrid .code-block .data:not(:last-of-type)::after,
-  .datagrid td.is-editing .code-block .data:not(:last-of-type)::after {
-    color: #5c5c5c;
-    content: '•';
-    font-size: 18px;
-    margin-right: 0;
-    padding-left: 15px;
-    position: relative;
-    top: 1px;
-  }
+.datagrid .code-block .data:not(:last-of-type)::after,
+.datagrid td.is-editing .code-block .data:not(:last-of-type)::after {
+  color: #5c5c5c;
+  content: '•';
+  font-size: 18px;
+  margin-right: 0;
+  padding-left: 15px;
+  position: relative;
+  top: 1px;
+}
 
-  .datagrid td.is-editing .code-block input[type='text'] {
-    padding: 8px 0;
-    width: 50%;
-  }
+.datagrid td.is-editing .code-block input[type='text'] {
+  padding: 8px 0;
+}
 
-  .datagrid td.is-editing .icon {
-    color: inherit;
-    top: auto;
-  }
+.datagrid td.is-editing .code-block #contact {
+  width: 50%;
+}
 
-  .datagrid td.is-editing .code-block input[type='text']:focus {
-    /* border: 1px solid #999; */
-  }
+.datagrid td.is-editing .code-block #location {
+  width: 65%;
+}
 
-  .datagrid td.is-editing .code-block input.lookup {
-    border-color: transparent;
-    padding: 0 2px 0 0;
-    transition: margin 0.5s ease, left 0.5s ease, padding 0.5s ease, width 0.5s ease;
-    vertical-align: baseline;
-    width: auto; /* IE doesnt support initial */
-    width: initial;
-  }
+.datagrid td.is-editing .code-block #customer-since {
+  width: 35%;
+}
 
-  .datagrid td.is-editing .code-block .lookup-wrapper {
-    padding-left: 0;
-    padding-top: 0;
-    vertical-align: baseline;
-  }
+.datagrid td.is-editing input + .icon {
+  color: inherit;
+  top: auto;
+}
 
-  .datagrid td.is-editing .code-block .field {
-    margin-right: 0;
-  }
+.datagrid td.is-editing .code-block input.lookup {
+  border-color: transparent;
+  padding: 0 2px 0 0;
+  transition: margin 0.5s ease, left 0.5s ease, padding 0.5s ease, width 0.5s ease;
+  vertical-align: baseline;
+  width: auto; /* IE doesnt support initial */
+  width: initial;
+}
 
-  .datagrid td.is-editing .code-block .field::after {
-    content: '';
-  }
+.datagrid td.is-editing .code-block .lookup-wrapper {
+  padding-left: 0;
+  padding-top: 0;
+  vertical-align: baseline;
+}
 
-  .datagrid td.is-editing .code-block input.lookup ~ .trigger .icon {
-    top: 8px;
-    width: 18px;
-  }
+.datagrid td.is-editing .code-block .field {
+  margin-right: 0;
+}
 
-  .datagrid td.is-editing .code-block input.lookup ~ .trigger {
-    margin-top: 0;
-  }
+.datagrid td.is-editing .code-block .field::after {
+  content: '';
+}
 
-  .datagrid td.is-editing .code-block .datagrid-cell-wrapper:focus {
-    outline: none;
-  }
+.datagrid td.is-editing .code-block input.lookup ~ .trigger .icon {
+  top: 8px;
+  width: 18px;
+}
 
-  .datagrid td.is-editing .code-block .lookup-wrapper .trigger {
-    margin-left: -33px;
-    margin-top: 0;
-  }
+.datagrid td.is-editing .code-block input.lookup ~ .trigger {
+  margin-top: 0;
+}
 
-  .field-options {
-    margin-right: 15px;
-  }
+.datagrid td.is-editing .code-block .datagrid-cell-wrapper:focus {
+  outline: none;
+}
 
-  .code-block-container > button {
-    display: inline-block;
-  }
+.datagrid td.is-editing .code-block .lookup-wrapper .trigger {
+  margin-left: -33px;
+  margin-top: 4px;
+}
 
-  .code-block-actions {
-    left: -17px;
-    transform: rotate(90deg);
-    visibility: visible;
-  }
+.field-options {
+  margin-right: 15px;
+}
 
-  .code-block-buttons {
-    display: inline-block;
-    left: 5px;
-    position: relative;
-  }
+.code-block-container > button {
+  display: inline-block;
+}
 
-  /* --- */
-  .code-block.is-active {
-    border: 1px solid #368ac0;
-    box-shadow: 0 0 4px 3px rgba(54, 138, 192, 0.3);
-  }
+.code-block-actions {
+  left: -17px;
+  transform: rotate(90deg);
+  visibility: visible;
+}
 
-  .code-block.is-active input {
-    box-shadow: none !important;
-  }
+.code-block-buttons {
+  display: inline-block;
+  left: 5px;
+  position: relative;
+}
 
-  .field.is-active {
-    border: 1px solid #368ac0;
-  }
+/* --- */
+.code-block.is-active {
+  border: 1px solid #368ac0;
+  box-shadow: 0 0 4px 3px rgba(54, 138, 192, 0.3);
+}
 
-  .field.is-active .field-options:not([disabled]) {
-    border-color: transparent !important;
-    box-shadow: none !important;
-  }
+.code-block.is-active input {
+  box-shadow: none !important;
+}
 
-  /* Make Label and Input Inline */
-  .lookup-wrapper,
-  .label {
-    display: inline;
-  }
+.field.is-active {
+  border: 1px solid #368ac0;
+  margin: 1px;
+}
 
-  .field {
-    border: 1px solid transparent;
-    border-radius: 2px;
-    display: inline-block;
-    height: 34px;
-    line-height: 34px;
-    margin: -3px -12px -3px -3px;
-    padding: 0 0 0 12px;
-    vertical-align: middle;
-  }
+.field.is-active .field-options:not([disabled]) {
+  border-color: transparent !important;
+  box-shadow: none !important;
+}
 
-  .field:not(:last-of-type):not(.is-active)::after {
-    color: #5c5c5c;
-    content: '•';
-    font-size: 18px;
-    position: absolute;
-    right: 18px;
-    top: -1px;
-    width: 4px;
-  }
+/* Make Label and Input Inline */
+.lookup-wrapper,
+.label {
+  display: inline;
+}
 
-  .field.is-active::after {
-    content: '';
-  }
+.field {
+  border: 1px solid transparent;
+  border-radius: 2px;
+  display: inline-block;
+  height: 34px;
+  line-height: 33px;
+  margin: -3px -12px -3px -3px;
+  padding: 0 0 0 12px;
+  vertical-align: middle;
+}
 
-  .field.is-active:focus {
-    box-shadow: none !important;
-  }
+.field:not(:last-of-type):not(.is-active)::after {
+  color: #5c5c5c;
+  content: '•';
+  font-size: 18px;
+  position: absolute;
+  right: 18px;
+  top: -1px;
+  width: 4px;
+}
 
-  /* Adjust labels and input styles */
-  .label {
-    position: relative;
-    top: -1px;
-  }
+.field.is-active::after {
+  content: '';
+}
 
-  /* Add a : After the label */
-  .label::after {
-    content: ':';
-  }
+.field.is-active:focus {
+  box-shadow: none !important;
+}
 
-  input {
-    border-color: transparent;
-    padding-left: 0;
-    transition: margin 0.5s ease, left 0.5s ease, padding 0.5s ease, width 0.5s ease;
-    width: auto; /* IE doesnt support initial */
-    width: initial;
-  }
+/* Adjust labels and input styles */
+.label {
+  position: relative;
+  top: -1px;
+}
 
-  .is-number-mask {
-    text-align: left;
-  }
+/* Add a : After the label */
+.label::after {
+  content: ':';
+}
 
-  .lookup,
-  input {
-    padding: 0;
-  }
+input {
+  border-color: transparent;
+  padding-left: 0;
+  transition: margin 0.5s ease, left 0.5s ease, padding 0.5s ease, width 0.5s ease;
+  width: auto; /* IE doesnt support initial */
+  width: initial;
+}
 
-  .lookup:focus {
-    box-shadow: none !important;
-  }
+.is-number-mask {
+  text-align: left;
+}
 
-  /* Other Input Types */
-  input[readonly] {
-    background-color: transparent;
-  }
+.lookup,
+input {
+  padding: 0;
+}
 
-  /* Make Elements Sit Well Next to Each other */
-  .field .field-options:not([disabled]).lookup,
-  .field.is-active .field-options:not([disabled]).lookup,
-  .field .field-options:not([disabled]),
-  .field .field-options:not([disabled]).datepicker,
-  .field.is-active .field-options:not([disabled]).datepicker,
-  .field .dropdown-wrapper {
-    margin-left: 3px;
-    margin-right: 18px;
-  }
+.lookup:focus {
+  box-shadow: none !important;
+}
 
-  /* Support for IE, Edge and FF */
-  .ie .field .field-options:not([disabled]).lookup,
-  .is-firefox .field .field-options:not([disabled]).lookup,
-  .ie .field.is-active .field-options:not([disabled]).lookup,
-  .is-firefox .field.is-active .field-options:not([disabled]).lookup,
-  .ie .field .field-options:not([disabled]),
-  .is-firefox .field .field-options:not([disabled]),
-  .ie .field .field-options:not([disabled]).datepicker,
-  .is-firefox .field .field-options:not([disabled]).datepicker,
-  .ie .field.is-active .field-options:not([disabled]).datepicker,
-  .is-firefox .field.is-active .field-options:not([disabled]).datepicker {
-    margin-right: 0;
-  }
+/* Other Input Types */
+input[readonly] {
+  background-color: transparent;
+}
 
-  .field.is-active .field-options:not([disabled]) {
-    margin-right: 9px;
-  }
+/* Make Elements Sit Well Next to Each other */
+.field .field-options:not([disabled]).lookup,
+.field.is-active .field-options:not([disabled]).lookup,
+.field .field-options:not([disabled]),
+.field .field-options:not([disabled]).datepicker,
+.field.is-active .field-options:not([disabled]).datepicker,
+.field .dropdown-wrapper {
+  margin-left: 3px;
+  margin-right: 18px;
+}
 
-  .field input.field-options:not([disabled]).lookup.is-active,
-  .field.is-active .field-options:not([disabled]).datepicker {
-    padding-right: 10px;
-  }
+/* Support for IE, Edge and FF */
+.ie .field .field-options:not([disabled]).lookup,
+.is-firefox .field .field-options:not([disabled]).lookup,
+.ie .field.is-active .field-options:not([disabled]).lookup,
+.is-firefox .field.is-active .field-options:not([disabled]).lookup,
+.ie .field .field-options:not([disabled]),
+.is-firefox .field .field-options:not([disabled]),
+.ie .field .field-options:not([disabled]).datepicker,
+.is-firefox .field .field-options:not([disabled]).datepicker,
+.ie .field.is-active .field-options:not([disabled]).datepicker,
+.is-firefox .field.is-active .field-options:not([disabled]).datepicker {
+  margin-right: 0;
+}
 
-  .field.is-active::before,
-  .datepicker + .icon {
-    visibility: hidden;
-  }
+.field.is-active .field-options:not([disabled]) {
+  margin-right: 9px;
+}
 
-  .datepicker.is-active + .icon {
-    visibility: visible;
-    z-index: 2;
-  }
+.field input.field-options:not([disabled]).lookup.is-active,
+.field.is-active .field-options:not([disabled]).datepicker {
+  padding-right: 10px;
+}
 
-  .trigger {
-    margin-left: -33px;
-    visibility: hidden;
-  }
+.field.is-active::before,
+.datepicker + .icon {
+  visibility: hidden;
+}
 
-  input.is-active + .trigger {
-    visibility: visible;
-  }
+.datepicker.is-active + .icon {
+  visibility: visible;
+  z-index: 2;
+}
 
-  input.is-active + .trigger .icon {
-    fill: #5c5c5c !important;
-  }
+.trigger {
+  margin-left: -33px;
+  visibility: hidden;
+}
 
-  .lookup-wrapper.is-active + .trigger {
-    visibility: visible;
-  }
+input.is-active + .trigger {
+  visibility: visible;
+}
 
-  /* Adjust the Field Options */
-  .btn-actions {
-    left: -15px;
-    margin-right: -22px;
-    top: 0;
-    visibility: hidden;
-    z-index: 1;
-  }
+input.is-active + .trigger .icon {
+  fill: #5c5c5c !important;
+}
 
-  .field.is-fieldoptions .lookup-wrapper .btn-actions {
-    left: -15px;
-  }
+.lookup-wrapper.is-active + .trigger {
+  visibility: visible;
+}
 
-  .field-options.checkbox ~ .btn-actions,
-  .field-options.dropdown ~ .btn-actions {
-    top: 0;
-  }
+/* Adjust the Field Options */
+.btn-actions {
+  left: -15px;
+  margin-right: -22px;
+  top: 0;
+  visibility: hidden;
+  z-index: 1;
+}
 
-  input.is-active + .trigger + .btn-actions {
-    border: none;
-    box-shadow: none !important;
-    left: -15px;
-    margin-right: -18px;
-    visibility: visible;
-  }
+.field.is-fieldoptions .lookup-wrapper .btn-actions {
+  left: -15px;
+}
 
-  /* Input Field with field options */
-  .btn-actions.is-active {
-    border: none;
-    box-shadow: none !important;
-    visibility: visible;
-  }
+.field-options.checkbox ~ .btn-actions,
+.field-options.dropdown ~ .btn-actions {
+  top: 0;
+}
 
-  .field.is-active::before {
-    visibility: hidden;
-  }
+input.is-active + .trigger + .btn-actions {
+  border: none;
+  box-shadow: none !important;
+  left: -15px;
+  margin-right: -18px;
+  visibility: visible;
+}
 
-  /* Readonly Styles */
-  .data {
-    font-size: 1.4rem;
-    padding-left: 3px;
-    padding-right: 41px;
-  }
+/* Input Field with field options */
+.btn-actions.is-active {
+  border: none;
+  box-shadow: none !important;
+  visibility: visible;
+}
 
-  .input-style.is-readonly .field::after {
-    right: 20px;
-    top: -3px;
-  }
+.field.is-active::before {
+  visibility: hidden;
+}
 
-  /* Style Datepicker alignment */
-  .field-options.datepicker {
-    width: auto; /* IE doesnt support initial */
-    width: initial;
-  }
+/* Readonly Styles */
+.data {
+  font-size: 1.4rem;
+  padding-left: 3px;
+  padding-right: 41px;
+}
 
-  /* Style Checkbox alignment */
-  .field .checkbox-label {
-    margin-right: 18px;
-  }
+.input-style.is-readonly .field::after {
+  right: 20px;
+  top: -3px;
+}
 
-  div.field + .field-checkbox {
-    margin-bottom: -3px !important;
-  }
+/* Style Datepicker alignment */
+.field-options.datepicker {
+  width: auto; /* IE doesnt support initial */
+  width: initial;
+}
 
-  /* Style Dropdown & alignment */
-  .dropdown {
-    border-width: 0;
-    height: 32px !important;
-    padding: 8px 0;
-    vertical-align: top;
-  }
+/* Style Checkbox alignment */
+.field .checkbox-label {
+  margin-right: 18px;
+}
 
-  .field .dropdown-sm {
-    max-width: 100px;
-    min-width: 61px;
-    padding-right: 0;
-    transition: padding 0.5s ease;
-    width: auto;
-  }
+div.field + .field-checkbox {
+  margin-bottom: -3px !important;
+}
 
-  .field .dropdown-sm.is-open {
-    padding-right: 28px;
-    transition: padding 0.5s ease;
-  }
+/* Style Dropdown & alignment */
+.dropdown {
+  border-width: 0;
+  height: 32px !important;
+  padding: 8px 0;
+  vertical-align: top;
+}
 
-  .dropdown + .icon {
-    right: 24px;
-    visibility: hidden;
-  }
+.field .dropdown-sm {
+  max-width: 100px;
+  min-width: 61px;
+  padding-right: 0;
+  transition: padding 0.5s ease;
+  width: auto;
+}
 
-  .field.is-active div.dropdown:not(.is-open) {
-    border-width: 0;
-    box-shadow: none;
-  }
+.field .dropdown-sm.is-open {
+  padding-right: 28px;
+  transition: padding 0.5s ease;
+}
+
+.dropdown + .icon {
+  right: 24px;
+  visibility: hidden;
+}
+
+.field.is-active div.dropdown:not(.is-open) {
+  border-width: 0;
+  box-shadow: none;
+}
+
 </style>
 
 <div class="row top-padding">
@@ -392,18 +401,45 @@
         return '' +
           '<span class="code-block">' +
             '<label for="contact" class="label">Contact</label>' +
-            '<span class="data">'+ rowData.contact +'</span>' +
+            '<span class="data">'+ value.contact +'</span>' +
             '<label for="location" class="label">Location</label>' +
-            '<span class="data">'+ rowData.location +'</span>' +
+            '<span class="data">'+ value.location +'</span>' +
             '<label for="customer-since" class="label">Customer Since</label>' +
-            '<span class="data">'+ rowData.customerSince +'</span>' +
+            '<span class="data">'+ value.customerSince +'</span>' +
           '</span>';
+      };
+
+      var getValues = function (str, currentValues) {
+        var labels = [
+          { val: 'contact', text: 'Contact' },
+          { val: 'location', text: 'Location' },
+          { val: 'customerSince', text: 'Customer Since' },
+        ];
+        var values = {};
+        if (str) {
+          str = str.replace(/Press Down arrow to select a date/gi, '');
+          str = str.replace(/. Use enter or down arrow to lookup./gi, '');
+        }
+        str = (str + '').replace('Press Down arrow to select a date', '');
+        for (var i = 0, l = labels.length; i<l; i++) {
+          var label = labels[i];
+
+          if (currentValues) {
+            values[label.val] = currentValues[i];
+          } else {
+            var begin = str.indexOf(label.text) + label.text.length;
+            var end = i !== (l-1) ? str.indexOf(labels[i+1].text) : str.length;
+            values[label.val] = str.slice(begin, end);
+          }
+        }
+        return values;
       };
 
       var customEditor = function (row, cell, value, container, column, event, grid, rowData) {
         // console.log({i: 'edit', row, cell, value, container, column, event, grid, rowData});
+        var values = getValues(value);
         this.name = 'MyCustom';
-        this.originalValue = value;
+        this.originalValue = values;
 
         this.init = function () {
           const btnHtml = function (id) {
@@ -429,28 +465,48 @@
             '<div class="code-block">' +
               '<div class="field">' +
                 '<label for="contact" class="label">Contact</label>' +
-                '<input type="text" name="contact" id="contact" value="'+ rowData.contact +'"/>' +
+                '<input type="text" name="contact" id="contact" value="'+ values.contact +'"/>' +
                 btnHtml('contact') +
               '</div>' +
               '<div class="field">' +
                 '<label for="location" class="label">Location</label>' +
-                '<input type="text" name="location" id="location" value="'+ rowData.location +'"/>' +
+                '<input type="text" name="location" id="location" value="'+ values.location +'"/>' +
                 btnHtml('location') +
               '</div>' +
               '<div class="field">' +
                 '<label for="customer-since" class="label">Customer Since</label>' +
-                '<input type="text" name="customer-since" id="customer-since" value="'+ rowData.customerSince +'"/>' +
+                '<input type="text" name="customer-since" id="customer-since" value="'+ values.customerSince +'"/>' +
                 btnHtml('customer-since') +
               '</div>' +
             '</div>';
 
           $(html).appendTo(container);
-          container.find('#customer-since').datepicker();
+          this.input = container.find('.code-block');
+          container.find('.btn-actions').popupmenu();
           container.find('[type="text"]').fieldoptions();
+          container.find('#customer-since').datepicker();
         };
 
-        this.val = function (value) {
-          return '';
+        this.val = function (v) {
+          var values = {};
+          var inputs = container.find('[type="text"]');
+          var inputsLen = inputs.length;
+          if (v) {
+            values = getValues(v);
+            valuesArr = Object.keys(values);
+            if (inputsLen = valuesArr.length) {
+              valuesArr.forEach(function (key, i) {
+                $(inputs[i]).val(values[key]);
+              });
+            }
+          } else {
+            arrVal = [];
+            inputs.each(function() {
+              arrVal.push($(this).val());
+            });
+            values = getValues(null, arrVal);
+          }
+          return values;
         };
 
         this.focus = function () {
@@ -458,6 +514,10 @@
         };
 
         this.destroy = function () {
+          setTimeout(() => {
+            grid.quickEditMode = false;
+            this.input.remove();
+          }, 0);
         };
 
         this.init();
@@ -468,131 +528,159 @@
           'id': 1,
           'companyId': '101',
           'companyName': 'Alexandar Gravel & Stone',
-          'phone': '414-821-0697',
-          'location': 'Terrencefort, TX',
-          'contact': 'Lida Snyder',
-          'customerSince': '04/25/2016',
-          'favorite': true
+          'info': {
+            'phone': '414-821-0697',
+            'location': 'Terrencefort, TX',
+            'contact': 'Lida Snyder',
+            'customerSince': '04/25/2016',
+            'favorite': true
+          }
         },
         {
           'id': 2,
           'companyId': '102',
           'companyName': 'Briar Valley Gravel',
-          'phone': '702-389-9973',
-          'location': 'Davontemouth, UT',
-          'contact': 'Bull Cunningham',
-          'customerSince': '05/02/2016'
+          'info': {
+            'phone': '702-389-9973',
+            'location': 'Davontemouth, UT',
+            'contact': 'Bull Cunningham',
+            'customerSince': '05/02/2016'
+          }
         },
         {
           'id': 3,
           'companyId': '103',
           'companyName': 'Riverhead Building Supply',
-          'phone': '929-769-3984',
-          'location': 'Hermistonhaven, AZ',
-          'contact': 'Johnny Fields',
-          'customerSince': '08/28/2016',
-          'favorite': true
+          'info': {
+            'phone': '929-769-3984',
+            'location': 'Hermistonhaven, AZ',
+            'contact': 'Johnny Fields',
+            'customerSince': '08/28/2016',
+            'favorite': true
+          }
         },
         {
           'id': 4,
           'companyId': '104',
           'companyName': 'Gravel Corp',
-          'phone': '299-166-7016',
-          'location': 'North Beau, NV',
-          'contact': 'Nina Mendez',
-          'customerSince': '01/25/2015'
+          'info': {
+            'phone': '299-166-7016',
+            'location': 'North Beau, NV',
+            'contact': 'Nina Mendez',
+            'customerSince': '01/25/2015'
+          }
         },
         {
           'id': 5,
           'companyId': '105',
           'companyName': 'United Construction',
-          'phone': '299-166-7016',
-          'location': 'New Abdul, TX',
-          'contact': 'Paul Strayer',
-          'customerSince': '04/21/2016'
+          'info': {
+            'phone': '299-166-7016',
+            'location': 'New Abdul, TX',
+            'contact': 'Paul Strayer',
+            'customerSince': '04/21/2016'
+          }
         },
         {
           'id': 6,
           'companyId': '106',
           'companyName': 'Gravel, Gravel, Gravel',
-          'phone': '299-166-7067',
-          'location': 'Smithsville, UT',
-          'contact': 'John Nasmith',
-          'customerSince': '06/25/2016'
+          'info': {
+            'phone': '299-166-7067',
+            'location': 'Smithsville, UT',
+            'contact': 'John Nasmith',
+            'customerSince': '06/25/2016'
+          }
         },
         {
           'id': 7,
           'companyId': '108',
           'companyName': 'Stone Gravel Supply Company',
-          'phone': '202-504-5299',
-          'location': 'Ryesmith, AK',
-          'contact': 'Spring Adams',
-          'customerSince': '07/25/2015'
+          'info': {
+            'phone': '202-504-5299',
+            'location': 'Ryesmith, AK',
+            'contact': 'Spring Adams',
+            'customerSince': '07/25/2015'
+          }
         },
         {
           'id': 8,
           'companyId': '109',
           'companyName': 'Smith Gravel & Stone',
-          'phone': '411-821-0697',
-          'location': 'Lancaster, TX',
-          'contact': 'Mary Adams',
-          'customerSince': '04/25/2016',
-          'favorite': true
+          'info': {
+            'phone': '411-821-0697',
+            'location': 'Lancaster, TX',
+            'contact': 'Mary Adams',
+            'customerSince': '04/25/2016',
+            'favorite': true
+          }
         },
         {
           'id': 9,
           'companyId': '110',
           'companyName': 'Hidden Valley Gravel',
-          'phone': '202-389-9973',
-          'location': 'Shark City, UT',
-          'contact': 'Donald Cunningham',
-          'customerSince': '05/01/2016'
+          'info': {
+            'phone': '202-389-9973',
+            'location': 'Shark City, UT',
+            'contact': 'Donald Cunningham',
+            'customerSince': '05/01/2016'
+          }
         },
         {
           'id': 10,
           'companyId': '111',
           'companyName': 'Copperhead Building Supply',
-          'phone': '929-769-3984',
-          'location': 'Hermistonhaven, AZ',
-          'contact': 'Johnny Smith',
-          'customerSince': '08/21/2016',
-          'favorite': true
+          'info': {
+            'phone': '929-769-3984',
+            'location': 'Hermistonhaven, AZ',
+            'contact': 'Johnny Smith',
+            'customerSince': '08/21/2016',
+            'favorite': true
+          }
         },
         {
           'id': 11,
           'companyId': '112',
           'companyName': 'Gravel Lovers Inc',
-          'phone': '299-166-7016',
-          'location': 'North Beau, NV',
-          'contact': 'Paulo Mendez',
-          'customerSince': '03/25/2014'
+          'info': {
+            'phone': '299-166-7016',
+            'location': 'North Beau, NV',
+            'contact': 'Paulo Mendez',
+            'customerSince': '03/25/2014'
+          }
         },
         {
           'id': 12,
           'companyId': '113',
-          'companyName': 'United Gravel',
-          'phone': '299-126-7016',
-          'location': 'New Manilla, TX',
-          'contact': 'Paul Strayer',
-          'customerSince': '04/21/2016'
+          'info': {
+            'companyName': 'United Gravel',
+            'phone': '299-126-7016',
+            'location': 'New Manilla, TX',
+            'contact': 'Paul Strayer',
+            'customerSince': '04/21/2016'
+          }
         },
         {
           'id': 13,
           'companyId': '114',
-          'companyName': 'Construction City',
-          'phone': '399-166-7067',
-          'location': 'Joanestown, UT',
-          'contact': 'Andy Nasmith',
-          'customerSince': '06/25/2015'
+          'info': {
+            'companyName': 'Construction City',
+            'phone': '399-166-7067',
+            'location': 'Joanestown, UT',
+            'contact': 'Andy Nasmith',
+            'customerSince': '06/25/2015'
+          }
         },
         {
           'id': 14,
           'companyId': '115',
           'companyName': 'Stone City Supply Company',
-          'phone': '202-504-5299',
-          'location': 'River Ridge, PA',
-          'contact': 'Winter Adams',
-          'customerSince': '01/25/2015'
+          'info': {
+            'phone': '202-504-5299',
+            'location': 'River Ridge, PA',
+            'contact': 'Winter Adams',
+            'customerSince': '01/25/2015'
+          }
         }
       ];
 
@@ -615,6 +703,7 @@
         },
         { id: 'codeBlock',
           name: 'Code Block',
+          field: 'info',
           sortable: false,
           formatter: customFormatter,
           filterType: 'text',

--- a/app/views/components/datagrid/test-editable-before-commitcelledit.html
+++ b/app/views/components/datagrid/test-editable-before-commitcelledit.html
@@ -1,20 +1,5 @@
 <div class="row">
   <div class="twelve columns">
-    <button id="can-commit" type="button" class="btn-menu btn-secondary">
-      <span>Can Commit (<span id="can-commit-text"></span>)</span>
-      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-        <use xlink:href="#icon-dropdown"></use>
-      </svg>
-    </button>
-    <ul class="popupmenu is-selectable">
-      <li><a href="#" data-value="true">True</a></li>
-      <li><a href="#" data-value="false">False</a></li>
-    </ul>
-  </div>
-</div>
-
-<div class="row">
-  <div class="twelve columns">
     <div role="toolbar" class="toolbar">
 
       <div class="title">
@@ -113,21 +98,8 @@
       columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, align: 'right', formatter: Formatters.Decimal, numberFormat: { minimumFractionDigits: 3, maximumFractionDigits: 3 }, editor: Editors.Input, mask: '###.000' });
       columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date5 });
 
+      // Edit mode
       var canCommit = false;
-      var canCommitBtn = $('#can-commit');
-      var canCommitText = $('#can-commit-text');
-
-      // Set button default values
-      var popupmenuApi = canCommitBtn.data('popupmenu');
-      popupmenuApi.select($('[data-value="'+ canCommit +'"]'));
-      canCommitText.html(popupmenuApi.menu.find('.is-checked').text());
-
-      // Bind button
-      canCommitBtn.on('selected', function (e, args) {
-        canCommitText.html(args.text());
-        canCommit = args.attr('data-value');
-      });
-
 
       // Init the grid
       $('#datagrid').datagrid({
@@ -137,8 +109,42 @@
         toolbar: { keywordFilter: true, results: true }
       })
       .on('beforecommitcelledit', function (e, args) {
-        console.log({ canCommit }, args);
-        return canCommit;
+        // console.log(args);
+        // return false;
+        var targetCell = (args && args.target) ? args.target : null;
+        var deferred = $.Deferred();
+
+        if (!canCommit) {
+          canCommit = true;
+
+          $('body').message({
+            title: 'Commit Edit',
+            message: 'You are about to Commit Cell Edit<br>Would you like to proceed?',
+            buttons: [{
+              text: 'Yes',
+              click: function(e, modal) {
+                canCommit = true;
+                deferred.resolve();
+                modal.close();
+              }
+            }, {
+              text: 'No',
+              click: function(e, modal) {
+                canCommit = false;
+                deferred.reject();
+                modal.close();
+              },
+              isDefault: true
+            }]
+          })
+          .on('afterclose.message', (e) => {
+            if (canCommit) {
+              args.target.focus();
+            }
+          });
+        }
+
+        return deferred.promise();
       });
 
     });

--- a/app/views/components/datagrid/test-editable-before-commitcelledit.html
+++ b/app/views/components/datagrid/test-editable-before-commitcelledit.html
@@ -1,3 +1,17 @@
+<div class="row">
+  <div class="twelve columns">
+    <button id="can-commit" type="button" class="btn-menu btn-secondary">
+      <span>Can Commit (<span id="can-commit-text"></span>)</span>
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use xlink:href="#icon-dropdown"></use>
+      </svg>
+    </button>
+    <ul class="popupmenu is-selectable">
+      <li><a href="#" data-value="true">True</a></li>
+      <li><a href="#" data-value="false">False</a></li>
+    </ul>
+  </div>
+</div>
 
 <div class="row">
   <div class="twelve columns">
@@ -40,137 +54,93 @@
 </div>
 
 <script>
-  var gridApi = null;
-
   $('body').one('initialized', function () {
-
     Locale.set('en-US').done(function () {
-        var grid,
-          data = [],
-          columns = [],
 
-          //lookup data
-          lookupOptions,
-          lookupData = [],
-          lookupColumns = [];
+      var data = [],
+        columns = [],
 
-          // Some Sample Data for Lookup
-          lookupData.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
-          lookupData.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
-          lookupData.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
-          lookupData.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
-          lookupData.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
-          lookupData.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
-          lookupData.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+      //lookup data
+      lookupOptions,
+      lookupData = [],
+      lookupColumns = [];
 
-          //Define Columns for the Lookup Grid.
-          lookupColumns.push({ id: 'productId', name: 'Product Id', field: 'productId', width: 140});
-          lookupColumns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', width: 250, formatter: Formatters.Hyperlink});
-          lookupColumns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', width: 125});
-          lookupColumns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', width: 125});
-          lookupColumns.push({ id: 'price', name: 'Price', field: 'price', width: 125, formatter: Formatters.Decimal});
-          lookupColumns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+      // Some Sample Data for Lookup
+      lookupData.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action' });
+      lookupData.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold' });
+      lookupData.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action' });
+      lookupData.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action' });
+      lookupData.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold' });
+      lookupData.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold' });
+      lookupData.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold' });
 
-          lookupOptions = {
-            // field: 'productId',
-            field: function (row, field, grid) {
-              return row.productId;
-            },
-            match: function (value, row, field, grid) {
-              return (row.productId) === value;
-            },
-            options: {
-              columns: lookupColumns,
-              dataset: lookupData,
-              selectable: 'single', //multiselect or single
-              toolbar: {title: 'Products', results: true, dateFilter: false ,keywordFilter: false, advancedFilter: true, actions: true, views: true , rowHeight: true}
-            }
-          };
+      // Define Columns for the Lookup Grid.
+      lookupColumns.push({ id: 'productId', name: 'Product Id', field: 'productId', width: 140 });
+      lookupColumns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', width: 250, formatter: Formatters.Hyperlink });
+      lookupColumns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', width: 125 });
+      lookupColumns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', width: 125 });
+      lookupColumns.push({ id: 'price', name: 'Price', field: 'price', width: 125, formatter: Formatters.Decimal });
+      lookupColumns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy' });
+
+      lookupOptions = {
+        // field: 'productId',
+        field: function (row, field, grid) {
+          return row.productId;
+        },
+        match: function (value, row, field, grid) {
+          return (row.productId) === value;
+        },
+        options: {
+          columns: lookupColumns,
+          dataset: lookupData,
+          selectable: 'single', //multiselect or single
+          toolbar: { title: 'Products', results: true, dateFilter: false ,keywordFilter: false, advancedFilter: true, actions: true, views: true , rowHeight: true }
+        }
+      };
+
+      // Some Sample Data
+      data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  '<svg/onload=alert(1)>', quantity: 1, price: 210.99, status: 'OK', orderDate:  new Date(2016, 2, 15, 12, 30, 36), portable: false, action: 'ac', description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning' });
+      data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, status: '', orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false, action: 'oh', description: 'The kit has an air blow gun that can be used for cleaning' });
+      data.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity:  'Inspect and Repair', portable: true, quantity: 1, price: 120.992, status: null, orderDate: new Date(2014, 6, 3), action: 'ac' });
+      data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', portable: true, quantity: 3, price: null, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'ac', description: 'Compressor comes with with air tool kit' });
+      data.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'oh' });
+      data.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', portable: false, quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'oh' });
+      data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'oh' });
+
+      // Define Columns for the Grid.
+      columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input });
+      columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, validate: 'required', editorOptions: lookupOptions, width: 120 });
+      columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, align: 'right', formatter: Formatters.Decimal, numberFormat: { minimumFractionDigits: 3, maximumFractionDigits: 3 }, editor: Editors.Input, mask: '###.000' });
+      columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date5 });
+
+      var canCommit = false;
+      var canCommitBtn = $('#can-commit');
+      var canCommitText = $('#can-commit-text');
+
+      // Set button default values
+      var popupmenuApi = canCommitBtn.data('popupmenu');
+      popupmenuApi.select($('[data-value="'+ canCommit +'"]'));
+      canCommitText.html(popupmenuApi.menu.find('.is-checked').text());
+
+      // Bind button
+      canCommitBtn.on('selected', function (e, args) {
+        canCommitText.html(args.text());
+        canCommit = args.attr('data-value');
+      });
 
 
-        // Some Sample Data
-        data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  '<svg/onload=alert(1)>', quantity: 1, price: 210.99, status: 'OK', orderDate:  new Date(2016, 2, 15, 12, 30, 36), portable: false, action: 'ac', description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning'});
-        data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, status: '', orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false, action: 'oh', description: 'The kit has an air blow gun that can be used for cleaning'});
-        data.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity:  'Inspect and Repair', portable: true, quantity: 1, price: 120.992, status: null, orderDate: new Date(2014, 6, 3), action: 'ac'});
-        data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', portable: true, quantity: 3, price: null, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'ac', description: 'Compressor comes with with air tool kit'});
-        data.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'oh'});
-        data.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', portable: false, quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'oh'});
-        data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'oh'});
+      // Init the grid
+      $('#datagrid').datagrid({
+        columns: columns,
+        dataset: data,
+        editable: true,
+        toolbar: { keywordFilter: true, results: true }
+      })
+      .on('beforecommitcelledit', function (e, args) {
+        console.log({ canCommit }, args);
+        return canCommit;
+      });
 
-        //Define Columns for the Grid.
-        columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input});
-        columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, validate: 'required', editorOptions: lookupOptions, width: 120 });
-        columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, align: 'right', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###.000'});
-        columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date5});
-
-        // Toast message
-        var toast = function (message, timeout) {
-          $('body').toast({
-            title: '',
-            message: message || '',
-            timeout: timeout || 1000
-          });
-        };
-
-        // Message (Success or Error)
-        var message = function(options) {
-          var isError = options.type === 'error';
-          $('body').message({
-            title: '<span>'+ (isError ? 'Error' : 'Success') +'</span>',
-            status: isError ? 'error' : 'success',
-            returnFocus: $(this),
-            message: options.msg || '',
-            buttons: [{
-              text: 'Ok',
-              click: function() {
-                $(this).data('modal').close();
-              },
-              isDefault: true
-            }]
-          });
-        };
-
-        const max = 3;
-        let index = 0;
-
-        //Init and get the api for the grid
-        grid = $('#datagrid').datagrid({
-          columns: columns,
-          dataset: data,
-          editable: true,
-          toolbar: {keywordFilter: true, results: true}
-        }).on('cellchange', function (e, args) {
-          console.log(e, args);
-        }).on('rowadd', function (e, args) {
-          console.log(e, args);
-        }).on('rowremove', function (e, args) {
-          console.log(e, args);
-        }).on('beforecommitcelledit', function (e, args) {
-          // index++;
-          // return index > max ? true : false;
-
-          // Lazy loading
-          console.log('Begin: Before Commit Cell Edit');
-          var delay = 3000;
-          toast('Begin: Before Commit Cell Edit', delay);
-
-          var deferred = $.Deferred();
-
-          setTimeout(function() {
-            var shouldGoAhead = false;
-            if (shouldGoAhead) {
-              deferred.resolve();
-            } else {
-              deferred.reject();
-              message({ type: 'error', msg: 'Cell Edit Not Commited (row: '+ args.row +', cell: '+ args.cell +')' });
-            }
-            console.log('Complete: Before Commit Cell Edit');
-          }, delay);
-
-          return deferred.promise();
-
-        });
     });
   });
-
 </script>

--- a/app/views/components/datagrid/test-editable-before-commitcelledit.html
+++ b/app/views/components/datagrid/test-editable-before-commitcelledit.html
@@ -98,9 +98,6 @@
       columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, align: 'right', formatter: Formatters.Decimal, numberFormat: { minimumFractionDigits: 3, maximumFractionDigits: 3 }, editor: Editors.Input, mask: '###.000' });
       columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date5 });
 
-      // Edit mode
-      var canCommit = false;
-
       // Init the grid
       $('#datagrid').datagrid({
         columns: columns,
@@ -111,39 +108,34 @@
       .on('beforecommitcelledit', function (e, args) {
         // console.log(args);
         // return false;
-        var targetCell = (args && args.target) ? args.target : null;
+
         var deferred = $.Deferred();
+        args.editor.notCommittable = true;
 
-        if (!canCommit) {
-          canCommit = true;
-
-          $('body').message({
-            title: 'Commit Edit',
-            message: 'You are about to Commit Cell Edit<br>Would you like to proceed?',
-            buttons: [{
-              text: 'Yes',
-              click: function(e, modal) {
-                canCommit = true;
-                deferred.resolve();
-                modal.close();
-              }
-            }, {
-              text: 'No',
-              click: function(e, modal) {
-                canCommit = false;
-                deferred.reject();
-                modal.close();
-              },
-              isDefault: true
-            }]
-          })
-          .on('afterclose.message', (e) => {
-            if (canCommit) {
-              args.target.focus();
+        $('body').message({
+          title: 'Commit Edit',
+          message: 'You are about to Commit Cell Edit<br>Would you like to proceed?',
+          buttons: [{
+            text: 'Yes',
+            click: function(e, modal) {
+              delete args.editor.notCommittable;
+              deferred.resolve();
+              modal.close();
             }
-          });
-        }
-
+          }, {
+            text: 'No',
+            click: function(e, modal) {
+              deferred.reject();
+              modal.close();
+            },
+            isDefault: true
+          }]
+        })
+        .on('afterclose.message', (e) => {
+          if (args.editor && !args.editor.notCommittable) {
+            args.target.focus();
+          }
+        });
         return deferred.promise();
       });
 

--- a/app/views/components/datagrid/test-editable-before-commitcelledit.html
+++ b/app/views/components/datagrid/test-editable-before-commitcelledit.html
@@ -1,0 +1,176 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <div role="toolbar" class="toolbar">
+
+      <div class="title">
+        Data Grid Header Title
+        <span class="datagrid-result-count">(N Results)</span>
+      </div>
+
+      <div class="buttonset">
+        <label class="audible" for="searchfield-01">Keyword Search</label>
+        <input id="searchfield-01" name="searchfield-01" class="searchfield" />
+      </div>
+      <div class="more">
+        <button class="btn-actions" type="button">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-more"></use>
+          </svg>
+          <span class="audible">More Actions</span>
+        </button>
+        <ul class="popupmenu">
+          <li><a href="#">Option One</a></li>
+          <li><a href="#">Option Two</a></li>
+          <li><a href="#">Option Three</a></li>
+          <li class="separator single-selectable-section"></li>
+          <li class="heading">Row Height</li>
+          <li class="is-selectable"><a data-option="row-short" href="#">Short</a></li>
+          <li class="is-selectable"><a data-option="row-medium" href="#">Medium</a></li>
+          <li class="is-selectable is-checked"><a data-option="row-normal" href="#">Normal</a></li>
+        </ul>
+
+      </div>
+    </div>
+
+    <div id="datagrid">
+
+    </div>
+  </div>
+</div>
+
+<script>
+  var gridApi = null;
+
+  $('body').one('initialized', function () {
+
+    Locale.set('en-US').done(function () {
+        var grid,
+          data = [],
+          columns = [],
+
+          //lookup data
+          lookupOptions,
+          lookupData = [],
+          lookupColumns = [];
+
+          // Some Sample Data for Lookup
+          lookupData.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+          lookupData.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+          lookupData.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+          lookupData.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+          lookupData.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+          lookupData.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+          lookupData.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+
+          //Define Columns for the Lookup Grid.
+          lookupColumns.push({ id: 'productId', name: 'Product Id', field: 'productId', width: 140});
+          lookupColumns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', width: 250, formatter: Formatters.Hyperlink});
+          lookupColumns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', width: 125});
+          lookupColumns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', width: 125});
+          lookupColumns.push({ id: 'price', name: 'Price', field: 'price', width: 125, formatter: Formatters.Decimal});
+          lookupColumns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+
+          lookupOptions = {
+            // field: 'productId',
+            field: function (row, field, grid) {
+              return row.productId;
+            },
+            match: function (value, row, field, grid) {
+              return (row.productId) === value;
+            },
+            options: {
+              columns: lookupColumns,
+              dataset: lookupData,
+              selectable: 'single', //multiselect or single
+              toolbar: {title: 'Products', results: true, dateFilter: false ,keywordFilter: false, advancedFilter: true, actions: true, views: true , rowHeight: true}
+            }
+          };
+
+
+        // Some Sample Data
+        data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  '<svg/onload=alert(1)>', quantity: 1, price: 210.99, status: 'OK', orderDate:  new Date(2016, 2, 15, 12, 30, 36), portable: false, action: 'ac', description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning'});
+        data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, status: '', orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false, action: 'oh', description: 'The kit has an air blow gun that can be used for cleaning'});
+        data.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity:  'Inspect and Repair', portable: true, quantity: 1, price: 120.992, status: null, orderDate: new Date(2014, 6, 3), action: 'ac'});
+        data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', portable: true, quantity: 3, price: null, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'ac', description: 'Compressor comes with with air tool kit'});
+        data.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'oh'});
+        data.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', portable: false, quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'oh'});
+        data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'oh'});
+
+        //Define Columns for the Grid.
+        columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input});
+        columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, validate: 'required', editorOptions: lookupOptions, width: 120 });
+        columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, align: 'right', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###.000'});
+        columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date5});
+
+        // Toast message
+        var toast = function (message, timeout) {
+          $('body').toast({
+            title: '',
+            message: message || '',
+            timeout: timeout || 1000
+          });
+        };
+
+        // Message (Success or Error)
+        var message = function(options) {
+          var isError = options.type === 'error';
+          $('body').message({
+            title: '<span>'+ (isError ? 'Error' : 'Success') +'</span>',
+            status: isError ? 'error' : 'success',
+            returnFocus: $(this),
+            message: options.msg || '',
+            buttons: [{
+              text: 'Ok',
+              click: function() {
+                $(this).data('modal').close();
+              },
+              isDefault: true
+            }]
+          });
+        };
+
+        const max = 3;
+        let index = 0;
+
+        //Init and get the api for the grid
+        grid = $('#datagrid').datagrid({
+          columns: columns,
+          dataset: data,
+          editable: true,
+          toolbar: {keywordFilter: true, results: true}
+        }).on('cellchange', function (e, args) {
+          console.log(e, args);
+        }).on('rowadd', function (e, args) {
+          console.log(e, args);
+        }).on('rowremove', function (e, args) {
+          console.log(e, args);
+        }).on('beforecommitcelledit', function (e, args) {
+          // index++;
+          // return index > max ? true : false;
+
+          // Lazy loading
+          console.log('Begin: Before Commit Cell Edit');
+          var delay = 3000;
+          toast('Begin: Before Commit Cell Edit', delay);
+
+          var deferred = $.Deferred();
+
+          setTimeout(function() {
+            var shouldGoAhead = false;
+            if (shouldGoAhead) {
+              deferred.resolve();
+            } else {
+              deferred.reject();
+              message({ type: 'error', msg: 'Cell Edit Not Commited (row: '+ args.row +', cell: '+ args.cell +')' });
+            }
+            console.log('Complete: Before Commit Cell Edit');
+          }, delay);
+
+          return deferred.promise();
+
+        });
+    });
+  });
+
+</script>

--- a/app/views/components/datagrid/test-editable-before-commitcelledit.html
+++ b/app/views/components/datagrid/test-editable-before-commitcelledit.html
@@ -110,7 +110,7 @@
         // return false;
 
         var deferred = $.Deferred();
-        args.editor.notCommittable = true;
+        args.editor.stayInEditMode = true;
 
         $('body').message({
           title: 'Commit Edit',
@@ -118,7 +118,7 @@
           buttons: [{
             text: 'Yes',
             click: function(e, modal) {
-              delete args.editor.notCommittable;
+              delete args.editor.stayInEditMode;
               deferred.resolve();
               modal.close();
             }
@@ -132,7 +132,7 @@
           }]
         })
         .on('afterclose.message', (e) => {
-          if (args.editor && !args.editor.notCommittable) {
+          if (args.editor && !args.editor.stayInEditMode) {
             args.target.focus();
           }
         });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### v4.18.0 Features
 
-- `[Datagrid]` Added support to multiple inputs in a editor will work with the keyboard. ([#355](https://github.com/infor-design/enterprise-ng/issues/355))
+- `[Datagrid]` Added support so if there are multiple inputs within an editor they work with the keyboard tab key. ([#355](https://github.com/infor-design/enterprise-ng/issues/355))
 - `[Mask]` Added a setting for passing a locale string, allowing Number masks to be localized.  This enables usage of the `groupSize` property, among others, from locale data in the Mask. ([#440](https://github.com/infor-design/enterprise/issues/440))
 
 ### v4.18.0 Fixes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### v4.18.0 Features
 
+- `[Datagrid]` Added support to multiple inputs in a editor will work with the keyboard. ([#355](https://github.com/infor-design/enterprise-ng/issues/355))
 - `[Mask]` Added a setting for passing a locale string, allowing Number masks to be localized.  This enables usage of the `groupSize` property, among others, from locale data in the Mask. ([#440](https://github.com/infor-design/enterprise/issues/440))
 
 ### v4.18.0 Fixes

--- a/src/components/datagrid/datagrid.editors.js
+++ b/src/components/datagrid/datagrid.editors.js
@@ -771,7 +771,7 @@ const editors = {
       if (event.type === 'keydown') {
         self.input.select().focus();
         td.on('keydown.editorlookup', (e) => {
-          if (e.keyCode === 40 && grid.quickEditMode) {
+          if (e.keyCode === 40) {
             e.preventDefault();
             e.stopPropagation();
           }

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5491,7 +5491,7 @@ Datagrid.prototype = {
           const startRowCount = parseInt($(e.target)[0].parentElement.parentElement.parentElement.getAttribute('data-index'), 10);
           const startColIndex = parseInt($(e.target)[0].parentElement.parentElement.getAttribute('aria-colindex'), 10) - 1;
 
-          if (self.editor && self.editor.input && !this.editor.notCommittable) {
+          if (self.editor && self.editor.input && !this.editor.stayInEditMode) {
             self.commitCellEdit(self.editor.input);
           }
           self.copyToDataSet(splitData, startRowCount, startColIndex, self.settings.dataset);
@@ -5790,7 +5790,7 @@ Datagrid.prototype = {
           if (!$('.lookup-modal.is-visible, #timepicker-popup, #monthview-popup, #colorpicker-menu').length &&
               self.editor) {
             if (focusElem.is('.spinbox, .trigger') ||
-              !$(target).is(':visible') || self.editor.notCommittable) {
+              !$(target).is(':visible') || self.editor.stayInEditMode) {
               return;
             }
 
@@ -5810,7 +5810,7 @@ Datagrid.prototype = {
         return;
       }
 
-      if (self.editor && self.editor.input && !this.editor.notCommittable) {
+      if (self.editor && self.editor.input && !this.editor.stayInEditMode) {
         self.commitCellEdit(self.editor.input);
       }
     });
@@ -7626,8 +7626,13 @@ Datagrid.prototype = {
       }
 
       if (self.settings.editable && key === 13) {
+        const target = $(e.target);
         // Allow shift to add a new line
-        if ($(e.target).is('textarea') && e.shiftKey) {
+        if (target.is('textarea') && e.shiftKey) {
+          return;
+        }
+        // Allow the menu buttons
+        if (target.is('.btn-menu') || target.closest('.popupmenu.is-open').length) {
           return;
         }
 
@@ -7772,7 +7777,7 @@ Datagrid.prototype = {
    */
   makeCellEditable(row, cell, event) {
     if (this.activeCell.node.closest('tr').hasClass('datagrid-summary-row') ||
-      (this.editor && this.editor.notCommittable)) {
+      (this.editor && this.editor.stayInEditMode)) {
       return;
     }
 
@@ -7787,7 +7792,7 @@ Datagrid.prototype = {
     }
 
     // Commit Previous Edit
-    if (this.editor && this.editor.input && !this.editor.notCommittable) {
+    if (this.editor && this.editor.input && !this.editor.stayInEditMode) {
       this.commitCellEdit(this.editor.input);
     }
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5491,7 +5491,7 @@ Datagrid.prototype = {
           const startRowCount = parseInt($(e.target)[0].parentElement.parentElement.parentElement.getAttribute('data-index'), 10);
           const startColIndex = parseInt($(e.target)[0].parentElement.parentElement.getAttribute('aria-colindex'), 10) - 1;
 
-          if (self.editor && self.editor.input) {
+          if (self.editor && self.editor.input && !this.editor.notCommittable) {
             self.commitCellEdit(self.editor.input);
           }
           self.copyToDataSet(splitData, startRowCount, startColIndex, self.settings.dataset);
@@ -5789,15 +5789,8 @@ Datagrid.prototype = {
 
           if (!$('.lookup-modal.is-visible, #timepicker-popup, #monthview-popup, #colorpicker-menu').length &&
               self.editor) {
-            if (focusElem.is('.spinbox')) {
-              return;
-            }
-
-            if (focusElem.is('.trigger')) {
-              return;
-            }
-
-            if (!$(target).is(':visible')) {
+            if (focusElem.is('.spinbox, .trigger') ||
+              !$(target).is(':visible') || self.editor.notCommittable) {
               return;
             }
 
@@ -5805,7 +5798,6 @@ Datagrid.prototype = {
               focusElem.closest(self.editor.className).length > 0) {
               return;
             }
-
             self.commitCellEdit(self.editor.input);
           }
         }, 150);
@@ -5814,11 +5806,11 @@ Datagrid.prototype = {
       }
 
       // Popups are open
-      if ($('#dropdown-list, .autocomplete.popupmenu.is-open, #timepicker-popup').is(':visible')) {
+      if ($('#dropdown-list, .autocomplete.popupmenu.is-open, #timepicker-popup, .is-editing .code-block').is(':visible')) {
         return;
       }
 
-      if (self.editor && self.editor.input) {
+      if (self.editor && self.editor.input && !this.editor.notCommittable) {
         self.commitCellEdit(self.editor.input);
       }
     });
@@ -7779,7 +7771,8 @@ Datagrid.prototype = {
    * @returns {boolean} returns true if the cell is editable
    */
   makeCellEditable(row, cell, event) {
-    if (this.activeCell.node.closest('tr').hasClass('datagrid-summary-row')) {
+    if (this.activeCell.node.closest('tr').hasClass('datagrid-summary-row') ||
+      (this.editor && this.editor.notCommittable)) {
       return;
     }
 
@@ -7794,7 +7787,7 @@ Datagrid.prototype = {
     }
 
     // Commit Previous Edit
-    if (this.editor && this.editor.input) {
+    if (this.editor && this.editor.input && !this.editor.notCommittable) {
       this.commitCellEdit(this.editor.input);
     }
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7465,6 +7465,13 @@ Datagrid.prototype = {
       const lastRow = visibleRows.last();
       const lastCell = self.settings.columns.length - 1;
 
+      // Tab, Left, Up, Right and Down arrow keys.
+      if ([9, 37, 38, 39, 40].indexOf(key) !== -1) {
+        if ($(e.target).closest('.code-block').length) {
+          return;
+        }
+      }
+
       // Tab, Left and Right arrow keys.
       if ([9, 37, 39].indexOf(key) !== -1) {
         if (key === 9 && self.settings.onKeyDown) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
For editable datagrid added support for
- Tab thru in edit mode
- Event `beforecommitcelledit` to stay in edit mode till ready to commit
- Example page for code block custom editor and event `beforecommitcelledit`

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#355

**Steps necessary to review your pull request (required)**:
http://localhost:4200/ids-enterprise-ng-demo/datagrid-code-block-editor
- Build and run enterprise-ng with this fix
- Open above link
- Go in to edit mode by pressing enter key or click to any cell in last column "Code Block"
- Should be able to navigate thru inputs in editor by tab key
- Press Enter key to go out from edit mode

http://localhost:4000/components/datagrid/test-codeblock.html
- Open above link (code-block style different then enterprise-ng)
- Go in to edit mode by pressing enter key or click to any cell in last column "Code Block"
- Should be able to navigate thru inputs in editor by tab key
- Press Enter key to go out from edit mode

http://localhost:4000/components/datagrid/test-editable-before-commitcelledit.html
- Open above link
- Any cell in column "Price" go in to edit mode and make some edit
- Press Enter to go out from edit mode
- It will pop up for to keep stay in edit mode
- It should not go out from edit mode till you ready to commit
