### PR TITLE
2018 - Fix misaligned Dropdown close icon on mobile [v4.18.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,7 @@
 - `[Dropdown]` Changed the way dropdowns work with screen readers to be a collapsible listbox.([#404](https://github.com/infor-design/enterprise/issues/404))
 - `[Dropdown]` Fixed an issue where multiselect dropdown unchecking "Select All" was not getting clear after close list with Safari browser.([#1882](https://github.com/infor-design/enterprise/issues/1882))
 - `[Dropdown]` Added an example of a color dropdown showing palette colors as icons.([#2013](https://github.com/infor-design/enterprise/issues/2013))
+- `[Datagrid]` Fixed a misalignment of the close icon on mobile. ([#2018](https://github.com/infor-design/enterprise/issues/2018))
 - `[Listbuilder]` Fixed an issue where the text was not sanitizing. ([#1692](https://github.com/infor-design/enterprise/issues/1692))
 - `[Lookup]` Fixed an issue where the tooltip was using audible text in the code block component. ([#354](https://github.com/infor-design/enterprise-ng/issues/354))
 - `[Locale]` Fixed trailing zeros were getting ignored when displaying thousands values. ([#404](https://github.com/infor-design/enterprise/issues/1840))

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -884,7 +884,7 @@ div.dropdown-xs,
     > .trigger {
       .icon {
         &.close {
-          top: 9px;
+          top: 10px;
         }
       }
     }
@@ -909,7 +909,7 @@ div.dropdown-xs,
       > .trigger {
         .icon {
           &.close {
-            top: 9px;
+            top: 10px;
           }
         }
       }

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -879,6 +879,16 @@ div.dropdown-xs,
       top: 4px;
     }
   }
+
+  .dropdown-list {
+    > .trigger {
+      .icon {
+        &.close {
+          top: 9px;
+        }
+      }
+    }
+  }
 }
 
 //for firefox on android
@@ -892,6 +902,16 @@ div.dropdown-xs,
 
       + .icon {
         top: 4px;
+      }
+    }
+
+    .dropdown-list {
+      > .trigger {
+        .icon {
+          &.close {
+            top: 9px;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Dropdown close icon was misaligned on iOS and Android.

**Related github/jira issue (required)**:
Closes #2018.

**Steps necessary to review your pull request (required)**:
- Pull branch
- Run app
- Visit each of the URLs on mobile and ensure the close icon is properly aligned.
  - http://localhost:4000/components/multiselect/example-index.html 
  - http://localhost:4000/components/dropdown/example-index.html