### PR TITLE
1906 - Add a fixes so that beforeSelect can be vetoed

### DIFF
--- a/app/views/components/accordion/test-close-children-on-collapse.html
+++ b/app/views/components/accordion/test-close-children-on-collapse.html
@@ -142,7 +142,7 @@
         $('#multiselect').data('dropdown').open();
         $('#datepicker').data('datepicker').open();
 
-        countTimer = 5;
+        countTimer = 50;
         count();
       });
 

--- a/app/views/components/accordion/test-close-children-on-collapse.html
+++ b/app/views/components/accordion/test-close-children-on-collapse.html
@@ -142,7 +142,7 @@
         $('#multiselect').data('dropdown').open();
         $('#datepicker').data('datepicker').open();
 
-        countTimer = 50;
+        countTimer = 5;
         count();
       });
 

--- a/app/views/components/datagrid/example-beforeselect-veto.html
+++ b/app/views/components/datagrid/example-beforeselect-veto.html
@@ -1,0 +1,59 @@
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+      var grid,
+        columns = [],
+        data = [];
+
+      // Create Some Sample Data
+      data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 0, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+      data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+      data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+      data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+      data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+      data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+      data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+
+      // Define Columns for the Grid.
+      columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
+      columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Readonly});
+      columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink});
+      columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity'});
+      columns.push({ id: 'price', name: 'Price', field: 'price', formatter: Formatters.Decimal});
+      columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+
+      // Init and get the api for the grid
+      gridApi = $('#datagrid').datagrid({
+        columns: columns,
+        dataset: data,
+        selectable: 'multiple',
+        onBeforeSelect: function(args) {
+          // Only one key can be pressed
+          if (Soho.keyboard.pressedKeys.size !== 1) {
+            $('body').toast({title: 'Selection Vetoed', message: 'In this example, selection is vetoed. You must hold CTRL and click a row to select (or Command on Mac)'});
+            return false;
+          }
+
+          // If just Control or Meta (Mac) is done then allow the select.
+          if (Soho.keyboard.pressedKeys.entries().next().value[0] === 'Control' ||
+            Soho.keyboard.pressedKeys.entries().next().value[0] === 'Meta') {
+            var isSelected = gridApi.isRowSelected(args.idx);
+            if (isSelected) {
+              gridApi.deselectRow(args.idx, false, true);
+            } else {
+              gridApi.selectRow(args.idx, false, true);
+            }
+          }
+          return false;
+        },
+        toolbar: {title: 'Data Grid Header Title', personalize: true, results: true, actions: true, rowHeight: true, selectCount: true}
+      }).data('datagrid');
+  });
+
+</script>

