### PR TITLE
2216 - Missing Languages on en-GB (or "child" languages) [v4.19.x]

### DIFF
--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -322,7 +322,9 @@ const Locale = {  // eslint-disable-line
     if (locale && !this.cultures[locale] && this.currentLocale.name !== locale) {
       this.setCurrentLocale(locale);
       // Fetch the local and cache it
-      this.appendLocaleScript(locale, !resolveToParent);
+      setTimeout(() => {
+        this.appendLocaleScript(locale, !resolveToParent);
+      });
     }
 
     if (locale && self.currentLocale.data && self.currentLocale.dataName === locale) {

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -313,8 +313,8 @@ const Locale = {  // eslint-disable-line
     let resolveToParent = false;
     const match = this.defaultLocales.filter(a => a.lang === lang);
     const parentLocale = match[0] || [{ default: 'en-US' }];
-    if (parentLocale.default && parentLocale.default !== 'en-US'
-      && parentLocale.default !== locale && !this.cultures[parentLocale.default]) {
+    if (parentLocale.default && parentLocale.default !== locale &&
+      !this.cultures[parentLocale.default]) {
       resolveToParent = true;
       this.appendLocaleScript(parentLocale.default, false, locale);
     }
@@ -322,9 +322,7 @@ const Locale = {  // eslint-disable-line
     if (locale && !this.cultures[locale] && this.currentLocale.name !== locale) {
       this.setCurrentLocale(locale);
       // Fetch the local and cache it
-      setTimeout(() => {
-        this.appendLocaleScript(locale, !resolveToParent);
-      });
+      this.appendLocaleScript(locale, !resolveToParent);
     }
 
     if (locale && self.currentLocale.data && self.currentLocale.dataName === locale) {

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -1433,7 +1433,7 @@ const Locale = {  // eslint-disable-line
       showBrackets = options.showBrackets;
     }
 
-    if (languageData.messages === undefined) {
+    if (languageData === undefined || languageData.messages === undefined) {
       return showAsUndefined ? undefined : `${showBrackets ? '[' : ''}${key}${showBrackets ? ']' : ''}`;
     }
 

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -378,7 +378,7 @@ Tooltip.prototype = {
       }
 
       // Could be a translation definition
-      content = Locale.translate(content, true) || content;
+      content = Locale.translate(content, { showAsUndefined: true }) || content;
 
       // Could be an ID attribute.
       // If it matches an element already on the page, grab that element's content

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -959,18 +959,16 @@ describe('Locale API', () => {
     expect(['22-03-2018 20:11 GMT-5', '22-03-2018 20:11 GMT-4', '22-03-2018 20:11 EDT']).toContain(Locale.formatDate(new Date(2018, 2, 22, 20, 11, 12), { pattern: 'dd-MM-yyyy HH:mm zz' }));
   });
 
-  if (!utils.isCI()) {
-    it('Should format dates with long timezones', () => {
-      Locale.set('en-US');
+  it('Should format dates with long timezones', () => {
+    Locale.set('en-US');
 
-      expect(['3/22/2018 8:11 PM Eastern Standard Time', '3/22/2018 8:11 PM Eastern Daylight Time']).toContain(Locale.formatDate(new Date(2018, 2, 22, 20, 11, 12), { date: 'timezoneLong' }));
-      expect(['22-03-2000 20:11 Eastern Standard Time', '22-03-2000 20:11 Eastern Daylight Time']).toContain(Locale.formatDate(new Date(2000, 2, 22, 20, 11, 12), { pattern: 'dd-MM-yyyy HH:mm zzzz' }));
-      Locale.set('nl-NL');
+    expect(['3/22/2018 8:11 PM Eastern Standard Time', '3/22/2018 8:11 PM Eastern Daylight Time']).toContain(Locale.formatDate(new Date(2018, 2, 22, 20, 11, 12), { date: 'timezoneLong' }));
+    expect(['22-03-2000 20:11 Eastern Standard Time', '22-03-2000 20:11 Eastern Daylight Time']).toContain(Locale.formatDate(new Date(2000, 2, 22, 20, 11, 12), { pattern: 'dd-MM-yyyy HH:mm zzzz' }));
+    Locale.set('nl-NL');
 
-      expect(['22-03-2018 20:11 Eastern-standaardtijd', '22-03-2018 20:11 Eastern-zomertijd']).toContain(Locale.formatDate(new Date(2018, 2, 22, 20, 11, 12), { date: 'timezoneLong' }));
-      expect(['22-03-2000 20:11 Eastern-standaardtijd', '22-03-2000 20:11 Eastern-zomertijd']).toContain(Locale.formatDate(new Date(2000, 2, 22, 20, 11, 12), { pattern: 'dd-MM-yyyy HH:mm zzzz' }));
-    });
-  }
+    expect(['22-03-2018 20:11 Eastern-standaardtijd', '22-03-2018 20:11 Eastern-zomertijd']).toContain(Locale.formatDate(new Date(2018, 2, 22, 20, 11, 12), { date: 'timezoneLong' }));
+    expect(['22-03-2000 20:11 Eastern-standaardtijd', '22-03-2000 20:11 Eastern-zomertijd']).toContain(Locale.formatDate(new Date(2000, 2, 22, 20, 11, 12), { pattern: 'dd-MM-yyyy HH:mm zzzz' }));
+  });
 
   it('Should parse dates with short timezones in current timezone', () => {
     Locale.set('en-US');

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -959,16 +959,18 @@ describe('Locale API', () => {
     expect(['22-03-2018 20:11 GMT-5', '22-03-2018 20:11 GMT-4', '22-03-2018 20:11 EDT']).toContain(Locale.formatDate(new Date(2018, 2, 22, 20, 11, 12), { pattern: 'dd-MM-yyyy HH:mm zz' }));
   });
 
-  it('Should format dates with long timezones', () => {
-    Locale.set('en-US');
+  if (!utils.isCI()) {
+    it('Should format dates with long timezones', () => {
+      Locale.set('en-US');
 
-    expect(['3/22/2018 8:11 PM Eastern Standard Time', '3/22/2018 8:11 PM Eastern Daylight Time']).toContain(Locale.formatDate(new Date(2018, 2, 22, 20, 11, 12), { date: 'timezoneLong' }));
-    expect(['22-03-2000 20:11 Eastern Standard Time', '22-03-2000 20:11 Eastern Daylight Time']).toContain(Locale.formatDate(new Date(2000, 2, 22, 20, 11, 12), { pattern: 'dd-MM-yyyy HH:mm zzzz' }));
-    Locale.set('nl-NL');
+      expect(['3/22/2018 8:11 PM Eastern Standard Time', '3/22/2018 8:11 PM Eastern Daylight Time']).toContain(Locale.formatDate(new Date(2018, 2, 22, 20, 11, 12), { date: 'timezoneLong' }));
+      expect(['22-03-2000 20:11 Eastern Standard Time', '22-03-2000 20:11 Eastern Daylight Time']).toContain(Locale.formatDate(new Date(2000, 2, 22, 20, 11, 12), { pattern: 'dd-MM-yyyy HH:mm zzzz' }));
+      Locale.set('nl-NL');
 
-    expect(['22-03-2018 20:11 Eastern-standaardtijd', '22-03-2018 20:11 Eastern-zomertijd']).toContain(Locale.formatDate(new Date(2018, 2, 22, 20, 11, 12), { date: 'timezoneLong' }));
-    expect(['22-03-2000 20:11 Eastern-standaardtijd', '22-03-2000 20:11 Eastern-zomertijd']).toContain(Locale.formatDate(new Date(2000, 2, 22, 20, 11, 12), { pattern: 'dd-MM-yyyy HH:mm zzzz' }));
-  });
+      expect(['22-03-2018 20:11 Eastern-standaardtijd', '22-03-2018 20:11 Eastern-zomertijd']).toContain(Locale.formatDate(new Date(2018, 2, 22, 20, 11, 12), { date: 'timezoneLong' }));
+      expect(['22-03-2000 20:11 Eastern-standaardtijd', '22-03-2000 20:11 Eastern-zomertijd']).toContain(Locale.formatDate(new Date(2000, 2, 22, 20, 11, 12), { pattern: 'dd-MM-yyyy HH:mm zzzz' }));
+    });
+  }
 
   it('Should parse dates with short timezones in current timezone', () => {
     Locale.set('en-US');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Saw some errors loading locales that depend on another locale on deployed pages. es-ES -> es-US and en-US -> en-GB ect..

**Related github/jira issue (required)**:
Fixes #2216 

**Steps necessary to review your pull request (required)**:
- go to https://2216-locale-error-enterprise.demo.design.infor.com/components/personalize/example-color-theme-api.html?locale=en-GB
- https://2216-locale-error-enterprise.demo.design.infor.com/components/personalize/example-color-theme-api.html?locale=es-ES
- https://2216-locale-error-enterprise.demo.design.infor.com/components/personalize/example-color-theme-api.html?locale=de-DE
- not not all languages are translated yet so if one is not found it should show in english and not with square brackets around
- ensure the languages are loaded (in the language or english and not with brackets around it) in the dropdowns and no errors in the console
- can try other locales like es-ES or es-US
- can test this page on localhost but never saw the issue there.
