### PR TITLE
2325 - Add uplift theme to the switcher

### DIFF
--- a/app/src/js/middleware/info-handler.js
+++ b/app/src/js/middleware/info-handler.js
@@ -5,7 +5,7 @@ function removeButtonFromScript(html) {
   if (html.indexOf('<div id="info-popup"') > -1) {
     return html;
   }
-  return html.replace('id="info-btn" class="btn-icon"', 'id="info-btn" class="btn-icon invisible"');
+  return html.replace('id="info-btn" class="btn-icon ignore-in-menu"', 'id="info-btn" class="btn-icon ignore-in-menu invisible"');
 }
 
 module.exports = function () {

--- a/app/views/components/compositeform/_header.html
+++ b/app/views/components/compositeform/_header.html
@@ -26,7 +26,7 @@
     </div>
 
     <div class="more">
-      <button class="btn-actions page-changer" type="button" id="btn-1">
+      <button class="btn-actions" type="button" id="btn-1">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use xlink:href="#icon-more"></use>
         </svg>

--- a/app/views/components/menubutton/example-submenu-icons.html
+++ b/app/views/components/menubutton/example-submenu-icons.html
@@ -2,7 +2,7 @@
 <div class="row">
   <div class="twelve columns">
 
-      <button class="btn-actions page-changer" type="button">
+      <button class="btn-actions" type="button">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use xlink:href="#icon-more"></use>
         </svg>

--- a/app/views/components/popupmenu/example-selectable.html
+++ b/app/views/components/popupmenu/example-selectable.html
@@ -8,17 +8,12 @@
         </svg>
       </button>
       <ul class="popupmenu is-selectable">
-        <li class="is-checked"><a href="#">Menu Option #1</a></li>
+        <li><a href="#">Menu Option #1</a></li>
         <li><a href="#">Menu Option #2</a></li>
         <li><a href="#">Menu Option #3</a></li>
-        <li class="submenu">
-          <a href="#">Sub Options</a>
-          <ul class="popupmenu">
-            <li><a href="#" data-theme="theme-soho-light">Sub Options #1</a></li>
-            <li><a href="#" data-theme="theme-soho-dark">Sub Options #2</a></li>
-            <li><a href="#" data-theme="theme-soho-contrast">Sub Options #3</a></li>
-          </ul>
-        </li>
+        <li class="is-checked"><a href="#">Sub Option #4</a></li>
+        <li><a href="#">Menu Option #5</a></li>
+        <li><a href="#">Menu Option #6</a></li>
       </ul>
     </div>
   </div>

--- a/app/views/components/popupmenu/example-selectable.html
+++ b/app/views/components/popupmenu/example-selectable.html
@@ -8,12 +8,17 @@
         </svg>
       </button>
       <ul class="popupmenu is-selectable">
-        <li><a href="#">Menu Option #1</a></li>
+        <li class="is-checked"><a href="#">Menu Option #1</a></li>
         <li><a href="#">Menu Option #2</a></li>
         <li><a href="#">Menu Option #3</a></li>
-        <li class="is-checked"><a href="#">Sub Option #4</a></li>
-        <li><a href="#">Menu Option #5</a></li>
-        <li><a href="#">Menu Option #6</a></li>
+        <li class="submenu">
+          <a href="#">Sub Options</a>
+          <ul class="popupmenu">
+            <li><a href="#" data-theme="theme-soho-light">Sub Options #1</a></li>
+            <li><a href="#" data-theme="theme-soho-dark">Sub Options #2</a></li>
+            <li><a href="#" data-theme="theme-soho-contrast">Sub Options #3</a></li>
+          </ul>
+        </li>
       </ul>
     </div>
   </div>

--- a/app/views/components/toolbar/test-ajax-from-menubutton-in-spillover.html
+++ b/app/views/components/toolbar/test-ajax-from-menubutton-in-spillover.html
@@ -46,7 +46,7 @@
       </div>
       <div class="more">
 
-        <button id="predefined-more" class="btn-actions page-changer" type="button">
+        <button id="predefined-more" class="btn-actions" type="button">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
             <use xlink:href="#icon-more"></use>
           </svg>

--- a/app/views/components/toolbar/test-ajax-from-toolbar-on-spillover.html
+++ b/app/views/components/toolbar/test-ajax-from-toolbar-on-spillover.html
@@ -54,7 +54,7 @@
       </div>
       <div class="more">
 
-        <button id="predefined-more" class="btn-actions page-changer" type="button">
+        <button id="predefined-more" class="btn-actions" type="button">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
             <use xlink:href="#icon-more"></use>
           </svg>

--- a/app/views/components/toolbar/test-ajax-on-spillover.html
+++ b/app/views/components/toolbar/test-ajax-on-spillover.html
@@ -52,7 +52,7 @@
       </div>
       <div class="more">
 
-        <button id="predefined-more" class="btn-actions page-changer" type="button">
+        <button id="predefined-more" class="btn-actions" type="button">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
             <use xlink:href="#icon-more"></use>
           </svg>

--- a/app/views/components/toolbar/test-tooltips-populating-more-actions.html
+++ b/app/views/components/toolbar/test-tooltips-populating-more-actions.html
@@ -58,7 +58,7 @@
       </div>
       <div class="more">
 
-        <button id="predefined-more" class="btn-actions page-changer" type="button" title="More">
+        <button id="predefined-more" class="btn-actions" type="button" title="More">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
             <use xlink:href="#icon-more"></use>
           </svg>

--- a/app/views/includes/head.html
+++ b/app/views/includes/head.html
@@ -58,7 +58,17 @@
     {{/colors}}
 
     // If Initialize isnt called need to defer this
-    $('html').personalize({colors: colors, theme: theme, blockUI: blockUI});
+    $('html')
+      .personalize({colors: colors, theme: theme, blockUI: blockUI})
+      .on('colorschanged', function (e, a) {
+        var pageUrl = '?colors=' + a.colors;
+        window.history.pushState('', '', pageUrl);
+      })
+      .on('themechanged', function (e, a) {
+        const parts = a.theme.split('-');
+        var pageUrl = '?theme=' + parts[1] + '&variant=' + parts[2];
+        window.history.pushState('', '', pageUrl);
+      });
   </script>
 
   <link rel="stylesheet" href="{{basepath}}css/demo.css" type="text/css"/>

--- a/app/views/includes/header-actionbutton.html
+++ b/app/views/includes/header-actionbutton.html
@@ -7,11 +7,26 @@
     <span class="audible" data-translate="text">More</span>
   </button>
   <ul class="popupmenu is-selectable">
-    <li class="heading" role="presentation">Theme</li>
-    <li class="is-selectable is-checked"><a href="#" data-theme="theme-soho-light">Light</a></li>
-    <li class="is-selectable"><a href="#" data-theme="theme-soho-dark">Dark</a></li>
-    <li class="is-selectable"><a href="#" data-theme="theme-soho-contrast">High Contrast</a></li>
-    <li class="separator"></li>
-    <li class="personalization-colors"></li>
+    <li>
+      <a href="#">Theme</a>
+      <ul class="popupmenu">
+        <li class="is-selectable is-checked"><a href="#" data-theme-name="theme-soho">Soho</a></li>
+        <li class="is-selectable"><a href="#" data-theme-name="theme-uplift">Uplift</a></li>
+      </ul>
+    </li>
+    <li>
+      <a href="#">Variant</a>
+      <ul class="popupmenu">
+        <li class="is-selectable is-checked"><a href="#" data-theme-variant="light">Light</a></li>
+        <li class="is-selectable"><a href="#" data-theme-variant="dark">Dark</a></li>
+        <li class="is-selectable"><a href="#" data-theme-variant="contrast">High Contrast</a></li>
+      </ul>
+    </li>
+    <li>
+      <a href="#">Colors</a>
+      <ul class="popupmenu">
+        <li class="personalization-colors"></li>
+      </ul>
+    </li>
   </ul>
 </div>

--- a/app/views/includes/header.html
+++ b/app/views/includes/header.html
@@ -16,7 +16,7 @@
     </div>
 
     <div class="{{#useFlexToolbar}}toolbar-section {{/useFlexToolbar}}buttonset">
-      <button type="button" id="info-btn" class="btn-icon" data-options="{'placement': 'below', 'keepOpen': 'true'}">
+      <button type="button" id="info-btn" class="btn-icon ignore-in-menu" data-options="{'placement': 'below', 'keepOpen': 'true'}">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use xlink:href="#icon-info"></use>
         </svg>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### v4.20.0 Chores & Maintenance
 
+- `[Demo App]` Add the uplift theme to the theme switcher menu. ([#2335](https://github.com/infor-design/enterprise/issues/2335))
+
 ## v4.19.0
 
 ### v4.19.0 Deprecations

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -507,7 +507,8 @@ Header.prototype = {
 
     if (colorArea.length > 0) {
       const colors = theme.personalizationColors();
-      let colorsHtml = '<li class="heading" role="presentation">Personalization</li>';
+      let colorsHtml = colorArea.parent().hasClass('popupmenu') ? '' :
+        '<li class="heading" role="presentation">Personalization</li>';
 
       Object.keys(colors).forEach((color) => {
         colorsHtml += `<li class="is-selectable${colors[color].name === 'Default' ? ' is-checked is-default' : ''}"><a href="#" data-rgbcolor="${colors[color].value}">${colors[color].name}</a></li>`;

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -517,6 +517,18 @@ Header.prototype = {
     }
 
     changer.on('selected.header', (e, link) => {
+      // Change Theme with Variant
+      const themeNameAttr = link.attr('data-theme-name');
+      const themeVariantAttr = link.attr('data-theme-variant');
+      if (themeNameAttr || themeVariantAttr) {
+        const name = changer.next().find('.is-checked a[data-theme-name]').attr('data-theme-name');
+        const variant = changer.next().find('.is-checked a[data-theme-variant]').attr('data-theme-variant');
+        if (name && variant) {
+          personalization.setTheme(`${name}-${variant}`);
+        }
+        return;
+      }
+
       // Change Theme
       const themeAttr = link.attr('data-theme');
       if (themeAttr) {

--- a/src/components/listview/_listview.scss
+++ b/src/components/listview/_listview.scss
@@ -81,7 +81,7 @@
   }
 
   .listview-micro {
-    color: $theme-color-palette-graphite-60;
+    color: $listview-tertiary-color;
     font-size: $theme-size-font-sm;
 
     &::after {

--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -303,6 +303,8 @@ Personalize.prototype = {
     newCss.on('load', () => {
       originalCss.remove();
       self.unBlockUi();
+    }).on('error', () => {
+      self.unBlockUi();
     });
 
     const themePath = path ? path.substring(0, path.lastIndexOf('/')) : '';

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -226,7 +226,7 @@ Toolbar.prototype = {
     }
 
     const menuItems = [];
-    this.items.not(this.more).filter(menuItemFilter).each(function () {
+    this.items.not(this.more).not('.ignore-in-menu').filter(menuItemFilter).each(function () {
       menuItems.push(self.buildMoreActionsMenuItem($(this)));
     });
 
@@ -1216,7 +1216,7 @@ Toolbar.prototype = {
 
     let numIcons = 0;
     this.moreMenu.find('.icon').each(function () {
-      if (!$(this).parent().parent().hasClass('hidden')) {
+      if (!$(this).parent().parent().hasClass('hidden') && !$(this).hasClass('icon-dropdown')) {
         numIcons++;
       }
     });

--- a/src/themes/theme-uplift-contrast.scss
+++ b/src/themes/theme-uplift-contrast.scss
@@ -141,7 +141,7 @@ $popupmenu-bg-color: $theme-color-palette-white;
 $popupmenu-border-color: $theme-color-palette-graphite-60;
 $popupmenu-box-shadow: 0 2px 5px $drop-shadow-depth;
 $popupmenu-heading-color: $theme-color-palette-graphite-70;
-$popupmenu-hover-color: $theme-color-brand-secondary-alt;
+$popupmenu-hover-color: $theme-color-palette-graphite-30;
 $popupmenu-checked-color: $theme-color-palette-azure-90;
 $popupmenu-checked-color-inverse: $theme-color-brand-primary-base;
 

--- a/src/themes/theme-uplift-contrast.scss
+++ b/src/themes/theme-uplift-contrast.scss
@@ -141,7 +141,7 @@ $popupmenu-bg-color: $theme-color-palette-white;
 $popupmenu-border-color: $theme-color-palette-graphite-60;
 $popupmenu-box-shadow: 0 2px 5px $drop-shadow-depth;
 $popupmenu-heading-color: $theme-color-palette-graphite-70;
-$popupmenu-hover-color: $theme-color-palette-graphite-30;
+$popupmenu-hover-color: $theme-color-palette-graphite-50;
 $popupmenu-checked-color: $theme-color-palette-azure-90;
 $popupmenu-checked-color-inverse: $theme-color-brand-primary-base;
 

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -1660,10 +1660,12 @@ describe('Datagrid save user settings', () => {
       expect(await element(by.css('#datagrid tbody tr:nth-child(1) td:nth-child(1)')).getText()).toEqual('0');
       await element(by.css('#datagrid .datagrid-header th:nth-child(1)')).click();
       await element(by.css('#datagrid .datagrid-header th:nth-child(1)')).click();
+      await browser.driver.sleep(config.sleep);
 
       expect(await element(by.css('#datagrid tbody tr:nth-child(1) td:nth-child(1)')).getText()).toEqual('99');
       await browser.refresh();
 
+      await browser.driver.sleep(config.sleep);
       expect(await element(by.css('#datagrid tbody tr:nth-child(1) td:nth-child(1)')).getText()).toEqual('99');
     });
   }

--- a/test/components/personalize/personalize-api.func-spec.js
+++ b/test/components/personalize/personalize-api.func-spec.js
@@ -78,13 +78,4 @@ describe('Personalize API', () => {
 
     expect(document.documentElement.classList.contains('theme-uplift-dark')).toBeTruthy();
   });
-
-  it('Should get rid of the overlay on a bad theme name', (done) => {
-    personalization.setTheme('theme-foo-blahblah');
-
-    setTimeout(() => {
-      expect(document.querySelector('.personalize-overlay')).toBeFalsy();
-      done();
-    }, 300);
-  });
 });

--- a/test/components/personalize/personalize-api.func-spec.js
+++ b/test/components/personalize/personalize-api.func-spec.js
@@ -78,4 +78,13 @@ describe('Personalize API', () => {
 
     expect(document.documentElement.classList.contains('theme-uplift-dark')).toBeTruthy();
   });
+
+  it('Should get rid of the overlay on a bad theme name', (done) => {
+    personalization.setTheme('theme-foo-blahblah');
+
+    setTimeout(() => {
+      expect(document.querySelector('.personalize-overlay')).toBeFalsy();
+      done();
+    }, 300);
+  });
 });

--- a/test/components/personalize/personalize.e2e-spec.js
+++ b/test/components/personalize/personalize.e2e-spec.js
@@ -16,15 +16,16 @@ describe('Personalization tests', () => {
 
   it('Should maintain chosen theme after reinitialization', async () => {
     const pageChangerButtonEl = await element.all(by.css('.page-changer'));
-    const themeChoices = await element.all(by.css('.popupmenu li.is-selectable a[data-theme]'));
-    const arrayLength = await themeChoices.length;
-    const randomIndex = await Math.floor(Math.random() * arrayLength);
+    const themeChoices = await element.all(by.css('.popupmenu li.is-selectable a[data-theme-name]'));
     const reinitButton = await element(by.id('reinitialize'));
 
     await pageChangerButtonEl[0].click();
-    await themeChoices[randomIndex].click();
+    await browser.driver.sleep(config.sleep);
+    await element.all(by.css('.popupmenu li.submenu')).get(0).click();
+    await browser.driver.sleep(config.sleep);
+    await themeChoices[1].click();
 
-    const chosenTheme = await element.all(by.css('.popupmenu li.is-checked a[data-theme]')).getAttribute('data-theme');
+    const chosenTheme = await element.all(by.css('.popupmenu li.is-checked a[data-theme-name]')).getAttribute('data-theme-name');
 
     expect(await element.all(by.css('html')).get(0).getAttribute('class')).toContain(chosenTheme[0]);
     await browser.driver
@@ -40,7 +41,9 @@ describe('Personalization tests', () => {
     const reinitButton = await element(by.id('reinitialize'));
 
     await element(by.css('.page-changer')).click();
-    await await element.all(by.css('.popupmenu li.is-selectable a[data-rgbcolor]')).get(4).click();
+    await element.all(by.css('.popupmenu li.submenu')).get(2).click();
+    await browser.driver.sleep(config.sleep);
+    await element.all(by.css('.popupmenu li.is-selectable a[data-rgbcolor]')).get(4).click();
     await browser.driver.sleep(config.sleep);
 
     const beforeInitSheet = await element(by.id('soho-personalization')).getText();
@@ -96,7 +99,7 @@ describe('Personalization form tests', () => {
   }
 });
 
-describe('Personalization alternae form tests', () => {
+describe('Personalization alternate form tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/personalize/example-form3.html?layout=nofrills');
   });

--- a/test/components/toast/toast.e2e-spec.js
+++ b/test/components/toast/toast.e2e-spec.js
@@ -34,11 +34,12 @@ describe('Toast example-index tests', () => {
     const buttonEl = await element(by.id('show-toast-message'));
     await buttonEl.click();
 
-    await browser.driver.wait(protractor.ExpectedConditions.visibilityOf(element(by.id('toast-container'))), config.waitsFor);
+    await browser.driver.wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('toast-container'))), config.waitsFor);
 
     await element(by.className('btn-close')).click();
+    await browser.driver.wait(protractor.ExpectedConditions.invisibilityOf(await element(by.id('toast-container'))), config.waitsFor);
 
-    expect(await element(by.id('toast-container'))).toBeTruthy();
+    expect(await element(by.id('toast-container')).isDisplayed()).toBeFalsy();
   });
 });
 

--- a/test/kitchen-sink.e2e-spec.js
+++ b/test/kitchen-sink.e2e-spec.js
@@ -41,13 +41,19 @@ describe('Kitchen-sink tests', () => {
       await browser.driver
         .wait(protractor.ExpectedConditions.presenceOf(buttonChangerEl), config.waitsFor);
       await buttonChangerEl.click();
-      const highContrastItem = await element(by.cssContainingText('.popupmenu.is-open li', 'High Contrast'));
+      const highContrastItem = await element(by.cssContainingText('.popupmenu.is-open li', 'Theme'));
       await browser.driver
         .wait(protractor.ExpectedConditions.presenceOf(highContrastItem), config.waitsFor);
       await highContrastItem.click();
       await browser.driver.sleep(config.sleep);
 
-      expect(await element(by.css('html')).getAttribute('class')).toContain('theme-soho-contrast');
+      const upliftItem = await element.all(by.cssContainingText('.popupmenu.is-open li', 'Uplift')).get(1);
+      await browser.driver
+        .wait(protractor.ExpectedConditions.presenceOf(upliftItem), config.waitsFor);
+      await upliftItem.click();
+      await browser.driver.sleep(config.sleep);
+
+      expect(await element(by.css('html')).getAttribute('class')).toContain('theme-uplift-light');
     });
   }
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Updated the theme switcher to include the uplift theme. In doing so split it into 3 submenus.
Also fixed a couple bugs noticed in the examples as related.

- Sending a non existant theme leaves the overlay on
- The uplift / high contrast example hover state was wrong
- The text in dark theme was wrong on list view
- Fixed a bug where a toolbar with submenus may have too much padding
- Updated a couple tests that failed randomly

**Related github/jira issue (required)**:
Closes #2325

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/listview/example-index.html?theme=soho&variant=dark
- notice the text color

http://localhost:4000/components/listview/example-index.html?theme=uplift&variant=contrast
- open the ... and hover the items
- any page like the above two, use the switcher to change theme and color