--- a/app/views/components/datagrid/test-contextmenu-in-events.html
+++ b/app/views/components/datagrid/test-contextmenu-in-events.html
@@ -1,0 +1,81 @@
+
+{{={{{ }}}=}}
+
+<div class="row">
+  <div class="twelve columns">
+    <div id="readonly-datagrid">
+    </div>
+  </div>
+</div>
+
+<ul id="grid-actions-menu" class="popupmenu">
+  <li><a href="#">Action One</a></li>
+  <li><a href="#">Action Two</a></li>
+  <li><a href="#">Action Three</a>
+    <ul class="popupmenu">
+      <li><a href="#">Action Four</a></li>
+      <li><a href="#">Action Five</a></li>
+    </ul>
+  </li>
+</ul>
+
+<ul id="grid-header-menu" class="popupmenu">
+  <li><a href="#">Split</a></li>
+  <li><a href="#">Sort</a></li>
+  <li><a href="#">Hide</a></li>
+</ul>
+
+<script>
+    $('body').on('initialized', function () {
+     //Locale.set('en-US').done(function () {
+      var grid,
+        columns = [],
+        data = [];
+
+      // Some Sample Data
+      data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action', ordered: 1, setting: {optionOne: 'One', optionTwo: 'One'}});
+      data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold', ordered: true, setting: {optionOne: 'One', optionTwo: 'One'}});
+      data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action', ordered: true, comment: 'Dynamic harness out-of-the-box /n syndicate models deliver. Disintermediate, technologies /n scale deploy social streamline, methodologies, killer podcasts innovate. Platforms A-list disintermediate, value visualize dot-com /n tagclouds platforms incentivize interactive vortals disintermediate networking, webservices envisioneer; tag share value-added, disintermediate, revolutionary.'});
+      data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 9, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action', ordered: true});
+      data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 18.00, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold', ordered: false});
+      data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 18, price: 9, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', comment: 'B2C ubiquitous communities maximize B2C synergies extend dynamic revolutionize, world-class robust peer-to-peer. Action-items semantic technologies clicks-and-mortar iterate min'});
+      data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', ordered: 0});
+      data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '100.99', status: 'OK', orderDate: new Date(2014, 6, 9, 12, 12, 12), action: 'On Hold', ordered: 0});
+
+      //Define Columns for the Grid.
+
+      var cellTemplate = '<p class="datagrid-row-heading">{{productId}}</p>' +
+                        '<p class="datagrid-row-subheading">{{productName}}</p>';
+
+      columns.push({ id: 'drilldown', name: 'Drill In', field: '', width: 80, formatter: Formatters.Drilldown, cssClass: 'l-center-text', click: function (e, args) {console.log('clicked', args);}});
+      //columns.push({ id: 'productName', name: 'Product Name', field: 'productName', width: 125, formatter: Formatters.Template, template: cellTemplate});
+      columns.push({ id: 'productId', hidden: true, name: 'Product Id', field: 'productId', width: 140, formatter: Formatters.Readonly });
+      columns.push({ id: 'productDesc', name: 'Product Desc', sortable: false, field: 'productName', width: 125, formatter: Formatters.Hyperlink, click: function (e, args) {console.log('link was clicked', args);}});
+      columns.push({ id: 'activity', name: 'Activity', field: 'activity', width: 160});
+      columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', width: 200});
+      columns.push({ id: 'price1', name: 'Price', field: 'price', width: 100, formatter: Formatters.Decimal});
+      columns.push({ id: 'price2', name: 'Price', field: 'price', width: 100, formatter: Formatters.Integer});
+      columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, width: 100, dateFormat: 'yy/MM/dd'});
+
+      //{date: 'datetime'
+      columns.push({ id: 'status', name: 'Status', field: 'status', width: 200, formatter: Formatters.Text});
+      columns.push({ id: 'alert', name: 'Alert', field: 'quantity', width: 200, formatter: Formatters.Alert, ranges: [{'min': 0, 'max': 8, 'classes': 'info', 'text': 'value'}, {'min': 9, 'max': 1000, 'classes': 'error', 'text': 'value'}]});
+      columns.push({ id: 'ordered', name: 'Ordered', field: 'ordered', width: 200, formatter: Formatters.Checkbox});
+      columns.push({ id: '', name: 'Actions', field: '', width: 200, formatter: Formatters.Actions, menuId: 'grid-actions-menu'});
+      columns.push({ id: 'nested', name: 'Nested Prop', field: 'setting.optionOne', width: 200, formatter: Formatters.Text});
+      columns.push({ id: 'comment', name: 'Comment', field: 'comment', formatter: Formatters.TextArea, width: 200});
+
+      //Init and get the api for the grid
+      $('#readonly-datagrid').datagrid({
+        columns: columns,
+        dataset: data
+      }).on('contextmenu', function (e, args) {
+        $(args.originalEvent.target).popupmenu({
+          menu: $('#grid-actions-menu'),
+          trigger: 'immediate'
+        });
+      });
+
+    });
+
+</script>

