### PR TITLE
2066 - Adds the ability to add a custom search in app menu

### DIFF
--- a/app/views/components/applicationmenu/test-filterable-custom.html
+++ b/app/views/components/applicationmenu/test-filterable-custom.html
@@ -1,0 +1,59 @@
+{{> includes/head}}
+
+<body class="no-scroll">
+  <a href="#maincontent" class="skip-link" data-translate="text">SkipToMain</a>
+  {{> includes/svg-inline-refs}}
+  {{> includes/applicationmenu-with-searchfield-custom}}
+
+  <div class="page-container scrollable" role="main">
+
+      <header class="header is-personalizable" id="maincontent">
+        <div class="toolbar">
+          <div class="title">
+            <button class="btn-icon application-menu-trigger" type="button">
+              <span class="audible">Show navigation</span>
+              <span class="icon app-header">
+                <span class="one"></span>
+                <span class="two"></span>
+                <span class="three"></span>
+              </span>
+            </button>
+
+            {{> includes/page-title}}
+          </div>
+
+          <div class="buttonset">
+            <button class="btn-icon header-search" type="button">
+              <span class="audible">Search</span>
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use xlink:href="#icon-search"></use>
+              </svg>
+            </button>
+          </div>
+
+          {{> includes/header-actionbutton}}
+        </div>
+
+      </header>
+
+  </div>
+
+  {{> includes/footer}}
+
+  <script>
+    $('#application-menu').on('filtered.test', function(e, results) {
+      var msg = (function() {
+        var str = '';
+        if (!results.length) {
+          return 'No filter results!';
+        } else {
+          for (var i = 0; i < results.length; i++) {
+            str += '<p>'+ results[i].text +'</p>';
+          }
+        }
+        return str;
+      })();
+    });
+  </script>
+</body>
+</html>

