### PR TITLE
2289 - Uplift Monthview Adjustments [v4.19.x]

### DIFF
--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -289,7 +289,7 @@ $swaplist-text-color-selected: $theme-color-palette-white;
 //Date Picker
 $datepicker-icon-active-color: $trigger-active-color;
 $datepicker-month-year-color: $theme-color-font-base;
-$datepicker-alternate-month-color: $theme-color-brand-secondary-base;
+$datepicker-alternate-month-color: $theme-color-palette-graphite-30;
 $datepicker-day-color: $theme-color-palette-graphite-60;
 $datepicker-focus-border-color: $theme-color-brand-primary-base;
 $datepicker-selected-bg-color: $theme-color-brand-primary-base;

--- a/src/themes/theme-soho-dark.scss
+++ b/src/themes/theme-soho-dark.scss
@@ -229,7 +229,7 @@ $dropdown-menu-separator-border-color: $theme-color-palette-slate-50;
 
 // Date Picker
 $datepicker-month-year-color: $inverse-color;
-$datepicker-alternate-month-color: $theme-color-palette-slate-40;
+$datepicker-alternate-month-color: $theme-color-palette-slate-50;
 $datepicker-day-color: $theme-color-palette-slate-30;
 $datepicker-focus-border-color: $theme-color-brand-primary-base;
 $datepicker-selected-bg-color: $theme-color-brand-primary-base;

--- a/src/themes/theme-uplift-dark.scss
+++ b/src/themes/theme-uplift-dark.scss
@@ -226,7 +226,7 @@ $dropdown-menu-separator-border-color: $theme-color-palette-slate-50;
 
 // Date Picker
 $datepicker-month-year-color: $inverse-color;
-$datepicker-alternate-month-color: $theme-color-palette-slate-40;
+$datepicker-alternate-month-color: $theme-color-palette-slate-60;
 $datepicker-day-color: $theme-color-palette-slate-30;
 $datepicker-focus-border-color: $theme-color-brand-primary-base;
 $datepicker-selected-bg-color: $theme-color-brand-primary-base;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR changes the colors of the "alternate" day text in the Monthview calendar layout to better stand out on all color schemes/variants.

**Related github/jira issue (required)**:
#2289 

**Steps necessary to review your pull request (required)**:
Pull branch, run app, test the following pages and ensure the text colors for the days that are displayed, but not part of the current month, are less "visible" than the days that ARE part of the current month:
- http://localhost:4000/components/monthview/example-index.html
- http://localhost:4000/components/monthview/example-index.html?theme=soho&variant=dark
- http://localhost:4000/components/monthview/example-index.html?theme=soho&variant=contrast
- http://localhost:4000/components/monthview/example-index.html?theme=uplift
- http://localhost:4000/components/monthview/example-index.html?theme=uplift&variant=dark
- http://localhost:4000/components/monthview/example-index.html?theme=uplift&variant=contrast
