### PR TITLE
1909 - Added support for custom tooltip callback with column chart

### DIFF
--- a/app/views/components/column/test-custom-tooltips.html
+++ b/app/views/components/column/test-custom-tooltips.html
@@ -1,0 +1,91 @@
+
+<div class="row">
+  <div class="two-thirds column">
+    <div class="widget">
+      <div class="widget-header">
+        <h2 class="widget-title">Column Chart Example</h2>
+      </div>
+      <div class="widget-content">
+        <div id="column-bar-example" class="chart-container"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+{{={{{ }}}=}}
+
+<script>
+$('body').on('initialized', function () {
+  var dataset = [{
+    data: [{
+      name: 'Automotive',
+      shortName: 'Auto',
+      abbrName: 'A',
+      value: 7,
+
+      // Any key/value can be used within tooltip
+      someCustomKey: 'Extra Info about {{someOtherCustomKey}}',
+      someOtherCustomKey: 'New {{name}}',
+
+      // Custom Tooltip just for this node as string
+      // including extra key/value
+      tooltip: 'Info: {{someCustomKey}}<br>Name: {{shortName}}<br>Value: {{value}}'
+    }, {
+      name: 'Distribution',
+      shortName: 'Dist',
+      abbrName: 'D',
+      value: 10,
+
+      // Custom Tooltip just for this nodes
+      tooltip: function (req, args) {
+        var data = args.data || {};
+        let content = 'Name: '+ data.name;
+        content += '<br>Short Name: '+ data.shortName;
+        content += '<br>Value: '+ data.value;
+        req(content);
+      }
+    }, {
+      name: 'Equipment',
+      shortName: 'Equip',
+      abbrName: 'E',
+      value: 14,
+
+      // Do not display tooltip just for this node
+      tooltip: false
+    }, {
+      name: 'Fashion',
+      shortName: 'Fash',
+      abbrName: 'F',
+      value: 10
+    }, {
+      name: 'Food',
+      shortName: 'Food',
+      abbrName: 'F',
+      value: 14
+    }, {
+      name: 'Healthcare',
+      shortName: 'Health',
+      abbrName: 'H',
+      value: 8
+    }, {
+      name: 'Other',
+      shortName: 'Other',
+      abbrName: 'O',
+      value: 7
+    }]
+  }];
+
+  $('#column-bar-example').chart({
+    type: 'column',
+    dataset: dataset,
+
+    // Custom Default Tooltip for all nodes
+    tooltip: function (req, args) {
+      var data = args.data || {};
+      const content = 'Name: '+ data.name +'<br>Value: '+ data.value;
+      req(content);
+    }
+  });
+
+});
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### v4.19.0 Features
 
+- `[Column]` Added support to existing custom tooltip content in the callback setting. ([#1909](https://github.com/infor-design/enterprise/issues/1909))
 - `[Datagrid]` Added support for disabling rows by data or a dynamic function, rows are disabled from selection and editing. ([#1614](https://github.com/infor-design/enterprise/issues/1614))
 
 ### v4.19.0 Fixes

--- a/test/components/column/column.e2e-spec.js
+++ b/test/components/column/column.e2e-spec.js
@@ -18,3 +18,62 @@ describe('Column empty tests', () => {
     expect(await element(by.css('.empty-title')).getText()).toEqual('No Data Found');
   });
 });
+
+describe('Custom Tooltips page tests', () => {
+  const tooltipContentSel = '#svg-tooltip .tooltip-content';
+
+  beforeEach(async () => {
+    await utils.setPage('/components/column/test-custom-tooltips.html');
+  });
+
+  it('Should display custom tooltip when hovering to all column nodes default method', async () => {
+    const tooltipText = 'Name: Other\nValue: 7';
+    await browser.actions()
+      .mouseMove(await element(by.css('.bar.series-6')))
+      .perform();
+
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.css(tooltipContentSel))), config.waitsFor); // eslint-disable-line
+
+    expect(await element(by.css(tooltipContentSel)).getText()).toEqual(tooltipText);
+  });
+
+  it('Should display custom tooltip when hovering to specific column node as string', async () => {
+    const tooltipText = 'Info: Extra Info about New Automotive\nName: Auto\nValue: 7';
+    await browser.actions()
+      .mouseMove(await element(by.css('.bar.series-0')))
+      .perform();
+
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.css(tooltipContentSel))), config.waitsFor); // eslint-disable-line
+
+    expect(await element(by.css(tooltipContentSel)).getText()).toEqual(tooltipText);
+  });
+
+  it('Should display custom tooltip when hovering to specific column node as method', async () => {
+    const tooltipText = 'Name: Distribution\nShort Name: Dist\nValue: 10';
+    await browser.actions()
+      .mouseMove(await element(by.css('.bar.series-1')))
+      .perform();
+
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.css(tooltipContentSel))), config.waitsFor); // eslint-disable-line
+
+    expect(await element(by.css(tooltipContentSel)).getText()).toEqual(tooltipText);
+  });
+
+  it('Should not display tooltip when hovering to specific column node', async () => {
+    await browser.actions()
+      .mouseMove(await element(by.css('.bar.series-2')))
+      .perform();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css(tooltipContentSel)).isDisplayed()).toBe(false);
+    await browser.actions()
+      .mouseMove(await element(by.css('.bar.series-4')))
+      .perform();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css(tooltipContentSel)).isDisplayed()).toBe(true);
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added support to existing custom tooltip content in the callback setting.

**Related github/jira issue (required)**:
Closes #1909

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/column/test-custom-tooltips.html
- Open above link
- Hover 1st column and see the tooltip (three lines info, name, value)
- Hover 2nd column and see the tooltip (three lines name, short name, value)
- Hover 3rd column should not show tooltip
- Any other columns should show tooltip	with two lines (name, value)
