### PR TITLE
2003 - Fixed previous selection was not clear with multiselect [4.18.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@
 - `[MenuButton]` Improved the way menu buttons work with screen readers.([#404](https://github.com/infor-design/enterprise/issues/404))
 - `[Message]` Added an audible announce of the message type.([#964](https://github.com/infor-design/enterprise/issues/964))
 - `[Modal]` Changed text and button font colors to pass accessibility checks.([#964](https://github.com/infor-design/enterprise/issues/964))
+- `[Multiselect]` Fixed an issue where previous selection was still selected after clear all by "Select All" option. ([#2003](https://github.com/infor-design/enterprise/issues/2003))
 - `[Notifications]` Fixed a few issues with notification background colors by using the corresponding ids-identity token for each. ([1857](https://github.com/infor-design/enterprise/issues/1857), [1865](https://github.com/infor-design/enterprise/issues/1865))
 - `[Notifications]` Fixed an issue where you couldn't click the close icon in Firefox. ([1573](https://github.com/infor-design/enterprise/issues/1573))
 - `[Radios]` Fixed the last radio item was being selected when clicking on the first when displayed horizontal. ([#1878](https://github.com/infor-design/enterprise/issues/1878))

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -2241,8 +2241,12 @@ Dropdown.prototype = {
 
     if (doSelectAll) {
       // Select all
-      items.forEach(node => node.classList.add('is-selected'));
+      items.forEach((node) => {
+        node.classList.add('is-selected');
+        node.setAttribute('aria-selected', true);
+      });
       options.forEach((node) => {
+        node.selected = true;
         node.setAttribute('selected', true);
       });
 
@@ -2253,10 +2257,14 @@ Dropdown.prototype = {
       }
     } else {
       // Clear all
-      items.forEach(node => node.classList.remove('is-selected'));
+      items.forEach((node) => {
+        node.classList.remove('is-selected');
+        node.removeAttribute('aria-selected');
+      });
       options.forEach((node) => {
         // Fix for ie-edge
         // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12087679/
+        node.selected = false;
         node.setAttribute('selected', false);
         node.removeAttribute('selected');
       });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed previous selection was not clear after uncheck "Select All" option.

**Related github/jira issue (required)**:
Closes #2003

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/multiselect/test-select-all.html
- Open above link
- Click on dropdown to open list
- Select Alabama then close the dropdown, Alabama will be displayed on the dropdown
- Open the dropdown again, click "Select All" then close the dropdown
- All States will be displayed on the dropdown
- Open the dropdown again and uncheck "Select All" then close the dropdown
- See dropdown should be all clear, previous selection should not be displayed
