### PR TITLE
2144 - Restore font changing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `[Editor]` Fixed an issue where button state for toolbar buttons were wrong when clicked one after another. ([#391](https://github.com/infor-design/enterprise/issues/391))
 - `[Listview]` Improved accessibility when configured as selectable (all types), as well as re-enabled accessibility e2e tests. ([#403](https://github.com/infor-design/enterprise/issues/403))
 - `[Listview]` Improved accessibility when configured as selectable (all types), as well as re-enabled accessibility e2e tests. ([#403](https://github.com/infor-design/enterprise/issues/403))
+- `[Locale]` Restored functionality to dynamic change fonts for some languages. ([#403](https://github.com/infor-design/enterprise/issues/403))
 - `[Monthview]` Fixes an issue where the previous and next buttons were not correctly reversed in right-to-left mode. ([1910](https://github.com/infor-design/enterprise/issues/1910))
 - `[Personalization]` Changed the default turquoise personalization to a darker one. ([#2063](https://github.com/infor-design/enterprise/issues/2063))
 - `[Personalization]` Changed the default turquoise personalization to a darker one. ([#2063](https://github.com/infor-design/enterprise/issues/2063))

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -76,14 +76,17 @@ const Locale = {  // eslint-disable-line
   defaultLocale: 'en-US',
 
   /**
-   * Sets the current language in the Html Header
+   * Sets the current lang tag in the Html element
    * @private
-   * @param  {string} lang The two digit language code.
+   * @param  {string} locale The locale, if just a two digit code is passed we use the default.
    */
-  updateLanguage(lang) {
+  updateLanguageTag(locale) {
     const html = $('html');
+    if (locale.length === 2) {
+      locale = this.defaultLocales.filter(a => a.lang === locale);
+    }
 
-    html.attr('lang', lang);
+    html.attr('lang', locale);
     if (this.isRTL()) {
       html.attr('dir', 'rtl');
     } else {
@@ -361,7 +364,7 @@ const Locale = {  // eslint-disable-line
 
     if (this.languages[lang]) {
       this.currentLanguage = this.languages[lang];
-      this.updateLanguage(lang);
+      this.updateLanguageTag(lang);
     } else {
       this.currentLanguage.name = lang;
     }
@@ -383,7 +386,7 @@ const Locale = {  // eslint-disable-line
       this.currentLocale.data = data;
       this.currentLocale.dataName = name;
       this.currentLanguage = this.languages[lang];
-      this.updateLanguage(lang);
+      this.updateLanguageTag(name);
     }
   },
 

--- a/src/components/typography/_typography-uplift.scss
+++ b/src/components/typography/_typography-uplift.scss
@@ -1,0 +1,24 @@
+// Typography Uplift
+//================================================== */
+
+// Special Fonts for Certain Languages. First in this list is placeholders for now,
+// until we figure out the best way to load these dynamically
+// https://fonts.google.com/specimen/Tajawal
+$cultures-font-family: (
+  'ar-EG': ('Tajawal', 'helvetica', 'arial'),
+  'ar-SA': ('Tajawal', 'helvetica', 'arial'),
+  'ja-JP': ('Source Han Sans', 'helvetica', 'arial'),
+  'ko-KR': ('Source Han Sans', 'Source Sans Pro', 'helvetica', 'arial'),
+  'zh-CN': ('Source Han Sans', 'Source Sans Pro', 'helvetica', 'arial'),
+  'zh-tw': ('Source Han Sans', 'Source Sans Pro', 'helvetica', 'arial'),
+  'zh-Hans': ('Source Han Sans', 'Source Sans Pro', 'helvetica', 'arial'),
+  'zh-Hant': ('Source Han Sans', 'Source Sans Pro', 'helvetica', 'arial')
+);
+
+html {
+  @each $key, $value in $cultures-font-family {
+    &[lang='#{$key}'] body {
+      font-family: $value;
+    }
+  }
+}

--- a/src/components/typography/_typography.scss
+++ b/src/components/typography/_typography.scss
@@ -9,7 +9,7 @@ $cultures-font-family: (
   'ar-EG': ('DejaVu', 'Tahoma', 'helvetica', 'arial'),
   'ar-SA': ('DejaVu', 'Tahoma', 'helvetica', 'arial'),
   'ja-JP': ('MS PGothic', 'ＭＳ Ｐゴシック', 'helvetica', 'arial'),
-  'ko-KR': ('Malgun Gothic', 'AppleGothic', 'Batang', 'helvetica', 'arial'),
+  'ko-KR': ('Malgun Gothic', 'AppleGothic', 'helvetica', 'arial'),
   'zh-CN': ('华文细黑', '宋体', '微软雅黑', 'Microsoft YaHei New', 'helvetica', 'arial'),
   'zh-tw': ('华文细黑', '宋体', '微软雅黑', 'Microsoft YaHei New', 'helvetica', 'arial'),
   'zh-Hans': ('华文细黑', '宋体', '微软雅黑', 'Microsoft YaHei New', 'helvetica', 'arial'),

--- a/src/components/typography/_typography.scss
+++ b/src/components/typography/_typography.scss
@@ -6,12 +6,14 @@ $font-source-sans: 'Source Sans Pro', helvetica, arial;
 
 // Special Fonts for Certain Languages
 $cultures-font-family: (
-  'ar-EG': ('helvetica', 'arial', 'Tahoma', 'DejaVu'),
-  'ar-SA': ('helvetica', 'arial', 'Tahoma', 'DejaVu'),
-  'ja-JP': ('helvetica', 'arial', 'MS PGothic'),
-  'ko-KR': ('helvetica', 'arial', 'Batang', 'Gulim'),
-  'zh-CN': ('helvetica', 'arial', 'Microsoft YaHei New', '微软雅黑', '宋体', 'SimSun', 'STXihei', '华文细黑'),
-  'zh-tw': ('helvetica', 'arial', 'MingLiU')
+  'ar-EG': ('DejaVu', 'Tahoma', 'helvetica', 'arial'),
+  'ar-SA': ('DejaVu', 'Tahoma', 'helvetica', 'arial'),
+  'ja-JP': ('MS PGothic', 'ＭＳ Ｐゴシック', 'helvetica', 'arial'),
+  'ko-KR': ('Malgun Gothic', 'AppleGothic', 'Batang', 'helvetica', 'arial'),
+  'zh-CN': ('华文细黑', '宋体', '微软雅黑', 'Microsoft YaHei New', 'helvetica', 'arial'),
+  'zh-tw': ('华文细黑', '宋体', '微软雅黑', 'Microsoft YaHei New', 'helvetica', 'arial'),
+  'zh-Hans': ('华文细黑', '宋体', '微软雅黑', 'Microsoft YaHei New', 'helvetica', 'arial'),
+  'zh-Hant': ('华文细黑', '宋体', '微软雅黑', 'Microsoft YaHei New', 'helvetica', 'arial'),
 );
 
 // Body Sizes and Color

--- a/src/core/_controls-uplift.scss
+++ b/src/core/_controls-uplift.scss
@@ -1,5 +1,6 @@
 // Required ====/
 @import './required';
+@import '../components/typography/typography-uplift';
 
 // Behaviors ====/
 @import '../components/drag/drag';

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -115,6 +115,34 @@ describe('Locale API', () => { //eslint-disable-line
     Locale.set('en-US');
   });
 
+  it('Should change font for some locales', () => {
+    Locale.set('ar-EG');
+    const body = window.getComputedStyle(document.body, null);
+
+    expect(body.getPropertyValue('font-family')).toEqual('DejaVu, Tahoma, helvetica, arial');
+    Locale.set('ar-SA');
+
+    expect(body.getPropertyValue('font-family')).toEqual('DejaVu, Tahoma, helvetica, arial');
+    Locale.set('ja-JP');
+
+    expect(body.getPropertyValue('font-family')).toEqual('"MS PGothic", "ＭＳ Ｐゴシック", helvetica, arial');
+    Locale.set('ko-KR');
+
+    expect(body.getPropertyValue('font-family')).toEqual('"Malgun Gothic", AppleGothic, helvetica, arial');
+    Locale.set('zh-CN');
+
+    expect(body.getPropertyValue('font-family')).toEqual('华文细黑, 宋体, 微软雅黑, "Microsoft YaHei New", helvetica, arial');
+    Locale.set('zh-tw');
+
+    expect(body.getPropertyValue('font-family')).toEqual('华文细黑, 宋体, 微软雅黑, "Microsoft YaHei New", helvetica, arial');
+    Locale.set('zh-Hans');
+
+    expect(body.getPropertyValue('font-family')).toEqual('华文细黑, 宋体, 微软雅黑, "Microsoft YaHei New", helvetica, arial');
+    Locale.set('zh-Hant');
+
+    expect(body.getPropertyValue('font-family')).toEqual('华文细黑, 宋体, 微软雅黑, "Microsoft YaHei New", helvetica, arial');
+  });
+
   it('Should map in-ID to id-ID', () => {
     Locale.set('in-ID');
 

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -102,7 +102,7 @@ describe('Locale API', () => { //eslint-disable-line
 
     let html = window.document.getElementsByTagName('html')[0];
 
-    expect(html.getAttribute('lang')).toEqual('de');
+    expect(html.getAttribute('lang')).toEqual('de-DE');
 
     Locale.set('ar-SA');
 
@@ -110,7 +110,7 @@ describe('Locale API', () => { //eslint-disable-line
 
     html = window.document.getElementsByTagName('html')[0];
 
-    expect(html.getAttribute('lang')).toEqual('ar');
+    expect(html.getAttribute('lang')).toEqual('ar-SA');
     expect(html.getAttribute('dir')).toEqual('rtl');
     Locale.set('en-US');
   });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Made some changes to the lang attribute that are actually wrong, so reverted them. This makes the fonts change again for some languages.

Noticed the font order was inverted and updated the fonts based on Korean and Chinese user feedback.

Added placeholders for fonts in uplift and made Source Sans Pro still work there for now.

**Related github/jira issue (required)**:
Fixes #2144 


**Steps necessary to review your pull request (required)**:

http://localhost:4000/components/datagrid/example-index.html?locale=ar-EG
http://localhost:4000/components/datagrid/example-index.html?locale=ar-SA
http://localhost:4000/components/datagrid/example-index.html?locale=ja-JP
http://localhost:4000/components/datagrid/example-index.html?locale=ko-KR
http://localhost:4000/components/datagrid/example-index.html?locale=zh-CN
http://localhost:4000/components/datagrid/example-index.html?locale=zh-tw
- all these links will change the font

Any of these in uplift
http://localhost:4000/components/datagrid/example-index.html?locale=ko-KR&theme=uplift
- will still be in uplift
