### PR TITLE
2052 - Fixed tooltip on mobile with dropdown [v4.18.x]

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -112,10 +112,12 @@ Dropdown.prototype = {
    * @returns {boolean} whether or not the text inside the in-page pseudo element too big to fit
    */
   get overflowed() {
-    const span = this.pseudoElem.find('span').css('max-width', '');
-    if (span.width() > this.pseudoElem.width()) {
-      span.css('max-width', '100%');
-      return true;
+    if (!this.isMobile() || (this.isMobile() && !this.isOpen())) {
+      const span = this.pseudoElem.find('span').css('max-width', '');
+      if (span.width() > this.pseudoElem.width()) {
+        span.css('max-width', '100%');
+        return true;
+      }
     }
     return false;
   },
@@ -519,7 +521,7 @@ Dropdown.prototype = {
     this.tooltipApi = this.pseudoElem.find('span').tooltip({
       content: optText,
       parentElement: this.pseudoElem,
-      trigger: 'hover',
+      trigger: this.isMobile() ? 'immediate' : 'hover',
     });
   },
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed previous selection tooltip was displaying on Mobile with Dropdown.

**Related github/jira issue (required)**:
Closes #2052

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/dropdown/example-index.html
http://localhost:4000/components/dropdown/example-tooltips.html
- Open above link with Android and iOS
- Select item in the dropdown
- Close the dropdown, then open again
- See tooltip should not show when not necessary

http://localhost:4000/components/multiselect/example-index.html
- Open above link with Android and iOS
- Select item/s in the dropdown
- Close the dropdown
- See tooltip should not show if text not overflowed

**Additional context**:
No change log as its not a new fix