### PR TITLE
2205 - Fix multiple hierarchy instance interference

### DIFF
--- a/app/views/components/hierarchy/test-multiple-charts.html
+++ b/app/views/components/hierarchy/test-multiple-charts.html
@@ -1,0 +1,95 @@
+<div class="row">
+  <div class="six columns">
+    <h2>Multiple Hierarchy Charts in Tab Control</h2>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+
+    <div id="tabs-normal" class="tab-container">
+      <ul class="tab-list">
+        <li class="tab is-selected"><a href="#tabs-one">ONE</a></li>
+        <li class="tab"><a href="#tabs-two">TWO</a></li>
+      </ul>
+    </div>
+    <div class="tab-panel-container">
+      <div id="tabs-one" class="tab-panel">
+        <figure class="hierarchy" id="hierarchy"></figure>
+
+        <script>
+          const optionsOne = {
+            templateId: 'hierarchyChartTemplate',
+            dataset: [],
+            layout: 'stacked'
+          };
+
+          // Initial load
+          $.getJSON('{{basepath}}api/hc-john-randolph', function(data) {
+            optionsOne.dataset = [data];
+            $('#hierarchy').hierarchy(optionsOne);
+          });
+
+          $('#hierarchy').on('selected', function(event, eventInfo) {
+            const hierarchyControl = $('#hierarchy').data('hierarchy');
+            console.log(event, eventInfo);
+
+            if (eventInfo.data.childrenUrl) {
+              $.getJSON(`{{basepath}}api/${eventInfo.data.childrenUrl}`, function(newData) {
+                reload(eventInfo, hierarchyControl, newData);
+              });
+            }
+          });
+
+          function reload(eventInfo, hierarchyControl, newData) {
+            eventInfo.data.children = newData;
+            optionsOne.dataset = [eventInfo.data.children];
+            hierarchyControl.reload(optionsOne);
+          }
+        </script>
+      </div>
+      <div id="tabs-two" class="tab-panel">
+        <figure class="hierarchy" id="hierarchyTwo"></figure>
+
+        <script>
+          const optionsTwo = {
+            templateId: 'hierarchyChartTemplate',
+            dataset: [],
+            layout: 'stacked'
+          };
+
+          // Initial load
+          $.getJSON('{{basepath}}api/hc-john-randolph', function(data) {
+            optionsTwo.dataset = [data];
+            $('#hierarchyTwo').hierarchy(optionsTwo);
+          });
+
+          $('#hierarchyTwo').on('selected', function(event, eventInfo) {
+            const hierarchyControl = $('#hierarchyTwo').data('hierarchy');
+            console.log(event, eventInfo);
+
+            if (eventInfo.data.childrenUrl) {
+              $.getJSON(`{{basepath}}api/${eventInfo.data.childrenUrl}`, function(newData) {
+                reload(eventInfo, hierarchyControl, newData);
+              });
+            }
+          });
+
+          function reload(eventInfo, hierarchyControl, newData) {
+            eventInfo.data.children = newData;
+            optionsTwo.dataset = [eventInfo.data.children];
+            hierarchyControl.reload(optionsTwo);
+          }
+        </script>
+      </div>
+  </div>
+</div>
+
+{{={{{ }}}=}}
+<script type="text/html" id="hierarchyChartTemplate">
+  <div class="leaf" id="{{id}}">
+    <div class="detail">
+      <p class="heading">{{id}}</p>
+    </div>
+  </div>
+</script>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fix for issue https://github.com/infor-design/enterprise/issues/2205. Fixes scoping issues which are preventing multiple hierarchy charts from loading properly on the same page.

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise/issues/2205

**Steps necessary to review your pull request (required)**:
1. Go to http://localhost:4000/components/hierarchy/test-multiple-charts.html
2. Click on tab two.
3. Both charts should load the same

<!-- Please include the following in your PR:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.
-->

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
