### PR TITLE
2336-Datagrid: Filter null values correctly

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - `[Datagrid]` Fixes the alignment of the alert and warning icons on a lookup editor. ([#2175](https://github.com/infor-design/enterprise/issues/2175))
 - `[Datagrid]` Fixes tooltip on the non displayed table errors. ([#2264](https://github.com/infor-design/enterprise/issues/2264))
+- `[Datagrid]` Fixes the filtering of null values. ([#2336](https://github.com/infor-design/enterprise/issues/2336))
 - `[Homepages]` Fixed an issue where personalize and chart text colors were not working with hero. ([#2097](https://github.com/infor-design/enterprise/issues/2097))
 - `[Fieldfilter]` Fixed an issue where Dropdown was not switching mode on example page. ([#2288](https://github.com/infor-design/enterprise/issues/2288))
 - `[Field Options]` Fixed an issue where input example was not working. ([#2348](https://github.com/infor-design/enterprise/issues/2348))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1934,7 +1934,7 @@ Datagrid.prototype = {
 
         if ((typeof rowValue === 'number' || (!isNaN(rowValue) && rowValue !== '') && !(conditions[i].value instanceof Array)) &&
               columnDef.filterType !== 'date' && columnDef.filterType !== 'time') {
-          rowValue = parseFloat(rowValue);
+          rowValue = rowValue === null ? rowValue : parseFloat(rowValue);
           conditionValue = Locale.parseNumber(conditionValue);
         }
 
@@ -2071,20 +2071,20 @@ Datagrid.prototype = {
             if (rangeData && rangeData.startDate && rangeData.endDate) {
               const d1 = rangeData.startDate.getTime();
               const d2 = rangeData.endDate.getTime();
-              isMatch = rowValue >= d1 && rowValue <= d2;
+              isMatch = rowValue >= d1 && rowValue <= d2 && rowValue !== null;
             }
             break;
           case 'less-than':
-            isMatch = (rowValue < conditionValue && rowValue !== '');
+            isMatch = (rowValue < conditionValue && (rowValue !== '' && rowValue !== null));
             break;
           case 'less-equals':
-            isMatch = (rowValue <= conditionValue && rowValue !== '');
+            isMatch = (rowValue <= conditionValue && (rowValue !== '' && rowValue !== null));
             break;
           case 'greater-than':
-            isMatch = (rowValue > conditionValue && rowValue !== '');
+            isMatch = (rowValue > conditionValue && (rowValue !== '' && rowValue !== null));
             break;
           case 'greater-equals':
-            isMatch = (rowValue >= conditionValue && rowValue !== '');
+            isMatch = (rowValue >= conditionValue && (rowValue !== '' && rowValue !== null));
             break;
           case 'selected':
             if (columnDef && columnDef.isChecked) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Null values are not filtered correctly as they displayed on a is not empty filter. Also found on greater then, less than for numbers and dates and also the date range.

**Related github/jira issue (required)**:
Closes #2336 

**Steps necessary to review your pull request (required)**:
Open 'http://localhost:4000/components/datagrid/example-filter.html'
In Price column, filter for 'Is not Empty'

Test all of the filter operators, to ensure that the empty rows are displayed or hidden as expected.

