### PR TITLE
2355- add attachToBody option to standalone-pager for pageSizeChooser menu [v4.19.x]

### DIFF
--- a/app/views/components/pager/example-standalone.html
+++ b/app/views/components/pager/example-standalone.html
@@ -12,6 +12,10 @@
       <label for="toggle-small-pagesize" class="checkbox-label">Use Small Page Size Selector</label>
       </div>
     <div class="field">
+      <input type="checkbox" class="checkbox" name="toggle-attach-to-body" id="toggle-attach-to-body" disabled="true" />
+      <label for="toggle-attach-to-body" class="checkbox-label">Attach Page Size Menu To Body</label>
+    </div>
+    <div class="field">
       <input type="checkbox" class="checkbox" name="toggle-first-button" id="toggle-first-button"/>
       <label for="toggle-first-button" class="checkbox-label">Hide First Button</label>
     </div>
@@ -79,7 +83,7 @@
       enableNextButton: true,
       showLastButton: true,
       enableLastButton: true,
-      attachPageSizeMenuToBody: true,
+      attachPageSizeMenuToBody: false,
       onFirstPage: function (elem, args) {
         $('body').toast({title: 'onFirstPage Callback Fired', message: ''});
       },
@@ -123,7 +127,13 @@
       }
 
       $('#toggle-small-pagesize').prop('disabled', !isChecked);
+      $('#toggle-attach-to-body').prop('disabled', !isChecked);
       api.updated(opts);
+    });
+
+    $('#toggle-attach-to-body').on('change.test', function() {
+      var isChecked = this.checked;
+      api.updated({attachPageSizeMenuToBody: isChecked});
     });
 
     $('#toggle-small-pagesize').on('change.test', function() {

--- a/app/views/components/pager/example-standalone.html
+++ b/app/views/components/pager/example-standalone.html
@@ -79,6 +79,7 @@
       enableNextButton: true,
       showLastButton: true,
       enableLastButton: true,
+      attachPageSizeMenuToBody: true,
       onFirstPage: function (elem, args) {
         $('body').toast({title: 'onFirstPage Callback Fired', message: ''});
       },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -103,6 +103,7 @@
 - `[Personalize]` Separated personalization styles into standalone file for improved maintainability. ([#2127](https://github.com/infor-design/enterprise/issues/2127))
 
 (84 Issues Solved this release, Backlog Enterprise 311, Backlog Ng 79, 839 Functional Tests, 876 e2e Test)
+
 ## v4.18.2
 
 ### v4.18.2 Fixes

--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -95,7 +95,8 @@ const PAGER_DEFAULTS = {
   firstPageTooltip: 'FirstPage',
   previousPageTooltip: 'PreviousPage',
   nextPageTooltip: 'NextPage',
-  lastPageTooltip: 'LastPage'
+  lastPageTooltip: 'LastPage',
+  attachToBody: false
 };
 
 function Pager(element, settings) {
@@ -998,7 +999,7 @@ Pager.prototype = {
       }
 
       // Render the button
-      const pageSizeButton = $(`<button type="button" class="btn-menu">
+      const pageSizeButton = $(`<button type="button" class="btn-menu"  data-options="{attachToBody: ${this.settings.attachToBody}}">
         ${recordHtml}
         ${dropdownIcon}
       </button>`).appendTo(pageSizeLi);

--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -96,7 +96,7 @@ const PAGER_DEFAULTS = {
   previousPageTooltip: 'PreviousPage',
   nextPageTooltip: 'NextPage',
   lastPageTooltip: 'LastPage',
-  attachToBody: false
+  attachPageSizeMenuToBody: false
 };
 
 function Pager(element, settings) {
@@ -999,7 +999,7 @@ Pager.prototype = {
       }
 
       // Render the button
-      const pageSizeButton = $(`<button type="button" class="btn-menu"  data-options="{attachToBody: ${this.settings.attachToBody}}">
+      const pageSizeButton = $(`<button type="button" class="btn-menu">
         ${recordHtml}
         ${dropdownIcon}
       </button>`).appendTo(pageSizeLi);
@@ -1022,7 +1022,8 @@ Pager.prototype = {
           parent: pageSizeButton,
           parentXAlignment: (Locale.isRTL() ? 'left' : 'right'),
           strategies: ['flip']
-        }
+        },
+        attachToBody: this.settings.attachPageSizeMenuToBody
       };
 
       pageSizeButton.popupmenu(popupOpts);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Because we have a position: sticky menu the pager dropdown menu is not sizing correctly when its open in our app. The existing option attachPageToBody fixes this but the pager doesnt have a way to set it.

**Related github/jira issue (required)**:
Fixes #2355 

**Steps necessary to review your pull request (required)**:

- go to http://localhost:4000/components/pager/example-standalone.html
- toggle the attach pagesize menu to body checkbox
- look in the dom and notice the page size menu 
   - if checked the page size chooser menu should be at the dom level
   - if unchecked the page size chooser will show in the pager element.
