### PR TITLE
2120 - Message unwanted visible alert [v4.18.x]

### DIFF
--- a/app/views/components/message/example-index.html
+++ b/app/views/components/message/example-index.html
@@ -18,10 +18,11 @@
     // Message.html View Specifics
     $('#show-application-error').on('click', function() {
       $('body').message({
-        title: '<span>Application Error</span>',
+        title: '<span>Lost connection</span>',
         status: 'error',
         returnFocus: $(this),
         message: 'This application has experienced a <b>system error</b> due to the lack of internet access.<br><em>Please</em> restart the application in order to proceed.',
+        audibleAlert: 'Error',
         buttons: [{
             text: 'Restart Now',
             click: function() {

--- a/app/views/components/message/example-index.html
+++ b/app/views/components/message/example-index.html
@@ -22,6 +22,7 @@
         status: 'error',
         returnFocus: $(this),
         message: 'This application has experienced a <b>system error</b> due to the lack of internet access.<br><em>Please</em> restart the application in order to proceed.',
+        audibleLabel: 'Error',
         buttons: [{
             text: 'Restart Now',
             click: function() {

--- a/app/views/components/message/example-index.html
+++ b/app/views/components/message/example-index.html
@@ -22,7 +22,6 @@
         status: 'error',
         returnFocus: $(this),
         message: 'This application has experienced a <b>system error</b> due to the lack of internet access.<br><em>Please</em> restart the application in order to proceed.',
-        audibleLabel: 'Error',
         buttons: [{
             text: 'Restart Now',
             click: function() {
@@ -79,6 +78,7 @@
         title: 'File Upload Complete',
         message: 'Your file "<em>photo.png</em>" was successfully uploaded to your personal folder and is now <strong>public for viewing</strong>.',
         returnFocus: $(this),
+        audibleLabel: 'Alert',
         buttons: [{
           text: 'Done',
           click: function() {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,7 @@
 - `[Locale]` Fixed trailing zeros were getting ignored when displaying thousands values. ([#404](https://github.com/infor-design/enterprise/issues/1840))
 - `[MenuButton]` Improved the way menu buttons work with screen readers.([#404](https://github.com/infor-design/enterprise/issues/404))
 - `[Message]` Added an audible announce of the message type.([#964](https://github.com/infor-design/enterprise/issues/964))
+- `[Message]` Change audible announce of message type added in #964 to an option that is strictly audible.([#2120](https://github.com/infor-design/enterprise/issues/2120))
 - `[Modal]` Changed text and button font colors to pass accessibility checks.([#964](https://github.com/infor-design/enterprise/issues/964))
 - `[Multiselect]` Fixed an issue where previous selection was still selected after clear all by "Select All" option. ([#2003](https://github.com/infor-design/enterprise/issues/2003))
 - `[Notifications]` Fixed a few issues with notification background colors by using the corresponding ids-identity token for each. ([1857](https://github.com/infor-design/enterprise/issues/1857), [1865](https://github.com/infor-design/enterprise/issues/1865))

--- a/src/components/message/message.js
+++ b/src/components/message/message.js
@@ -1,6 +1,7 @@
 import * as debug from '../../utils/debug';
 import { utils } from '../../utils/utils';
 import { xssUtils } from '../../utils/xss';
+import { Locale } from '../locale/locale';
 
 // jQuery Components
 import '../modal/modal';

--- a/src/components/message/message.js
+++ b/src/components/message/message.js
@@ -20,7 +20,8 @@ const COMPONENT_NAME = 'message';
  * @param {object} [settings.buttons=null]  Array of buttons to add to the message (see modal examples as well)
  * @param {string} [settings.cssClass=null]  Extra Class to add to the dialog for customization.
  * @param {string} [settings.returnFocus=null]  JQuery Element selector to focus on return.
- * @param {string} [allowedTags='<a><b><br><br/><del><em><i><ins><mark><small><strong><sub><sup>']  String of allowed HTML tags.
+ * @param {string} [settings.allowedTags='<a><b><br><br/><del><em><i><ins><mark><small><strong><sub><sup>']  String of allowed HTML tags.
+ * @param {string} [settings.audibleLabel='']  String to include in message title that is strictly audible.
  */
 const MESSAGE_DEFAULTS = {
   title: 'Message Title',
@@ -30,7 +31,8 @@ const MESSAGE_DEFAULTS = {
   buttons: null,
   cssClass: null,
   returnFocus: null,
-  allowedTags: '<a><b><br><br/><del><em><i><ins><mark><small><strong><sub><sup>'
+  allowedTags: '<a><b><br><br/><del><em><i><ins><mark><small><strong><sub><sup>',
+  audibleLabel: ''
 };
 
 function Message(element, settings) {
@@ -60,8 +62,8 @@ Message.prototype = {
     this.title = $(`<h1 class="modal-title" id="message-title">${allowTags ? xssUtils.stripTags(this.settings.title, tags) : xssUtils.stripHTML(this.settings.title)}</h1>`).appendTo(this.messageContent).wrap('<div class="modal-header"></div>');
     this.content = $(`<div class="modal-body"><p class="message" id="message-text">${allowTags ? xssUtils.stripTags(this.settings.message, tags) : xssUtils.stripHTML(this.settings.message)}</p></div>`).appendTo(this.messageContent);
 
-    if (this.title.text().toLowerCase().indexOf('alert') === -1) {
-      this.title.text(`Alert: ${this.title.text()}`);
+    if (this.settings.audibleLabel !== '') {
+      this.title.prepend(`<span class="audible">${Locale.translate(this.settings.audibleLabel)}</span>`);
     }
 
     // Append The Content if Passed in

--- a/test/components/message/message-xss.func-spec.js
+++ b/test/components/message/message-xss.func-spec.js
@@ -51,7 +51,7 @@ describe('Message XSS Prevention', () => {
     messageTitleEl = document.querySelector('.modal .modal-title');
     messageContentEl = document.querySelector('.modal .modal-body');
 
-    expect(messageTitleEl.innerText).toEqual('Alert: You have disallowed any tags from appearing in this message. All are stripped.');
+    expect(messageTitleEl.innerText).toEqual('You have disallowed any tags from appearing in this message. All are stripped.');
     expect(messageContentEl.innerText).toEqual('You have disallowed any tags from appearing in this message. All are stripped.');
   });
 });


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
Markup was visibly added to the title of the message component. This is now an option and is strictly audible.

**Related github/jira issue (required)**:
Closes #2120.

**Steps necessary to review your pull request (required)**:
- Pull branch, run app
- Visit http://localhost:4000/components/message/example-index.html
  - ensure audible text is in message title of first button through dev tool
  - use JAWS to ensure it's read 

**This PR includes**:
- [x] A note to the change log.