### PR TITLE
1962 - Fixes failed QA personalized tabs bugs

### DIFF
--- a/app/views/components/personalize/example-classes.html
+++ b/app/views/components/personalize/example-classes.html
@@ -71,6 +71,9 @@
     if ($('.personalize-header').css('background-color') === 'rgba(0, 0, 0, 0)') {
       // None set
       $('html').personalize({ colors: { header: '2578A9' } });
+
+     // Intercept the Default Item as it cant work here 100%
+     $('li.is-default').removeClass('is-default');
     }
   });
 </script>

--- a/app/views/components/personalize/example-tabs.html
+++ b/app/views/components/personalize/example-tabs.html
@@ -52,5 +52,8 @@
       // None set
       $('html').personalize({ colors: { header: '2578A9' } });
     }
+
+    // Intercept the Default Item as it cant work here 100%
+    $('li.is-default').removeClass('is-default');
   });
 </script>

--- a/src/components/monthview/monthview.js
+++ b/src/components/monthview/monthview.js
@@ -2,6 +2,7 @@ import { utils } from '../../utils/utils';
 import { stringUtils } from '../../utils/string';
 import { Locale } from '../locale/locale';
 import { xssUtils } from '../../utils/xss';
+import { colorUtils } from '../../utils/color';
 
 // Settings and Options
 const COMPONENT_NAME = 'monthview';
@@ -764,7 +765,6 @@ MonthView.prototype = {
     }
 
     const hex = this.getLegendColor(year, month, date);
-    const self = this;
 
     elem[0].style.backgroundColor = '';
     elem.off('mouseenter.legend mouseleave.legend');
