### PR TITLE
2296 - Fix a bug restoring filter [v4.19.x]

### DIFF
--- a/app/views/components/datagrid/test-editor-dropdown-source.html
+++ b/app/views/components/datagrid/test-editor-dropdown-source.html
@@ -75,19 +75,21 @@
     };
 
     columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
-    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input});
+    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, filterType: 'text', editor: Editors.Input});
     columns.push({ id: 'status', name: 'Status', field: 'price', formatter: Formatters.Alert, readonly: true, ranges: [{'min': LOW_RANGE_LOW_NUMBER, 'max': LOW_RANGE_HIGH_NUMBER, 'classes': 'success', text: 'Confirmed'}, {'min': HIGH_RANGE_LOW_NUMBER, 'max': HIGH_RANGE_HIGH_NUMBER, 'classes': 'error', text: 'Error'}]});
     columns.push({ id: 'price', name: 'Price', field: 'price', align: 'right', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###.000'});
-    columns.push({ id: 'action', name: 'Action', field: 'action', formatter: dropDownFormatter, editor: Editors.Dropdown, editorOptions: {editable: false, source: dropDownSource} });
+    columns.push({ id: 'action', name: 'Action', field: 'action', formatter: dropDownFormatter, filterType: 'multiselect', options:  [ { label: ' ', value: ' '} ], editor: Editors.Multiselect, editorOptions: {editable: false, source: dropDownSource} });
     columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date});
 
     //Init and get the api for the grid
     grid = $('#datagrid').datagrid({
       columns: columns,
       dataset: data,
+      disableClientFilter:  true,
       editable: true,
       clickToSelect: false,
       selectable: 'multiple',
+      filterable: true,
       toolbar: { keywordFilter: true, results: true }
     }).on('activecellchange', function (e, args) {
       console.log('e', e);
@@ -98,6 +100,10 @@
       console.log(e, args);
     }).on('rowremove', function (e, args) {
       console.log(e, args);
+    })
+    .on('filtered', function (e, args) {
+      console.log('filtered', args);
+      gridApi.loadData(data , { type: 'filtered', activePage: gridApi.activePage });
     });
 
     gridApi = $('#datagrid').data('datagrid');

--- a/app/views/components/datagrid/test-editor-dropdown-source.html
+++ b/app/views/components/datagrid/test-editor-dropdown-source.html
@@ -78,7 +78,7 @@
     columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, filterType: 'text', editor: Editors.Input});
     columns.push({ id: 'status', name: 'Status', field: 'price', formatter: Formatters.Alert, readonly: true, ranges: [{'min': LOW_RANGE_LOW_NUMBER, 'max': LOW_RANGE_HIGH_NUMBER, 'classes': 'success', text: 'Confirmed'}, {'min': HIGH_RANGE_LOW_NUMBER, 'max': HIGH_RANGE_HIGH_NUMBER, 'classes': 'error', text: 'Error'}]});
     columns.push({ id: 'price', name: 'Price', field: 'price', align: 'right', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###.000'});
-    columns.push({ id: 'action', name: 'Action', field: 'action', formatter: dropDownFormatter, filterType: 'multiselect', options:  [ { label: ' ', value: ' '} ], editor: Editors.Multiselect, editorOptions: {editable: false, source: dropDownSource} });
+    columns.push({ id: 'action', name: 'Action', field: 'action', formatter: dropDownFormatter, filterType: 'multiselect', options:  [ { label: ' ', value: ' '} ], editor: Editors.Dropdown, editorOptions: {editable: false, source: dropDownSource} });
     columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date});
 
     //Init and get the api for the grid
