### PR TITLE
2298 - Fix personalize examples for IE11 [v4.19.x]

### DIFF
--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -350,11 +350,11 @@ function personalizeStyles(colors) {
 
 .is-personalizable .personalize-header,
 .is-personalizable.tab-container {
-  background-color: ${colors.base};
+  background-color: ${colors.base} !important;;
 }
 
 .is-personalizable .personalize-subheader {
-  background-color: ${colors.lighter};
+  background-color: ${colors.lighter} !important;;
 }
 
 .is-personalizable .personalize-text {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes IE11 issues with the personalize examples

**Related github/jira issue (required)**:
Fixes #2298  (Failed comment) 
Fixes #2277 (Failed comment) 

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/personalize/example-classes.html?theme=uplift
http://localhost:4000/components/personalize/example-form.html?theme=uplift
http://localhost:4000/components/personalize/example-form2.html?theme=uplift
http://localhost:4000/components/personalize/example-form3.html?theme=uplift
http://localhost:4000/components/components/personalize/example-form4.html?theme=uplift
http://localhost:4000/components/components/personalize/example-form4.html?theme=uplift

- on all those example the same problem is fixed
- open IE11
- change to emerald
- change to dark mode
- top should now be emerald as expeced