### PR TITLE
1961 - Datagrid aria-checked incorrect

### DIFF
--- a/app/views/components/tabs/example-activated-event.html
+++ b/app/views/components/tabs/example-activated-event.html
@@ -25,7 +25,7 @@
         <p>Facilitate cultivate monetize, seize e-services peer-to-peer content integrateAJAX-enabled user-centric strategize. Mindshare; repurpose integrate global addelivery leading-edge frictionless, harness real-time plug-and-play standards-compliant 24/7 enterprise strategize robust infomediaries: functionalities back-end. Killer disintermediate web-enabled ubiquitous empower relationships, solutions, metrics architectures.</p>
       </div>
       <div id="tabs-normal-opportunities" class="tab-panel">
-        <p>Bricks-and-clicks? Evolve ubiquitous matrix B2B 24/365 vertical 24/365 platforms standards-compliant global leverage dynamic 24/365 intuitive ROI seamless rss-capable. Cutting-edge grow morph web services leverage; ROI, unleash reinvent innovative podcasts citizen-media networking.</p>
+        <p>Bricks-and-clicks? Evolve ubiquitous matrix B2B 24/365 vertical 24/365 platforms standards-compliant global leverage dynamic 24/365 intuitive ROI seamless rss-capable. Cutting-edge grow morph web services leverage; ROI, unleash reinvent innovative podcasts citizen-media networking. Frictionless webservices, killer open-source innovate, best-of-breed.</p>
       </div>
       <div id="tabs-normal-attachments" class="tab-panel">
         <p>Frictionless webservices, killer open-source innovate, best-of-breed, whiteboard interactive back-end optimize capture dynamic front-end. Initiatives ubiquitous 24/7 enhance channels B2B drive frictionless web-readiness generate recontextualize widgets applications. Sexy sticky matrix, user-centred, rich user-centric: peer-to-peer podcasting networking addelivery optimize streamline integrated proactive: granular morph.</p>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@
 - `[Datagrid]` Fixed a bug where text would be misaligned when repeatedly toggling the filter row. ([#1969](https://github.com/infor-design/enterprise/issues/1969))
 - `[Datagrid]` Added an example of expandOnActivate on a customer editor. ([#353](https://github.com/infor-design/enterprise-ng/issues/353))
 - `[Datagrid]` Added ability to pass a function to the tooltip option for custom formatting. ([#354](https://github.com/infor-design/enterprise-ng/issues/354))
+- `[Datagrid]` Fixed `aria-checked` not toggling correctly on selection of multiselect checkbox. ([#1961](https://github.com/infor-design/enterprise/issues/1961))
 - `[Dropdown]` Changed the way dropdowns work with screen readers to be a collapsible listbox.([#404](https://github.com/infor-design/enterprise/issues/404))
 - `[Dropdown]` Fixed an issue where multiselect dropdown unchecking "Select All" was not getting clear after close list with Safari browser.([#1882](https://github.com/infor-design/enterprise/issues/1882))
 - `[Listbuilder]` Fixed an issue where the text was not sanitizing. ([#1692](https://github.com/infor-design/enterprise/issues/1692))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5762,7 +5762,7 @@ Datagrid.prototype = {
 
           self.selectAllRows();
         } else {
-          checkbox.removeClass('is-checked').attr('aria-checked', 'true');
+          checkbox.removeClass('is-checked').attr('aria-checked', 'false');
           self.unSelectAllRows();
         }
       });

--- a/test/components/tabs/tabs-api.func-spec.js
+++ b/test/components/tabs/tabs-api.func-spec.js
@@ -54,11 +54,14 @@ describe('Tabs API', () => {
     expect(tabsObj.hasMoreButton()).toBeFalsy();
   });
 
-  it('Should have more button at 400px', () => {
+  it('Should have more button at 400px', (done) => {
     tabsEl.style.width = '400px';
     $('body').triggerHandler('resize');
 
-    expect(tabsObj.hasMoreButton()).toBeTruthy();
+    setTimeout(() => {
+      expect(tabsObj.hasMoreButton()).toBeTruthy();
+      done();
+    }, 300);
   });
 
   it('Should not be in responsive mode', () => {
@@ -323,12 +326,15 @@ describe('Tabs API', () => {
     expect(allVisibleTabs.length).toEqual(4);
   });
 
-  it('Should not return overflowed tabs at 300px', () => {
+  it('Should not return overflowed tabs at 300px', (done) => {
     tabsEl.style.width = '300px';
     $('body').triggerHandler('resize');
     const tab = tabsObj.getOverflowTabs();
 
-    expect(tab.length).toBeFalsy();
+    setTimeout(() => {
+      expect(tab.length).toBeFalsy();
+      done();
+    }, 300);
   });
 
   it('Should select tab, and focus', () => {
@@ -337,12 +343,15 @@ describe('Tabs API', () => {
     expect(document.querySelector('.tab.is-selected').innerText).toEqual('Contracts');
   });
 
-  it('Should return false whether tabs are overflowed at 300px', () => {
+  it('Should return false whether tabs are overflowed at 300px', (done) => {
     tabsEl.style.width = '300px';
     $('body').triggerHandler('resize');
     const tabItem = document.querySelectorAll('[aria-selected="true"]');
 
-    expect(tabsObj.isTabOverflowed($(tabItem))).toBeFalsy();
+    setTimeout(() => {
+      expect(tabsObj.isTabOverflowed($(tabItem))).toBeFalsy();
+      done();
+    }, 300);
   });
 
   it('Should return last visible tabs', () => {
@@ -401,7 +410,7 @@ describe('Tabs API', () => {
     expect(document.querySelectorAll('.tab')[4].classList).toContain('is-disabled');
   });
 
-  it('Should enable all tabs', () => {
+  it('Should enable all tabs', (done) => {
     tabsObj.disable(false);
 
     expect(document.querySelectorAll('.tab')[0].classList).toContain('is-disabled');
@@ -411,11 +420,14 @@ describe('Tabs API', () => {
     expect(document.querySelectorAll('.tab')[4].classList).toContain('is-disabled');
     tabsObj.enable();
 
-    expect(document.querySelectorAll('.tab')[0].classList).not.toContain('is-disabled');
-    expect(document.querySelectorAll('.tab')[1].classList).not.toContain('is-disabled');
-    expect(document.querySelectorAll('.tab')[2].classList).not.toContain('is-disabled');
-    expect(document.querySelectorAll('.tab')[3].classList).not.toContain('is-disabled');
-    expect(document.querySelectorAll('.tab')[4].classList).not.toContain('is-disabled');
+    setTimeout(() => {
+      expect(document.querySelectorAll('.tab')[0].classList).not.toContain('is-disabled');
+      expect(document.querySelectorAll('.tab')[1].classList).not.toContain('is-disabled');
+      expect(document.querySelectorAll('.tab')[2].classList).not.toContain('is-disabled');
+      expect(document.querySelectorAll('.tab')[3].classList).not.toContain('is-disabled');
+      expect(document.querySelectorAll('.tab')[4].classList).not.toContain('is-disabled');
+      done();
+    }, 300);
   });
 
   it('Should remove tab dismissible tab from tab list', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
`aria-checked` attribute was not toggling on selection of header checkbox.

**Related github/jira issue (required)**:
Closes #1961.

**Steps necessary to review your pull request (required)**:
- Pull branch
- Run app
- Visit http://localhost:4000/components/datagrid/example-multiselect
- Open Dev Tools
  - Find `multiselect` checkbox in header in Elements tab
  - Interact multiple times with header `multiselect` checkbox and ensure `aria-checked` toggles correctly