### PR TITLE
2348 - Fix input example was not working with field options

### DIFF
--- a/app/views/components/field-options/example-input-fields.html
+++ b/app/views/components/field-options/example-input-fields.html
@@ -1,4 +1,25 @@
-<ul id="action-popupmenu" data-init="false" class="popupmenu">
+<ul id="action-popupmenu-xs" data-init="false" class="popupmenu">
+  <li><a href="#">Show Extra Small</a></li>
+  <li><a href="#">Show History</a></li>
+  <li><a href="#">Edit Record</a></li>
+</ul>
+<ul id="action-popupmenu-sm" data-init="false" class="popupmenu">
+  <li><a href="#">Show Small</a></li>
+  <li><a href="#">Show History</a></li>
+  <li><a href="#">Edit Record</a></li>
+</ul>
+<ul id="action-popupmenu-md" data-init="false" class="popupmenu">
+  <li><a href="#">Show Medium</a></li>
+  <li><a href="#">Show History</a></li>
+  <li><a href="#">Edit Record</a></li>
+</ul>
+<ul id="action-popupmenu-lg" data-init="false" class="popupmenu">
+  <li><a href="#">Show Large</a></li>
+  <li><a href="#">Show History</a></li>
+  <li><a href="#">Edit Record</a></li>
+</ul>
+
+<ul id="action-popupmenu-full" data-init="false" class="popupmenu">
   <li><a href="#">Cut</a></li>
   <li><a href="#">Copy</a></li>
   <li><a href="#">Paste</a></li>
@@ -45,7 +66,7 @@
       <label for="input-xs">Input XS</label>
       <input id="input-xs" type="text" class="input-xs field-options" />
 
-      <button id="input-xs-fieldopts" class="btn-actions btn-menu" type="button" data-options='{ "menu": "action-popupmenu" }'>
+      <button id="input-xs-fieldopts" class="btn-actions btn-menu" type="button" data-options='{ "menu": "action-popupmenu-xs" }'>
         <span class="audible">Actions for Extra-small Input Field</span>
         <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
           <use xlink:href="#icon-more"/>
@@ -62,7 +83,7 @@
       <label for="input-sm">Input SM</label>
       <input id="input-sm" type="text" class="input-sm field-options" />
 
-      <button id="input-sm-fieldopts" class="btn-actions btn-menu" type="button" data-options='{ "menu": "action-popupmenu" }'>
+      <button id="input-sm-fieldopts" class="btn-actions btn-menu" type="button" data-options='{ "menu": "action-popupmenu-sm" }'>
         <span class="audible">Actions for Small Input Field</span>
         <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
           <use xlink:href="#icon-more"/>
@@ -79,7 +100,7 @@
       <label for="input-md">Input MD</label>
       <input id="input-md" type="text" class="input-md field-options" />
 
-      <button id="input-md-fieldopts" class="btn-actions btn-menu" type="button" data-options='{ "menu": "action-popupmenu" }'>
+      <button id="input-md-fieldopts" class="btn-actions btn-menu" type="button" data-options='{ "menu": "action-popupmenu-md" }'>
         <span class="audible">Actions for Medium Input Field</span>
         <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
           <use xlink:href="#icon-more"/>
@@ -96,7 +117,7 @@
       <label for="input-lg">Input LG</label>
       <input id="input-lg" type="text" class="input-lg field-options" />
 
-      <button id="input-lg-fieldopts" class="btn-actions btn-menu" type="button" data-options='{ "menu": "action-popupmenu" }'>
+      <button id="input-lg-fieldopts" class="btn-actions btn-menu" type="button" data-options='{ "menu": "action-popupmenu-lg" }'>
         <span class="audible">Actions for Large Input Field</span>
         <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
           <use xlink:href="#icon-more"/>
@@ -113,7 +134,7 @@
       <label for="input-full">Input Full</label>
       <input id="input-full" type="text" class="input-full field-options" />
 
-      <button id="input-full-fieldopts" class="btn-actions btn-menu" type="button" data-options='{ "menu": "action-popupmenu" }'>
+      <button id="input-full-fieldopts" class="btn-actions btn-menu" type="button" data-options='{ "menu": "action-popupmenu-full" }'>
         <span class="audible">Actions for Full-sized Input Field</span>
         <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
           <use xlink:href="#icon-more"/>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `[Homepages]` Fixed an issue where personalize and chart text colors were not working with hero. ([#2097](https://github.com/infor-design/enterprise/issues/2097))
 - `[Fieldfilter]` Fixed an issue where Dropdown was not switching mode on example page. ([#2288](https://github.com/infor-design/enterprise/issues/2288))
+- `[Field Options]` Fixed an issue where input example was not working. ([#2348](https://github.com/infor-design/enterprise/issues/2348))
 - `[Modal]` Fixed an issue where the modal component would disappear if its content had a checkbox in it in RTL. ([#332](https://github.com/infor-design/enterprise-ng/issues/332))
 
 ### v4.20.0 Chores & Maintenance


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed input example was not working with field options.

**Related github/jira issue (required)**:
Closes #2348

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demoapp
- Navigate to http://localhost:4000/components/contextmenu/example-field-options.html
- Open the field options data for Input SM
- Open the field options data for Input LG
- Focus should disappear on the previous field

- [x] A note to the change log.
