### PR TITLE
2279 - Fixes a JSON error in datagrid with lookups [v4.19.x]

### DIFF
--- a/app/views/components/datagrid/test-save-settings.html
+++ b/app/views/components/datagrid/test-save-settings.html
@@ -51,9 +51,39 @@
     var statuses = [{id: '', value: '', label:'&nbsp;'},
                       {id:'Confirmed', value:'Confirmed', label:'Confirmed'},
                       {id:'Error', value:'Error', label:'Error'}];
+    var lookupOptions = {
+      field: function (row, field, grid) {
+        return row.productId;
+      },
+      match: function (value, row, field, grid) {
+        return (row.productId) === value;
+      },
+      beforeShow: function (api, response) {
+        var url = '{{basepath}}api/lookupInfo';
+
+        $.getJSON(url, function(data) {
+          api.settings.options.columns = data[0].columns;
+          api.settings.options.dataset = data[0].dataset;
+          response();
+        });
+      },
+      options: {
+        saveUserSettings: {
+           columns: true,
+           rowHeight: true,
+           sortOrder: true,
+           pagesize: true,
+           activePage: true,
+           filter: true
+        },
+        selectable: 'single',
+        toolbar: {title: 'Products', results: true, dateFilter: false ,keywordFilter: false, advancedFilter: true, actions: true, views: true , rowHeight: true}
+      }
+    };
 
     //Define Columns for the Grid.
     columns.push({ id: 'id', name: 'Id', field: 'id', formatter: Formatters.Text, filterType: 'text'});
+    columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editorOptions: lookupOptions, width: 120, filterType: 'lookup' });
     columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink, filterType: 'text'});
     columns.push({ id: 'activity', name: 'Activity', field: 'activity', filterType: 'text'});
     columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', filterType: 'integer'});

--- a/app/views/components/datagrid/test-save-settings.html
+++ b/app/views/components/datagrid/test-save-settings.html
@@ -83,7 +83,7 @@
 
     //Define Columns for the Grid.
     columns.push({ id: 'id', name: 'Id', field: 'id', formatter: Formatters.Text, filterType: 'text'});
