### PR TITLE
2130 - Datagrid: Fixes last column to stay stretched/filled

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Datagrid]` Fixes a column alignment issue when resizing and sorting columns that were originally set to percentage width. ([#1797](https://github.com/infor-design/enterprise/issues/1797))
 - `[Datagrid]` Fixes a column alignment issue when there are duplicate column ids. ([#1797](https://github.com/infor-design/enterprise/issues/1797))
 - `[Datagrid]` Fixes a column alignment by clearing a cache to help prevent column misalignment from randomly happening. ([#1797](https://github.com/infor-design/enterprise/issues/1797))
+- `[Datagrid]` Fixes the last column to stay stretched after resizing on any column. ([#2130](https://github.com/infor-design/enterprise/issues/2130))
 
 ### v4.19.0 Fixes
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@
 - `[Datagrid]` Fixes a column alignment issue when resizing and sorting columns that were originally set to percentage width. ([#1797](https://github.com/infor-design/enterprise/issues/1797))
 - `[Datagrid]` Fixes a column alignment issue when there are duplicate column ids. ([#1797](https://github.com/infor-design/enterprise/issues/1797))
 - `[Datagrid]` Fixes a column alignment by clearing a cache to help prevent column misalignment from randomly happening. ([#1797](https://github.com/infor-design/enterprise/issues/1797))
-- `[Datagrid]` Fixes the last column to stay stretched after resizing on any column. ([#2130](https://github.com/infor-design/enterprise/issues/2130))
+- `[Datagrid]` Fixes the last column to stay stretched when resizing on any column. ([#2130](https://github.com/infor-design/enterprise/issues/2130))
 
 ### v4.19.0 Fixes
 

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -719,7 +719,7 @@ $datagrid-short-row-height: 23px;
   font-size: $theme-size-font-base;
   //This lets us resize to lower than content width but it causes layout issues with default col sizes
   table-layout: fixed;
-  width: 100%;
+  width: 100% !important;
 
   //Row Height Feature
   &.medium-rowheight {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes the last column to stay stretched when resizing on any column.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/2130

**Steps necessary to review your pull request (required)**:
- Pull this branch
- Navigate to http://localhost:4000/components/datagrid/example-index.html
- Resize any column, make it smaller
- Last column should stay filled

Issue:

<img width="1200" alt="datagrid-issue" src="https://user-images.githubusercontent.com/8839327/57511760-949c1600-733c-11e9-8172-35d47ba0c4b2.png">

Fix:

<img width="1200" alt="datagrid-fix" src="https://user-images.githubusercontent.com/8839327/57511852-c8773b80-733c-11e9-938d-a6241db21f00.png">


<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
