### PR TITLE
https://github.com/infor-design/enterprise/issues/1697

### DIFF
--- a/app/views/patterns/stepprocess-markup1.html
+++ b/app/views/patterns/stepprocess-markup1.html
@@ -1,0 +1,162 @@
+{{> includes/svg-inline-refs}}
+<header class="header is-personalizable top-header">
+  <div class="toolbar">
+    <div class="title">
+      <h1>
+        <span class="panel-title">Designer Application</span>
+        <span class="panel-subhead">Last saved at <i id="savedTime">8:02am</i></span>
+      </h1>
+    </div>
+    <div class="buttonset">
+      <button class="btn js-btn-save-changes" type="button">
+        <span>Save</span>
+      </button>
+    </div>
+    {{> includes/header-actionbutton}}
+  </div>
+</header>
+
+<div class="step-process-container two-column fixed page-container no-scroll show-main" role="main">
+
+  <div class="sidebar">
+    <div class="toolbar toolbar-custom toolbar-collapsible phone-visible">
+      <div class="title title-wide">Steps to complete</div>
+    </div>
+    <ul class="tree js-step-list-scroll" data-init="false" id="step-list">
+
+      <li class="js-step is-selected">
+        <a class="js-step-link" href="#step1">
+          <svg class="step-alert icon-empty-circle icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-empty-circle"></use>
+          </svg>
+          <span class="tree-text">Step 1</span>
+        </a>
+      </li>
+      <li class="js-step">
+        <a class="js-step-link is-disabled" href="#step2">
+          <svg class="step-alert icon-empty-circle icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-empty-circle"></use>
+          </svg>
+          <span class="tree-text">Step 2</span>
+        </a>
+      </li>
+    </ul>
+  </div>
+
+  <div class="main no-scroll" role="main">
+
+    <div class="toolbar toolbar-custom toolbar-collapsible">
+      <div class="title">
+        <button class="btn-icon btn-toggle-steps js-toggle-sidebar" type="button">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-bullet-steps"></use>
+          </svg>
+          <span class="audible">Steps</span>
+        </button>
+        <div class="dual-title">
+          Preferences
+          <small>Page X of XX</small>
+        </div>
+      </div>
+      <div class="buttonset phone-hidden">
+        <button class="btn-tertiary js-step-link-prev" type="button">
+          <span>Previous</span>
+        </button>
+        <button class="btn-tertiary js-step-link-next" type="button">
+          <span>Next</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="scrollable step-container js-step-container-scroll">
+
+      <div id="step1" class="js-step-panel">
+        <div class="field">
+          <h2>Step 1</h2>
+        </div>
+        <form>
+          <div class="field">
+            <input type="checkbox" class="checkbox" id="vetocheckbox1"/>
+            <label for="vetocheckbox1" class="checkbox-label">Veto Next Step</label>
+          </div>
+        </form>
+      </div>
+
+      <div id="step2" class="js-step-panel">
+        <div class="field">
+          <h2>Step 2</h2>
+        </div>
+        <form>
+          <div class="field">
+            <label for="slider-competency">How competent do you think you are?</label>
+            <input id="slider-competency" name="slider-competency1" class="slider" type="range" min="0" max="4" value="0" step="1" data-ticks='[
+              {"value": 0, "description": "0%"},
+              {"value": 1, "description": "25%"},
+              {"value": 2, "description": "50%"},
+              {"value": 3, "description": "75%"},
+              {"value": 4, "description": "100%"}
+            ]' />
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <div class="phone-action-bar phone-visible">
+      <button class="btn js-btn-save-changes" type="button">Save &amp; Close</button>
+      <button class="btn-primary js-step-link-next" type="button">Next</button>
+    </div>
+  </div>
+</div>
+
+<script>
+  $(function() {
+
+    // Init Step Process
+    var stepElem = $('.step-process-container').stepprocess({
+      'beforeSelectStep': stepFunctions.beforeSelectStep,
+      'linearProgression': false
+    });
+
+    // Example button save event
+    $('.js-btn-save-changes').click(function(e) {
+      e.preventDefault();
+      $('body').message({
+        title: 'Step Saved',
+        isError: false,
+        returnFocus: $(this),
+        message: 'This has been saved.',
+        buttons: [{
+          text: 'Ok',
+          click: function() {
+            $(this).data('modal').close();
+          },
+          isDefault: true
+        }]
+      });
+    });
+  });
+
+  // Step Functions
+  var stepFunctions = {
+    // When a folder opens
+    beforeSelectStep: function(args) {
+
+      var deferred = $.Deferred();
+
+      // simulate ajax call
+      setTimeout(function()
+      {
+        if (args.isStepping === 'next' && !args.stepLink) {
+          var stepLinkToSelect = $('.js-step-link[href="#step2"]');
+          stepLinkToSelect.removeClass("is-disabled");
+          deferred.resolve(true, stepLinkToSelect);
+        } else {
+          deferred.resolve(true);
+        }
+      },100);
+
+      return deferred.promise();
+    },
+  };
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,7 @@
 # What's New with Enterprise
 
 ## v4.20.0
-
+- `[Stepprocess]` Not showing the next step. ([#2391](https://github.com/infor-design/enterprise/issues/2391))
 ### v4.20.0 Deprecation
 
 ### v4.20.0 Features

--- a/src/patterns/stepprocess/stepprocess.js
+++ b/src/patterns/stepprocess/stepprocess.js
@@ -402,7 +402,19 @@ Stepprocess.prototype = {
       self.selectStep(stepLink, 'next');
     } else if (typeof self.settings.beforeSelectStep === 'function') {
       const args = { isStepping: 'next' };
-      self.settings.beforeSelectStep(args);
+      const result = self.settings.beforeSelectStep(args);
+
+      if (result.done && typeof result.done === 'function') { // A promise is returned
+        result.done((continueSelectNode, stepLinkToSelect) => {
+          if (continueSelectNode) {
+            if (stepLinkToSelect) {
+              self.selectStepFinish(stepLinkToSelect);
+            }
+          }
+        });
+      } else if (result) { // boolean is returned instead of a promise
+        self.selectStepFinish(stepLink);
+      }
     }
   },
 


### PR DESCRIPTION
Step process next and previous selects a disabled step

**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Unable to add steps to the process.  In the case where the an action taken on the last valid panel adds more panels. When on the last step of a step process wizard and the next button calls the beforeSelectStep promise which enables more steps to become valid. The newly enables step is NOT rendered.


**Related github/jira issue (required)**:
Fixes #2391 2391

**Steps necessary to review your pull request (required)**:
- Go to http://localhost:4000/patterns/stepprocess-markup1.html
- Click on Next
- Expected behavior: The next valid step (step 2) should be rendered.


