### PR TITLE
2228 - Fix an issue with the sort indicator being missing [v4.19.x]

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -805,10 +805,10 @@ Datagrid.prototype = {
       this.restoreUserSettings();
       this.renderRows();
       this.renderHeader();
-    } else if (pagerInfo.type === 'filtered') {
-      this.renderRows();
     } else {
-      this.rerender();
+      this.clearHeaderCache();
+      this.renderRows();
+      this.syncColGroups();
     }
 
     // Setup focus on the first cell
@@ -1286,10 +1286,8 @@ Datagrid.prototype = {
       self.createDraggableColumns();
     }
 
-    if (this.restoreSortOrder) {
-      this.setSortIndicator(this.sortColumn.sortId, this.sortColumn.sortAsc);
-      this.restoreSortOrder = false;
-    }
+    this.restoreSortOrder = false;
+    this.setSortIndicator(this.sortColumn.sortId, this.sortColumn.sortAsc);
 
     if (this.restoreFilter) {
       this.restoreFilter = false;
@@ -1300,6 +1298,23 @@ Datagrid.prototype = {
     }
 
     this.activeEllipsisHeaderAll();
+  },
+
+  /**
+   * Sync the colgroups and widths between the body and the header.
+   * @private
+   */
+  syncColGroups() {
+    if (this.bodyColGroup) {
+      this.headerColGroup.children().remove();
+      this.bodyColGroup.children().clone().appendTo(this.headerColGroup);
+    }
+    if (this.table && this.headerTable && this.table.css('min-width')) {
+      this.headerTable.css('min-width', this.table.css('min-width'));
+    }
+    if (this.table && this.headerTable && this.table.css('width')) {
+      this.headerTable.css('width', this.table.css('width'));
+    }
   },
 
   /**

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -699,6 +699,21 @@ describe('Datagrid paging tests', () => {
     expect(await element(by.css('tbody tr:nth-child(10) td:nth-child(2) span')).getText()).toEqual('49');
   });
 
+  it('Should work with sort', async () => {
+    expect(await element(by.css('#datagrid .datagrid-header th:nth-child(2).is-sorted-desc')).isPresent()).toBeFalsy();
+
+    await element(by.css('#datagrid .datagrid-header th:nth-child(2)')).click();
+    await element(by.css('#datagrid .datagrid-header th:nth-child(2)')).click();
+
+    expect(await element(by.css('#datagrid .datagrid-header th:nth-child(2).is-sorted-desc')).isPresent()).toBeTruthy();
+
+    await element(by.css('.pager-next a')).click();
+    await element(by.css('.pager-prev a')).click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('#datagrid .datagrid-header th:nth-child(2).is-sorted-desc')).isPresent()).toBeTruthy();
+  });
+
   if (!utils.isCI()) {
     it('Should not move on a page that is more than the max', async () => {
       expect(await element(by.css('tbody tr:nth-child(1) td:nth-child(2) span')).getText()).toEqual('0');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Re-adds the fix from https://github.com/infor-design/enterprise/pull/2243 to the correct branch.

**Related github/jira issue (required)**:
Fixes #2228 

**Steps necessary to review your pull request (required)**:
- Navigate to http://localhost:4000/components/datagrid/example-paging-client-side.html
- Click Id column header to sort
- Click the Next Page button, then Click Previous Page
- See sorting arrow icon should stay even after changing grid page

ColGroup Test.
- Navigate to http://localhost:4000/components/datagrid/test-paging-select-indeterminate-single.html
- Click the Next Page button
