### PR TITLE
1978 - Expandable area updates within application menu (Readded)

### DIFF
--- a/app/views/components/applicationmenu/example-personalized-role-switcher.html
+++ b/app/views/components/applicationmenu/example-personalized-role-switcher.html
@@ -78,7 +78,7 @@
     // May need to do more here.
     $('.application-menu-switcher-panel .accordion').on('selected', function (e, args) {
       $('body').toast({title: 'Role ' + args.innerText + ' Selected',  message: 'In a real application, you could refresh the app menu with new contents for the selected role.'});
-      $('.expandable-area').data('expandablearea').close()
+       $('.application-menu').data('applicationmenu').closeSwitcherPanel();
     });
   </script>
 </body>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - `[App Menu]` Fixed an issue where the menu would not be entirely colored if short. ([#2062](https://github.com/infor-design/enterprise/issues/2062))
 - `[App Menu]` Changed the scroll area to the outside when using a footer. ([#2062](https://github.com/infor-design/enterprise/issues/2062))
+- `[App Menu]` Expandable area updates within application menu. ([#1982](https://github.com/infor-design/enterprise/pull/1982))
 - `[Colorpicker]` Fixed an issue where the colorpicker label is cut off in extra small input field. ([#2023](https://github.com/infor-design/enterprise/issues/2023))
 - `[Context Menu]` Fixes a bug where a left click on the originating field would not close a context menu opened with a right click. ([#1992](https://github.com/infor-design/enterprise/issues/1992))
 - `[Datagrid]` Fixed charts in columns not resizing correctly to short row height. ([#1930](https://github.com/infor-design/enterprise/issues/1930))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@
 - `[Personalize]` Separated personalization styles into standalone file for improved maintainability. ([#2127](https://github.com/infor-design/enterprise/issues/2127))
 
 (nn Issues Solved this release, Backlog Enterprise nn, Backlog Ng nn, nn Functional Tests, nn e2e Test)
+
 ## v4.18.1
 
 ### v4.18.1 Fixes

--- a/src/components/applicationmenu/applicationmenu.js
+++ b/src/components/applicationmenu/applicationmenu.js
@@ -157,6 +157,12 @@ ApplicationMenu.prototype = {
     const switchTrigger = this.element.find('.application-menu-switcher-trigger');
     if (switchTrigger.length > 0) {
       this.switcherPanel = switchTrigger.next('.expandable-area');
+
+      const expandableArea = this.switcherPanel.data('expandablearea');
+      if (!expandableArea) {
+        this.switcherPanel.expandablearea();
+      }
+
       this.switcherPanel.on('beforeexpand.applicationmenu', () => {
         const height = this.element.height();
 
@@ -613,6 +619,18 @@ ApplicationMenu.prototype = {
     }
 
     this.closeMenu();
+  },
+
+  /**
+   * Closes the switcher panel area controlled by switcher
+   */
+  closeSwitcherPanel() {
+    if (this.switcherPanel) {
+      const expandableArea = this.switcherPanel.data('expandablearea');
+      if (expandableArea) {
+        expandableArea.close();
+      }
+    }
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Do not know why but https://github.com/infor-design/enterprise/pull/1982 when merged never actually went into master.. its simply not in the histroy https://github.com/infor-design/enterprise/commits/master/src/components/applicationmenu/applicationmenu.js

No clue what happened so resubmitted

- Initialize expandable area within application menu
- Add support to close expandable area

**Related github/jira issue (required)**:
Fixes #1978

**Steps necessary to review your pull request (required)**:
- Open http://localhost:4000/components/applicationmenu/example-personalized-role-switcher.html
- Make sure role switcher is expanding/collapsing and expandable area is closed when a role is selected
