### PR TITLE
2001 - Fix incorrectly exported Datagrid CSV/Excel data [v4.18.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,7 +30,7 @@
 - `[Datagrid]` Fixed a bug where text would be misaligned when repeatedly toggling the filter row. ([#1969](https://github.com/infor-design/enterprise/issues/1969))
 - `[Datagrid]` Added an example of expandOnActivate on a customer editor. ([#353](https://github.com/infor-design/enterprise-ng/issues/353))
 - `[Datagrid]` Added ability to pass a function to the tooltip option for custom formatting. ([#354](https://github.com/infor-design/enterprise-ng/issues/354))
-- `[Datagrid]` Fixed incorrectly exported CSV/Excel data. ([#2001](https://github.com/infor-design/enterprise-ng/issues/2001))
+- `[Datagrid]` Fixed incorrectly exported CSV/Excel data. ([#2001](https://github.com/infor-design/enterprise/issues/2001))
 - `[Dropdown]` Changed the way dropdowns work with screen readers to be a collapsible listbox.([#404](https://github.com/infor-design/enterprise/issues/404))
 - `[Dropdown]` Fixed an issue where multiselect dropdown unchecking "Select All" was not getting clear after close list with Safari browser.([#1882](https://github.com/infor-design/enterprise/issues/1882))
 - `[Listbuilder]` Fixed an issue where the text was not sanitizing. ([#1692](https://github.com/infor-design/enterprise/issues/1692))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@
 - `[Datagrid]` Fixed a bug where text would be misaligned when repeatedly toggling the filter row. ([#1969](https://github.com/infor-design/enterprise/issues/1969))
 - `[Datagrid]` Added an example of expandOnActivate on a customer editor. ([#353](https://github.com/infor-design/enterprise-ng/issues/353))
 - `[Datagrid]` Added ability to pass a function to the tooltip option for custom formatting. ([#354](https://github.com/infor-design/enterprise-ng/issues/354))
+- `[Datagrid]` Fixed incorrectly exported CSV/Excel data. ([#2001](https://github.com/infor-design/enterprise-ng/issues/2001))
 - `[Dropdown]` Changed the way dropdowns work with screen readers to be a collapsible listbox.([#404](https://github.com/infor-design/enterprise/issues/404))
 - `[Dropdown]` Fixed an issue where multiselect dropdown unchecking "Select All" was not getting clear after close list with Safari browser.([#1882](https://github.com/infor-design/enterprise/issues/1882))
 - `[Listbuilder]` Fixed an issue where the text was not sanitizing. ([#1692](https://github.com/infor-design/enterprise/issues/1692))

--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -21,6 +21,7 @@ excel.cleanExtra = function (customDs, self) {
     };
     const nonExportables = [];
     const elements = [].slice.call(table[0].querySelectorAll('tr, th, td, div, span'));
+
     elements.forEach((el) => {
       if (el.classList.contains('is-hidden') || el.classList.contains('datagrid-expandable-row')) {
         removeNode(el);
@@ -30,7 +31,7 @@ excel.cleanExtra = function (customDs, self) {
       // THEAD
       const attrExportable = el.getAttribute('data-exportable');
       if (attrExportable && attrExportable === 'no') {
-        const index = Array.prototype.slice.call(el.parentElement.children).indexOf(el);
+        const index = parseInt(el.id.slice(-1));
         nonExportables.push(index + 1);
         removeNode(el);
         return;
@@ -59,6 +60,7 @@ excel.cleanExtra = function (customDs, self) {
         el.textContent = `'${text}'`;
       }
     });
+
     return table;
   };
 

--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -31,7 +31,7 @@ excel.cleanExtra = function (customDs, self) {
       // THEAD
       const attrExportable = el.getAttribute('data-exportable');
       if (attrExportable && attrExportable === 'no') {
-        const index = parseInt(el.id.slice(-1));
+        const index = parseInt(el.id.slice(-1), 10);
         nonExportables.push(index + 1);
         removeNode(el);
         return;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Exported data was incorrectly lining up between `thead` and `tbody` elements.

`indexOf` was being called on elements in an array of elements wherein the elements were themselves being actively removed in a loop; causing `indexOf` to report false positives based on a changing base.

**Related github/jira issue (required)**:
Closes #2001.

**Steps necessary to review your pull request (required)**:
- Pull branch
- Run app
- Visit http://localhost:4000/components/datagrid/example-export-from-button.html
  - Use the two "Export..." buttons and ensure the downloaded files correctly reflect the visible data.