### PR TITLE
392 - Fixed context menu with datagrid was not properly destroyed

### DIFF
--- a/app/views/components/datagrid/test-destroy.html
+++ b/app/views/components/datagrid/test-destroy.html
@@ -1,0 +1,82 @@
+<div class="row">
+  <div class="twelve columns">
+    <button type="button" class="btn-secondary" id="destroy">Destroy</button>
+    <button type="button" class="btn-secondary" id="invoke">Invoke</button>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<ul id="grid-actions-menu" class="popupmenu">
+  <li><a href="#">Action One</a></li>
+  <li><a href="#">Action Two</a>
+    <ul class="popupmenu">
+      <li><a href="#">Action Three</a></li>
+      <li><a href="#">Action Four</a></li>
+    </ul>
+  </li>
+</ul>
+
+<ul id="grid-header-menu" class="popupmenu">
+  <li><a href="#">Sort Column</a></li>
+  <li><a href="#">Hide Column</a></li>
+</ul>
+
+<script>
+    $('body').on('initialized', function () {
+      var elem = $('#datagrid');
+
+      // Some Sample Data
+      var data = [
+        { name: 'Adam', time: '5' },
+        { name: 'Bob', time: '3' }
+      ];
+
+      // Columns for the Grid.
+      var columns = [
+        { id: 'name', name: 'Name', field: 'name' },
+        { id: 'time', name: 'Time', field: 'time' }
+      ];
+
+      // Grid Settings
+      var settings = {
+        columns: columns,
+        dataset: data,
+        menuId: 'grid-actions-menu',
+        headerMenuId: 'grid-header-menu',
+        menuSelected: function (e, item) {
+          console.log('selected:', item.text());
+        },
+        headerMenuSelected: function (e, item) {
+          console.log('selected:', item.text());
+        }
+      };
+
+      // Invoke the Grid
+      function invokeGrid() {
+        $('#datagrid').datagrid(settings);
+      }
+
+      // Initialize Grid
+      invokeGrid();
+
+      // Destroy
+      $('#destroy').on('click', function () {
+        elem.destroy();
+      });
+
+      // Invoke
+      $('#invoke').on('click', function () {
+        if (!elem.data('datagrid')) {
+          invokeGrid();
+        }
+      });
+
+    });
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[App Menu]` Changed the scroll area to the outside when using a footer. ([#2062](https://github.com/infor-design/enterprise/issues/2062))
 - `[Colorpicker]` Fixed an issue where the colorpicker label is cut off in extra small input field. ([#2023](https://github.com/infor-design/enterprise/issues/2023))
 - `[Context Menu]` Fixes a bug where a left click on the originating field would not close a context menu opened with a right click. ([#1992](https://github.com/infor-design/enterprise/issues/1992))
+- `[Datagrid]` Fixed an issue where using the context menu with datagrid was not properly destroyed which being created multiple times. ([#392](https://github.com/infor-design/enterprise-ng/issues/392))
 - `[Datagrid]` Fixed charts in columns not resizing correctly to short row height. ([#1930](https://github.com/infor-design/enterprise/issues/1930))
 - `[Datagrid]` Fixed an issue for xss where console.log was not sanitizing and make grid to not render. ([#1941](https://github.com/infor-design/enterprise/issues/1941))
 - `[Datagrid]` Fixed charts in columns not resizing correctly to short row height. ([#1930](https://github.com/infor-design/enterprise/issues/1930))
@@ -37,6 +38,7 @@
 - `[Personalize]` Separated personalization styles into standalone file for improved maintainability. ([#2127](https://github.com/infor-design/enterprise/issues/2127))
 
 (nn Issues Solved this release, Backlog Enterprise nn, Backlog Ng nn, nn Functional Tests, nn e2e Test)
+
 ## v4.18.1
 
 ### v4.18.1 Fixes

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5642,15 +5642,15 @@ Datagrid.prototype = {
           menuId: col.menuId,
           trigger: 'immediate',
           offset: { y: 5 }
-        }).off('close').on('close', function () {
+        }).off('close.gridpopupbtn').on('close.gridpopupbtn', function () {
           const el = $(this);
-          if (el.data('popupmenu')) {
+          if (el.data('popupmenu') && !el.data('tooltip')) {
             el.data('popupmenu').destroy();
           }
         });
 
         if (col.selected) {
-          btn.on('selected.datagrid', col.selected);
+          btn.off('selected.gridpopupbtn').on('selected.gridpopupbtn', col.selected);
         }
       }
 
@@ -5721,13 +5721,14 @@ Datagrid.prototype = {
           attachToBody: true,
           trigger: 'immediate'
         })
-          .off('selected').on('selected', (selectedEvent, args) => {
+          .off('selected.gridpopuptr')
+          .on('selected.gridpopuptr', (selectedEvent, args) => {
             if (self.settings.menuSelected) {
               self.settings.menuSelected(selectedEvent, args);
             }
           })
-          .off('close')
-          .on('close', function () {
+          .off('close.gridpopuptr')
+          .on('close.gridpopuptr', function () {
             const elem = $(this);
             if (elem.data('popupmenu')) {
               elem.data('popupmenu').destroy();
@@ -5791,12 +5792,12 @@ Datagrid.prototype = {
               beforeOpen: self.settings.headerMenuBeforeOpen,
               trigger: 'immediate'
             })
-            .off('selected.gridpopup')
-            .on('selected.gridpopup', (selectedEvent, args) => {
+            .off('selected.gridpopupth')
+            .on('selected.gridpopupth', (selectedEvent, args) => {
               self.settings.headerMenuSelected(selectedEvent, args);
             })
-            .off('close')
-            .on('close', function () {
+            .off('close.gridpopupth')
+            .on('close.gridpopupth', function () {
               const elem = $(this);
               if (elem.data('popupmenu')) {
                 elem.data('popupmenu').destroy();
@@ -10196,6 +10197,10 @@ Datagrid.prototype = {
   destroy() {
     // Remove grid tooltip
     this.removeTooltip();
+
+    // Unbind context menu events
+    this.element.add(this.element.find('*'))
+      .off('selected.gridpopupth close.gridpopupth selected.gridpopuptr close.gridpopuptr selected.gridpopupbtn close.gridpopupbtn');
 
     // UnBind the pager
     if (this.pagerAPI) {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5633,8 +5633,21 @@ Datagrid.prototype = {
 
       // Handle Context Menu on Some
       if (col.menuId) {
+        self.closePrevPopupmenu();
         const btn = $(this).find('button');
-        btn.popupmenu({ attachToBody: true, autoFocus: false, mouseFocus: true, menuId: col.menuId, trigger: 'immediate', offset: { y: 5 } });
+        btn.popupmenu({
+          attachToBody: true,
+          autoFocus: false,
+          mouseFocus: true,
+          menuId: col.menuId,
+          trigger: 'immediate',
+          offset: { y: 5 }
+        }).off('close').on('close', function () {
+          const el = $(this);
+          if (el.data('popupmenu')) {
+            el.data('popupmenu').destroy();
+          }
+        });
 
         if (col.selected) {
           btn.on('selected.datagrid', col.selected);
@@ -5695,6 +5708,7 @@ Datagrid.prototype = {
       if (!self.isSubscribedTo(e, 'contextmenu')) {
         return;
       }
+      self.closePrevPopupmenu();
 
       self.triggerRowEvent('contextmenu', e, (!!self.settings.menuId));
       e.preventDefault();
@@ -5766,6 +5780,7 @@ Datagrid.prototype = {
       }).off('contextmenu.datagrid').on('contextmenu.datagrid', 'th', (e) => {
         // Add Header Context Menu Support
         e.preventDefault();
+        self.closePrevPopupmenu();
 
         if (self.settings.headerMenuId) {
           $(e.currentTarget)
@@ -5779,6 +5794,13 @@ Datagrid.prototype = {
             .off('selected.gridpopup')
             .on('selected.gridpopup', (selectedEvent, args) => {
               self.settings.headerMenuSelected(selectedEvent, args);
+            })
+            .off('close')
+            .on('close', function () {
+              const elem = $(this);
+              if (elem.data('popupmenu')) {
+                elem.data('popupmenu').destroy();
+              }
             });
         }
 
@@ -5838,6 +5860,21 @@ Datagrid.prototype = {
 
       if (self.editor && self.editor.input && !this.editor.stayInEditMode) {
         self.commitCellEdit(self.editor.input);
+      }
+    });
+  },
+
+  /**
+  * Close any previous opened popupmenus.
+  * @private
+  * @returns {void}
+  */
+  closePrevPopupmenu() {
+    const nodes = [].slice.call(this.element[0].querySelectorAll('.is-open:not(.popupmenu)'));
+    nodes.forEach((node) => {
+      const elem = $(node);
+      if (elem.data('popupmenu')) {
+        elem.trigger('close');
       }
     });
   },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed when using context menu with datagrid was not properly destroyed which being created multiple times.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#392
Closes #2140

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-destroy.html
- Open above link
- Open developer tools
- Run on console `$('.popupmenu-wrapper').length;`
- Should result 1
- Right click on both rows to open context menus
- While menu is open, run on console `$('.popupmenu-wrapper').length;`
- Should result 2
- Click on top buttons "Destroy" then "Invoke"
- Run on console `$('.popupmenu-wrapper').length;`
- Should result 1
- Right click on both rows to open context menus
- Again while menu is open, run on console `$('.popupmenu-wrapper').length;`
- Should result 2
- So if you run while open menu result should be 2 otherwise 1 as many time menu opens/close or destroy/invoke the grid, `$('.popupmenu-wrapper').length;` 

http://localhost:4000/components/datagrid/test-all-formatters.html
- Open above link
- Open developer tools
- Scroll over to the `Action` column
- Click any button `...` to open a menu
- Click another row
- See console there should not be any error
