### PR TITLE
2383 - Fix for Multiselect filter issues [v4.19.x]

### DIFF
--- a/app/views/components/datagrid/example-custom-toolbar.html
+++ b/app/views/components/datagrid/example-custom-toolbar.html
@@ -31,7 +31,7 @@
           <li><a href="#">Option One</a></li>
           <li><a href="#">Option Two</a></li>
           <li><a href="#">Option Three</a></li>
-          <li class="separator single-selectable-section"></li>
+          <li class="separator"></li>
           <li><a data-option="personalize-columns" href="#" data-translate="text">PersonalizeColumns</a></li>
           <li><a data-option="reset-layout" href="#" data-translate="text">ResetDefault</a></li>
           <li class="separator"></li>

--- a/app/views/components/datagrid/example-drilldown.html
+++ b/app/views/components/datagrid/example-drilldown.html
@@ -26,7 +26,10 @@
 
         //Define Columns for the Grid.
         columns.push({ id: 'drilldown', name: '', field: '', resizable: false, formatter: Formatters.Drilldown, click: function(e, args) {
-          console.log(args);
+          $('body').toast({
+            title: 'Drill Down',
+            message: 'This action would drill down into more info for row: ' + args[0].row + ' cell: ' + args[0].cell
+          });
         }, align: 'center', sortable: false});
         columns.push({ id: 'productId', name: 'Product Id', field: 'productId', width: 140, formatter: Formatters.Readonly});
         columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', width: 170, formatter: Formatters.Hyperlink});

--- a/app/views/components/datagrid/example-paging-client-side.html
+++ b/app/views/components/datagrid/example-paging-client-side.html
@@ -44,7 +44,7 @@
           selectable: 'multiple',
           paging: true,
           pagesize: 15,
-          toolbar: {title: 'Compressors', results: true, dateFilter: false , keywordFilter: true, advancedFilter: true, actions: true, views: true, rowHeight: true}
+          toolbar: {title: 'Compressors', results: true, keywordFilter: true, actions: true, rowHeight: true}
           }).on('selected', function (e, args) {
             console.log(args);
           }).on('unselected', function (e, args) {

--- a/app/views/components/datagrid/example-paging.html
+++ b/app/views/components/datagrid/example-paging.html
@@ -76,7 +76,7 @@
             response(res.data, req);
           });
         },
-        toolbar: {title: 'Data Grid Header Title',filterRow: true, personalize: true, results: true, dateFilter: false ,keywordFilter: true, advancedFilter: true, actions: true, views: true, rowHeight: true, collapsibleFilter: true}
+        toolbar: {title: 'Data Grid Header Title',filterRow: true, personalize: true, results: true, keywordFilter: true, actions: true, rowHeight: true, collapsibleFilter: true}
       })
       .on('selected', function (e, args) {
         console.log('Selected: ', args);

--- a/app/views/components/datagrid/example-reorder.html
+++ b/app/views/components/datagrid/example-reorder.html
@@ -1,53 +1,8 @@
 
 <div class="row">
   <div class="twelve columns">
-
-    <div class="toolbar" role="toolbar">
-      <div class="title">
-        Compressors
-        <span class="datagrid-result-count">(N Results)</span>
-      </div>
-      <div class="buttonset">
-        <button  type="button" class="btn">
-          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-            <use xlink:href="#icon-filter"></use>
-          </svg>
-          <span>Filter</span>
-        </button>
-      </div>
-
-      <div class="more">
-        <button  type="button" class="btn-actions">
-          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-            <use xlink:href="#icon-more"></use>
-          </svg>
-          <span class="audible">More Actions</span>
-        </button>
-        <ul class="popupmenu">
-          <li><a data-option="personalize-columns" href="#">Personalize Columns</a></li>
-          <li><a data-option="reset-layout" href="#">Reset to Default</a></li>
-          <li class="separator"></li>
-
-          <li class="heading">Filter</li>
-          <li class="is-checked is-toggleable"><a data-option="show-filter-row">Show Filter Row</a></li>
-          <li class="is-indented"><a data-option="run-filter">Run Filter</a></li>
-          <li class="is-indented"><a data-option="clear-filter">Clear Filter</a></li>
-
-          <li class="separator single-selectable-section"></li>
-          <li class="heading">Row Height</li>
-          <li class="is-selectable"><a data-option="row-short" href="#">Short</a></li>
-          <li class="is-selectable"><a data-option="row-medium" href="#">Medium</a></li>
-          <li class="is-selectable is-checked"><a data-option="row-normal" href="#">Normal</a></li>
-
-          <li class="heading">Filter</li>
-          <li class="is-indented"><a data-option="export-to-excel" href="#">Export to Excel</a></li>
-
-        </ul>
-      </div>
-    </div>
     <div id="datagrid">
     </div>
-
   </div>
 </div>
   toolbar: {title: 'Filterable Datagrid', filterRow: true, results: true, dateFilter: false ,keywordFilter: false, actions: true, views: false, rowHeight: true, collapsibleFilter: false}
@@ -95,7 +50,7 @@
                              sortOrder: true,
                              pagesize: true,
                              filter: true},
-          toolbar: {personalize: true, filterRow: true, results: true, resetLayout: true}
+          toolbar: {title: 'Compressors', actions: true, results: true, personalize: true, filterRow: true, results: true, resetLayout: true}
         }).on('settingschanged', function (e, args) {
           console.log('Settings Changed', args);
         });

