### PR TITLE
2081 - Excel Export Fails on Windows [v4.18.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Personalize]` Added classes for the personalization colors so that you can personalize certain form elements. ([#1847](https://github.com/infor-design/enterprise/issues/1847))
 - `[Expandable Area]` Added example of a standalone button the toggles a form area. ([#1935](https://github.com/infor-design/enterprise/issues/1935))
 - `[Datagrid]` Added support so if there are multiple inputs within an editor they work with the keyboard tab key. ([#355](https://github.com/infor-design/enterprise-ng/issues/355))
+- `[Datagrid]` Fixed an error on IE when doing an excel export. ([#2018](https://github.com/infor-design/enterprise/issues/2018))
 - `[Editor]` Added a JS setting and CSS styles to support usage of a Flex Toolbar ([#1120](https://github.com/infor-design/enterprise/issues/1120))
 - `[Header]` Added a JS setting and CSS styles to support usage of a Flex Toolbar ([#1120](https://github.com/infor-design/enterprise/issues/1120))
 - `[Mask]` Added a setting for passing a locale string, allowing Number masks to be localized.  This enables usage of the `groupSize` property, among others, from locale data in the Mask. ([#440](https://github.com/infor-design/enterprise/issues/440))

--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -82,7 +82,7 @@ excel.cleanExtra = function (customDs, self) {
       const headerNode = allHeaderNodes[i];
       const cell = row.insertCell(i);
       cell.innerHTML = headerNode.querySelector('.datagrid-header-text').textContent.trim();
-      cell.classList = headerNode.classList;
+      cell.setAttribute('class', headerNode.classList);
       cell.setAttribute('id', headerNode.getAttribute('id'));
       if (headerNode.getAttribute('data-exportable')) {
         cell.setAttribute('data-exportable', headerNode.getAttribute('data-exportable'));


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Since 4.17 the export failed on windows. This is because IE doesnt like assigning to classList so i changed it to set it as an attribute.

**Related github/jira issue (required)**:
Fixes #2018 

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/example-export-from-button.html
- hit the two buttons and export to see a download
- test on all browsers (especially IE)