### PR TITLE
2251 - Datagrid grouping multiselect not sortable [v4.19.x]

### DIFF
--- a/app/views/components/datagrid/example-grouping-multiselect.html
+++ b/app/views/components/datagrid/example-grouping-multiselect.html
@@ -1,0 +1,46 @@
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+
+<script>
+  $('body').one('initialized', function () {
+
+      var grid,
+        columns = [],
+        data = [];
+
+      //Define Columns for the Grid.
+      columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
+      columns.push({ id: 'id', name: 'Customer Id', field: 'id'});
+      columns.push({ id: 'type', name: 'Type', field: 'type'});
+      columns.push({ id: 'location', name: 'Location', field: 'location', formatter: Formatters.Hyperlink});
+      columns.push({ id: 'firstname', name: 'First Name', field: 'firstname'});
+      columns.push({ id: 'lastname', name: 'Last Name', field: 'lastname'});
+      columns.push({ id: 'phone', name: 'Phone', field: 'phone'});
+      columns.push({ id: 'purchases', name: 'Purchases', field: 'purchases'});
+
+      //Get some data via ajax
+      var url = '{{basepath}}api/accounts';
+
+      $.getJSON(url, function(res) {
+
+        $('#datagrid').datagrid({
+          columns: columns,
+          dataset: res,
+          selectable: 'multiple',
+          groupable: {
+            fields: ['type'],
+            expanded: true
+          },
+          toolbar: {title: 'Accounts', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: false}
+        }).on('click', function (e, args) {
+            console.log('Row Click ', args)
+        });
+      });
+ });
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,6 +53,7 @@
 - `[Datagrid]` Fixed an issue where custom filter conditions were not setting up filter button. ([#2234](https://github.com/infor-design/enterprise/issues/2234))
 - `[Datagrid]` Fixed an issue where pager was not updating while removing rows. ([#1985](https://github.com/infor-design/enterprise/issues/1985))
 - `[Datagrid]` Adds a function to add a visual dirty indictaor and a new function to get all modified rows. Modified means either dirty, in-progress or in error. Existing API's are not touched. ([#2091](https://github.com/infor-design/enterprise/issues/2091))
+- `[Datagrid]` Fixed grouped headers not sorting when selectable is multiselect. ([#2251](https://github.com/infor-design/enterprise/issues/2251))
 - `[Dropdown]` Fixed the dropdown appearing misaligned at smaller screen sizes. ([#2248](https://github.com/infor-design/enterprise/issues/2248))
 - `[Editor]` Fixed an issue where button state for toolbar buttons were wrong when clicked one after another. ([#391](https://github.com/infor-design/enterprise/issues/391))
 - `[Field Options]` Fixed an issue where field options were misaligning, especially spin box was focusing outside of the field. ([#1862](https://github.com/infor-design/enterprise/issues/1862))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9844,9 +9844,9 @@ Datagrid.prototype = {
 
     for (let i = 0, data; i < dataset.length; i++) {
       if (s.groupable) {
-        for (let k = 0; k < dataset[i].values.length; k++) {
+        for (let k = 0; k < Object.values(dataset[i]).length; k++) {
           idx++;
-          data = dataset[i].values[k];
+          data = Object.values(dataset[i])[k];
           if (this.isRowSelected(data)) {
             this._selectedRows.push({
               idx,

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9844,9 +9844,10 @@ Datagrid.prototype = {
 
     for (let i = 0, data; i < dataset.length; i++) {
       if (s.groupable) {
-        for (let k = 0; k < Object.values(dataset[i]).length; k++) {
+        // Object.values is not supported in IE11; hence usage of Object.keys and Map
+        for (let k = 0; k < Object.keys(dataset[i]).length; k++) {
           idx++;
-          data = Object.values(dataset[i])[k];
+          data = Object.keys(dataset[i]).map(v => dataset[i][v]);
           if (this.isRowSelected(data)) {
             this._selectedRows.push({
               idx,

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -2040,6 +2040,22 @@ describe('Datagrid paging with empty dataset', () => {
     await element(by.css('.pager-toolbar .pager-next')).click();
     await browser.driver.sleep(config.sleep);
 
-    expect(await element.all(by.css('#datagrid tbody tr[aria-rowindex]')).count()).toEqual(1);
+    expect(await element.all(by.css('#datagrid tbody tr:nth-child(1)')).count()).toEqual(1);
+  });
+});
+
+describe('Datagrid multiselect sorting test', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/example-grouping-multiselect?layout=nofrills');
+
+    const datagridEl = await element(by.css('#datagrid thead th:nth-child(2)'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    const thEl = await element(by.css('#datagrid thead th:nth-child(2)'));
+    await thEl.click();
+    await utils.checkForErrors();
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Sorting is not working on columns when `selectable: 'multiselect'`.

**Related github/jira issue (required)**:
Closes #2251.

**Steps necessary to review your pull request (required)**:
- Pull branch and run app
- Visit http://localhost:4000/components/datagrid/example-grouping-multiselect.html
  - Ensure sorting works on all headers.
  - Also test other grouping examples.

~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.