### PR TITLE
2018 - Dropdown close icon misaligned FAILED QA [v4.18.x]

### DIFF
--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -891,7 +891,7 @@ div.dropdown-xs,
   }
 }
 
-//for firefox on android
+// for firefox on android
 .is-firefox {
   &.android {
     div.dropdown,
@@ -904,13 +904,16 @@ div.dropdown-xs,
         top: 4px;
       }
     }
+  }
+}
 
-    .dropdown-list {
-      > .trigger {
-        .icon {
-          &.close {
-            top: 10px;
-          }
+// for android
+.android {
+  .dropdown-list {
+    > .trigger {
+      .icon {
+        &.close {
+          top: 10px;
         }
       }
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Dropdown close icon on Chrome in Android on mobile was misaligned.

**Related github/jira issue (required)**:
Relates to #2018.

**Steps necessary to review your pull request (required)**:
- Pull branch
- Run app
- Visit http://localhost:4000/components/dropdown/example-editable in Chrome on Android mobile
  - Ensure close icon on dropdown is correctly aligned after opening dropdown