--- a/app/views/components/datagrid/test-editor-dropdown-source.html
+++ b/app/views/components/datagrid/test-editor-dropdown-source.html
@@ -1,15 +1,10 @@
 <div class="row">
   <div class="six columns">
 
-    <h2>Datagrid Test: Dropdown Editor Uses Source EditorOptions</h2>
-
+    <h2>Datagrid Test: Dropdown Editor Uses Source with Multiselect</h2>
     <p>
-      <a class="hyperlink" href="https://github.com/infor-design/enterprise/issues/1185" target="_blank">GIT #1185</a>.<br />
+      <a class="hyperlink" href="https://github.com/infor-design/enterprise/issues/2383" target="_blank">GIT #2383</a>.<br />
     </p>
-
-    <p>Open the dropdown options for the "Action" column, with the dropdown open click elsewhere in the grid (for example click the Order Date column). The column's value is changed to an empty string.</p>
-    <p>When the dropdown is opened the current value is not selected in the dropdown list.</p>
-
   </div>
 </div>
 
@@ -33,7 +28,11 @@
   $('body').one('initialized', function () {
     var grid,
       columns = [],
-      data = [];
+      dataAll = [],
+      dataPOH = [],
+      dataSS = [],
+      dataCC = [],
+      dataRR = [];
 
     var LOW_RANGE_LOW_NUMBER = 0,
         LOW_RANGE_HIGH_NUMBER = 150,
@@ -42,7 +41,6 @@
 
     // Define all possible "Action" column options for the grid
     var actionOptions = [
-      {label: '&nbsp;', value: 'blank'},
       {label: 'Place On-Hold', value: 'poh'},
       {label: 'Request Review', value: 'rr'},
       {label: 'Send to Shipping', value: 'ss'},
@@ -50,13 +48,24 @@
     ];
 
     // Some Sample Data
-    data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  '<svg/onload=alert(1)>', quantity: 1, price: 210.99, orderDate:  new Date(2016, 2, 15, 12, 30, 36), portable: false, action: 'poh', description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning'});
-    data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false, action: 'poh', description: 'The kit has an air blow gun that can be used for cleaning'});
-    data.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity:  'Inspect and Repair', portable: true, quantity: 1, price: 120.992, orderDate: new Date(2014, 6, 3), action: 'ss'});
-    data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', portable: true, quantity: 3, price: null, orderDate: new Date(2015, 3, 3), action: 'ss', description: 'Compressor comes with with air tool kit'});
-    data.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, orderDate: new Date(2015, 5, 5), action: 'rr'});
-    data.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', portable: false, quantity: 41, price: 120.99, orderDate: new Date(2014, 6, 9), action: 'cc'});
-    data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', portable: true, quantity: 41, price: 123.99, orderDate: new Date(2014, 6, 9), action: 'ss'});
+    dataAll.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  '<svg/onload=alert(1)>', quantity: 1, price: 210.99, orderDate:  new Date(2016, 2, 15, 12, 30, 36), portable: false, action: 'poh', description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning'});
+    dataAll.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false, action: 'poh', description: 'The kit has an air blow gun that can be used for cleaning'});
+    dataAll.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity:  'Inspect and Repair', portable: true, quantity: 1, price: 120.992, orderDate: new Date(2014, 6, 3), action: 'ss'});
+    dataAll.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', portable: true, quantity: 3, price: null, orderDate: new Date(2015, 3, 3), action: 'ss', description: 'Compressor comes with with air tool kit'});
+    dataAll.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, orderDate: new Date(2015, 5, 5), action: 'rr'});
+    dataAll.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', portable: false, quantity: 41, price: 120.99, orderDate: new Date(2014, 6, 9), action: 'cc'});
+    dataAll.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', portable: true, quantity: 41, price: 123.99, orderDate: new Date(2014, 6, 9), action: 'ss'});
+
+    dataPOH.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  '<svg/onload=alert(1)>', quantity: 1, price: 210.99, orderDate:  new Date(2016, 2, 15, 12, 30, 36), portable: false, action: 'poh', description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning'});
+    dataPOH.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false, action: 'poh', description: 'The kit has an air blow gun that can be used for cleaning'});
+
+    dataSS.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity:  'Inspect and Repair', portable: true, quantity: 1, price: 120.992, orderDate: new Date(2014, 6, 3), action: 'ss'});
+    dataSS.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', portable: true, quantity: 3, price: null, orderDate: new Date(2015, 3, 3), action: 'ss', description: 'Compressor comes with with air tool kit'});
+    dataSS.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', portable: true, quantity: 41, price: 123.99, orderDate: new Date(2014, 6, 9), action: 'ss'});
+
+    dataRR.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, orderDate: new Date(2015, 5, 5), action: 'rr'});
+
+    dataCC.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', portable: false, quantity: 41, price: 120.99, orderDate: new Date(2014, 6, 9), action: 'cc'});
 
     var dropDownFormatter = function (row, cell, value, col) {
       for (let index = 0, len = actionOptions.length; index < len; index++) {
@@ -75,7 +84,7 @@
     };
 
     columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
-    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, filterType: 'text', editor: Editors.Input});
+    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input});
     columns.push({ id: 'status', name: 'Status', field: 'price', formatter: Formatters.Alert, readonly: true, ranges: [{'min': LOW_RANGE_LOW_NUMBER, 'max': LOW_RANGE_HIGH_NUMBER, 'classes': 'success', text: 'Confirmed'}, {'min': HIGH_RANGE_LOW_NUMBER, 'max': HIGH_RANGE_HIGH_NUMBER, 'classes': 'error', text: 'Error'}]});
     columns.push({ id: 'price', name: 'Price', field: 'price', align: 'right', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###.000'});
     columns.push({ id: 'action', name: 'Action', field: 'action', formatter: dropDownFormatter, filterType: 'multiselect', options:  [ { label: ' ', value: ' '} ], editor: Editors.Dropdown, editorOptions: {editable: false, source: dropDownSource} });
@@ -83,14 +92,33 @@
 
     //Init and get the api for the grid
     grid = $('#datagrid').datagrid({
+      cellNavigation: true,
       columns: columns,
-      dataset: data,
+      dataset: dataAll,
+      disableClientSort:    true,
       disableClientFilter:  true,
+      filterWhenTyping: true,
       editable: true,
       clickToSelect: false,
+      redrawOnResize:       false,
+      isList: true,
+      menuId: 'datagrid',
       selectable: 'multiple',
       filterable: true,
-      toolbar: { keywordFilter: true, results: true }
+      enableTooltips:       true,
+      toolbar: { keywordFilter: true, results: true },
+      actionableMode: true,
+      showDirty: true,
+      emptyMessage: null,
+      rowHeight: 'short',
+      saveUserSettings:     {
+      columns: false,
+        rowHeight: false,
+        sortOrder: false,
+        pagesize: false,
+        activePage: false,
+        filter: false
+      },
     }).on('activecellchange', function (e, args) {
       console.log('e', e);
       console.log('args', args);
@@ -103,7 +131,31 @@
     })
     .on('filtered', function (e, args) {
       console.log('filtered', args);
-      gridApi.loadData(data , { type: 'filterrow' });
+
+      if (args.conditions.length === 0) {
+        gridApi.loadData(dataAll);
+      } else {
+        let results = [];
+        for (let value of args.conditions[0].value) {
+          switch(value) {
+            case 'poh':
+              results = $.merge(results, dataPOH);
+              break;
+            case 'rr':
+              results = $.merge(results, dataRR);
+              break;
+            case 'ss':
+              results = $.merge(results, dataSS);
+              break;
+            case 'cc':
+              results = $.merge(results, dataCC);
+              break;
+            case 'blank':
+              break;
+          }
+        }
+        gridApi.loadData(results);
+      }
     });
 
     gridApi = $('#datagrid').data('datagrid');

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # What's New with Enterprise
 
+## v4.19.3
+
+- `[Datagrid]` Fixes the multiselect filter on header from reloading during serverside filtering. ([#2383](https://github.com/infor-design/enterprise/issues/2383))
+
+## v4.19.2
+
+- `[Build]` Fixes missing minified files in the build and a missing svg-extended.html deprecated file for backwards compatibility. ([Teams](https://bit.ly/2FlzYCT))
+
 ## v4.19.0
 
 ### v4.19.0 Deprecations

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -753,7 +753,7 @@ Datagrid.prototype = {
       pagerInfo.activePage = 1;
       pagerInfo.pagesize = this.settings.pagesize;
       pagerInfo.total = -1;
-      pagerInfo.type = 'initial';
+
       if (this.settings.treeGrid) {
         pagerInfo.preserveSelected = true;
       }
@@ -781,7 +781,7 @@ Datagrid.prototype = {
     if (pagerInfo.preserveSelected === undefined) {
       if (this.settings.source) {
         this._selectedRows = [];
-      } else if (pagerInfo.type === 'initial') {
+      } else if (pagerInfo.type === 'initial' || !pagerInfo.type) {
         this.unSelectAllRows();
       }
     } else if (pagerInfo.preserveSelected === false) {
@@ -807,9 +807,7 @@ Datagrid.prototype = {
       this.renderRows();
       this.renderHeader();
     } else {
-      this.clearHeaderCache();
       this.renderRows();
-      this.syncColGroups();
     }
 
     // Setup focus on the first cell
@@ -1629,6 +1627,7 @@ Datagrid.prototype = {
       elem.find('select.multiselect').each(function () {
         const multiselect = $(this);
         multiselect.multiselect(col.editorOptions).on('selected.datagrid', () => {
+          self.restoreFilterClientSide = false;
           self.applyFilter(null, 'selected');
         });
 

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -2654,7 +2654,14 @@ Dropdown.prototype = {
         }
 
         const selectedValues = (self.selectedValues && self.selectedValues.indexOf(val) > -1);
-        if (option.value === val || selectedValues) {
+        if (self.settings.multiple) {
+          val.forEach((value) => {
+            if (value === option.value) {
+              option.selected = true;
+              selected = ' selected';
+            }
+          });
+        } else if (option.value === val || selectedValues) {
           option.selected = true;
           selected = ' selected';
         }

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -661,7 +661,6 @@ describe('Datagrid paging tests', () => {
     expect(await element(by.css('tbody tr:nth-child(10) td:nth-child(2) span')).getText()).toEqual('9');
 
     await element(by.css('.pager-last a')).click();
-    await browser.driver.sleep(config.sleep);
     await element(by.css('.pager-first a')).click();
     await browser.driver.sleep(config.sleep);
 
@@ -705,6 +704,7 @@ describe('Datagrid paging tests', () => {
 
       await element(by.css('#datagrid .datagrid-header th:nth-child(2)')).click();
       await element(by.css('#datagrid .datagrid-header th:nth-child(2)')).click();
+      await browser.driver.sleep(config.sleep);
 
       expect(await element(by.css('#datagrid .datagrid-header th:nth-child(2).is-sorted-desc')).isPresent()).toBeTruthy();
 
@@ -896,7 +896,26 @@ describe('Datagrid editor dropdown source tests', () => {
     expect(await element(by.css('.is-focused'))).toBeTruthy();
     const focusEl = await element(by.css('.is-focused'));
 
-    expect(await focusEl.getText()).toEqual(' ');
+    expect(await focusEl.getText()).toEqual('Place On-Hold');
+  });
+
+  it('Should select and filter', async () => {
+    expect(await element.all(by.css('#datagrid tbody tr')).count()).toEqual(7);
+    const multiselectEl = await element(by.css('.datagrid-filter-wrapper div.dropdown'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(multiselectEl), config.waitsFor);
+    await multiselectEl.click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('ul[role="listbox"]'))), config.waitsFor);
+    const multiselectSearchEl = await element(by.id('dropdown-search'));
+    await multiselectSearchEl.click();
+    await multiselectSearchEl.sendKeys(protractor.Key.ARROW_DOWN);
+    await multiselectSearchEl.sendKeys(protractor.Key.ARROW_DOWN);
+    await multiselectSearchEl.sendKeys(protractor.Key.SPACE);
+    await multiselectSearchEl.sendKeys(protractor.Key.ARROW_DOWN);
+    await multiselectSearchEl.sendKeys(protractor.Key.SPACE);
+
+    expect(await element.all(by.css('#datagrid tbody tr')).count()).toEqual(4);
   });
 });
 
@@ -1741,7 +1760,7 @@ describe('Datagrid select event tests', () => {
   it('Should fire a toast on select', async () => {
     await element(by.css('#testing-datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(2)')).click();
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(await element(by.id('toast-container'))), config.waitsFor);
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('toast-container'))), config.waitsFor);
 
     expect(await element.all(by.css('#toast-container .toast-message')).getText()).toEqual(['The row #1 containing the product name Compressor triggered a selected event']);
   });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When using serverside filtering and a multiselect as the grid is filtered the header row would reload and the context/data in the multiselect would fail. To fix it made a fix to handle arrays in dropdown.js and made loadData not reload the header the majority of the time except for init.
Also while testing all examples did some light cleanup.

**Impact**:
- Full regression test of dropdown and datagrid and multiselect
- @Sovia please test this in landmark

**Related github/jira issue (required)**:
Fixes #2383 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-editor-dropdown-source
- open the filter dropdown in the header and select values
- try selecting one or more
- try closing the dropdown and reopening
- should hold its state.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
