### PR TITLE
332 - Fix the modal was disappears if its content use checkbox in it with rtl

### DIFF
--- a/app/views/components/modal/test-checkbox.html
+++ b/app/views/components/modal/test-checkbox.html
@@ -1,0 +1,52 @@
+
+<div class="row top-padding">
+  <div class="twelve columns">
+
+    <button class="btn-secondary" type="button" id="show">Show Modal</button>
+
+    <div id="modal" class="modal">
+       <div class="modal-content">
+
+          <div class="modal-header">
+            <h1 class="modal-title" >Add Comment</h1>
+          </div>
+
+          <div class="modal-body-wrapper">
+            <div class="modal-body">
+
+              <div>
+                <div class="field">
+                  <input class="checkbox" id="allowOpen" type="checkbox">
+                  <label class="checkbox-label" for="allowOpen">Allow Open</label>
+                </div>
+                <div class="field">
+                  <input class="checkbox" id="allowClose" type="checkbox">
+                  <label class="checkbox-label" for="allowClose">Allow Close</label>
+                </div>
+                <div class="field">
+                  <input class="checkbox" id="allowDestroy" type="checkbox">
+                  <label class="checkbox-label" for="allowDestroy">Allow Destroy</label>
+                </div>
+              </div>
+
+              <div class="modal-buttonset">
+                <button type="button" class="btn-modal">Cancel</button>
+                <button type="button" id="submit" class="btn-modal-primary">Submit</button>
+              </div>
+            </div>
+          </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<script>
+  $('#show').on('click', function () {
+
+    $('body').modal({
+      content: $('#modal')
+    });
+
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### v4.20.0 Fixes
 
 - `[Homepages]` Fixed an issue where personalize and chart text colors were not working with hero. ([#2097](https://github.com/infor-design/enterprise/issues/2097))
-- `[Modal]` Fixed an issue where the modal component would disappears if its content had a checkbox in it in RTL. ([#332](https://github.com/infor-design/enterprise-ng/issues/332))
+- `[Modal]` Fixed an issue where the modal component would disappear if its content had a checkbox in it in RTL. ([#332](https://github.com/infor-design/enterprise-ng/issues/332))
 
 ### v4.20.0 Chores & Maintenance
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### v4.20.0 Fixes
 
 - `[Homepages]` Fixed an issue where personalize and chart text colors were not working with hero. ([#2097](https://github.com/infor-design/enterprise/issues/2097))
-- `[Modal]` Fixed an issue where Modal was disappears if its content use checkbox in it with RTL settings. ([#332](https://github.com/infor-design/enterprise-ng/issues/332))
+- `[Modal]` Fixed an issue where the modal component would disappears if its content had a checkbox in it in RTL. ([#332](https://github.com/infor-design/enterprise-ng/issues/332))
 
 ### v4.20.0 Chores & Maintenance
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### v4.20.0 Fixes
 
 - `[Homepages]` Fixed an issue where personalize and chart text colors were not working with hero. ([#2097](https://github.com/infor-design/enterprise/issues/2097))
-- `[Modal]` Fixed an issue where Modal was disappears if its content use checkbox in it with RTL settings. ([#332](https://github.com/infor-design/enterprise/issues/332))
+- `[Modal]` Fixed an issue where Modal was disappears if its content use checkbox in it with RTL settings. ([#332](https://github.com/infor-design/enterprise-ng/issues/332))
 
 ### v4.20.0 Chores & Maintenance
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### v4.20.0 Fixes
 
 - `[Homepages]` Fixed an issue where personalize and chart text colors were not working with hero. ([#2097](https://github.com/infor-design/enterprise/issues/2097))
+- `[Modal]` Fixed an issue where Modal was disappears if its content use checkbox in it with RTL settings. ([#332](https://github.com/infor-design/enterprise/issues/332))
 
 ### v4.20.0 Chores & Maintenance
 

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -344,6 +344,12 @@ html[dir='rtl'] {
     }
   }
 
+  input.checkbox,
+  span.checkbox > input {
+    left: auto;
+    right: -99999px;
+  }
+
 }
 
 // Short Fields


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the Modal was disappears if its content use checkbox in it with RTL settings.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#332

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the demoapp
- Navigate to http://localhost:4000/components/modal/test-checkbox.html?locale=ar-EG
- Click on button "Show Modal" to open modal
- Modal should open and show it's content fine

- [x] A note to the change log.
