### PR TITLE
1943 - Fixed cap close button was misaligned

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### v4.19.0 Features
 
 - `[Column]` Added support to existing custom tooltip content in the callback setting. ([#1909](https://github.com/infor-design/enterprise/issues/1909))
+- `[Contextual Action Panel]` Fixed an issue where the close button was misaligned. ([#1943](https://github.com/infor-design/enterprise/issues/1943))
 - `[Datagrid]` Added support for disabling rows by data or a dynamic function, rows are disabled from selection and editing. ([#1614](https://github.com/infor-design/enterprise/issues/1614))
 - `[Datagrid]` Fixes a column alignment issue when resizing and sorting columns that were originally set to percentage width. ([#1797](https://github.com/infor-design/enterprise/issues/1797))
 - `[Datagrid]` Fixes a column alignment issue when there are duplicate column ids. ([#1797](https://github.com/infor-design/enterprise/issues/1797))

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -325,7 +325,7 @@
     }
   }
 
-  .btn-close {
+  > .btn-close {
     position: absolute;
     right: 0;
     top: 0;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed contextual action panel the close button was misaligned.

**Related github/jira issue (required)**:
Closes #1943

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/contextualactionpanel/test-full-content.html
http://localhost:4000/components/modal/example-close-btn.html
- Open above links
- Click button to open
- See the close button should not misaligned
