### PR TITLE
2228 - Fix sort indicator was not showing after paging with datagrid [v4.19.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,6 +49,7 @@
 - `[Datagrid]` Fixed an issue for xss where console.log was not sanitizing and make grid to not render. ([#1941](https://github.com/infor-design/enterprise/issues/1941))
 - `[Input]` Improved alignment of icons in the uplift theme input components. ([#2072](https://github.com/infor-design/enterprise/issues/2072))
 - `[Datagrid]` Added an onBeforeSelect call back that you can return false from to disable row selection. ([#1906](https://github.com/infor-design/enterprise/issues/1906))
+- `[Datagrid]` Fixed an issue where sort indicator was not showing after paging. ([#2228](https://github.com/infor-design/enterprise/issues/2228))
 - `[Listview]` Improved accessibility when configured as selectable (all types), as well as re-enabled accessibility e2e tests. ([#403](https://github.com/infor-design/enterprise/issues/403))
 - `[Locale]` Synced up date and time patterns with the CLDR several time patterns in particular were corrected. ([#2022](https://github.com/infor-design/enterprise/issues/2022))
 - `[Datagrid]` Fixed an issue where pager was not updating while removing rows. ([#1985](https://github.com/infor-design/enterprise/issues/1985))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1288,6 +1288,8 @@ Datagrid.prototype = {
     if (this.restoreSortOrder) {
       this.setSortIndicator(this.sortColumn.sortId, this.sortColumn.sortAsc);
       this.restoreSortOrder = false;
+    } else if ((this.sortColumn && this.sortColumn.sortId)) {
+      this.setSortIndicator(this.sortColumn.sortId, this.sortColumn.sortAsc);
     }
 
     if (this.restoreFilter) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed sort indicator was not showing after paging with datagrid.

**Related github/jira issue (required)**:
Closes #2228

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp
- Navigate to http://localhost:4000/components/datagrid/example-paging-client-side.html
- Click Id column header to sort
- Click the Next Page button, then Click Previous Page
- See sorting arrow icon should stay even after changing grid page

- [x] A note to the change log.
