### PR TITLE
2249 - Contextual Action Panel title too close to edge at mobile [v4.19.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@
 - `[Colorpicker]` Fixed an issue where the colorpickers are not responsive at mobile screen sizes. ([#1995](https://github.com/infor-design/enterprise/issues/1995))
 - `[Colorpicker]` Fixed an issue where the text is not visible on IE11 after choosing a color. ([#2134](https://github.com/infor-design/enterprise/issues/2134))
 - `[Context Menu]` Fixes a bug where a left click on the originating field would not close a context menu opened with a right click. ([#1992](https://github.com/infor-design/enterprise/issues/1992))
+- `[Contextual Action Panel]` Fixed an issue where the CAP title is too close to the edge at small screen sizes. ([#2249](https://github.com/infor-design/enterprise/issues/2249))
 - `[Completion Chart]` Cleaned up excessive padding in some cases. ([#2171](https://github.com/infor-design/enterprise/issues/2171))
 - `[Datagrid]` Fixed an issue where using the context menu with datagrid was not properly destroyed which being created multiple times. ([#392](https://github.com/infor-design/enterprise-ng/issues/392))
 - `[Datagrid]` Fixed charts in columns not resizing correctly to short row height. ([#1930](https://github.com/infor-design/enterprise/issues/1930))

--- a/src/components/contextualactionpanel/_contextualactionpanel.scss
+++ b/src/components/contextualactionpanel/_contextualactionpanel.scss
@@ -134,7 +134,6 @@ html[dir='rtl'] {
       margin-bottom: 0;
 
       .title {
-        margin-left: 0;
         margin-right: 15px;
       }
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Contextual Action Panel title is too close to the left side at phone screen size.

**Related github/jira issue (required)**:
Closes #2249.

**Steps necessary to review your pull request (required)**:
- Pull branch, run app
- Visit http://localhost:4000/components/contextualactionpanel/example-index.html
- Ensure at small screen sizes (under phone) the CAP title is not too close to the edge.

~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.