### PR TITLE
2289 - Uplift Accordion Adjustments [v4.19.x]

### DIFF
--- a/src/components/accordion/_accordion-uplift.scss
+++ b/src/components/accordion/_accordion-uplift.scss
@@ -9,9 +9,32 @@
 // TODO: Remove this rule in favor of something better.
 .accordion-pane {
   .accordion-header {
+    > a {
+      padding-bottom: 6px;
+      padding-top: 6px;
+    }
+
     > [class*='btn'] {
       height: 23px;
       min-height: 23px;
+
+      + a {
+        padding-bottom: 6px;
+        padding-top: 6px;
+      }
+    }
+  }
+}
+
+html {
+  &:not([dir='rtl']):not(.is-firefox):not(.ie11) {
+    .accordion-pane {
+      .accordion-header {
+        > [class*='btn'] {
+          height: 24px;
+          min-height: 24px;
+        }
+      }
     }
   }
 }

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -1386,34 +1386,6 @@ html[dir='rtl'] {
   }
 }
 
-//Button for Safari issue
-.is-safari {
-  .accordion-header {
-    &.has-chevron {
-      > [class^='btn'] {
-        height: 45px;
-        left: 0;
-        margin: 0;
-        padding: 13px 0 28px 13px;
-        position: absolute;
-        width: 100%;
-
-        &:focus:not(.hide-focus) {
-          border-color: transparent;
-          box-shadow: none;
-        }
-
-        .icon.chevron {
-          margin-top: 5px;
-          position: absolute;
-          right: 0;
-          width: 50px;
-        }
-      }
-    }
-  }
-}
-
 // Windows-style popup for truncated text elements
 .tooltip {
   &.tooltip-accordion-style {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Minor adjustments for the visual style of the accordion on the Uplift theme:
- Fix alignment of text to expander icons on subheaders
- Removes some Safari-specific CSS that was causing alignment issues of the Chevron in both the Soho and Uplift themes.

**Related github/jira issue (required)**:
#2289 

**Steps necessary to review your pull request (required)**:
- Pull this branch, run app
- Open http://localhost:4000/components/accordion/example-accordion-panels.html?theme=uplift in various browsers
- Open the "Learning" header on any of the three accordions.  Ensure the alignment of the text to the (+/-) buttons looks centered.
- Open the same page in Safari against both Uplift and Soho themes.  Ensure the alignment of the Chevron is correctly centered against the text.
