### PR TITLE
1963 - Fixes some personalize examples to work in IE 11

### DIFF
--- a/app/views/components/personalize/example-classes.html
+++ b/app/views/components/personalize/example-classes.html
@@ -68,8 +68,9 @@
 
 <script>
   $('body').on('initialized', function () {
-    if ($('.personalize-header').css('background-color') === 'rgba(0, 0, 0, 0)') {
-      // None set
+    var bgColor = $('.personalize-header').css('background-color');
+    if (bgColor === 'rgba(0, 0, 0, 0)' || bgColor === 'transparent') {
+    // None set
       $('html').personalize({ colors: { header: '2578A9' } });
 
      // Intercept the Default Item as it cant work here 100%

--- a/app/views/components/personalize/example-form.html
+++ b/app/views/components/personalize/example-form.html
@@ -166,8 +166,9 @@
 
 <script>
   $('body').on('initialized', function () {
-    if ($('.personalize-header').css('background-color') === 'rgba(0, 0, 0, 0)') {
-      // None set
+    var bgColor = $('.personalize-header').css('background-color');
+    if (bgColor === 'rgba(0, 0, 0, 0)' || bgColor === 'transparent') {
+    // None set
       $('html').personalize({ colors: { header: '2578A9' } });
 
       // Intercept the Default Item as it cant work here 100%

--- a/app/views/components/personalize/example-form2.html
+++ b/app/views/components/personalize/example-form2.html
@@ -206,7 +206,8 @@
 
 <script>
   $('body').on('initialized', function () {
-    if ($('.personalize-header').css('background-color') === 'rgba(0, 0, 0, 0)') {
+    var bgColor = $('.personalize-header').css('background-color');
+    if (bgColor === 'rgba(0, 0, 0, 0)' || bgColor === 'transparent') {
       // None set
       $('html').personalize({ colors: { header: '2578A9' } });
 

--- a/app/views/components/personalize/example-tabs.html
+++ b/app/views/components/personalize/example-tabs.html
@@ -48,8 +48,9 @@
 
 <script>
   $('body').on('initialized', function () {
-    if ($('.personalize-header').css('background-color') === 'rgba(0, 0, 0, 0)') {
-      // None set
+    var bgColor = $('.personalize-header').css('background-color');
+    if (bgColor === 'rgba(0, 0, 0, 0)' || bgColor === 'transparent') {
+    // None set
       $('html').personalize({ colors: { header: '2578A9' } });
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

IE 11 shows a check as transparent and not RGBA so the example didnt work in IE11.
This fixes that.

**Related github/jira issue (required)**:
Fixes #1963 for IE

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/personalize/example-form2.html
http://localhost:4000/components/personalize/example-form.html
- load these in IE and the blue color will show initially
