### PR TITLE
2234 - Fix custom filter conditions for filter button popup with datagrid [v4.19.x]

### DIFF
--- a/app/views/components/datagrid/test-filter-lookup-click-function.html
+++ b/app/views/components/datagrid/test-filter-lookup-click-function.html
@@ -14,7 +14,6 @@
 
     var numericFilterConditions= [ 'equals', 'does-not-equal', 'is-empty', 'is-not-empty', 'less-than', 'less-equals', 'greater-than', 'greater-equals' ];
 
-
     // Define Some Sample Data
     data.push({ id: 1, productId: undefined, productName: 'Compressor', inStock: true, activity:  'Assemble Paint', quantity: 1, price: 410.99, orderDate: new Date(2014, 12, 8), action: 'Action', status: 'Error'});
     data.push({ id: 2, productId: 2241202, productName: '1 Different Compressor', inStock: true, activity:  'Inspect and Repair', quantity: 2, price: 310.99, orderDate: new Date(2015, 7, 3), action: 'On Hold', status: 'Error'});

--- a/app/views/components/datagrid/test-filter-lookup-click-function.html
+++ b/app/views/components/datagrid/test-filter-lookup-click-function.html
@@ -12,6 +12,9 @@
       columns = [],
       data = [];
 
+    var numericFilterConditions= [ 'equals', 'does-not-equal', 'is-empty', 'is-not-empty', 'less-than', 'less-equals', 'greater-than', 'greater-equals' ];
+
+
     // Define Some Sample Data
     data.push({ id: 1, productId: undefined, productName: 'Compressor', inStock: true, activity:  'Assemble Paint', quantity: 1, price: 410.99, orderDate: new Date(2014, 12, 8), action: 'Action', status: 'Error'});
     data.push({ id: 2, productId: 2241202, productName: '1 Different Compressor', inStock: true, activity:  'Inspect and Repair', quantity: 2, price: 310.99, orderDate: new Date(2015, 7, 3), action: 'On Hold', status: 'Error'});
@@ -61,7 +64,7 @@
 
     // Define Columns for the Grid.
     columns.push({ id: 'id', name: 'Id', field: 'id', formatter: Formatters.Readonly, filterType: 'text'});