--- a/app/views/includes/applicationmenu-with-searchfield-custom.html
+++ b/app/views/includes/applicationmenu-with-searchfield-custom.html
@@ -1,0 +1,123 @@
+<nav id="application-menu" class="application-menu is-open" data-options='{ "filterable": false }'>
+
+  <div class="searchfield-wrapper">
+    <label class="audible" for="application-menu-searchfield">Search</label>
+    <input id="application-menu-searchfield" class="searchfield" data-options='{ "clearable": true }' placeholder="Search this menu"/>
+  </div>
+
+  <div class="accordion panel inverse" data-options="{'allowOnePane': true}" >
+    <div class="accordion-header">
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use xlink:href="#icon-user"></use>
+      </svg>
+      <a href="#"><span>My Account</span></a>
+    </div>
+    <div class="accordion-pane">
+      <div class="accordion-content panel logout">
+        <svg class="icon avatar" viewBox="0 0 48 48" focusable="false" aria-hidden="true" role="presentation">
+          <use xlink:href="#icon-user-avatar"></use>
+        </svg>
+        <span class="content">
+          <span class="name">Ming.le User</span>
+          <span><a href="#" class="hyperlink">Sign Out</a></span>
+        </span>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Notifications</span></a>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Administrator</span></a>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>User Settings</span></a>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Help</span></a>
+      </div>
+    </div>
+
+    <div class="accordion-header">
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use xlink:href="#icon-bookmark-filled"></use>
+      </svg>
+      <a href="#"><span>Bookmarks</span></a>
+    </div>
+
+    <div class="accordion-header">
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use xlink:href="#icon-clock"></use>
+      </svg>
+      <a href="#"><span>History</span></a>
+    </div>
+
+    <div class="accordion-header">
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use xlink:href="#icon-home"></use>
+      </svg>
+      <a href="#"><span>Homepages</span></a>
+    </div>
+
+    <div class="accordion-header">
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use xlink:href="#icon-roles"></use>
+      </svg>
+      <a href="#"><span>My Roles</span></a>
+    </div>
+    <div class="accordion-pane">
+      <div class="accordion-header">
+        <a href="#"><span>Role #1</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="accordion-header list-item">
+          <a href="#"><span>Role #1 Task #1</span></a>
+        </div>
+
+        <div class="accordion-header list-item">
+          <a href="#"><span>Role #1 Task #2</span></a>
+        </div>
+
+        <div class="accordion-header list-item">
+          <a href="#"><span>Role #1 Task #3</span></a>
+        </div>
+      </div>
+
+      <div class="accordion-header">
+        <a href="#"><span>Role #2</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="accordion-header list-item">
+          <a href="#"><span>Role #2 Task #1</span></a>
+        </div>
+
+        <div class="accordion-header list-item">
+          <a href="#"><span>Role #2 Task #2</span></a>
+        </div>
+
+        <div class="accordion-header list-item">
+          <a href="#"><span>Role #2 Task #3</span></a>
+        </div>
+      </div>
+
+      <div class="accordion-header">
+        <a href="#"><span>Role #3</span></a>
+      </div>
+
+      <div class="accordion-header">
+        <a href="#"><span>Role #4</span></a>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="branding">
+    <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
+      <use xlink:href="#icon-logo"></use>
+    </svg>
+  </div>
+</nav>
+
+<script>
+  $('#application-menu-searchfield').on('change', function() {
+    $('body').toast({ title: 'Search', message: 'Search Manually for ' + $(this).val() + '. This example purposely doesnt interact with the menu.' });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[App Menu]` Changed the scroll area to the outside when using a footer. ([#2062](https://github.com/infor-design/enterprise/issues/2062))
 - `[App Menu]` Expandable area updates within application menu. ([#1982](https://github.com/infor-design/enterprise/pull/1982))
 - `[App Menu]` Fixed an issue where role switcher was not clickable with long title. ([#2060](https://github.com/infor-design/enterprise/issues/2060))
+- `[App Menu]` Fixed an issue where it was not possible to manually add a filter field that you can control on your own. Caveat to this is if you set filterable: false it will no longer remove the filter field from the DOM, if you do that you must now do it manually. ([#2066](https://github.com/infor-design/enterprise/issues/2066))
 - `[Colorpicker]` Fixed an issue where the colorpicker label is cut off in extra small input field. ([#2023](https://github.com/infor-design/enterprise/issues/2023))
 - `[Context Menu]` Fixes a bug where a left click on the originating field would not close a context menu opened with a right click. ([#1992](https://github.com/infor-design/enterprise/issues/1992))
 - `[Datagrid]` Fixed charts in columns not resizing correctly to short row height. ([#1930](https://github.com/infor-design/enterprise/issues/1930))

--- a/src/components/applicationmenu/applicationmenu.js
+++ b/src/components/applicationmenu/applicationmenu.js
@@ -139,10 +139,6 @@ ApplicationMenu.prototype = {
           return self.filterResultsCallback(results, done);
         }
       });
-    } else if (this.searchfield.length) {
-      this.searchfield.off();
-      this.searchfield.parent('.searchfield-wrapper').remove();
-      delete this.searchfield;
     }
 
     // Sync with application menus that have an 'is-open' CSS class.

--- a/test/components/applicationmenu/applicationmenu.e2e-spec.js
+++ b/test/components/applicationmenu/applicationmenu.e2e-spec.js
@@ -180,3 +180,25 @@ describe('Applicationmenu role switcher tests', () => {
     await utils.checkForErrors();
   });
 });
+
+describe('Applicationmenu custom search tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/applicationmenu/test-filterable-custom');
+  });
+
+  it('Should show the search even though filterable is false', async () => {
+    expect(await element(by.css('#application-menu-searchfield')).isPresent()).toBeTruthy();
+  });
+
+  it('Should have a search but not filter the menu when filterable is false', async () => {
+    const button = await element(by.css('#application-menu-searchfield'));
+    await button.sendKeys('Role');
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element.all(by.css('.accordion-header.filtered')).count()).toEqual(0);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Was requested to have a manual search field in the app menu that doesnt function by filtering the list. To do this now if you set `filterable: false` it wont actively remove the menu enabling you to do this.

**Related github/jira issue (required)**:
Fixes #2066 

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/applicationmenu/test-filterable-custom.html
- the filter field should show up
- typing in it will just do a toast now and not filter the list, simulating the usage.

http://localhost:4000/components/applicationmenu/example-filterable.html
- type role in the filter field
- this should still work
