### PR TITLE
2289 - Uplift Module Tabs Adjustments [v4.19.x]

### DIFF
--- a/src/components/tabs-module/_tabs-module-uplift.scss
+++ b/src/components/tabs-module/_tabs-module-uplift.scss
@@ -1,0 +1,37 @@
+// Uplift Module Tabs
+//================================================== //
+
+.tab-container.module-tabs {
+  .tab {
+    > a {
+      padding: 5px 6px 7px;
+    }
+
+    &.dismissible {
+      a {
+        padding: 5px 35px 7px 6px;
+      }
+
+      .icon {
+        height: 11px;
+      }
+    }
+
+    &.application-menu-trigger {
+      a {
+        padding: 5px 6px 7px;
+        width: 100%;
+      }
+    }
+  }
+
+  &.has-more-button {
+    .tab-more {
+      padding: 5px 6px 7px;
+    }
+  }
+
+  .icon.app-header {
+    top: -6px;
+  }
+}

--- a/src/components/tabs/_tabs-uplift.scss
+++ b/src/components/tabs/_tabs-uplift.scss
@@ -4,3 +4,5 @@
 .animated-bar {
   height: 7px;
 }
+
+@import '../tabs-module/tabs-module-uplift';


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a problem in Module tabs where the "More Tabs" dropdown no longer works properly, due to a miscalculation on overflowed tabs.  This was happening because of the tab sizes changing.

**Related github/jira issue (required)**:
#2289

**Steps necessary to review your pull request (required)**:
- Pull this branch, run app
- Open http://localhost:4000/components/tabs-module/example-app-menu-button.html?theme=uplift
- Ensure tabs look right, and on desktop breakpoint, the app menu trigger along with three tabs are displayed, and the more button is not displayed.
- Ensure that collapsing to phone breakpoint causes the more button to display.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
