### PR TITLE
2075 - Fix placeholder text and "X" button on in-page Toolbar Searchfields [v4.18.x]

### DIFF
--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -40,7 +40,7 @@ $toolbarsearchfield-category-empty-width: 51px;
     &::-webkit-input-placeholder,
     &::-moz-placeholder,
     &:-ms-input-placeholder {
-      color: $searchfield-text-color;
+      color: $searchfield-placeholder-text-color;
       font-size: $theme-size-font-sm;
       font-weight: $theme-number-font-weight-bold;
     }
@@ -179,21 +179,21 @@ $toolbarsearchfield-category-empty-width: 51px;
       text-transform: none;
 
       &::-webkit-input-placeholder {
-        color: $searchfield-text-color;
+        color: $searchfield-placeholder-text-color;
         font-size: $theme-size-font-base;
         font-weight: $theme-number-font-weight-base;
         text-transform: none;
       }
 
       &::-moz-placeholder {
-        color: $searchfield-text-color;
+        color: $searchfield-placeholder-text-color;
         font-size: $theme-size-font-base;
         font-weight: $theme-number-font-weight-base;
         text-transform: none;
       }
 
       &:-ms-input-placeholder {
-        color: $searchfield-text-color;
+        color: $searchfield-placeholder-text-color;
         font-size: $theme-size-font-base;
         font-weight: $theme-number-font-weight-base;
         text-transform: none;
@@ -211,6 +211,20 @@ $toolbarsearchfield-category-empty-width: 51px;
       .btn {
         background-color: rgba($searchfield-alt-bg-color, 1);
         border-bottom-color: rgba($searchfield-alt-border-color, 1);
+      }
+
+      .searchfield {
+        &::-webkit-input-placeholder {
+          color: $searchfield-lighter-placeholder-text-color;
+        }
+
+        &::-moz-placeholder {
+          color: $searchfield-lighter-placeholder-text-color;
+        }
+
+        &:-ms-input-placeholder {
+          color: $searchfield-lighter-placeholder-text-color;
+        }
       }
     }
   }
@@ -330,6 +344,11 @@ $toolbarsearchfield-category-empty-width: 51px;
     }
   }
 
+  &:not(.is-open) {
+    .icon.close {
+      pointer-events: none;
+    }
+  }
 }
 
 .azure07 .active input {
@@ -611,21 +630,21 @@ $toolbarsearchfield-category-empty-width: 51px;
       text-transform: none;
 
       &::-webkit-input-placeholder {
-        color: $searchfield-text-color;
+        color: $searchfield-placeholder-text-color;
         font-size: $theme-size-font-base;
         font-weight: $theme-number-font-weight-base;
         text-transform: none;
       }
 
       &::-moz-placeholder {
-        color: $searchfield-text-color;
+        color: $searchfield-placeholder-text-color;
         font-size: $theme-size-font-base;
         font-weight: $theme-number-font-weight-base;
         text-transform: none;
       }
 
       &:-ms-input-placeholder {
-        color: $searchfield-text-color;
+        color: $searchfield-placeholder-text-color;
         font-size: $theme-size-font-base;
         font-weight: $theme-number-font-weight-base;
         text-transform: none;

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -54,9 +54,11 @@ $cubic-bezier-ease: cubic-bezier(0.17, 0.04, 0.03, 0.94);
     }
   }
 
-  &:hover input:not([disabled]):not(:focus) {
-    + svg {
-      color: $button-color-tertiary-hover-font;
+  &:not(.toolbar-searchfield-wrapper):hover {
+    input:not([disabled]):not(:focus) {
+      + .icon {
+        color: $button-color-tertiary-hover-font;
+      }
     }
   }
 

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -686,8 +686,10 @@ $searchfield-bg-color: $theme-color-palette-graphite-20;
 $searchfield-border-color: $theme-color-palette-graphite-30;
 $searchfield-icon-color: $button-color-tertiary-initial-font;
 $searchfield-text-color: $button-color-tertiary-initial-font;
+$searchfield-placeholder-text-color: $theme-color-palette-graphite-40;
 $searchfield-lighter-bg-color: $theme-color-palette-graphite-10;
 $searchfield-lighter-text-color: $theme-color-brand-secondary-alt;
+$searchfield-lighter-placeholder-text-color: $theme-color-brand-secondary-alt;
 $searchfield-active-icon-color: $theme-color-brand-primary-alt;
 
 $searchfield-alt-bg-color: $theme-color-palette-white;

--- a/src/themes/dark-theme.scss
+++ b/src/themes/dark-theme.scss
@@ -597,8 +597,10 @@ $searchfield-bg-color: $theme-color-palette-slate-90;
 $searchfield-border-color: $theme-color-palette-slate-100;
 $searchfield-icon-color: $button-color-tertiary-initial-font;
 $searchfield-text-color: $button-color-tertiary-initial-font;
+$searchfield-placeholder-text-color: $theme-color-palette-slate-60;
 $searchfield-lighter-bg-color: $theme-color-palette-slate-80;
 $searchfield-lighter-text-color: $theme-color-palette-slate-40;
+$searchfield-lighter-placeholder-text-color: $theme-color-brand-secondary-alt;
 $searchfield-active-icon-color: $theme-color-brand-primary-alt;
 
 $searchfield-alt-bg-color: $theme-color-palette-slate-70;

--- a/src/themes/high-contrast-theme.scss
+++ b/src/themes/high-contrast-theme.scss
@@ -618,8 +618,10 @@ $searchfield-bg-color: $theme-color-palette-white;
 $searchfield-border-color: $theme-color-palette-graphite-30;
 $searchfield-icon-color: $button-color-tertiary-initial-font;
 $searchfield-text-color: $button-color-tertiary-initial-font;
+$searchfield-placeholder-text-color: $theme-color-palette-graphite-40;
 $searchfield-lighter-bg-color: $theme-color-palette-graphite-20;
 $searchfield-lighter-text-color: $theme-color-palette-graphite-50;
+$searchfield-lighter-placeholder-text-color: $theme-color-brand-secondary-alt;
 $searchfield-active-icon-color: $theme-color-palette-azure-90;
 
 $searchfield-alt-bg-color: $theme-color-palette-white;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes some problems with the Toolbar Searchfield found during Q/A:
- There was previously no difference between the color of the placeholder text and the user-keyed text on in-page Toolbar Searchfields, which was making it hard to discern which Searchfields had user-keyed text entered.
- If text had previously been entered into a collapsible Toolbar Searchfield, it was possible to close the Searchfield, and see the "X" button present while hovering the Searchfield.

**Related github/jira issue (required)**:
Closes #2075

**Steps necessary to review your pull request (required)**:
Examine the following pages on all available themes, and ensure that the color of the placeholder text in the Searchfield components blends into the background slightly more than the actual keyed text:
- http://localhost:4000/patterns/list-detail.html
- http://localhost:4000/components/toolbarsearchfield/example-collapsible-on-mobile.html
- http://localhost:4000/components/toolbarsearchfield/example-alternate-style.html

Additionally, ensure that hovering over a closed Toolbar Searchfield, inlined on the page, with text inside it, doesn't result in an "X" button being displayed.
