### PR TITLE
2313-Add minWidth and maxWidth to the columns

### DIFF
--- a/app/views/components/datagrid/test-columns-min-max-widths.html
+++ b/app/views/components/datagrid/test-columns-min-max-widths.html
@@ -1,0 +1,50 @@
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+
+      var grid,
+        columns = [],
+        data = [];
+
+      // Some Sample Data
+      data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  '', quantity: 1, price: 210.99, status: 'OK', orderDate:  '', portable: false, action: 1, description: ''});
+      data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, status: '', orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false, action: 1, description: 'Short Description'});
+      data.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity:  '', portable: true, quantity: null, price: 120.992, status: null, orderDate: new Date(2014, 6, 3), action: 2});
+      data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', portable: true, quantity: 3, price: null, status: 'OK', orderDate: new Date(2015, 3, 3), action: 3, description: ''});
+      data.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 1});
+      data.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', portable: false, quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 2});
+      data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 2});
+
+      //Define Columns for the Grid.
+
+      columns.push({ id: 'drilldown', name: '', field: '', formatter: Formatters.Drilldown, align: 'center', resizable: false, sortable: false});
+      columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink});
+      columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity'});
+      columns.push({ id: 'description', name: 'Description', field: 'description', formatter: Formatters.Textarea, editor: Editors.Textarea, minWidth: 300, maxWidth: 550 });
+      columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date });
+      columns.push({ id: 'price', name: 'Price', field: 'price', formatter: Formatters.Decimal});
+
+      //Init and get the api for the grid
+      grid = $('#datagrid').datagrid({
+        columns: columns,
+        dataset: data,
+        stretchColumnOnChange: true,
+        actionableMode: true,
+        editable: true,
+        clickToSelect: false,
+        selectable: 'multiple',
+        toolbar: {title: 'Data Grid Header Title', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: true,  collapsibleFilter: true},
+        paging: true,
+        pagesize: 5,
+        pagesizes: [2, 5, 6]
+      });
+
+});
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - `[Datagrid]` Added support to resize column widths after a value change via the stretchColumnOnChange setting. ([#2174](https://github.com/infor-design/enterprise/issues/2174))
 - `[Datagrid]` Added a Sort Function to the datagrid column to allow the value to be formatted for the sort. ([#1766](https://github.com/infor-design/enterprise/issues/2274)))
+- `[Datagrid]` Added support to restrict the size of a column with minWidth and maxWidth setting on the column. ([#2313](https://github.com/infor-design/enterprise/issues/2313))
 
 ### v4.20.0 Fixes
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9061,7 +9061,7 @@ Datagrid.prototype = {
         newWidth = col.maxWidth;
       }
       const diff = newWidth - this.headerWidths[cell].width;
-      if (diff != 0 && this.headerWidths[cell].width !== '') {
+      if (diff > 0 && this.headerWidths[cell].width !== '') {
         this.resizeColumnWidth(cellNode, newWidth, diff);
         this.headerWidths[cell].width = newWidth;
       }

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4235,6 +4235,16 @@ Datagrid.prototype = {
       col.width = colWidth;
     }
 
+    // make sure that the column is atleast the minimum width
+    if (col.minWidth && colWidth < col.minWidth) {
+      colWidth = col.minWidth;
+    }
+
+    // make sure that the column is no more than the maximum width
+    if (col.minWidth && colWidth > col.maxWidth) {
+      colWidth = col.maxWidth;
+    }
+
     // cache the header widths
     this.headerWidths[index] = {
       id: col.id,
@@ -9041,9 +9051,17 @@ Datagrid.prototype = {
     
     // resize on change
     if (this.settings.stretchColumnOnChange && col && !col.width) {
-      const newWidth = this.calculateTextWidth(col);
+      let newWidth = this.calculateTextWidth(col);
+      // make sure that the column is atleast the minimum width
+      if (col.minWidth && newWidth < col.minWidth) {
+        newWidth = col.minWidth;
+      }
+      // make sure that the column is no more than the maximum width
+      if (col.minWidth && newWidth > col.maxWidth) {
+        newWidth = col.maxWidth;
+      }
       const diff = newWidth - this.headerWidths[cell].width;
-      if (diff > 0 && this.headerWidths[cell].width !== '') {
+      if (diff != 0 && this.headerWidths[cell].width !== '') {
         this.resizeColumnWidth(cellNode, newWidth, diff);
         this.headerWidths[cell].width = newWidth;
       }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Request a mechanism to constrain a column width, as this is useful for textarea columns to allow for some wrapping.

**Related github/jira issue (required)**:
Closes #2313 

**Steps necessary to review your pull request (required)**:
1. Goto 'http://localhost:4000/components/datagrid/test-columns-min-max-widths.html'
The Description column has a min and max constraint
2. Edit any description so that it is wider than 550 px, the maximum constraint value.
3. Page to next page 
4. Page to next page 
5. Change the edited description to a shorter description

The datagrid has stretchColumnOnChange enabled so the resize can happens on the change. (The column will only shrink on paging)
