### PR TITLE
Adds backward-compat for accessible required input field labels [v4.18.x]

### DIFF
--- a/app/views/components/input/example-required-fields.html
+++ b/app/views/components/input/example-required-fields.html
@@ -1,0 +1,25 @@
+<div class="row">
+  <div class="six columns">
+    <h2 class="fieldset-title">Accessibility-Friendly Required Fields</h2>
+    <p>The fields on this page automatically have accessible markup added to their labels to assist screen-reading tools. For more information, please see IDS Github Issues <a class="hyperlink" href="https://github.com/infor-design/enterprise/issues/421" target="_blank">#421</a> and <a class="hyperlink" href="https://github.com/infor-design/enterprise/issues/2118" target="_blank">#2118</a></p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="one-half column">
+    <div class="field">
+      <label class="required accessible" for="first-name">First Name</label>
+      <input type="text" id="first-name" name="first-name" placeholder="ex: John" data-validate="required"/>
+    </div>
+
+    <div class="field">
+      <label class="required accessible" for="last-name">Last Name</label>
+      <input type="text" id="last-name" aria-required="true" name="last-name" placeholder="ex: Smith" data-validate="required"/>
+    </div>
+
+    <div class="field">
+      <label class="required accessible" for="email-address">Email Address</label>
+      <input type="text" id="email-address" aria-required="true" name="email-address" data-validate="required email" data-validation-events="{'required': 'blur change', 'email': 'blur change'}" placeholder="ex: company@address.com"/>
+    </div>
+  </div>
+</div>

--- a/app/views/components/input/test-legacy-required-fields.html
+++ b/app/views/components/input/test-legacy-required-fields.html
@@ -1,0 +1,25 @@
+<div class="row">
+  <div class="six columns">
+    <h2 class="fieldset-title">Required Fields</h2>
+    <p>The fields on this page demonstrate the legacy, standard handling of displaying required fields. For more information, please see IDS Github Issues <a class="hyperlink" href="https://github.com/infor-design/enterprise/issues/421" target="_blank">#421</a> and <a class="hyperlink" href="https://github.com/infor-design/enterprise/issues/2118" target="_blank">#2118</a></p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="one-half column">
+    <div class="field">
+      <label class="required" for="first-name">First Name</label>
+      <input type="text" id="first-name" name="first-name" placeholder="ex: John" data-validate="required"/>
+    </div>
+
+    <div class="field">
+      <label class="required" for="last-name">Last Name</label>
+      <input type="text" id="last-name" aria-required="true" name="last-name" placeholder="ex: Smith" data-validate="required"/>
+    </div>
+
+    <div class="field">
+      <label class="required" for="email-address">Email Address</label>
+      <input type="text" id="email-address" aria-required="true" name="email-address" data-validate="required email" data-validation-events="{'required': 'blur change', 'email': 'blur change'}" placeholder="ex: company@address.com"/>
+    </div>
+  </div>
+</div>

--- a/app/views/components/signin/example-index.html
+++ b/app/views/components/signin/example-index.html
@@ -14,12 +14,12 @@
         <form id="signin" data-validate-on="submit" autocomplete="off">
 
           <div class="field">
-            <label for="username" class="required">Email</label>
+            <label for="username" class="required accessible">Email</label>
             <input type="text" name="username" id="username" autocomplete="off" data-validate="required"/>
           </div>
 
           <div class="field">
-            <label for="password" class="required">Password</label>
+            <label for="password" class="required accessible">Password</label>
             <input type="password" id="password" data-validate="required" name="password"/>
           </div>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise
 
