### PR TITLE
2153 - Update swedish translation for set time with timepicker

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -54,6 +54,7 @@
 - `[Personalization]` Added several form examples with buttons and completion chart that can be personalized. ([#1963](https://github.com/infor-design/enterprise/issues/1963))
 - `[Personalization]` Added an example of normal tabs behaving like header tabs in a personalized area. ([#1962](https://github.com/infor-design/enterprise/issues/1962))
 - `[Popupmenu]` Fixed an issue where disabled submenus were opening on mouseover. ([#1863](https://github.com/infor-design/enterprise/issues/1863))
+- `[Timepicker]` Updated the Swedish translation for Set Time. ([#2153](https://github.com/infor-design/enterprise/issues/2153))
 - `[Tree]` Fixed an issue where children property null was breaking tree to not render. ([#1908](https://github.com/infor-design/enterprise/issues/1908))
 
 ### v4.19.0 Chores & Maintenance

--- a/docs/TRANSLATIONS.md
+++ b/docs/TRANSLATIONS.md
@@ -27,6 +27,7 @@ When you get the file back.
 - zh-TW and  zh-Hant are copies of each other so copy zh-TW to both and change the names
 - zh-CN and  zh-Hans are copies of each other so copy zh-TW to both and change the names
 - all the en- ones and es- ones are copies
+- sv-SE ensure value for `SetTime` it updated from `Klockslag` to `Sätt tid` ([#2153](https://github.com/infor-design/enterprise/issues/2153))
 
 To add a new translation string and use it in the code add it in the en-US.js
 

--- a/src/components/locale/cultures/sv-SE.js
+++ b/src/components/locale/cultures/sv-SE.js
@@ -312,7 +312,7 @@ Soho.Locale.addCulture('sv-SE', {
     Selected: { id: 'Selected', value: 'Markerat', comment: 'text describing a selected object' },
     SelectAll: { id: 'SelectAll', value: 'Markera alla', comment: 'describes the action of selecting all items available in a list' },
     Send: { id: 'Send', value: 'Skicka', comment: 'Send tooltip' },
-    SetTime: { id: 'SetTime', value: 'Klockslag', comment: 'button text that inserts time when clicked' },
+    SetTime: { id: 'SetTime', value: 'Sätt tid', comment: 'button text that inserts time when clicked' },
     Settings: { id: 'Settings', value: 'Inställningar', comment: 'Settings tooltip' },
     Short: { id: 'Short', value: 'Kort', comment: 'Describes a Shorted Row Height in a grid/list' },
     ShowFilterRow: { id: 'ShowFilterRow', value: 'Visa filterrad', comment: 'Toggle a row with filer info above a list' },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Updated Swedish translation for `set Time` with Timepicker.

**Related github/jira issue (required)**:
Closes #2153

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp
- Navigate to http://localhost:4000/components/timepicker/example-index.html?locale=sv-SE
- Click clock icon to open time picker popup
- See the button text should be `Sätt tid`
