### PR TITLE
2289 - Uplift Editor Adjustments [v4.19.x]

### DIFF
--- a/src/components/editor/_editor.scss
+++ b/src/components/editor/_editor.scss
@@ -176,19 +176,15 @@
   }
 
   h3 {
-    @include rem(line-height, 2.4rem);
-    @include rem(margin-bottom, 1.5rem);
-
     color: $editor-color;
     font-size: $theme-size-font-xl;
+    line-height: normal;
   }
 
   h4 {
-    @include rem(line-height, 1.8rem);
-    @include rem(margin-bottom, 1.5rem);
-
     color: $editor-color;
     font-size: $theme-size-font-lg;
+    line-height: normal;
   }
 
   ul,


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes an issue with the Uplift Editor's H3/H4 tags, which previously appeared to overlap when spanning multiple lines.

**Related github/jira issue (required)**:
#2289 

**Steps necessary to review your pull request (required)**:
- Pull branch, run app
- Open http://localhost:4000/components/editor/example-index.html.  Change the top paragraph to an H3 and then an H4.  Ensure the text doesn't overlap itself.
- Open http://localhost:4000/components/editor/example-index.html?theme=uplift.  Change the top paragraph to an H3 and then an H4.  Ensure the text doesn't overlap itself.