+## v4.18.1
+
+### v4.18.1 Fixes
+
+- `[Input]` Added backwards-compatibility for previous accessibility changes to labels. ([#2118](https://github.com/infor-design/enterprise/issues/2118)). Additional information can be found in the [Form Component documentation](https://github.com/infor-design/enterprise/blob/4.18.x/src/components/form/readme.md#field-labels).
+
 ## v4.18.0
 
 ### v4.18.0 Features

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -106,6 +106,10 @@ $(() => {
   const selector = 'label.required .label-text, .label.required .label-text, label:not(.inline).required, .label:not(.inline).required';
   const labels = [].slice.call(document.body.querySelectorAll(selector));
   labels.forEach((label) => {
+    if (label.className.indexOf('accessible') === -1) {
+      return;
+    }
+
     const asterisk = label.querySelector('.required-asterisk');
     if (!asterisk) {
       label.insertAdjacentHTML('beforeend', '<span class="required-asterisk" aria-hidden="true">*</span>');

--- a/src/components/form/readme.md
+++ b/src/components/form/readme.md
@@ -32,6 +32,12 @@ The following classes can be used for form and label alignment.
 - `label-left` - Used to put a label and data label to the left of each other rather than on top. This may be used on some forms but not with editable inputs. [See Example](./demo/form/example-labels?font=source-sans)
 - `compound-field` - Used to put several fields next to each other in a row. This may be used for related fields like phone + extension [See Example](./demo/form/example-forms?font=source-sans)
 
+## Accessibility
+
+### Field labels
+
+In/After IDS version 4.18.1, changes were made to form labels with a required asterisk `(*)` that provide better identification in screen readers. This involves a breaking change to existing required label elements, since adding additional markup is necessary. The Form component will automatically convert labels to the new, accessibility-friendly method of display if the developer simply adds an `.accessible` CSS class to the `<label>` or `.label-text` element. For more information, see Github issues [#421](https://github.com/infor-design/enterprise/issues/421) and [#2118](https://github.com/infor-design/enterprise/issues/2118).
+
 ## Testability
 
 - Please refer to the [Application Testability Checklist](/resources/application-testability-checklist) for further details.

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -305,12 +305,24 @@ textarea {
 label,
 .label {
   &.required {
-    &:not(.inline) .required-asterisk {
-      @include required-indicator($is-content: false);
+    &:not(.inline) {
+      &:not(.accessible)::after {
+        @include required-indicator($is-content: true);
+      }
+
+      .required-asterisk {
+        @include required-indicator($is-content: false);
+      }
     }
 
-    .label-text .required-asterisk {
-      @include required-indicator($is-content: false);
+    .label-text {
+      &:not(.accessible)::after {
+        @include required-indicator($is-content: true);
+      }
+
+      .required-asterisk {
+        @include required-indicator($is-content: false);
+      }
     }
   }
 

--- a/src/components/input/readme.md
+++ b/src/components/input/readme.md
@@ -20,6 +20,8 @@ demo:
     slug: example-clearable
   - name: Input with Right Click Context Menu
     slug: example-contextmenu
+  - name: Input with Accessible Required Labels
+    slug: example-required-fields
 ---
 
 The Text Input Field supports both unstructured and structured entries. Certain types of values (such as phone numbers, credit card numbers, part codes, even decimal values, etc.) may have more complex formatting rules than simple text and decimal entries. You can use smart (forgiving) and structured formats within a text input field to support more of these types of values.


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR reverses some changes that removed the display of the red asterisk from required form field labels.  The previous method of displaying these asterisks was not accessibility friendly, but has been added back to provide backwards compatibility, and time for deprecation.  The new, more-accessible method of using these asterisks has been made "opt-in" by way of adding an additional CSS class to the label.

Additionally, the Form component's automatic appending of the accessibility-friendly markup has been changed to check for the class.  Documentation and a changelog note for these changes have also been added.

**Related github/jira issue (required)**:
- Related to #421
- Reverses some changes in #1877
- Closes #2118

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp
- Navigate to http://localhost:4000/components/signin/example-index.html. Ensure that only one asterisk is present on each required form field.
- Navigate to http://localhost:4000/components/input/example-index.html. Ensure that only one asterisk is present on each required form field.
- Navigate to http://localhost:4000/components/input/example-required-fields.html. See that all labels are using the asterisk span (use dev tools to confirm).
- Navigate to http://localhost:4000/components/input/test-legacy-required-fields.html. See that all labels are using the original `::after` pseudo-element (use dev tools to confirm).

**Included in this PR:**
- ⛔️ An e2e or functional test for the bug or feature.
- ✅ A note to the change log.

----
paging @volante007 