### PR TITLE
2274 - Datagrid Column sortFunction

### DIFF
--- a/app/views/components/datagrid/example-list.html
+++ b/app/views/components/datagrid/example-list.html
@@ -16,7 +16,7 @@
       columns.push({ id: 'phone', name: 'Phone', field: 'phone'});
       columns.push({ id: 'location', name: 'Location', field: 'location'});
       columns.push({ id: 'contact', name: 'Contact Name', field: 'contact'});
-      columns.push({ id: 'customerSince', name: 'Customer Since', field: 'customerSince'});
+      columns.push({ id: 'customerSince', name: 'Customer Since', field: 'customerSince', sortFunction: function (value) { return Locale.parseDate(value).getTime(); } });
       columns.push({ id: 'action', name: 'Action Item', field: 'action', text: 'New Order', formatter: Formatters.Button, focusable: true, click: function () {console.log('Nice Clicking'); }, width: 170 });
 
       var url = '{{basepath}}api/companies';

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### v4.20.0 Features
 
-- `[Datagrid]` Added a Sort Function to the datagrid column to allow for the value to be formatted for the sort. ([#1766](https://github.com/infor-design/enterprise/issues/2274)))
+- `[Datagrid]` Added a Sort Function to the datagrid column to allow the value to be formatted for the sort. ([#1766](https://github.com/infor-design/enterprise/issues/2274)))
 
 ### v4.20.0 Fixes
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### v4.20.0 Features
 
+- `[Datagrid]` Added a Sort Function to the datagrid column to allow for the value to be formatted for the sort. ([#1766](https://github.com/infor-design/enterprise/issues/2274)))
+
 ### v4.20.0 Fixes
 
 - `[Homepages]` Fixed an issue where personalize and chart text colors were not working with hero. ([#2097](https://github.com/infor-design/enterprise/issues/2097))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9951,8 +9951,8 @@ Datagrid.prototype = {
   sortFunction(id, ascending) {
     const column = this.columnById(id);
     // Assume the field and id match if no column found
-    const col  = column.length === 0 ? null : column[0];
-    const field = column.length === 0 ? id : column[0].field;
+    const col = column.length === 0 ? null : column[0];
+    const field = col === null ? id : col.field;
     
     const self = this;
     const primer = function (a) {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9951,8 +9951,9 @@ Datagrid.prototype = {
   sortFunction(id, ascending) {
     const column = this.columnById(id);
     // Assume the field and id match if no column found
+    const col  = column.length === 0 ? null : column[0];
     const field = column.length === 0 ? id : column[0].field;
-
+    
     const self = this;
     const primer = function (a) {
       a = (a === undefined || a === null ? '' : a);
@@ -9967,7 +9968,10 @@ Datagrid.prototype = {
       return a;
     };
 
-    const key = function (x) { return primer(self.fieldValue(x, field)); };
+    let key = function (x) { return primer(self.fieldValue(x, field)); };
+    if (col && col.sortFunction) {
+      key = function (x) { return col.sortFunction(self.fieldValue(x, field)); };
+    }
 
     ascending = !ascending ? -1 : 1;
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Text date in the dataset are sorted as text, you can not always determine if the string is a date or if it needs to be parsed to a date to sort correctly, so I added a sortFunction to allow the value to be converted to a value for the sort. This can then be used for any column type, eg DropDown list sorted by the label or value. 

**Related github/jira issue (required)**:
Closes #2274 

**Steps necessary to review your pull request (required)**:
1. Go to http://localhost:4000/components/datagrid/example-list
2. Click the "Customer Since" column header to sort in ascending order
