### PR TITLE
1957 - Fixes datagrid misaligned columns on mobile

### DIFF
--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -3616,6 +3616,17 @@ html[dir='rtl'] {
       border-right-color: transparent;
     }
   }
+
+  &.ios .datagrid-container,
+  &.android .datagrid-container {
+    &.has-vertical-scroll {
+      &:not(.has-frozen-right-columns):not(.has-frozen-left-columns) {
+        .datagrid-header:not(.left):not(.right) {
+          margin-left: 0;
+        }
+      }
+    }
+  }
 }
 
 // Reorder Column styles


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Extra margins for scrollbars were causing RTL fixed header columns to be misaligned. This PR adds css overrides to remove the margin on ios and android.

**Related github/jira issue (required)**:
closes #1957 

**Steps necessary to review your pull request (required)**:
- pull branch
- go to http://localhost:4000/components/datagrid/example-fixed-header.html?locale=he-IL#
- In mobile dev tools select an android or ios device and make sure the header columns remain aligned when scrolling horizontally.

<!-- Please include the following in your PR:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.
-->

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
