### PR TITLE
Add ES6 browser code compatibility linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,8 @@ module.exports = {
   },
   'plugins': [
     'jasmine',
-    'jasmine-jquery'
+    'jasmine-jquery',
+    'compat'
   ],
   'env': {
     'browser': true,
@@ -30,6 +31,9 @@ module.exports = {
     'protractor': true
   },
   'rules': {
+    // Browser compatibility
+    "compat/compat": "error",
+
     // require function expressions to have a name
     // https://eslint.org/docs/rules/func-names
     'func-names': 'off',

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "documentation": "^5.3.5",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",
+    "eslint-plugin-compat": "^3.1.1",
     "eslint-plugin-import": "^2.17.1",
     "eslint-plugin-jasmine": "^2.10.1",
     "eslint-plugin-jasmine-jquery": "^1.0.0",
@@ -147,5 +148,9 @@
     "uglify-es": "^3.3.10",
     "webpack": "^4.30.0",
     "yargs": "^11.0.0"
-  }
+  },
+  "browserslist": [
+    "last 2 versions",
+    "not ie 10"
+  ]
 }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1017,8 +1017,8 @@ utils.hasClass = function hasClass(elem, classStr) {
  * @returns {number} A number representing the sign of the given argument. If the argument is a positive number, negative number, positive zero or negative zero, the function will return 1, -1, 0 or -0 respectively. Otherwise, NaN is returned.
  */
 math.sign = function (x) {
-  if (Math.sign) {
-    return Math.sign(x);
+  if (Math.sign) { // eslint-disable-line compat/compat
+    return Math.sign(x); // eslint-disable-line compat/compat
   }
 
   x = +x;

--- a/test/components/bar/bar-api.func-spec.js
+++ b/test/components/bar/bar-api.func-spec.js
@@ -142,7 +142,7 @@ describe('Bar API', () => { //eslint-disable-line
 
   it('Should be able to hide legend', (done) => {
     barObj.destroy();
-    const newSettings = Object.assign({ showLegend: true, dataset: twoSeriesData }, settings);
+    const newSettings = Object.assign({ showLegend: true, dataset: twoSeriesData }, settings); // eslint-disable-line
     newSettings.dataset = twoSeriesData;
     barObj = new Bar(barEl, newSettings);
 

--- a/test/components/searchfield/searchfield-categories.func-spec.js
+++ b/test/components/searchfield/searchfield-categories.func-spec.js
@@ -48,7 +48,7 @@ describe('Searchfield API (full categories)', () => {
     searchfieldMultiAPI.destroy();
 
     svgEl.parentNode.removeChild(svgEl);
-    Array.from(rowEls).forEach((row) => {
+    Array.from(rowEls).forEach((row) => { // eslint-disable-line compat/compat
       row.parentNode.removeChild(row);
     });
   });

--- a/test/helpers/func-utils.js
+++ b/test/helpers/func-utils.js
@@ -19,7 +19,7 @@ function cleanup(item) {
   }
 
   // Handle a single CSS selector
-  const els = Array.from(document.querySelectorAll(item));
+  const els = Array.from(document.querySelectorAll(item)); // eslint-disable-line compat/compat
   if (els && els.length) {
     els.forEach((el) => {
       el.parentNode.removeChild(el);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Add a plugin to `eslint` to check for browser compatible code (using `browerslist` requirements).

**Related github/jira issue (required)**:
n/a

**Steps necessary to review your pull request (required)**:
1. Watch the tests and make sure `estlint` succeeds
2. If you want you can run `npm run eslint` on your own.

---

🔧  An e2e or functional test for the bug or feature.
🚫  A note to the change log.