### PR TITLE
1985 - Fix where pager was not working while removing rows with datagrid

### DIFF
--- a/app/views/components/datagrid/example-paging.html
+++ b/app/views/components/datagrid/example-paging.html
@@ -43,7 +43,7 @@
         filterable: true,
         pagesize: 10,
         resultsText: function (grid, count, filterCount) {
-          console.log(grid, count, filterCount);
+          console.log('ResultsText:', grid, count, filterCount);
           if (filterCount > 0 ) {
             return '(' + filterCount + ' of '+ count + ')';
           }
@@ -77,12 +77,21 @@
           });
         },
         toolbar: {title: 'Data Grid Header Title',filterRow: true, personalize: true, results: true, dateFilter: false ,keywordFilter: true, advancedFilter: true, actions: true, views: true, rowHeight: true, collapsibleFilter: true}
-      }).on('selected', function (e, args) {
-        console.log(args);
+      })
+      .on('selected', function (e, args) {
+        console.log('Selected: ', args);
+      })
+      .on('rowremove', function (e, args) {
+        console.log('Removed:', args);
       });
 
       $('#datagrid-remove-btn').on('click', function() {
+        // Will trigger `rowremove` with every row removed for more then one selected rows
         $('#datagrid').data('datagrid').removeSelected();
+
+        // Will trigger `rowremove` one time only for more then one selected rows
+        // If passed the `boolean:true` to catch all the removed rows at once
+        // $('#datagrid').data('datagrid').removeSelected(true);
       });
 
   });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Datagrid]` Fixed an issue for xss where console.log was not sanitizing and make grid to not render. ([#1941](https://github.com/infor-design/enterprise/issues/1941))
 - `[Datagrid]` Fixed charts in columns not resizing correctly to short row height. ([#1930](https://github.com/infor-design/enterprise/issues/1930))
 - `[Datagrid]` Fixed an issue for xss where console.log was not sanitizing and make grid to not render. ([#1941](https://github.com/infor-design/enterprise/issues/1941))
+- `[Datagrid]` Fixed an issue where pager was not updating while removing rows. ([#1985](https://github.com/infor-design/enterprise/issues/1985))
 - `[Datagrid]` Adds a function to add a visual dirty indictaor and a new function to get all modified rows. Modified means either dirty, in-progress or in error. Existing API's are not touched. ([#2091](https://github.com/infor-design/enterprise/issues/2091))
 - `[Editor]` Fixed an issue where button state for toolbar buttons were wrong when clicked one after another. ([#391](https://github.com/infor-design/enterprise/issues/391))
 - `[Listview]` Improved accessibility when configured as selectable (all types), as well as re-enabled accessibility e2e tests. ([#403](https://github.com/infor-design/enterprise/issues/403))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -564,40 +564,56 @@ Datagrid.prototype = {
   * Remove a row of data to the grid and dataset.
   * @param {number} row The row index
   * @param {boolean} nosync Dont sync the selected rows.
+  * @param {boolean} noTrigger Dont if true.
+  * @returns {object|boolean} if noTrigger given as true, will return trigger data args
   */
-  removeRow(row, nosync) {
+  removeRow(row, nosync, noTrigger) {
     const rowNode = this.tableBody.find(`tr[aria-rowindex="${row + 1}"]`);
     const rowData = this.settings.dataset[row];
 
     this.unselectRow(row, nosync);
     this.settings.dataset.splice(row, 1);
+    this.preventSelection = true;
     this.renderRows();
+    delete this.preventSelection;
 
-    /**
-    *  Fires after a row is removed via the api
-    * @event rowremove
-    * @memberof Datagrid
-    * @property {object} event The jquery event object
-    * @property {object} args Object with the arguments
-    * @property {number} args.row The row index
-    * @property {number} args.cell The cell index
-    * @property {HTMLElement} args.target The row node that is being dragged.
-    * @property {HTMLElement} args.item The dragged rows data.
-    */
-    this.element.trigger('rowremove', { row, cell: null, target: rowNode, item: rowData, oldValue: rowData });
+    const args = { row, cell: null, target: rowNode, item: rowData, oldValue: rowData };
+
+    if (!noTrigger) {
+      /**
+      *  Fires after a row is removed via the api
+      * @event rowremove
+      * @memberof Datagrid
+      * @property {object} event The jquery event object
+      * @property {object} args Object with the arguments
+      * @property {number} args.row The row index
+      * @property {number} args.cell The cell index
+      * @property {HTMLElement} args.target The row node that is being dragged.
+      * @property {HTMLElement} args.item The dragged rows data.
+      */
+      this.element.trigger('rowremove', args);
+    } else {
+      return args;
+    }
+
+    return true;
   },
 
   /**
   * Remove all selected rows from the grid and dataset.
+  * @param {boolean} isTrigger if true will trigger `rowremove` one time only with all selection data for more then one selected.
   */
-  removeSelected() {
+  removeSelected(isTrigger) {
     this._selectedRows.sort((a, b) => (a.idx < b.idx ? -1 : (a.idx > b.idx ? 1 : 0)));
+    const args = [];
 
     for (let i = this._selectedRows.length - 1; i >= 0; i--) {
-      this.removeRow(this._selectedRows[i].idx, true);
+      args.push(this.removeRow(this._selectedRows[i].idx, true, isTrigger));
     }
-    this.pagerRefresh();
-    this.syncSelectedUI();
+
+    if (isTrigger) {
+      this.element.trigger('rowremove', [args]);
+    }
   },
 
   /**
@@ -3160,7 +3176,9 @@ Datagrid.prototype = {
 
     // Deselect rows when changing pages
     if (self.settings.paging && self.settings.source && !self.settings.allowSelectAcrossPages) {
-      self._selectedRows = [];
+      if (!self.preventSelection) {
+        self._selectedRows = [];
+      }
       self.syncSelectedUI();
     }
 
@@ -6991,7 +7009,6 @@ Datagrid.prototype = {
     const unselectNode = function (elem, index) {
       const removeSelected = function (node, selIdx) {
         delete node._selected;
-        self.selectedRowCount--;
         if (typeof selIdx === 'undefined') {
           selIdx = index;
         }

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -565,7 +565,7 @@ Datagrid.prototype = {
   * @param {number} row The row index
   * @param {boolean} nosync Dont sync the selected rows.
   * @param {boolean} noTrigger If true, do not trigger the removerow event.
-  * @returns {object|boolean} if noTrigger given as true, will return trigger data args
+  * @returns {object|boolean} If noTrigger is true then return the event args otherwise nothing is returned
   */
   removeRow(row, nosync, noTrigger) {
     const rowNode = this.tableBody.find(`tr[aria-rowindex="${row + 1}"]`);

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -564,7 +564,7 @@ Datagrid.prototype = {
   * Remove a row of data to the grid and dataset.
   * @param {number} row The row index
   * @param {boolean} nosync Dont sync the selected rows.
-  * @param {boolean} noTrigger Dont if true.
+  * @param {boolean} noTrigger If true, do not trigger the removerow event.
   * @returns {object|boolean} if noTrigger given as true, will return trigger data args
   */
   removeRow(row, nosync, noTrigger) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed pager was not working while removing rows with datagrid. After removing 1 Row in 1000 data, the page was became 1 of 1.

**Related github/jira issue (required)**:
Closes #1985

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp
- Navigate to http://localhost:4000/components/datagrid/example-paging.html
- See bottom of grid pager should have 1 of 100
- Select any row
- Contextual toolbar with button "Remove" should show up
- Click on button "Remove"
- See the pager should be updated
- If page get refresh or any other call to load data like filter, next/prev page or records per page change
- Then removed rows will render back because this example use server side data, so after removing it will not save data.


- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.