### PR TITLE
391 - Fixed button states in toolbar for editor

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Listview]` Improved accessibility when configured as selectable (all types), as well as re-enabled accessibility e2e tests. ([#403](https://github.com/infor-design/enterprise/issues/403))
 - `[Datagrid]` Fixed charts in columns not resizing correctly to short row height. ([#1930](https://github.com/infor-design/enterprise/issues/1930))
 - `[Datagrid]` Fixed an issue for xss where console.log was not sanitizing and make grid to not render. ([#1941](https://github.com/infor-design/enterprise/issues/1941))
+- `[Editor]` Fixed an issue where button state for toolbar buttons were wrong when clicked one after another. ([#391](https://github.com/infor-design/enterprise/issues/391))
 - `[Tree]` Fixed an issue where children property null was breaking tree to not render. ([#1908](https://github.com/infor-design/enterprise/issues/1908))
 
 ### v4.19.0 Chores & Maintenance

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -1881,6 +1881,7 @@ Editor.prototype = {
           break;
       }
     }
+    this.checkSelection();
   },
 
   insertImage(url) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed button state for toolbar buttons when clicked one after another.

**Related github/jira issue (required)**:
Closes #391

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/editor/example-index.html
- Open above link
- Type a line "this is a header"
- Select and make it H4
- See toolbar button H4 should be blue color
- Select and make it H3
- See toolbar button H4 should be default color
- Only H3 button should be blue color at this point
