### PR TITLE
1862 - Fix Clearable Input/Field Options alignment

### DIFF
--- a/src/components/field-options/_field-options.scss
+++ b/src/components/field-options/_field-options.scss
@@ -270,6 +270,17 @@
     }
   }
 
+  // Clearable Inputs that are not Searchfields
+  [data-clearable='true'] {
+    ~ .btn-actions {
+      left: -5px;
+    }
+
+    ~ .icon.close.is-empty ~ .btn-actions {
+      left: -10px;
+    }
+  }
+
   &.is-disabled {
     .btn-actions:not(.is-checkbox) {
       display: none;
@@ -684,20 +695,6 @@ html[dir='rtl'] {
         right: -8px;
       }
     }
-
-    &[data-clearable='true'] {
-      ~ .btn-actions {
-        left: auto;
-        right: 27px;
-      }
-
-      ~ .is-empty {
-        ~ .btn-actions {
-          left: auto;
-          right: -11px;
-        }
-      }
-    }
   }
 
   .is-fieldoptions {
@@ -726,6 +723,24 @@ html[dir='rtl'] {
     .lookup {
       ~ .btn-actions {
         right: -8px;
+      }
+    }
+
+    // Clearable Inputs that are not Searchfields
+    [data-clearable='true'] {
+      ~ .btn-actions {
+        left: auto;
+        right: 24px;
+      }
+
+      ~ .icon.close.is-empty ~ .btn-actions {
+        right: -11px;
+      }
+    }
+
+    .searchfield-wrapper {
+      .btn-actions {
+        top: -1px;
       }
     }
   }

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -355,6 +355,11 @@ $cubic-bezier-ease: cubic-bezier(0.17, 0.04, 0.03, 0.94);
 // RTL Styles
 html[dir='rtl'] {
   .searchfield-wrapper {
+    .searchfield {
+      padding-left: 10px;
+      padding-right: 34px;
+    }
+
     > .icon {
       &:not(.close) {
         left: auto;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR changes CSS values that affect the placement of the field options button when attached to input fields with a clearable (X) button attached.  Previously the button was appearing inside the input field. 

This was reported as an additional Q/A issue [here](https://github.com/infor-design/enterprise/issues/1862#issuecomment-494337434).

**Related github/jira issue (required)**:
Closes #1862 

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp
- Navigate to http://localhost:4000/components/field-options/example-index  
- Find the input field labeled "Clearable Input" and ensure that the Field Options button is properly aligned with/without text inside.
