### PR TITLE
2115 - Hide the header hamburger on large-form-factor Builder-pattern screens

### DIFF
--- a/app/views/patterns/builder-nosidebar.html
+++ b/app/views/patterns/builder-nosidebar.html
@@ -14,15 +14,14 @@
           <div class="buttonset">
             <input class="searchfield" placeholder="Search">
           </div>
-
         </div>
       </header>
 
       <div class="listview scrollable" id="task-listview" data-options="{'template': 'task-tmpl', 'source': '{{basepath}}api/inventory-tasks'}"></div>
     </div>
 
-    <div class="main no-scroll builder-pane" role="main">
-      <header class="header  is-personalizable">
+    <div id="maincontent" class="main no-scroll builder-pane" role="main">
+      <header class="header is-personalizable">
         <div class="toolbar">
           <div class="title">
 

--- a/app/views/patterns/builder-nosidebar.html
+++ b/app/views/patterns/builder-nosidebar.html
@@ -2,7 +2,7 @@
   <a href="#maincontent" class="skip-link" data-translate="text">SkipToMain</a>
   {{> includes/svg-inline-refs}}
 
-  <div class="page-container no-scroll builder two-column">
+  <div id="list-detail-container" class="list-detail two-column page-container no-scroll builder" data-options='{ "listElement": "#task-listview", "detailElement": "#maincontent", "backElement": "#header-hamburger" }'>
 
     <div class="sidebar no-scroll" role="complementary">
       <header class="header is-personalizable">
@@ -26,7 +26,7 @@
         <div class="toolbar">
           <div class="title">
 
-            <button class="btn-icon list-detail-back-button go-back" type="button">
+            <button id="header-hamburger" class="btn-icon list-detail-back-button go-back visible-sm hidden-md hidden-lg hidden-xl" type="button">
               <span class="audible">Show navigation</span>
               <span class="icon app-header">
                 <span class="one"></span>

--- a/app/views/patterns/builder-subtitle-test.html
+++ b/app/views/patterns/builder-subtitle-test.html
@@ -2,7 +2,7 @@
   <a href="#maincontent" class="skip-link" data-translate="text">SkipToMain</a>
   {{> includes/svg-inline-refs}}
 
-  <div class="page-container no-scroll builder two-column">
+  <div id="list-detail-container" class="list-detail two-column page-container no-scroll builder" data-options='{ "listElement": "#task-listview", "detailElement": "#maincontent", "backElement": "#header-hamburger" }'>
 
     <div class="sidebar no-scroll" role="complementary">
       <header class="header is-personalizable">
@@ -25,7 +25,7 @@
         <div class="toolbar">
           <div class="title">
 
-            <button class="btn-icon list-detail-back-button go-back" type="button">
+            <button id="header-hamburger" class="btn-icon list-detail-back-button go-back visible-sm hidden-md hidden-lg hidden-xl" type="button">
               <span class="audible">Show navigation</span>
               <span class="icon app-header">
                 <span class="one"></span>
@@ -52,7 +52,7 @@
           <div class="buttonset">
             <button type="button" id="sidebar-responsive-menu" class="btn-tertiary hidden-lg hidden-xl" data-popdown="builder-popdown-content">
               <svg class="icon" focusable="false" aria-hidden="true">
-                <use xlink:href="#icon-settings"></use>
+                <use xlink:href="#icon-cart"></use>
               </svg>
               <span>Sidebar Popup</span>
             </button>

--- a/app/views/patterns/builder-wizard.html
+++ b/app/views/patterns/builder-wizard.html
@@ -2,7 +2,7 @@
   <a href="#maincontent" class="skip-link" data-translate="text">SkipToMain</a>
   {{> includes/svg-inline-refs}}
 
-  <div class="page-container no-scroll builder two-column">
+  <div id="list-detail-container" class="list-detail two-column page-container no-scroll builder" data-options='{ "listElement": "#task-listview", "detailElement": "#maincontent", "backElement": "#header-hamburger" }'>
 
     <div class="sidebar no-scroll" role="complementary">
       <header class="header is-personalizable">
@@ -25,7 +25,7 @@
         <div class="toolbar">
           <div class="title">
 
-            <button class="btn-icon list-detail-back-button go-back" type="button">
+            <button id="header-hamburger" class="btn-icon list-detail-back-button go-back visible-sm hidden-md hidden-lg hidden-xl" type="button">
               <span class="audible">Show navigation</span>
               <span class="icon app-header">
                 <span class="one"></span>
@@ -52,7 +52,7 @@
           <div class="buttonset">
             <button type="button" id="sidebar-responsive-menu" class="btn-tertiary hidden-lg hidden-xl" data-popdown="builder-popdown-content">
               <svg class="icon" focusable="false" aria-hidden="true">
-                <use xlink:href="#icon-settings"></use>
+                <use xlink:href="#icon-cart"></use>
               </svg>
               <span>Sidebar Popup</span>
             </button>

--- a/app/views/patterns/builder.html
+++ b/app/views/patterns/builder.html
@@ -2,7 +2,7 @@
   <a href="#maincontent" class="skip-link" data-translate="text">SkipToMain</a>
   {{> includes/svg-inline-refs}}
 
-  <div class="page-container no-scroll two-column builder">
+  <div class="list-detail page-container no-scroll two-column builder" data-options='{ "listElement": "#task-listview", "detailElement": "#maincontent", "backElement": "#header-hamburger" }'>
 
     <div class="sidebar no-scroll" role="complementary">
       <header class="header is-personalizable">
@@ -26,7 +26,7 @@
         <div class="toolbar">
           <div class="title">
 
-            <button class="btn-icon list-detail-back-button go-back" type="button">
+            <button id="header-hamburger" class="btn-icon list-detail-back-button go-back visible-sm hidden-md hidden-lg hidden-xl" type="button">
               <span class="audible">Show navigation</span>
               <span class="icon app-header">
                 <span class="one"></span>
@@ -54,7 +54,7 @@
             <div class="buttonset">
               <button type="button" id="sidebar-responsive-menu" class="btn-tertiary hidden-lg hidden-xl" data-popdown="builder-popdown-content">
                 <svg class="icon" focusable="false" aria-hidden="true">
-                  <use xlink:href="#icon-settings"></use>
+                  <use xlink:href="#icon-cart"></use>
                 </svg>
                 <span>Sidebar Popup</span>
               </button>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR Fixes a demoapp issue where a Header Hamburger button is present on the "detail" area of the Builder pattern while on larger form factors.  This button doesn't have any functionality in this pattern while on the "desktop" view.  It should only be present when the viewport lands on the "detail" area while in "tablet"/"phone" view, where it acts as a "Go Back" button.

Additionally, this PR restores the navigation ability that used to be present when clicking an item on the "list" side while looking at the "phone"/"tablet" views.

**Related github/jira issue (required)**:
Closes #2115 

**Steps necessary to review your pull request (required)**:
- Pull this branch, run app
- Look at all the `builder` samples in http://localhost:4000/patterns/.
- Ensure that the desktop view on all these components does not display a Header Hamburger button.
- Ensure that on the mobile view, after clicking an item in the list, the detail area shows, and a "Go Back" button with an arrow is present.
- Clicking that button should return the user to the "list" view.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