-    columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, validate: 'required', editorOptions: lookupOptions, width: 170, filterType: 'lookup' });
+    columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, validate: 'required', editorOptions: lookupOptions, width: 170, filterType: 'lookup', filterConditions: numericFilterConditions });
     columns.push({ id: 'productName', name: 'Product Name', field: 'productName',  formatter: Formatters.Hyperlink, filterType: 'text'});
     columns.push({ id: 'activity', name: 'Activity', field: 'activity', formatter: Formatters.Dropdown, filterType: 'multiselect', options: activities, editorOptions: {showSelectAll: true}});
     columns.push({ id: 'quantity', name: 'Qty', field: 'quantity', align: 'right', filterType: 'integer'});

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,7 @@
 - `[Input]` Improved alignment of icons in the uplift theme input components. ([#2072](https://github.com/infor-design/enterprise/issues/2072))
 - `[Datagrid]` Added an onBeforeSelect call back that you can return false from to disable row selection. ([#1906](https://github.com/infor-design/enterprise/issues/1906))
 - `[Datagrid]` Fixed an issue where header checkbox was not sync after removing selected rows. ([#2226](https://github.com/infor-design/enterprise/issues/2226))
+- `[Datagrid]` Fixed an issue where custom filter conditions were not setting up filter button. ([#2234](https://github.com/infor-design/enterprise/issues/2234))
 - `[Listview]` Improved accessibility when configured as selectable (all types), as well as re-enabled accessibility e2e tests. ([#403](https://github.com/infor-design/enterprise/issues/403))
 - `[Locale]` Synced up date and time patterns with the CLDR several time patterns in particular were corrected. ([#2022](https://github.com/infor-design/enterprise/issues/2022))
 - `[Datagrid]` Fixed an issue where pager was not updating while removing rows. ([#1985](https://github.com/infor-design/enterprise/issues/1985))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1714,8 +1714,9 @@ Datagrid.prototype = {
       return ($.inArray(s, array) > -1);
     };
     const render = function (icon, text, checked) {
+      const isChecked = filterConditions.length && filterConditions[0] === icon ? true : checked;
       return filterConditions.length && !inArray(icon) ?
-        '' : self.filterItemHtml(icon, text, checked);
+        '' : self.filterItemHtml(icon, text, isChecked);
     };
     const renderButton = function (defaultValue) {
       return `<button type="button" class="btn-menu btn-filter" data-init="false" ${isDisabled ? ' disabled' : ''}${defaultValue ? ` data-default="${defaultValue}"` : ''} type="button"><span class="audible">Filter</span>` +
@@ -1724,6 +1725,7 @@ Datagrid.prototype = {
       }</button><ul class="popupmenu has-icons is-translatable is-selectable">`;
     };
     let btnMarkup = '';
+    let btnDefault = '';
 
     // Just the dropdown
     if (col.filterType === 'contents' || col.filterType === 'select' || col.filterType === 'multiselect') {
@@ -1731,31 +1733,34 @@ Datagrid.prototype = {
     }
 
     if (col.filterType === 'text') {
-      btnMarkup = renderButton('contains') +
+      btnDefault = filterConditions.length ? filterConditions[0] : 'contains';
+      btnMarkup = renderButton(btnDefault) +
         render('contains', 'Contains', true) +
         render('does-not-contain', 'DoesNotContain') +
         render('equals', 'Equals') +
         render('does-not-equal', 'DoesNotEqual') +
         render('is-empty', 'IsEmpty') +
         render('is-not-empty', 'IsNotEmpty');
-      btnMarkup = btnMarkup.replace('{{icon}}', 'contains');
+      btnMarkup = btnMarkup.replace('{{icon}}', btnDefault);
     }
 
     if (col.filterType === 'checkbox') {
-      btnMarkup += renderButton('selected-notselected') +
+      btnDefault = filterConditions.length ? filterConditions[0] : 'selected-notselected';
+      btnMarkup += renderButton(btnDefault) +
         render('selected-notselected', 'All', true) +
         render('selected', 'Selected') +
         render('not-selected', 'NotSelected');
-      btnMarkup = btnMarkup.replace('{{icon}}', 'selected-notselected');
+      btnMarkup = btnMarkup.replace('{{icon}}', btnDefault);
     }
 
     if (col.filterType !== 'checkbox' && col.filterType !== 'text') {
-      btnMarkup += renderButton('equals') +
+      btnDefault = filterConditions.length ? filterConditions[0] : 'equals';
+      btnMarkup += renderButton(btnDefault) +
         render('equals', 'Equals', (col.filterType === 'lookup' || col.filterType === 'integer' || col.filterType === 'decimal' || col.filterType === 'date' || col.filterType === 'time')) +
         render('does-not-equal', 'DoesNotEqual') +
         render('is-empty', 'IsEmpty') +
         render('is-not-empty', 'IsNotEmpty');
-      btnMarkup = btnMarkup.replace('{{icon}}', 'equals');
+      btnMarkup = btnMarkup.replace('{{icon}}', btnDefault);
     }
 
     if (col.filterType === 'date') {
@@ -1781,7 +1786,8 @@ Datagrid.prototype = {
     }
 
     if (col.filterType === 'lookup') {
-      btnMarkup = renderButton('contains') +
+      btnDefault = filterConditions.length ? filterConditions[0] : 'contains';
+      btnMarkup = renderButton(btnDefault) +
         render('contains', 'Contains', true) +
         render('does-not-contain', 'DoesNotContain') +
         render('equals', 'Equals') +
@@ -1796,7 +1802,7 @@ Datagrid.prototype = {
         render('less-equals', 'LessOrEquals') +
         render('greater-than', 'GreaterThan') +
         render('greater-equals', 'GreaterOrEquals');
-      btnMarkup = btnMarkup.replace('{{icon}}', 'contains');
+      btnMarkup = btnMarkup.replace('{{icon}}', btnDefault);
     }
 
     btnMarkup += '</ul>';

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -1024,6 +1024,17 @@ describe('Datagrid filter lookup custom click function tests', () => {
     expect(browser.driver.switchTo().alert().getText()).toBe('Grid information found');
     await browser.driver.switchTo().alert().accept();
   });
+
+  it('Should use custom filter conditions for filter button popup', async () => {
+    expect(await element.all(by.css('.datagrid-row')).count()).toEqual(9);
+    const filterBtn = await element(by.css('#test-filter-lookup-click-function-datagrid-1-header-1 div.datagrid-filter-wrapper .btn-filter'));
+
+    expect(await filterBtn.getAttribute('data-default')).toEqual('equals');
+    await filterBtn.click();
+
+    expect(await element(by.css('ul.popupmenu.is-open')).isDisplayed()).toBeTruthy();
+    expect(await element(by.css('ul.popupmenu.is-open > li:nth-child(1)')).getText()).toBe('Equals');
+  });
 });
 
 describe('Datagrid filter masks', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed custom filter conditions were not setting up filter button with datagrid.

**Related github/jira issue (required)**:
Closes #2234

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp
- Navigate to http://localhost:4000/components/datagrid/test-filter-lookup-click-function.html
- Open developer tools
- Click on the filter options next to the lookup for column `Product Id`
- See in console should not be any error
- Popup should open to select filter conditions

- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
