### PR TITLE
2240 - Fix the markup to allow proper tab/arrow keying [4.19.x]

### DIFF
--- a/app/views/includes/applicationmenu-personalized-role-switcher.html
+++ b/app/views/includes/applicationmenu-personalized-role-switcher.html
@@ -116,19 +116,19 @@
             </svg>
             <span>Settings</span>
           </button>
-          <button class="btn-icon l-pull-right" type="button" title="Log Out">
+          <button class="btn-icon" type="button" title="Proxy as user">
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-              <use xlink:href="#icon-logout"></use>
+              <use xlink:href="#icon-employee-directory"></use>
             </svg>
           </button>
-          <button class="btn-icon l-pull-right" type="button" title="About this App">
+          <button class="btn-icon" type="button" title="About this App">
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
               <use xlink:href="#icon-info"></use>
             </svg>
           </button>
-          <button class="btn-icon l-pull-right" type="button" title="Proxy as user">
+          <button class="btn-icon" type="button" title="Log Out">
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-              <use xlink:href="#icon-employee-directory"></use>
+              <use xlink:href="#icon-logout"></use>
             </svg>
           </button>
         </div>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The button html was backwards due to the usage of the `float` class and therefore the arrow key movement was reversed.

**Related github/jira issue (required)**:
Fixes #2240  

**Steps necessary to review your pull request (required)**:
1. `npm start`
1. Go to http://localhost:4000/components/applicationmenu/example-personalized-role-switcher.html
1. Click on "Find a Coworker"
1. Tab down to the settings
1. Arrow left and right
    - Verify that the focus is on the icons in order of left-to-right


---
🚫  An e2e or functional test for the bug or feature.
🚫  A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
