### PR TITLE
2258 - Allow manual personalization [v4.19.x]

### DIFF
--- a/app/views/includes/head.html
+++ b/app/views/includes/head.html
@@ -38,10 +38,10 @@
   <script src="../../js/cultures/{{locale}}.js"></script>-->
 
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600" rel="stylesheet"/>
-
+  <link rel="stylesheet" id="sohoxi-stylesheet" href="{{basepath}}css/theme-{{theme.name}}-{{theme.variant}}.css" type="text/css"/>
   <script>
     var colors;
-    var theme;
+    var theme = 'theme-{{theme.name}}-{{theme.variant}}';
     var blockUI = '{{layout}}'.indexOf('embedded') > -1 ? false : true;
 
     {{#colors}}
@@ -61,6 +61,5 @@
     $('html').personalize({colors: colors, theme: theme, blockUI: blockUI});
   </script>
 
-  <link rel="stylesheet" id="sohoxi-stylesheet" href="{{basepath}}css/theme-{{theme.name}}-{{theme.variant}}.css" type="text/css"/>
   <link rel="stylesheet" href="{{basepath}}css/demo.css" type="text/css"/>
 </head>

--- a/src/components/colorpicker/colorpicker.js
+++ b/src/components/colorpicker/colorpicker.js
@@ -491,7 +491,7 @@ ColorPicker.prototype = {
    */
   getThemeVariant(activeTheme) {
     const legacyThemes = Object.keys(COLORPICKER_DEFAULTS.themes);
-    const res = legacyThemes.filter(legacyTheme => activeTheme.indexOf(legacyTheme));
+    const res = legacyThemes.filter(legacyTheme => activeTheme.indexOf(legacyTheme) > -1);
     let variant = 'light';
     if (res.length > 0) {
       variant = res[0];

--- a/src/components/personalize/personalize.bootstrap.js
+++ b/src/components/personalize/personalize.bootstrap.js
@@ -1,11 +1,15 @@
 import { Personalize, COMPONENT_NAME } from './personalize';
 
+// Handle incoming settings from `SohoConfig`
+let instanceSettings = {};
+if (typeof window.SohoConfig === 'object' && typeof window.SohoConfig.personalize === 'object') {
+  instanceSettings = window.SohoConfig.personalize;
+}
+
 /**
  * Setup a single instance of the Personalization system on the HTML tag.
  * Personalization is top-level.
  */
-const personalization = new Personalize(document.documentElement, {
-  theme: 'light'
-});
+const personalization = new Personalize(document.documentElement, instanceSettings);
 
 export { personalization, COMPONENT_NAME };

--- a/src/components/personalize/personalize.bootstrap.js
+++ b/src/components/personalize/personalize.bootstrap.js
@@ -4,6 +4,7 @@ import { Personalize, COMPONENT_NAME } from './personalize';
 let instanceSettings = {
   theme: 'theme-soho-light'
 };
+
 if (typeof window.SohoConfig === 'object' && typeof window.SohoConfig.personalize === 'object') {
   instanceSettings = window.SohoConfig.personalize;
 }

--- a/src/components/personalize/personalize.bootstrap.js
+++ b/src/components/personalize/personalize.bootstrap.js
@@ -1,7 +1,9 @@
 import { Personalize, COMPONENT_NAME } from './personalize';
 
 // Handle incoming settings from `SohoConfig`
-let instanceSettings = {};
+let instanceSettings = {
+  theme: 'theme-soho-light'
+};
 if (typeof window.SohoConfig === 'object' && typeof window.SohoConfig.personalize === 'object') {
   instanceSettings = window.SohoConfig.personalize;
 }

--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -13,7 +13,8 @@ const PERSONALIZE_DEFAULTS = {
   colors: '',
   theme: '',
   font: '',
-  blockUI: true
+  blockUI: true,
+  noInit: false
 };
 
 /**
@@ -26,7 +27,8 @@ const PERSONALIZE_DEFAULTS = {
  * @param {string} [settings.theme] The theme name (light, dark or high-contrast)
  * @param {string} [settings.font] Use the newer source sans font
  * @param {boolean} [settings.blockUI=true] Cover the UI and animate when changing theme.
-*/
+ * @param {boolean} [settings.noInit=false] If true, prevents automatic setup of personalized theme/colors/font, allowing for manual triggering at a more convenient time.
+ */
 function Personalize(element, settings) {
   this.element = $(element);
   this.settings = utils.mergeSettings(this.element[0], settings, PERSONALIZE_DEFAULTS);
@@ -46,6 +48,11 @@ Personalize.prototype = {
    */
   init() {
     this.handleEvents();
+
+    // Skip automatic setup of theme/colors/font.
+    if (this.settings.noInit) {
+      return this;
+    }
 
     if (this.settings.theme) {
       this.setTheme(this.settings.theme);

--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -265,6 +265,10 @@ Personalize.prototype = {
   */
   setTheme(incomingTheme) {
     const $html = $('html');
+    if (!incomingTheme) {
+      return;
+    }
+
     if (theme.currentTheme.id === incomingTheme) {
       if (!$html.hasClass(incomingTheme)) {
         $html.addClass(incomingTheme);
@@ -367,7 +371,7 @@ Personalize.prototype = {
    */
   unBlockUi() {
     const self = this;
-    if (!self.settings.blockUI) {
+    if (!self.settings.blockUI || !self.pageOverlay) {
       return;
     }
 

--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -269,6 +269,9 @@ Personalize.prototype = {
       return;
     }
 
+    // Somehow colorpicker uses this, so keep it
+    this.currentTheme = incomingTheme;
+
     if (theme.currentTheme.id === incomingTheme) {
       if (!$html.hasClass(incomingTheme)) {
         $html.addClass(incomingTheme);
@@ -318,9 +321,6 @@ Personalize.prototype = {
     // record state of theme in settings
     this.settings.theme = incomingTheme;
     theme.setTheme(incomingTheme);
-
-    // Somehow colorpicker uses this, so keep it
-    this.currentTheme = incomingTheme;
 
     /**
     * Fires after the theme is changed

--- a/src/components/personalize/readme.md
+++ b/src/components/personalize/readme.md
@@ -60,6 +60,20 @@ We expose a series of classes that you can use to personalize some items on the 
 - `personalize-horizontal-bottom-border` - Adds a 1px border matching the personalization color to the element on the bottom.
 - `personalize-horizontal-bottom-border` - Adds a 1px border matching the personalization color to the element on the top.
 
+## Manual Personalization
+
+It may be necessary to gain control of the timing in which personalized colors/themes/fonts are applied to your application, instead of allowing IDS to automatically set up these items.  If this is necessary, you can configure a property in the `SohoConfig` object to disable automatic initialization:
+
+```js
+const SohoConfig = {
+  personalize: {
+    noInit: true
+  }
+};
+```
+
+Insert this object in a script that runs before IDS is loaded.
+
 ## Accessibility
 
 - The contrast and actual colors can be a concern for visibility impaired and color blind people. Choose colors that pass contrast guidelines.

--- a/test/components/personalize/personalize-api.func-spec.js
+++ b/test/components/personalize/personalize-api.func-spec.js
@@ -1,0 +1,81 @@
+import { Personalize } from '../../../src/components/personalize/personalize';
+
+let personalization = {};
+
+describe('Personalize API', () => {
+  beforeEach(() => {
+    personalization = new Personalize(document.documentElement, { theme: 'theme-soho-light' });
+  });
+
+  it('Should define personalization', () => {
+    expect(personalization).toBeDefined();
+  });
+
+  it('Should define currentTheme', () => {
+    expect(personalization.currentTheme).toEqual('theme-soho-light');
+  });
+
+  it('Should not run if config is ignored', () => {
+    personalization = new Personalize(document.documentElement, { noInit: true });
+
+    expect(personalization.currentTheme).toBeUndefined();
+  });
+
+  it('Should set theme on html tag', () => {
+    expect(document.documentElement.classList.contains('theme-soho-light')).toBeTruthy();
+  });
+
+  it('Should set theme on html tag for random theme name', () => {
+    personalization = new Personalize(document.documentElement, { theme: 'cat-in-a-hat' });
+
+    expect(document.documentElement.classList.contains('cat-in-a-hat')).toBeTruthy();
+  });
+
+  it('Should set theme on legacy light theme', () => {
+    personalization = new Personalize(document.documentElement, { theme: 'light' });
+
+    expect(document.documentElement.classList.contains('light-theme')).toBeTruthy();
+  });
+
+  it('Should set theme on legacy dark theme', () => {
+    personalization = new Personalize(document.documentElement, { theme: 'dark' });
+
+    expect(document.documentElement.classList.contains('dark-theme')).toBeTruthy();
+  });
+
+  it('Should set theme on legacy high-contrast theme', () => {
+    personalization = new Personalize(document.documentElement, { theme: 'high-contrast' });
+
+    expect(document.documentElement.classList.contains('high-contrast-theme')).toBeTruthy();
+  });
+
+  it('Should set theme on soho light theme', () => {
+    personalization = new Personalize(document.documentElement, { theme: 'theme-soho-light' });
+
+    expect(document.documentElement.classList.contains('theme-soho-light')).toBeTruthy();
+  });
+
+  it('Should set theme on soho dark theme', () => {
+    personalization = new Personalize(document.documentElement, { theme: 'theme-soho-dark' });
+
+    expect(document.documentElement.classList.contains('theme-soho-dark')).toBeTruthy();
+  });
+
+  it('Should set theme on soho contrast theme', () => {
+    personalization = new Personalize(document.documentElement, { theme: 'theme-soho-contrast' });
+
+    expect(document.documentElement.classList.contains('theme-soho-contrast')).toBeTruthy();
+  });
+
+  it('Should set theme on uplift light theme', () => {
+    personalization = new Personalize(document.documentElement, { theme: 'theme-uplift-light' });
+
+    expect(document.documentElement.classList.contains('theme-uplift-light')).toBeTruthy();
+  });
+
+  it('Should set theme on uplift dark theme', () => {
+    personalization = new Personalize(document.documentElement, { theme: 'theme-uplift-dark' });
+
+    expect(document.documentElement.classList.contains('theme-uplift-dark')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Landmark used manual themes which would cause an extra overlay to occur in some cases. In addition fixed some bugs:
- Color picker was not initializing
- Added a config to skip default Personalization Init (This may not be needed to solve landmarks issue 100% but just in case)
- Fix to prevent the theme and overlay from adding extra times

**Related github/jira issue (required)**:
Fixes #2258 

**Steps necessary to review your pull request (required)**:
1. Go to: http://localhost:4000/components/personalize/example-form.html?theme=uplift&variant=dark

    - look at the theme on the html tag
    - use theme theme switcher and make sure the tag is correct
    - debug personalize init and make sure its not been called way too many times
    - try with more url params like `theme=soho&variant=contrast`

2. Go to: http://localhost:4000/components/color-picker/example-index
    
    - open the picker
    - pick an item in about he middle of the color set
    - try with all three theme variants
    - make sure the checkbox and borders look ok and you see no errors

3. Landmark
- [x] Verify in landmark cc @pwpatton 