### PR TITLE
2016 - Fixed tooltip was not displaying with dropdown [4.18.x]

### DIFF
--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -98,8 +98,7 @@ div.multiselect {
   }
 
   > span {
-    display: block;
-    min-height: 16px;
+    display: inline-block;
     overflow: hidden;
     text-overflow: ellipsis;
     vertical-align: top;

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -323,12 +323,7 @@ Dropdown.prototype = {
     this.setDisplayedValues();
     this.setInitial();
     this.setWidth();
-
-    if (this.overflowed) {
-      this.setTooltip();
-    } else if (this.tooltipApi) {
-      this.removeTooltip();
-    }
+    this.toggleTooltip();
 
     this.element.triggerHandler('rendered');
 
@@ -499,6 +494,19 @@ Dropdown.prototype = {
     }
 
     self.listIcon.hasIcons = hasIcons;
+  },
+
+  /**
+   * Toggle toooltip (add if text over flowed)
+   * @private
+   * @returns {void}
+   */
+  toggleTooltip() {
+    if (this.overflowed) {
+      this.setTooltip();
+    } else if (this.tooltipApi) {
+      this.removeTooltip();
+    }
   },
 
   /**
@@ -2081,6 +2089,7 @@ Dropdown.prototype = {
     */
     this.element.trigger('listclosed', action);
     this.activate();
+    this.toggleTooltip();
     this.list = null;
     this.searchInput = null;
     this.listUl = null;
@@ -2280,6 +2289,7 @@ Dropdown.prototype = {
     }
     this.activate(true);
     this.setBadge(last);
+    this.toggleTooltip();
 
     this.element.trigger('change').triggerHandler('selected');
   },
@@ -2440,11 +2450,7 @@ Dropdown.prototype = {
       // Fire the change event with the new value if the noTrigger flag isn't set
       this.element.trigger('change').triggerHandler('selected', [option, isAdded]);
 
-      if (this.overflowed) {
-        this.setTooltip();
-      } else if (this.tooltipApi) {
-        this.removeTooltip();
-      }
+      this.toggleTooltip();
     }
 
     /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed tooltip was not displaying with dropdown.

**Related github/jira issue (required)**:
Closes #2016

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/dropdown/example-tooltips.html
- Open above link
- Hover on the dropdown
- Tooltip should show

http://localhost:4000/components/dropdown/test-multiselect-with-tooltip.html
http://localhost:4000/components/multiselect/example-index.html
- Open above link
- Click on dropdown to open list
- Select items so it can over flow the text box
- Close the dropdown list
- Hover on the dropdown
- Tooltip should show

**Additional context**:
No change log as its not a new fix