@@ -772,10 +772,10 @@ MonthView.prototype = {
     if (hex) {
       // set color on elem at .3 of provided color as per design
       elem.addClass('is-colored');
-      elem[0].style.backgroundColor = this.hexToRgba(hex, 0.3);
+      elem[0].style.backgroundColor = colorUtils.hexToRgba(hex, 0.3);
 
-      const normalColor = self.hexToRgba(hex, 0.3);
-      const hoverColor = self.hexToRgba(hex, 0.7);
+      const normalColor = colorUtils.hexToRgba(hex, 0.3);
+      const hoverColor = colorUtils.hexToRgba(hex, 0.7);
 
       // handle hover states
       elem.on('mouseenter.legend', function () {
@@ -1283,37 +1283,13 @@ MonthView.prototype = {
       const series = s.legend[i];
       const item = '' +
         `<div class="monthview-legend-item">
-          <span class="monthview-legend-swatch" style="background-color: ${this.hexToRgba(series.color, 0.3)}"></span>
+          <span class="monthview-legend-swatch" style="background-color: ${colorUtils.hexToRgba(series.color, 0.3)}"></span>
           <span class="monthview-legend-text">${series.name}</span>
         </div>`;
 
       this.legend.append(item);
     }
     this.table.after(this.legend);
-  },
-
-  /**
-   * Convert the provided hex to an RGBA for states
-   * This may be later moved into a colors file along with getLuminousColorShade
-   * @private
-   * @param {string} hex to set.
-   * @param {string} opacity to check.
-   * @returns {string} converted rgba
-   */
-  hexToRgba(hex, opacity) {
-    let c;
-    if (/^#([A-Fa-f0-9]{3}){1,2}$/.test(hex)) {
-      c = hex.substring(1).split('');
-
-      if (c.length === 3) {
-        c = [c[0], c[0], c[1], c[1], c[2], c[2]];
-      }
-
-      c = `0x${c.join('')}`;
-      // eslint-disable-next-line
-      return `rgba(${[(c >> 16) & 255, (c >> 8) & 255, c & 255].join(',')},${opacity.toString()})`;
-    }
-    return '';
   },
 
   /**

--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -1,5 +1,6 @@
 import * as debug from '../../utils/debug';
 import { utils } from '../../utils/utils';
+import { colorUtils } from '../../utils/color';
 import { xssUtils } from '../../utils/xss';
 import { theme } from '../theme/theme';
 import { personalizeStyles } from './personalize.styles';
@@ -80,22 +81,6 @@ Personalize.prototype = {
   },
 
   /**
-   * Validates a string containing a hexadecimal number
-   * @private
-   * @param {string} hex A hex color.
-   * @returns {string} a validated hexadecimal string.
-   */
-  validateHex(hex) {
-    hex = String(hex).replace(/[^0-9a-f]/gi, '');
-
-    if (hex.length < 6) {
-      hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
-    }
-
-    return `#${hex}`;
-  },
-
-  /**
    * Create new CSS rules in head and override any existing
    * @private
    * @param {object} cssRules The rules to append.
@@ -162,24 +147,24 @@ Personalize.prototype = {
 
     // If an event sends a blank string through instead of a hex,
     // reset any color values back to the theme defaults.  Otherwise, get a valid hex value.
-    colors.header = this.validateHex(colors.header || defaultColors.header);
-    colors.text = this.validateHex(colors.text || defaultColors.text);
-    colors.subheader = this.validateHex(colors.subheader ||
-      this.getLuminousColorShade(colors.header, 0.2));
-    colors.button = this.validateHex(colors.button ||
-      this.getLuminousColorShade(colors.text, -0.80));
-    colors.inactive = this.validateHex(colors.inactive ||
-      this.getLuminousColorShade(colors.header, -0.22));
-    colors.verticalBorder = this.validateHex(colors.verticalBorder ||
-      this.getLuminousColorShade(colors.header, 0.1));
-    colors.horizontalBorder = this.validateHex(colors.horizontalBorder ||
-      this.getLuminousColorShade(colors.header, -0.4));
-    colors.hover = this.validateHex(colors.hover ||
-      this.getLuminousColorShade(colors.header, -0.5));
-    colors.btnColorHeader = this.validateHex(colors.btnColorHeader ||
-      this.getLuminousColorShade(colors.subheader, -0.025));
-    colors.btnColorSubheader = this.validateHex(colors.btnColorSubheader ||
-      this.getLuminousColorShade(colors.header, -0.025));
+    colors.header = colorUtils.validateHex(colors.header || defaultColors.header);
+    colors.text = colorUtils.validateHex(colors.text || defaultColors.text);
+    colors.subheader = colorUtils.validateHex(colors.subheader ||
+      colorUtils.getLuminousColorShade(colors.header, 0.2));
+    colors.button = colorUtils.validateHex(colors.button ||
+      colorUtils.getLuminousColorShade(colors.text, -0.80));
+    colors.inactive = colorUtils.validateHex(colors.inactive ||
+      colorUtils.getLuminousColorShade(colors.header, -0.22));
+    colors.verticalBorder = colorUtils.validateHex(colors.verticalBorder ||
+      colorUtils.getLuminousColorShade(colors.header, 0.1));
+    colors.horizontalBorder = colorUtils.validateHex(colors.horizontalBorder ||
+      colorUtils.getLuminousColorShade(colors.header, -0.4));
+    colors.hover = colorUtils.validateHex(colors.hover ||
+      colorUtils.getLuminousColorShade(colors.header, -0.5));
+    colors.btnColorHeader = colorUtils.validateHex(colors.btnColorHeader ||
+      colorUtils.getLuminousColorShade(colors.subheader, -0.025));
+    colors.btnColorSubheader = colorUtils.validateHex(colors.btnColorSubheader ||
+      colorUtils.getLuminousColorShade(colors.header, -0.025));
 
     return personalizeStyles(colors);
   },
@@ -225,33 +210,6 @@ Personalize.prototype = {
     if (sheet) {
       sheet.parentNode.removeChild(sheet);
     }
-  },
-
-  /**
-  * Takes a color and performs a change in luminosity of that color programatically.
-  * @private
-  * @param {string} hex  The original Hexadecimal base color.
-  * @param {string} lum  A percentage used to set luminosity
-  * change on the base color:  -0.1 would be 10% darker, 0.2 would be 20% brighter
-  * @returns {string} hexadecimal color.
-  */
-  getLuminousColorShade(hex, lum) {
-    // validate hex string
-    hex = this.validateHex(hex).substr(1);
-    lum = lum || 0;
-
-    // convert to decimal and change luminosity
-    let rgb = '#';
-    let c;
-    let i;
-
-    for (i = 0; i < 3; i++) {
-      c = parseInt(hex.substr(i * 2, 2), 16);
-      c = Math.round(Math.min(Math.max(0, c + (c * lum)), 255)).toString(16);
-      rgb += (`00${c}`).substr(c.length);
-    }
-
-    return rgb;
   },
 
   /**

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -1,3 +1,5 @@
+import { colorUtils } from '../../utils/color';
+
 function personalizeStyles(colors) {
   return `
 .tab-container.module-tabs.is-personalizable {
@@ -73,12 +75,14 @@ function personalizeStyles(colors) {
   color: ${colors.text} !important;
 }
 
-.header.is-personalizable.has-tabs .tab-container.header-tabs > .tab-list-container .tab {
+.header.is-personalizable.has-tabs .tab-container.header-tabs > .tab-list-container .tab,
+.is-personalizable.tab-container.header-tabs > .tab-list-container .tab  {
   color: ${colors.text} !important;
   opacity: .8;
 }
 
-.header.is-personalizable.has-tabs .tab-container.header-tabs > .tab-list-container .tab:hover:not(.is-disabled) {
+.header.is-personalizable.has-tabs .tab-container.header-tabs > .tab-list-container .tab:hover:not(.is-disabled),
+.is-personalizable.tab-container.header-tabs > .tab-list-container .tab:hover:not(.is-disabled)  {
   color: ${colors.text} !important;
   opacity: 1;
 }
@@ -174,11 +178,11 @@ function personalizeStyles(colors) {
 }
 
 .is-personalizable .tab-container.header-tabs::before {
-  background-image: linear-gradient(to right, ${colors.header} , rgba(37, 120, 169, 0));
+  background-image: linear-gradient(to right, ${colors.header} , ${colorUtils.hexToRgba(colors.header, 0)});
 }
 
 .is-personalizable .tab-container.header-tabs::after {
-  background-image: linear-gradient(to right, rgba(37, 120, 169, 0), ${colors.header});
+  background-image: linear-gradient(to right, ${colorUtils.hexToRgba(colors.header, 0)}, ${colors.header});
 }
 
 .hero-widget.is-personalizable {

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -1,0 +1,69 @@
+const colorUtils = {};
+
+/**
+ * Convert the provided hex to an RGBA with an opacity.
+ * @private
+ * @param {string} hex to set.
+ * @param {string} opacity to check.
+ * @returns {string} converted rgba
+ */
+colorUtils.hexToRgba = function hexToRgba(hex, opacity) {
+  let c;
+  if (/^#([A-Fa-f0-9]{3}){1,2}$/.test(hex)) {
+    c = hex.substring(1).split('');
+
+    if (c.length === 3) {
+      c = [c[0], c[0], c[1], c[1], c[2], c[2]];
+    }
+
+    c = `0x${c.join('')}`;
+    // eslint-disable-next-line
+    return `rgba(${[(c >> 16) & 255, (c >> 8) & 255, c & 255].join(',')},${opacity.toString()})`;
+  }
+  return '';
+};
+
+/**
+* Takes a color and performs a change in luminosity of that color programatically.
+* @private
+* @param {string} hex  The original Hexadecimal base color.
+* @param {string} lum  A percentage used to set luminosity
+* change on the base color:  -0.1 would be 10% darker, 0.2 would be 20% brighter
+* @returns {string} hexadecimal color.
+*/
+colorUtils.getLuminousColorShade = function getLuminousColorShade(hex, lum) {
+  // validate hex string
+  hex = this.validateHex(hex).substr(1);
+  lum = lum || 0;
+
+  // convert to decimal and change luminosity
+  let rgb = '#';
+  let c;
+  let i;
+
+  for (i = 0; i < 3; i++) {
+    c = parseInt(hex.substr(i * 2, 2), 16);
+    c = Math.round(Math.min(Math.max(0, c + (c * lum)), 255)).toString(16);
+    rgb += (`00${c}`).substr(c.length);
+  }
+
+  return rgb;
+};
+
+/**
+ * Validates a string containing a hexadecimal number
+ * @private
+ * @param {string} hex A hex color.
+ * @returns {string} a validated hexadecimal string.
+ */
+colorUtils.validateHex = function validateHex(hex) {
+  hex = String(hex).replace(/[^0-9a-f]/gi, '');
+
+  if (hex.length < 6) {
+    hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+  }
+
+  return `#${hex}`;
+};
+
+export { colorUtils }; //eslint-disable-line


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Brian noted some problems on the personalized tabs example https://github.com/infor-design/enterprise/issues/1962#issuecomment-491172208 this fixes them. Also to reuse a function i extracted it into its own color utils and added a few color functions i was aware of.

**Related github/jira issue (required)**:
Fixes #1962 (Further)

**Steps necessary to review your pull request (required)**:
Issue 1
http://localhost:4000/components/personalize/example-tabs.html
- change color to anything but azure or default
- change back to default (should stay azure on default)

Issue 2
http://localhost:4000/components/personalize/example-tabs.html
- this wont happen now because 1 is fixed.

Issue 3
http://localhost:4000/components/personalize/example-tabs.html
- can test on safari or IOS safari
- resize the page to smaller
- change the color
- the sides should properly blend in now.

Issue 4
http://localhost:4000/components/personalize/example-tabs.html
- in chrome
- change color and change to dark
- tabs should no longer be a strange color

Regression Tests due to refactor
http://localhost:4000/components/datepicker/example-legend.html
http://localhost:4000/components/monthview
http://localhost:4000/components/personalize