@@ -103,7 +103,7 @@
     })
     .on('filtered', function (e, args) {
       console.log('filtered', args);
-      gridApi.loadData(data , { type: 'filtered', activePage: gridApi.activePage });
+      gridApi.loadData(data , { type: 'filterrow' });
     });
 
     gridApi = $('#datagrid').data('datagrid');

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -2346,6 +2346,9 @@ Datagrid.prototype = {
       input.val(conditions[i].value);
 
       if (input.is('select')) {
+        if (conditions[i].innerHTML) {
+          input[0].innerHTML = conditions[i].innerHTML;
+        }
         if (conditions[i].value instanceof Array) {
           for (let j = 0; j < conditions[i].value.length; j++) {
             input.find(`option[value="${conditions[i].value[j]}"]`).prop('selected', true);
@@ -2422,6 +2425,10 @@ Datagrid.prototype = {
       if (input.data('timepicker')) {
         format = input.data('timepicker').settings.timeFormat;
         condition.format = format;
+      }
+
+      if (input.is('select')) {
+        condition.innerHTML = input[0].innerHTML;
       }
 
       filterExpr.push(condition);

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -110,7 +110,7 @@ const COMPONENT_NAME = 'datagrid';
  * @param {object}   [settings.emptyMessage.icon='icon-empty-no-data']
  * An empty message will be displayed when there is no rows in the grid. This accepts an object of the form
  * emptyMessage: {title: 'No Data Available', info: 'Make a selection on the list above to see results',
- * icon: 'icon-empty-no-data', button: {text: 'xxx', click: <function>}} set this to null for no message
+ * icon: 'icon-empty-no-data', button: {text: 'Button Text', click: <function>}} set this to null for no message
  * or will default to 'No Data Found with an icon.'
  * @param {boolean}  [settings.allowChildExpandOnMatch=false] use  with filter
  * if true:
@@ -2349,12 +2349,15 @@ Datagrid.prototype = {
         if (conditions[i].innerHTML) {
           input[0].innerHTML = conditions[i].innerHTML;
         }
-        if (conditions[i].value instanceof Array) {
+        if (conditions[i].value instanceof Array && !conditions[i].selectedOptions) {
           for (let j = 0; j < conditions[i].value.length; j++) {
             input.find(`option[value="${conditions[i].value[j]}"]`).prop('selected', true);
           }
         } else {
           input.find(`option[value="${conditions[i].value}"]`).prop('selected', true);
+        }
+        if (conditions[i].innerHTML) {
+          //xxx input.val(conditions[i].selectedOptions);
         }
         input.trigger('updated');
       }
@@ -2429,6 +2432,7 @@ Datagrid.prototype = {
 
       if (input.is('select')) {
         condition.innerHTML = input[0].innerHTML;
+        // xxx condition.selectedOptions = input.val();
       }
 
       filterExpr.push(condition);

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -2356,9 +2356,6 @@ Datagrid.prototype = {
         } else {
           input.find(`option[value="${conditions[i].value}"]`).prop('selected', true);
         }
-        if (conditions[i].innerHTML) {
-          //xxx input.val(conditions[i].selectedOptions);
-        }
         input.trigger('updated');
       }
 
@@ -2432,7 +2429,6 @@ Datagrid.prototype = {
 
       if (input.is('select')) {
         condition.innerHTML = input[0].innerHTML;
-        // xxx condition.selectedOptions = input.val();
       }
 
       filterExpr.push(condition);

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -2485,7 +2485,7 @@ Dropdown.prototype = {
 
     // If multiselect, reset the menu to the unfiltered mode
     if (this.settings.multiple) {
-      if (this.list.hasClass('search-mode')) {
+      if (this.list && this.list.hasClass('search-mode')) {
         this.resetList();
       }
       this.activate(true);

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -896,7 +896,7 @@ describe('Datagrid editor dropdown source tests', () => {
     expect(await element(by.css('.is-focused'))).toBeTruthy();
     const focusEl = await element(by.css('.is-focused'));
 
-    expect(await focusEl.getText()).toEqual('Place On-Hold');
+    expect(await focusEl.getText()).toEqual(' ');
   });
 });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The way landmark does filtering with clientSideFilter set the values in the filter row would be reset.

**Related github/jira issue (required)**:
Fixes #2296 

**Steps necessary to review your pull request (required)**:
Go to http://localhost:4000/components/datagrid/test-editor-dropdown-source.html#
- open the filter dropdown on the header and pick one value
- close the filter dropdown by clicking out and the value should show
- type a value in the text input filter in the header and hit enter
- both values should still be there
-  open the filter dropdown on the header and pick one two values
- close the filter dropdown by clicking out and the value should show

IMPORTANT: This example shows server side filtering which is not implemented. The bug is just that the value was reseting. So dont expect the filter to work.
