### PR TITLE
2073 - Fixed dropdown border colors for iOS with datagrid [v4.18.x]

### DIFF
--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -2502,7 +2502,7 @@ $datagrid-short-row-height: 23px;
         width: 16px;
       }
 
-      div.dropdown {
+      div.dropdown:not(.is-disabled) {
         border: 1px solid $datagrid-filter-border-color;
 
         &:hover {
@@ -3989,11 +3989,17 @@ html[dir='rtl'] {
 }
 
 // Ios Hacks
-.ios .datagrid:not(.short-rowheight):not(.medium-rowheight) {
-  .icon-error,
-  .icon-success,
-  .icon-pending {
-    top: 15px !important;
+.ios {
+  .datagrid:not(.short-rowheight):not(.medium-rowheight) {
+    .icon-error,
+    .icon-success,
+    .icon-pending {
+      top: 15px !important;
+    }
+  }
+
+  .datagrid-header .datagrid-filter-wrapper .dropdown.is-disabled {
+    opacity: 0.4;
   }
 }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed dropdown border colors were inconsistent in iOS devices with filterable datagrid.

**Related github/jira issue (required)**:
Closes #2073

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-filter-disabled.html
- Open above link with iOS
- See dropdown borders color in header filter
- Should not be inconsistent

**Additional context**:
No change log as its not a new fix
