### PR TITLE
2107 - Fixes spinbox tolerance on long press

### DIFF
--- a/src/components/spinbox/spinbox.js
+++ b/src/components/spinbox/spinbox.js
@@ -278,7 +278,7 @@ Spinbox.prototype = {
       if ($(e.currentTarget).is(':hover')) {
         self.handleClick(e);
       }
-    }, 140);
+    }, 300);
   },
 
   /**
@@ -552,6 +552,7 @@ Spinbox.prototype = {
 
     val = this.checkForNumeric(val);
     this.element[0].setAttribute('aria-valuenow', val || '0');
+    this.element[0].setAttribute('autocomplete', 'off');
 
     // Toggle min/max buttons
     this.setIsDisabled(this.buttons.up, (val !== '' && max && val >= max) ? 'disable' : 'enable');

--- a/src/components/spinbox/spinbox.js
+++ b/src/components/spinbox/spinbox.js
@@ -278,7 +278,7 @@ Spinbox.prototype = {
       if ($(e.currentTarget).is(':hover')) {
         self.handleClick(e);
       }
-    }, 300);
+    }, 250);
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

QA failed #2017 on edge as it appeared like it was inserting twice on click. This is really just the long press but it seems a little more sensitive on edge. Also added autocomplete off as saw the browser autocomplete popping up on testing.

**Related github/jira issue (required)**:
Fixes #2107

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/field-options/example-index.html
or
http://localhost:4000/components/spinbox/example-index.html

- click once on + and - and it should add or subtract one
- press down on either button and it should more slowly count up and down
- try on edge 