### PR TITLE
2052 - Fixed tooltip on mobile was not closing with multiselect [v4.18.x]

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -518,11 +518,16 @@ Dropdown.prototype = {
   setTooltip() {
     const opts = this.element.find('option:selected');
     const optText = this.getOptionText(opts);
-    this.tooltipApi = this.pseudoElem.find('span').tooltip({
-      content: optText,
-      parentElement: this.pseudoElem,
-      trigger: this.isMobile() ? 'immediate' : 'hover',
-    });
+    this.tooltipApi = this.pseudoElem.find('span')
+      .tooltip({
+        content: optText,
+        parentElement: this.pseudoElem,
+        trigger: this.isMobile() ? 'immediate' : 'hover',
+      })
+      .on('blur.dropdowntooltip', () => {
+        this.removeTooltip();
+      })
+      .data('tooltip');
   },
 
   /**
@@ -530,8 +535,11 @@ Dropdown.prototype = {
    * @returns {void}
    */
   removeTooltip() {
-    this.tooltipApi.destroy();
-    this.tooltipApi = null;
+    if (this.tooltipApi) {
+      this.tooltipApi.element.off('blur.dropdowntooltip');
+      this.tooltipApi.destroy();
+      this.tooltipApi = null;
+    }
   },
 
   /**
@@ -1569,6 +1577,10 @@ Dropdown.prototype = {
     }
 
     function completeOpen() {
+      if (self.isMobile()) {
+        $('.tooltip:not(.is-hidden)').hide();
+      }
+
       self.updateList();
       self.openList();
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed tooltip was not closing on Mobile with multiselect.

**Related github/jira issue (required)**:
Closes #2052

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/multiselect/example-index.html
- Open above link with Android and iOS
- Select items many in the dropdown list so text overflowed
- Close the dropdown list
- See tooltip should show
- Click anywhere else or open another dropdown
- Tooltip opened should close at this point

**Additional context**:
No change log as its not a new fix