-    columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editorOptions: lookupOptions, width: 120, filterType: 'lookup' });
+    columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editorOptions: lookupOptions, filterType: 'lookup' });
     columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink, filterType: 'text'});
     columns.push({ id: 'activity', name: 'Activity', field: 'activity', filterType: 'text'});
     columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', filterType: 'integer'});

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,6 +53,8 @@
 - `[Datagrid]` Fixed an issue where custom filter conditions were not setting up filter button. ([#2234](https://github.com/infor-design/enterprise/issues/2234))
 - `[Datagrid]` Fixed an issue where pager was not updating while removing rows. ([#1985](https://github.com/infor-design/enterprise/issues/1985))
 - `[Datagrid]` Adds a function to add a visual dirty indictaor and a new function to get all modified rows. Modified means either dirty, in-progress or in error. Existing API's are not touched. ([#2091](https://github.com/infor-design/enterprise/issues/2091))
+- `[Datagrid]` Fixes an error when saving columns if you have a lookup column. ([#2279](https://github.com/infor-design/enterprise/issues/2279))
+- `[Datagrid]` Fixed a bug with column reset not working sometimes. ([#1921](https://github.com/infor-design/enterprise/issues/1921))
 - `[Dropdown]` Fixed the dropdown appearing misaligned at smaller screen sizes. ([#2248](https://github.com/infor-design/enterprise/issues/2248))
 - `[Editor]` Fixed an issue where button state for toolbar buttons were wrong when clicked one after another. ([#391](https://github.com/infor-design/enterprise/issues/391))
 - `[Field Options]` Fixed an issue where field options were misaligning, especially spin box was focusing outside of the field. ([#1862](https://github.com/infor-design/enterprise/issues/1862))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -252,7 +252,7 @@ Datagrid.prototype = {
     this.isInModal = false;
     this.appendTooltip();
     this.initSettings();
-    this.originalColumns = this.columnsFromString(JSON.stringify(this.settings.columns));
+    this.originalColumns = JSON.stringify(this.settings.columns);
     this.removeToolbarOnDestroy = false;
     this.nonVisibleCellErrors = [];
     this.recordCount = 0;
@@ -4553,8 +4553,8 @@ Datagrid.prototype = {
     if (columnGroups === undefined) {
       columnGroups = null;
     }
-    if (JSON.stringify(this.settings.columns) === JSON.stringify(columns) &&
-          (JSON.stringify(this.settings.columnGroups) === JSON.stringify(columnGroups))) {
+    if (this.copyThenStringify(this.settings.columns) === this.copyThenStringify(columns) &&
+      (JSON.stringify(this.settings.columnGroups) === JSON.stringify(columnGroups))) {
       columnsChanged = false;
     }
 
@@ -4619,7 +4619,7 @@ Datagrid.prototype = {
 
     // Save Columns
     if (savedSettings.columns) {
-      localStorage[this.uniqueId('usersettings-columns')] = JSON.stringify(this.settings.columns);
+      localStorage[this.uniqueId('usersettings-columns')] = this.copyThenStringify(this.settings.columns);
     }
 
     // Save Row Height
@@ -4844,6 +4844,26 @@ Datagrid.prototype = {
   },
 
   /**
+   * Copy the object and remove some uneeded properties from the object
+   * @param  {object} columns The column set to stringify.
+   * @returns {string} The JSON object as a string
+   */
+  copyThenStringify(columns) {
+    if (!columns) {
+      return JSON.stringify(columns);
+    }
+
+    const clone = columns.map((col) => {
+      const newCol = col;
+      if (newCol.editorOptions) {
+        delete newCol.editorOptions;
+      }
+      return newCol;
+    });
+    return JSON.stringify(clone);
+  },
+
+  /**
   * Reset Columns to defaults (used on restore menu item)
   */
   resetColumns() {
@@ -4852,7 +4872,7 @@ Datagrid.prototype = {
     }
 
     if (this.originalColumns) {
-      const originalColumns = this.columnsFromString(JSON.stringify(this.originalColumns));
+      const originalColumns = this.originalColumns;
       const columnGroups = this.settings.columnGroups && this.originalColGroups ?
         this.originalColGroups : null;
       this.updateColumns(originalColumns, columnGroups);

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -252,7 +252,7 @@ Datagrid.prototype = {
     this.isInModal = false;
     this.appendTooltip();
     this.initSettings();
-    this.originalColumns = JSON.stringify(this.settings.columns);
+    this.originalColumns = this.columnsFromString(JSON.stringify(this.settings.columns));
     this.removeToolbarOnDestroy = false;
     this.nonVisibleCellErrors = [];
     this.recordCount = 0;
@@ -4845,6 +4845,7 @@ Datagrid.prototype = {
 
   /**
    * Copy the object and remove some uneeded properties from the object
+   * @private
    * @param  {object} columns The column set to stringify.
    * @returns {string} The JSON object as a string
    */

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4855,7 +4855,7 @@ Datagrid.prototype = {
     }
 
     const clone = columns.map((col) => {
-      const newCol = col;
+      const newCol = utils.extend({}, col);
       if (newCol.editorOptions) {
         delete newCol.editorOptions;
       }

--- a/src/components/tooltip/_tooltip-uplift.scss
+++ b/src/components/tooltip/_tooltip-uplift.scss
@@ -1,0 +1,3 @@
+.tooltip-content {
+  padding: 5px 10px;
+}

--- a/src/components/tooltip/_tooltip-uplift.scss
+++ b/src/components/tooltip/_tooltip-uplift.scss
@@ -1,3 +1,0 @@
-.tooltip-content {
-  padding: 5px 10px;
-}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes a bug when using a lookup column with editorOptions some operations. Also fixes column reset.

**Related github/jira issue (required)**:
Fixes #2279 
Fixes #1921 (coincidentally)

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-filter-lookup-click-function.html
- in this example an alert should show if the grid object is found on the clickArgs (should still alert)

http://localhost:4000/components/datagrid/test-save-settings.html
- drag, sort page, extend columns
- reload the page and things should still be saved
- click the lookup filter and it should still open a dialog
- reset columns will set back to factory defaults

http://localhost:4000/components/datagrid/test-save-settings-manual.html
http://localhost:4000/components/datagrid/test-save-settings-serverside.html
- these two examples do the same sort of things , like move and drag columns and reset.

All the while watch console for any errors.