### PR TITLE
2091 - Fixes some QA issues on the external dirty examples

### DIFF
--- a/app/views/components/datagrid/test-dirty-change-cell-externally.html
+++ b/app/views/components/datagrid/test-dirty-change-cell-externally.html
@@ -112,8 +112,8 @@
       // Need two things
       // 1. dirtyRows should also include rows that are in error or in-progress ... like it did in 3.5 getDirtyRows
       // 2. method to setDirtyCell to visually show cell has been updated
-      var modifiedRows = gridApi.getModifiedRows();
-      gridApi.setDirtyIndicator(0, gridApi.columnIdxById('quantity'), true);
+      const data = { originalVal: 1, value: 50, isDirty: true };
+      gridApi.setDirtyIndicator(0, gridApi.columnIdxById('quantity'), true, data);
       console.log(modifiedRows);
     });
 
@@ -123,6 +123,7 @@
   // A few other ways
   $('#clear').on('click', function (e, args) {
     gridApi.clearAllErrors();
+    gridApi.clearDirty();
   });
 
 </script>

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1295,7 +1295,7 @@ Datagrid.prototype = {
       this.applyFilter(this.savedFilter, 'render');
       this.savedFilter = null;
     } else if (this.filterExpr && this.filterExpr.length > 0) {
-      this.setFilterConditions(this.filterExpr); 
+      this.setFilterConditions(this.filterExpr);
     }
 
     this.activeEllipsisHeaderAll();
@@ -1860,10 +1860,10 @@ Datagrid.prototype = {
     if (this.filterExpr === undefined) {
       this.filterExpr = [];
     }
-    
+
     if (JSON.stringify(conditions) !== JSON.stringify(this.filterExpr)) {
       this.filterExpr = conditions;
-      filterChanged = true;  
+      filterChanged = true;
     }
 
     const checkRow = function (rowData) {
@@ -2162,7 +2162,7 @@ Datagrid.prototype = {
         type: 'filtered'
       });
     }
-    
+
     if (this.restoreFilterClientSide) {
       this.restoreFilterClientSide = false;
     } else {
@@ -2271,7 +2271,7 @@ Datagrid.prototype = {
     this.applyFilter();
     this.element.trigger('filtered', { op: 'clear', conditions: [] });
   },
-  
+
   /**
   * Clear the Filter fields.
   */
@@ -4094,7 +4094,7 @@ Datagrid.prototype = {
         }
         this.isInModal = true;
       }
-      
+
       this.widthSpecified = false;
       this.widthPixel = false;
     }
@@ -4228,7 +4228,7 @@ Datagrid.prototype = {
         const stretchColumn = $.grep(this.headerWidths, e => e.id === this.settings.stretchColumn);
         if ((diff2 > 0) && !stretchColumn[0].widthPercent) {
           stretchColumn[0].width += diff2 - 2;
-        }  
+        }
         this.totalWidths[container] = this.isInModal ? this.elemWidth : '100%';
       }
 
@@ -4239,7 +4239,7 @@ Datagrid.prototype = {
       } else {
         this.table.css('width', '');
       }
-      
+
       if (!isNaN(this.totalMinWidths.center) && this.totalMinWidths.center > 0) {
         this.table.css('min-width', `${this.totalMinWidths.center}px`);
       }
@@ -4525,7 +4525,7 @@ Datagrid.prototype = {
           (JSON.stringify(this.settings.columnGroups) === JSON.stringify(columnGroups))) {
       columnsChanged = false;
     }
-      
+
     this.settings.columns = columns;
 
     if (columnGroups) {
@@ -4536,7 +4536,7 @@ Datagrid.prototype = {
       this.rerender();
       this.resetPager('updatecolumns');
     }
-    
+
     /**
     * Fires after the entire grid is rendered.
     * @event columnchange
@@ -6213,7 +6213,7 @@ Datagrid.prototype = {
     if (this.virtualRange && this.virtualRange.rowHeight) {
       this.virtualRange.rowHeight = (height === 'normal' ? 40 : (height === 'medium' ? 30 : 25));
     }
-    
+
     this.saveUserSettings();
     this.refreshSelectedRowHeight();
 
@@ -6279,7 +6279,7 @@ Datagrid.prototype = {
       }
       return obj;
     }
-    
+
     if (this.filterExpr && this.filterExpr.length === 1) {
       if (this.filterExpr[0].value !== '') {
         pagingInfo.activePage = this.pagerAPI.filteredActivePage || 1;
@@ -9034,9 +9034,14 @@ Datagrid.prototype = {
    * @param {number} row The row index
    * @param {number} cell The cell index
    * @param {boolean} toggle True to set it and false to remove it
+   * @param {object} data Adds dirty data to the internal tracker
    */
-  setDirtyIndicator(row, cell, toggle) {
+  setDirtyIndicator(row, cell, toggle, data) {
     const cellNode = this.cellNode(row, cell);
+
+    if (data) {
+      this.addToDirtyArray(row, cell, data);
+    }
 
     if (row < 0 || cell < 0) {
       return;
@@ -9731,7 +9736,7 @@ Datagrid.prototype = {
       if (wasFocused && this.activeCell.node.length === 1) {
         this.setActiveCell(this.activeCell.row, this.activeCell.cell);
       }
-    
+
       this.resetPager('sorted');
     }
     this.tableBody.removeClass('is-loading');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Based on QA comments, made an option to save the indicator across page. Also fixes some line endings. @davidcarlsonberg To address these comments https://github.com/infor-design/enterprise/pull/2194#pullrequestreview-240072985

1. I made the cells also clear
2. But the ! line means in progress it doesnt get added to all lines, it was just part of the example for the first line

**Related github/jira issue (required)**:
Fixes #2091

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-dirty-change-cell-externally.html
- press change cell
- also edit a cell on row 2 for example quantity
- go to page two
- go back to page one
- should now show both as dirty still on page one