### PR TITLE
2371 - PopupMenu: SubMenu still have is-open class after selection

### DIFF
--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -327,7 +327,7 @@ Accordion.prototype = {
       e.stopPropagation();
     }
 
-    this.closePopups();
+    this.closePopups(e);
 
     /**
      * If the anchor is a real link, follow the link and die here.
@@ -385,8 +385,10 @@ Accordion.prototype = {
       headers.each(function () {
         const api = $(this).data('popupmenu');
         api.close();
-        e.stopPropagation();
-        e.stopImmediatePropagation();
+        if (e !== undefined) {
+          e.stopPropagation();
+          e.stopImmediatePropagation();
+        }
         return false;
       });
     }
@@ -414,7 +416,7 @@ Accordion.prototype = {
       e.stopPropagation();
     }
 
-    this.closePopups(e);
+    this.closePopups();
 
     const pane = header.next('.accordion-pane');
     if (pane.length) {

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -2131,6 +2131,7 @@ PopupMenu.prototype = {
       this.element.closest('.popupmenu-wrapper').prev('button').removeClass('is-open');
     }
 
+    this.menu.find('.popupmenu.is-open').removeClass('is-open');
     /**
      * Fires when close.
      *


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The popup close method, should close all the menus including the submenus. 
The accordion has two calls to closePopups(e), and one does not pass the event, so this should be checked before running any methods.

**Related github/jira issue (required)**:
Closes #2371 

**Steps necessary to review your pull request (required)**:
1. Go to 'http://localhost:4000/components/accordion/test-with-contextmenu.html'
2. Click on the more button on the page and set the color
3. Click on the Personal accordion item to expand
Other checks include leaving the more button menu open and using the accordion, and using the accordion's popup, right click on the header and then using the accordion while the popup is open.

