### PR TITLE
Only run CI on master and release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ addons:
     paths:
       - $(ls test/.tmp/diff/*.png | tr "\n" ":")
 language: node_js
-dist: trusty
 # Leave node_js version blank to
 # use version in `.nvmrc`
 node_js:
@@ -59,3 +58,10 @@ stages:
     # do not run the deploy stage for Pull Request checks
     # and require the branch name to be master (note for PRs this is the base branch name)
     if: NOT type IN (pull_request) AND branch = master
+
+# safelist
+#only allow master and release branches like 4.10.x
+branches:
+  only:
+  - master
+  - /(\d).(\d*).x/i


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

- This will change the CI to only Build (test) pushed branches:
    - `master`
    - `A.B.x` branches (i.e. `4.10.x`)

- Existing functionality should continue to...
    - Build/test pull requests into `master` AND released branches
    - Only deploy when the base branch is `master`

**Related github/jira issue (required)**:
n/a

**Steps necessary to review your pull request (required)**:
1. Make sure that non-master and non-released branches are not building like they were before
1. Make sure testing still happens on PRs
1. Make sure `master` still deploys on merges from PRs
1. Generally check for anything woky
