### PR TITLE
2289 - Fix Datagrid uplift + dark filter row [v4.19.x]

### DIFF
--- a/src/themes/theme-uplift-dark.scss
+++ b/src/themes/theme-uplift-dark.scss
@@ -521,12 +521,12 @@ $datagrid-list-header-checkbox-border-color: $theme-color-palette-slate-50;
 $datagrid-list-header-active-color: $theme-color-palette-slate-100;
 $datagrid-list-row-group-hover-color: $datagrid-row-selected-color;
 
-$datagrid-filter-border-color: $theme-color-palette-slate-50;
+$datagrid-filter-border-color: $theme-color-palette-slate-70;
 $datagrid-filter-hover-border-color: $theme-color-palette-slate-100;
 $datagrid-filter-color: $theme-color-palette-slate-100;
 $datagrid-filter-hover-color: $theme-color-palette-slate-100;
 $datagrid-filter-disabled-color: $theme-color-palette-slate-40;
-$datagrid-filter-icon-color: $theme-color-palette-slate-50;
+$datagrid-filter-icon-color: $theme-color-palette-slate-70;
 $datagrid-filter-focus-color: $theme-color-brand-primary-alt;
 $datagrid-filter-active-color: $theme-color-brand-primary-alt;
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The filter row color was incorrect for dark/uplift, changed the color in the config.

**Related github/jira issue (required)**:
#2289 

**Steps necessary to review your pull request (required)**:
Go to 
http://localhost:4000/components/datagrid/example-filter.html?theme=uplift&variant=dark
- filter row icons and text should be visible now
