### PR TITLE
2150 - Fix disabled button color for contextual toolbar in datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `[Datagrid]` Fixed charts in columns not resizing correctly to short row height. ([#1930](https://github.com/infor-design/enterprise/issues/1930))
 - `[Datagrid]` Fixed a layout issue on primary buttons in expandable rows. ([#1999](https://github.com/infor-design/enterprise/issues/1999))
 - `[Datagrid]` Fixed an layout issue on short row grouped header buttons. ([#2005](https://github.com/infor-design/enterprise/issues/2005))
+- `[Datagrid]` Fixed an issue where disabled button color for contextual toolbar was not applying. ([#2150](https://github.com/infor-design/enterprise/issues/2150))
 - `[Datagrid]` Fixed an issue for xss where console.log was not sanitizing and make grid to not render. ([#1941](https://github.com/infor-design/enterprise/issues/1941))
 - `[Listview]` Improved accessibility when configured as selectable (all types), as well as re-enabled accessibility e2e tests. ([#403](https://github.com/infor-design/enterprise/issues/403))
 - `[Locale]` Synced up date and time patterns with the CLDR several time patterns in particular were corrected. ([#2022](https://github.com/infor-design/enterprise/issues/2022))

--- a/src/components/toolbar/_toolbar.scss
+++ b/src/components/toolbar/_toolbar.scss
@@ -328,6 +328,19 @@ $toolbar-buttonset-height: 40px;
       .ripple {
         background-color: $contextual-toolbar-color;
       }
+
+      &[disabled] {
+        color: $contextual-toolbar-button-disabled-color;
+
+        .icon {
+          color: $contextual-toolbar-button-disabled-color;
+        }
+
+        &:hover {
+          background-color: transparent;
+          border-color: transparent;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed disabled button color for contextual toolbar in datagrid was not applying.

**Related github/jira issue (required)**:
Closes #2150

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp
- Navigate to http://localhost:4000/components/datagrid/example-multiselect.html
- Open developer tools
- Select any row
- Contextual toolbar with button "Remove" should show up
- Run on console `$('#remove-btn').disable();`
- See button "Remove" should have disabled color