### PR TITLE
414 - Fix js error was showing after removing item with popupmenu

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `[Homepages]` Fixed an issue where personalize and chart text colors were not working with hero. ([#2097](https://github.com/infor-design/enterprise/issues/2097))
 - `[Modal]` Fixed an issue where the modal component would disappear if its content had a checkbox in it in RTL. ([#332](https://github.com/infor-design/enterprise-ng/issues/332))
+- `[Popupmenu]` Fixed an issue where js error was showing after removing menu item. ([#414](https://github.com/infor-design/enterprise-ng/issues/414))
 
 ### v4.20.0 Chores & Maintenance
 

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -755,7 +755,7 @@ PopupMenu.prototype = {
         return;
       }
 
-      if (self.menu.hasClass('is-open')) {
+      if (self.menu.add(self.element).hasClass('is-open')) {
         self.close();
       } else {
         self.open(e);
@@ -787,9 +787,7 @@ PopupMenu.prototype = {
       // Left-Click activation
       if (leftClick) {
         this.element.on('click.popupmenu', (e) => {
-          if (!this.element.is('.is-open')) {
-            contextMenuHandler(e, true);
-          }
+          contextMenuHandler(e, true);
         });
       }
 
@@ -2074,7 +2072,7 @@ PopupMenu.prototype = {
       isCancelled = false;
     }
 
-    if (!this.menu.hasClass('is-open')) {
+    if (!this.menu.add(this.element).hasClass('is-open')) {
       return;
     }
 
@@ -2127,6 +2125,11 @@ PopupMenu.prototype = {
     // Get rid of internal flags that check for how the menu was opened
     delete this.keydownThenClick;
     delete this.holdingDownClick;
+
+    // If `this.element` comes as `ul` element
+    if (this.element.is('ul.popupmenu')) {
+      this.element.closest('.popupmenu-wrapper').prev('button').removeClass('is-open');
+    }
 
     /**
      * Fires when close.

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -786,14 +786,11 @@ PopupMenu.prototype = {
     if (!immediate) {
       // Left-Click activation
       if (leftClick) {
-        this.element
-          .on('click.popupmenu', (e) => {
-            if (this.element.hasClass('is-open')) {
-              self.close();
-            } else {
-              contextMenuHandler(e, true);
-            }
-          });
+        this.element.on('click.popupmenu', (e) => {
+          if (!this.element.is('.is-open')) {
+            contextMenuHandler(e, true);
+          }
+        });
       }
 
       // Right-Click activation

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -788,7 +788,12 @@ PopupMenu.prototype = {
       if (leftClick) {
         this.element
           .on('click.popupmenu', (e) => {
-            contextMenuHandler(e, true);
+            // contextMenuHandler(e, true);
+            if (this.element.hasClass('is-open')) {
+              self.close();
+            } else {
+              contextMenuHandler(e, true);
+            }
           });
       }
 

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -788,7 +788,6 @@ PopupMenu.prototype = {
       if (leftClick) {
         this.element
           .on('click.popupmenu', (e) => {
-            // contextMenuHandler(e, true);
             if (this.element.hasClass('is-open')) {
               self.close();
             } else {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed js error was showing after removing menu item with Popupmenu.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#414

**Steps necessary to review your pull request (required)**:
- Pull and build this EP branch
- Pull and build NG branch ([414-popupmenu-removed-item](https://github.com/infor-design/enterprise-ng/tree/414-popupmenu-removed-item))
- Copy and replace "dist" folder from `enterprise` to `⁨enterprise-ng⁩/node_modules⁩/ids-enterprise`
- Navigate to http://localhost:4200/ids-enterprise-ng-demo/menu-button
- Open developer tools
- Click the charts menu to open
- Click last item `Click this to remove myself`
- See the console, should not be any error


- [x] A note to the change log.