--- a/app/views/utils/example-keyboard.html
+++ b/app/views/utils/example-keyboard.html
@@ -1,0 +1,22 @@
+<div class="row">
+  <div class="six columns">
+    <h2>Keyboard Manager</h2>
+    <p>Press any key(s) on the keyboard.</p>
+  </div>
+</div>
+
+ <div class="row top-padding">
+  <div class="six columns">
+    <p>
+      <span id="pressed-keys-console"></span>
+    </p>
+  </div>
+</div>
+
+ <script id="test-script">
+  $('body').on('keys.test', function(e, keys) {
+    const keysStr = keys.join(', ');
+    document.querySelector('#pressed-keys-console').innerText = keysStr;
+    console.log(Soho.keyboard.pressedKeys)
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[Datagrid]` Fixes a column alignment issue when resizing and sorting columns that were originally set to percentage width. ([#1797](https://github.com/infor-design/enterprise/issues/1797))
 - `[Datagrid]` Fixes a column alignment issue when there are duplicate column ids. ([#1797](https://github.com/infor-design/enterprise/issues/1797))
 - `[Datagrid]` Fixes a column alignment by clearing a cache to help prevent column misalignment from randomly happening. ([#1797](https://github.com/infor-design/enterprise/issues/1797))
+- `[Keyboard]` Added a new API that you can call at anytime to see what key is being pressed at the moment. ([#1906](https://github.com/infor-design/enterprise/issues/1906))
 
 ### v4.19.0 Fixes
 
@@ -25,6 +26,7 @@
 - `[Datagrid]` Fixed an issue for xss where console.log was not sanitizing and make grid to not render. ([#1941](https://github.com/infor-design/enterprise/issues/1941))
 - `[Datagrid]` Fixed charts in columns not resizing correctly to short row height. ([#1930](https://github.com/infor-design/enterprise/issues/1930))
 - `[Datagrid]` Fixed an issue for xss where console.log was not sanitizing and make grid to not render. ([#1941](https://github.com/infor-design/enterprise/issues/1941))
+- `[Datagrid]` Added an onBeforeSelect call back that you can return false from to disable row selection. ([#1906](https://github.com/infor-design/enterprise/issues/1906))
 - `[Listview]` Improved accessibility when configured as selectable (all types), as well as re-enabled accessibility e2e tests. ([#403](https://github.com/infor-design/enterprise/issues/403))
 - `[Locale]` Synced up date and time patterns with the CLDR several time patterns in particular were corrected. ([#2022](https://github.com/infor-design/enterprise/issues/2022))
 - `[Datagrid]` Adds a function to add a visual dirty indictaor and a new function to get all modified rows. Modified means either dirty, in-progress or in error. Existing API's are not touched. ([#2091](https://github.com/infor-design/enterprise/issues/2091))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -65,6 +65,7 @@ const COMPONENT_NAME = 'datagrid';
  * @param {string}   [settings.uniqueId=null] Unique DOM ID to use as local storage reference and internal variable names
  * @param {string}   [settings.rowHeight=normal] Controls the height of the rows / number visible rows. May be (short, medium or normal)
  * @param {string}   [settings.selectable=false] Controls the selection Mode this may be: false, 'single' or 'multiple' or 'mixed' or 'siblings'
+ * @param {null|function} [settings.onBeforeSelect=null] If defined as a function will fire as callback before rows are selected. You can return false to veto row selection.
  * @param {object}   [settings.groupable=null]  Controls fields to use for data grouping Use Data grouping, e.g. `{fields: ['incidentId'], supressRow: true, aggregator: 'list', aggregatorOptions: ['unitName1']}`
  * @param {boolean}  [settings.spacerColumn=false] if true and the grid is not wide enough to fit the last column will get filled with an empty spacer column.
  * @param {boolean}  [settings.showNewRowIndicator=true] If true, the new row indicator will display after adding a row.
@@ -151,6 +152,7 @@ const DATAGRID_DEFAULTS = {
   rowHeight: 'normal', // (short, medium or normal)
   selectable: false, // false, 'single' or 'multiple' or 'siblings'
   selectChildren: true, // can prevent selecting of all child nodes on multiselect
+  onBeforeSelect: null,
   allowSelectAcrossPages: null,
   groupable: null,
   spacerColumn: false,
@@ -5711,38 +5713,41 @@ Datagrid.prototype = {
     * @property {object} args.originalEvent The original event object.
     */
     this.element.off('contextmenu.datagrid').on('contextmenu.datagrid', 'tbody tr', (e) => {
-      if (!self.isSubscribedTo(e, 'contextmenu')) {
-        return;
+      const hasMenu = self.settings.menuId && $(`#${self.settings.menuId}`).length > 0;
+      self.triggerRowEvent('contextmenu', e, (!!self.settings.menuId));
+
+      if (!self.isSubscribedTo(e, 'contextmenu') && !hasMenu) {
+        return true;
       }
+      e.preventDefault();
       self.closePrevPopupmenu();
 
-      self.triggerRowEvent('contextmenu', e, (!!self.settings.menuId));
-      e.preventDefault();
-
-      if (self.settings.menuId && $(`#${self.settings.menuId}`).length > 0) {
-        $(e.currentTarget).popupmenu({
-          menuId: self.settings.menuId,
-          eventObj: e,
-          beforeOpen: self.settings.menuBeforeOpen,
-          attachToBody: true,
-          trigger: 'immediate'
-        })
-          .off('selected.gridpopuptr')
-          .on('selected.gridpopuptr', (selectedEvent, args) => {
-            if (self.settings.menuSelected) {
-              self.settings.menuSelected(selectedEvent, args);
-            }
-          })
-          .off('close.gridpopuptr')
-          .on('close.gridpopuptr', function () {
-            const elem = $(this);
-            if (elem.data('popupmenu')) {
-              elem.data('popupmenu').destroy();
-            }
-          });
+      if (!hasMenu) {
+        return true;
       }
 
-      return false; // eslint-disable-line
+      $(e.currentTarget).popupmenu({
+        menuId: self.settings.menuId,
+        eventObj: e,
+        beforeOpen: self.settings.menuBeforeOpen,
+        attachToBody: true,
+        trigger: 'immediate'
+      })
+        .off('selected.gridpopuptr')
+        .on('selected.gridpopuptr', (selectedEvent, args) => {
+          if (self.settings.menuSelected) {
+            self.settings.menuSelected(selectedEvent, args);
+          }
+        })
+        .off('close.gridpopuptr')
+        .on('close.gridpopuptr', function () {
+          const elem = $(this);
+          if (elem.data('popupmenu')) {
+            elem.data('popupmenu').destroy();
+          }
+        });
+
+      return false;
     });
 
     // Move the drag handle to the end or start of the column
@@ -5890,14 +5895,15 @@ Datagrid.prototype = {
   * Check if the event is subscribed to.
   * @private
   * @param {object} e The update empty message config object.
-  * @param {object} eventName The update empty message config object.
+  * @param {string} eventName The update empty message config object.
   * @returns {boolean} If the event is subscribed to.
   */
   isSubscribedTo(e, eventName) {
     const self = this;
+    const gridEvents = $._data(self.element[0]).events;
 
-    for (const event in $._data(self.element[0]).events) { //eslint-disable-line
-      if (event === eventName) {
+    for (const event in gridEvents) { //eslint-disable-line
+      if (event === eventName && !(gridEvents[event].length === 1 && gridEvents[event][0].namespace === 'datagrid')) {
         return true;
       }
     }
@@ -6476,6 +6482,13 @@ Datagrid.prototype = {
 
     if (!rowNode || (!rowNode.length && s.source)) {
       return;
+    }
+
+    if (typeof s.onBeforeSelect === 'function' && !noTrigger) {
+      const result = s.onBeforeSelect({ node: rowNode, idx: dataRowIndex });
+      if (result === false) { // Boolean false is returned so cancel
+        return;
+      }
     }
 
     if (s.selectable === 'single') {

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,9 @@ export { base } from './utils/base';
 // Renderloop needs a single instance of itself
 export { renderLoop, RenderLoopItem } from './utils/renderloop';
 
+// Keyboard needs a single instance of itself
+export { keyboard } from './utils/keyboard';
+
 // Theme/Personalization need single instances of themselves
 export { personalization } from './components/personalize/personalize.bootstrap';
 export * from './components/personalize/personalize.hooks';

--- a/src/utils/keyboard.js
+++ b/src/utils/keyboard.js
@@ -1,0 +1,70 @@
+const UTIL_NAME = 'keyboard';
+
+function Keyboard() {
+  this.pressedKeys = new Map();
+  this.init();
+}
+
+Keyboard.prototype = {
+  /**
+   * Initializes the keyboard management system
+   * @private
+   */
+  init() {
+    $(document)
+      .on(`keydown.${UTIL_NAME}`, (e) => {
+        this.press(e.key);
+        this.announceKeys();
+      })
+      .on(`keyup.${UTIL_NAME}`, (e) => {
+        this.unpress(e.key);
+        this.announceKeys();
+      });
+  },
+
+  /**
+   * Triggers a 'keys' event on the body tag that passes the current list of keys pressed.
+   * @private
+   */
+  announceKeys() {
+    const keys = [];
+    this.pressedKeys.forEach((val, key) => {
+      keys.push(key);
+    });
+
+    $('body').triggerHandler('keys', [keys]);
+  },
+
+  /**
+   * Add a key to the pressedKeys Map.
+   * @private
+   * @param {string} key a string representing a {KeyboardEvent.key} that was pressed.
+   * @returns {Map} the current set of pressed keys
+   */
+  press(key) {
+    return this.pressedKeys.set(`${key}`, true);
+  },
+
+  /**
+   * Remove a key from the pressedKeys map.
+   * @private
+   * @param {string} key a string representing a {KeyboardEvent.key} that is no longer being pressed.
+   * @returns {boolean} whether or not the key had been previously logged as "pressed".
+   */
+  unpress(key) {
+    return this.pressedKeys.delete(`${key}`);
+  },
+
+  /**
+   * Describes whether or not a key is currently being pressed.
+   * @param {string} key a string representing the {KeyboardEvent.key} that needs to be checked.
+   * @returns {boolean} whether or not the key is currently logged as "pressed".
+   */
+  isPressed(key) {
+    return this.pressedKeys.has(`${key}`);
+  }
+};
+
+const keyboard = new Keyboard();
+
+export { keyboard };

--- a/test/components/accordion/accordion.e2e-spec.js
+++ b/test/components/accordion/accordion.e2e-spec.js
@@ -118,7 +118,7 @@ describe('Accordion Collapse Children tests', () => {
     const buttonEl = await element(by.css('#start-test'));
     await buttonEl.click();
 
-    await browser.driver.sleep(1600);
+    await browser.driver.sleep(2000);
 
     expect(await element.all(by.css('#dropdown-list')).count()).toBe(0);
     expect(await element.all(by.css('#monthview-popup')).count()).toBe(0);

--- a/test/components/datagrid/datagrid-selection.func-spec.js
+++ b/test/components/datagrid/datagrid-selection.func-spec.js
@@ -440,4 +440,40 @@ describe('Datagrid Selection API', () => {
       done();
     }, 1);
   });
+
+  it('Should be able to call onBeforeSelect', (done) => {
+    datagridObj.destroy();
+
+    const options = {
+      dataset: data,
+      columns,
+      selectable: 'multiple',
+      onBeforeSelect: (args) => {
+        expect(args.idx).toEqual(2);
+        done();
+        return false;
+      }
+    };
+    datagridObj = new Datagrid(datagridEl, options);
+    datagridObj.selectRow(2);
+  });
+
+  it('Should be able to veto selection with onBeforeSelect', (done) => {
+    datagridObj.destroy();
+
+    const options = {
+      dataset: data,
+      columns,
+      selectable: 'multiple',
+      onBeforeSelect: (args) => {
+        expect(args).toBeTruthy();
+        return false;
+      }
+    };
+    datagridObj = new Datagrid(datagridEl, options);
+    datagridObj.selectRow(2);
+
+    expect(datagridObj.selectedRows().length).toEqual(0);
+    done();
+  });
 });

--- a/test/components/datagrid/datagrid-settings.func-spec.js
+++ b/test/components/datagrid/datagrid-settings.func-spec.js
@@ -67,6 +67,7 @@ describe('Datagrid Settings', () => {
       uniqueId: null,
       rowHeight: 'normal',
       selectable: false,
+      onBeforeSelect: null,
       selectChildren: true,
       allowSelectAcrossPages: null,
       groupable: null,

--- a/test/components/keyboard/keyboard.func-spec.js
+++ b/test/components/keyboard/keyboard.func-spec.js
@@ -1,0 +1,42 @@
+import { keyboard } from '../../../src/utils/keyboard';
+import { cleanup } from '../../helpers/func-utils';
+
+const html = require('../../../app/views/utils/example-keyboard.html');
+
+const keyPress = function (key) {
+  const event = document.createEvent('Event');
+  event.key = key;
+  event.initEvent('keydown');
+  document.dispatchEvent(event);
+};
+
+describe('Keyboard Manager Tests', () => {
+  beforeEach(() => {
+    document.body.insertAdjacentHTML('afterbegin', html);
+  });
+
+  afterEach(() => {
+    cleanup([
+      '.row',
+      '#test-script'
+    ]);
+  });
+
+  it('Can be trigger a keys event', (done) => {
+    const spyEvent = spyOnEvent('body', 'keys');
+    $('body').on('keys', (e, a) => {
+      expect(a[0]).toBeTruthy('Ctrl');
+      done();
+    });
+    keyPress('Ctrl');
+    $('body').off('keys');
+
+    expect(spyEvent).toHaveBeenTriggered();
+  });
+
+  it('Can query pressedKeys', () => {
+    keyPress('Ctrl');
+
+    expect(keyboard.pressedKeys).toBeTruthy();
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adds a beforeSelect callback to datagrid so that you can veto row selection. The requirements listed needed to also know if CTRL or shift is pressed, so re-added the keyboard module to start up #643 , this had the functionality needed to see the pressed keys anytime. To let the events run through had to fix up the contextmenu function. Bonus: can now right click datagrid as long as no context menu functionality is attached for inspection.

**Related github/jira issue (required)**:
Fixes #1906 

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/example-beforeselect-veto.html
- Selecting rows is not possible.
- But if you hold down CTRL key or Command (on Mac) and click a row it will select.
- This mimics M3 functionality in a non invasive way

http://localhost:4000/utils/example-keyboard.html
- hold a key of any kind and it will show

- Everything is nicely covered by the new tests
- Retest Datagrid Context Menu
http://localhost:4000/components/datagrid/test-tree-contextmenu.html
http://localhost:4000/components/datagrid/test-contextmenu.html
http://localhost:4000/components/datagrid/test-contextmenu-dynamic.html
http://localhost:4000/components/datagrid/test-contextmenu-in-events.html (new test)

<!-- Please include the following in your PR:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
-->
