### PR TITLE
1995 - Colorpicker large cut off FAILED QA

### DIFF
--- a/src/components/colorpicker/_colorpicker.scss
+++ b/src/components/colorpicker/_colorpicker.scss
@@ -220,7 +220,7 @@
   }
 }
 
-@include respond-to(phonedown) {
+@include respond-to(phablet) {
   .colorpicker-container {
     width: 100% !important;
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The large color picker's individual elements are stacking right before the 480px breakpoint where they become responsive. This PR increases the breakpoint at which they become responsive and prevents the stacking.

**Related github/jira issue (required)**:
Closes #1995.
Relates to #2123.

**Steps necessary to review your pull request (required)**:
- Pull branch and run app
- Visit http://localhost:4000/components/colorpicker/example-sizes.html
  - ensure all colorpickers work as expected and are responsive to smaller breakpoints.
- Visit http://localhost:4000/components/form/example-inputs.html
  - ensure the colorpicker acts responsively within the grid
- Visit any other colorpicker pages in any other browser

~- [ ] An e2e or functional test for the bug or feature.~
~- [] A note to the change log.~