### PR TITLE
2321 - Fix an ie 11 incompatibility in the example [v4.19.x]

### DIFF
--- a/app/views/components/datagrid/example-beforeselect-veto.html
+++ b/app/views/components/datagrid/example-beforeselect-veto.html
@@ -41,15 +41,18 @@
           }
 
           // If just Control or Meta (Mac) is done then allow the select.
-          if (Soho.keyboard.pressedKeys.entries().next().value[0] === 'Control' ||
-            Soho.keyboard.pressedKeys.entries().next().value[0] === 'Meta') {
+          if (Soho.keyboard.pressedKeys.get('Control') ||
+            Soho.keyboard.pressedKeys.get('Meta')) {
             var isSelected = gridApi.isRowSelected(args.idx);
             if (isSelected) {
               gridApi.deselectRow(args.idx, false, true);
             } else {
               gridApi.selectRow(args.idx, false, true);
             }
+            return true;
           }
+
+          $('body').toast({title: 'Selection Vetoed', message: 'In this example, selection is vetoed. You must hold CTRL and click a row to select (or Command on Mac)'});
           return false;
         },
         toolbar: {title: 'Data Grid Header Title', personalize: true, results: true, actions: true, rowHeight: true, selectCount: true}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The veto example used a feature not available in IE11. Changed the logic.

**Related github/jira issue (required)**:
Fixes #2321

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/example-beforeselect-veto.html
- open in IE11 (and retest other browsers)
- hold ctrl or command (mac)
- click the checkbox and it should select
- check the console for no errors