### PR TITLE
1857 - Only use 1 parameter for classList.add() for IE11 support [4.18.x]

### DIFF
--- a/src/components/notification/notification.js
+++ b/src/components/notification/notification.js
@@ -50,7 +50,10 @@ Notification.prototype = {
    */
   build() {
     this.notificationEl = document.createElement('div');
-    this.notificationEl.classList.add('notification', this.settings.type);
+
+    // IE 10/11 does not support multiple paramets for classList.add()
+    this.notificationEl.classList.add('notification');
+    this.notificationEl.classList.add(this.settings.type);
 
     const htmlIcon = `
       <svg class="icon notification-icon icon-${this.settings.type}" focusable="false" aria-hidden="true" role="presentation">


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The different notification classes were not being added to the notification DOM elements, because IE11's `classList` implementation does NOT support multiple parameters for the `add()` & `remove()` methods. See [caniuse classList()](https://caniuse.com/#feat=classlist).

**Related github/jira issue (required)**:
- https://github.com/infor-design/enterprise/issues/1857

**Steps necessary to review your pull request (required)**:
1. View the screenshots in the issue above
1. `npm run start`
1. Open Chrome
    1. Go to http://localhost:4000/components/notification/example-index.html
    1. verify the notifications look right
1. Open IE11
    1. Go to <http://localhost:4000/components/notification/example-index.html>
    1. See that notification are styled properly

🚫 An e2e or functional test for the bug or feature.
🚫 A note to the change log.