### PR TITLE
2408 - Datagrid: placeholder on additional Formatters

### DIFF
--- a/app/views/components/datagrid/example-placeholder.html
+++ b/app/views/components/datagrid/example-placeholder.html
@@ -11,12 +11,51 @@
   $('body').one('initialized', function () {
          var grid,
           columns = [],
-          data = [];
+          data = [],
+          
+          //lookup data
+          lookupOptions,
+          lookupData = [],
+          lookupColumns = [];
+
+        // Some Sample Data for Lookup
+        lookupData.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+        lookupData.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+        lookupData.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+        lookupData.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+        lookupData.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+        lookupData.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+        lookupData.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+        lookupData.push({ id: 7, productId: 11111111111, productName: 'Invalid Entry', activity:  'inspect and Repair', quantity: 42, price: 134.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+
+        //Define Columns for the Lookup Grid.
+        lookupColumns.push({ id: 'productId', name: 'Product Id', field: 'productId', width: 140});
+        lookupColumns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', width: 250, formatter: Formatters.Hyperlink});
+        lookupColumns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', width: 125});
+        lookupColumns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', width: 125});
+        lookupColumns.push({ id: 'price', name: 'Price', field: 'price', width: 125, formatter: Formatters.Decimal});
+        lookupColumns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+
+        lookupOptions = {
+          // field: 'productId',
+          field: function (row, field, grid) {
+            return row.productId;
+          },
+          match: function (value, row, field, grid) {
+            return (row.productId) === value;
+          },
+          options: {
+            columns: lookupColumns,
+            dataset: lookupData,
+            selectable: 'single', //multiselect or single
+            toolbar: {title: 'Products', results: true, dateFilter: false ,keywordFilter: false, advancedFilter: true, actions: true, views: true , rowHeight: true}
+          }
+        };
 
         // Some Sample Data
-        data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  '<svg/onload=alert(1)>', quantity: 1, price: 210.99, status: 'OK', orderDate:  '', portable: false, action: 'ac', description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning'});
+        data.push({ id: 1, productId: null, productName: null, activity:  null, quantity: null, price: null, status: null, orderDate:  null, portable: false, action: null, description: null});
         data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, status: '', orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false, action: 'oh', description: 'The kit has an air blow gun that can be used for cleaning'});
-        data.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity:  '', portable: true, quantity: null, price: 120.992, status: null, orderDate: new Date(2014, 6, 3), action: 'ac'});
+        data.push({ id: 3, productId: '', productName: 'Portable Compressor', activity:  '', portable: true, quantity: null, price: 120.992, status: null, orderDate: new Date(2014, 6, 3), action: 'ac'});
         data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', portable: true, quantity: 3, price: null, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'ac', description: 'Compressor comes with with air tool kit'});
         data.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'oh'});
         data.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', portable: false, quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'oh'});
@@ -26,16 +65,17 @@
         columns.push({ id: 'rowStatus', sortable: false, resizable: false, formatter: Formatters.Status, align: 'center'});
         columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
         columns.push({ id: 'id', name: 'Row Id', field: 'id', formatter: Formatters.Readonly});
-        columns.push({ id: 'productName', hidden: true, name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input});
+        columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, placeholder: 'Default Product', editor: Editors.Lookup, editorOptions: lookupOptions });
+        columns.push({ id: 'productName', hidden: true, name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, placeholder: 'First Select Product', editor: Editors.Input});
         columns.push({ id: 'activity', name: 'Activity', field: 'activity', formatter: Formatters.Placeholder, editor: Editors.Input, placeholder: 'Default Activity' });  //maxLength: 2
         columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', align: 'right', formatter: Formatters.Placeholder, editor: Editors.Input, mask: '###', placeholder: dynamicPlaceholder, isEditable: function (row, cell, value, col, item) {
             //For this fake logic just disable odd rows
             return (row % 2 === 0);
           }});
         columns.push({ id: 'portable', name: 'Portable', field: 'portable', align: 'center', formatter: Formatters.Checkbox, editor: Editors.Checkbox});
-        columns.push({ id: 'price', name: 'Price', field: 'price', align: 'right', formatter: Formatters.Decimal, validate: 'required', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input});
+        columns.push({ id: 'price', name: 'Price', field: 'price', align: 'right', formatter: Formatters.Decimal, placeholder: 'Default Price', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input});
         columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date , validate: 'required date'});
-        columns.push({ id: 'action', name: 'Action', field: 'action', formatter: Formatters.Dropdown, editor: Editors.Dropdown, validate: 'required',
+        columns.push({ id: 'action', name: 'Action', field: 'action', formatter: Formatters.Dropdown, editor: Editors.Dropdown, placeholder: 'Default Action',
         options: [{id: '', label: '', value: -1}, {id: 'oh1', label: 'On Hold', value: 'oh'}, {id: 'sh1', label: 'Shipped', value: 'sh'} , {id: 'ac1', label: 'Action', value: 'ac'}]
         });
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Datagrid]` Added support to resize column widths after a value change via the stretchColumnOnChange setting. ([#2174](https://github.com/infor-design/enterprise/issues/2174))
 - `[Datagrid]` Added a Sort Function to the datagrid column to allow the value to be formatted for the sort. ([#1766](https://github.com/infor-design/enterprise/issues/2274))
 - `[Datagrid]` Added a Sort Function to the datagrid column to allow the value to be formatted for the sort. ([#1766](https://github.com/infor-design/enterprise/issues/2274)))
+- `[Datagrid]` Added placeholder functionality to Lookup, Dropdown, and Decimal Formatrers. ([#2408](https://github.com/infor-design/enterprise/issues/2408)))
 - `[Datagrid]` Added support to restrict the size of a column with minWidth and maxWidth setting on the column. ([#2313](https://github.com/infor-design/enterprise/issues/2313))
 - `[ListFilter]` Added `phraseStartsWith` filterMode for only matching a search term against the beginning of a string. ([#1606](https://github.com/infor-design/enterprise/issues/1606))
 

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -7,19 +7,18 @@ import { xssUtils } from '../../utils/xss';
 * @private
 */
 function calculatePlaceholder(placeholder, formattedValue, row, cell, value, col, item) {
-    if (placeholder && formattedValue === '') {
-      const getType = {};
-      if (getType.toString.call(placeholder) === '[object Function]') {
-        placeholder = placeholder(row, cell, value, col, item);
-      } else if (item && placeholder in item) {
-        placeholder = item[placeholder];
-      }
-      
-      return placeholder;
-    } 
-    else {
-      return '';  
+  if (placeholder && formattedValue === '') {
+    const getType = {};
+    if (getType.toString.call(placeholder) === '[object Function]') {
+      placeholder = placeholder(row, cell, value, col, item);
+    } else if (item && placeholder in item) {
+      placeholder = item[placeholder];
     }
+
+    return placeholder;
+  }
+
+  return '';  
 }
 
 /**
@@ -153,7 +152,8 @@ const formatters = {
     let formatted = ((value === null || value === undefined) ? '' : value);
     let isPlaceholder = false;
     
-    const placeholder = calculatePlaceholder(col.placeholder, formatted, row, cell, value, col, item);
+    const placeholder = calculatePlaceholder(col.placeholder, 
+      formatted, row, cell, value, col, item);
     if (placeholder !== '') {
       isPlaceholder = true;
     }

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -190,7 +190,8 @@ const formatters = {
     
     formatted = (formatted === null || formatted === undefined || formatted === 'NaN') ? '' : formatted;
     
-    const placeholder = calculatePlaceholder(col.placeholder, formatted, row, cell, value, col, item);
+    const placeholder = calculatePlaceholder(col.placeholder, 
+      formatted, row, cell, value, col, item);
     if (placeholder !== '') {
       const html = `<span class="is-placeholder">${placeholder}</span>`;
 
@@ -558,7 +559,8 @@ const formatters = {
       }
     }
     
-    const placeholder = calculatePlaceholder(col.placeholder, formattedValue, row, cell, value, col, item);
+    const placeholder = calculatePlaceholder(col.placeholder, formattedValue, 
+      row, cell, value, col, item);
     if (placeholder !== '') {
       isPlaceholder = true;
       formattedValue = placeholder;

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -24,19 +24,13 @@ const formatters = {
   },
 
   Placeholder(row, cell, value, col, item) {
-    if (col.placeholder && value === '') {
-      let placeholder = col.placeholder;
-      const getType = {};
-      if (getType.toString.call(placeholder) === '[object Function]') {
-        placeholder = placeholder(row, cell, value, col, item);
-      } else if (item && placeholder in item) {
-        placeholder = item[placeholder];
-      }
+    const placeholder = calculatePlaceholder(col.placeholder, value, row, cell, value, col, item);
+    if (placeholder  !== '') {
       const html = `<span class="is-placeholder">${placeholder}</span>`;
 
       return html;
     }
-
+    
     const str = ((value === null || value === undefined || value === '') ? '' : value.toString());
     return str;
   },
@@ -83,6 +77,7 @@ const formatters = {
     if (!col.editor || isReturnValue === true) {
       return formatted;
     }
+    
     return `<span class="trigger">${formatted}</span>${$.createIcon({ icon: 'calendar', classes: ['icon-calendar'] })}`;
   },
 
@@ -136,17 +131,11 @@ const formatters = {
 
   Lookup(row, cell, value, col, item) {
     let formatted = ((value === null || value === undefined) ? '' : value);
-    let placeholder = col.placeholder;
     let isPlaceholder = false;
     
-    if (placeholder && formatted === '') {
+    const placeholder = calculatePlaceholder(col.placeholder, formatted, row, cell, value, col, item);
+    if (placeholder  !== '') {
       isPlaceholder = true;
-      const getType = {};
-      if (getType.toString.call(placeholder) === '[object Function]') {
-        placeholder = placeholder(row, cell, value, col, item);
-      } else if (item && placeholder in item) {
-        placeholder = item[placeholder];
-      }
     }
     
     if (!col.editor) {
@@ -181,14 +170,8 @@ const formatters = {
     
     formatted = (formatted === null || formatted === undefined || formatted === 'NaN') ? '' : formatted;
     
-    if (col.placeholder && formatted === '') {
-      let placeholder = col.placeholder;
-      const getType = {};
-      if (getType.toString.call(placeholder) === '[object Function]') {
-        placeholder = placeholder(row, cell, value, col, item);
-      } else if (item && placeholder in item) {
-        placeholder = item[placeholder];
-      }
+    const placeholder = calculatePlaceholder(col.placeholder, formatted, row, cell, value, col, item);
+    if (placeholder  !== '') {
       const html = `<span class="is-placeholder">${placeholder}</span>`;
 
       return html;
@@ -539,7 +522,6 @@ const formatters = {
     let compareValue;
     let option;
     let optionValue;
-    let placeholder = col.placeholder;
     let isPlaceholder = false;
     
     if (col.options && value !== undefined) {
@@ -556,17 +538,11 @@ const formatters = {
       }
     }
     
-    if (placeholder && formattedValue === '') {
+    const placeholder = calculatePlaceholder(col.placeholder, formattedValue, row, cell, value, col, item);
+    if (placeholder  !== '') {
       isPlaceholder = true;
-      const getType = {};
-      if (getType.toString.call(placeholder) === '[object Function]') {
-        placeholder = placeholder(row, cell, value, col, item);
-      } else if (item && placeholder in item) {
-        placeholder = item[placeholder];
-      }
-      
       formattedValue = placeholder;
-    }    
+    }
 
     let html = `<span class="trigger dropdown-trigger ${isPlaceholder ? 'is-placeholder' : ''}">${formattedValue}</span>${$.createIcon({ icon: 'dropdown' })}`;
 
@@ -688,5 +664,26 @@ const formatters = {
   // Color Picker (Low)
   // Radio
 };
+
+
+/**
+* Calculate if a Placeholder is required and its value.
+* @private
+*/
+function calculatePlaceholder(placeholder, formattedValue, row, cell, value, col, item) {
+    if (placeholder && formattedValue === '') {
+      const getType = {};
+      if (getType.toString.call(placeholder) === '[object Function]') {
+        placeholder = placeholder(row, cell, value, col, item);
+      } else if (item && placeholder in item) {
+        placeholder = item[placeholder];
+      }
+      
+      return placeholder;
+    } 
+    else {
+      return '';  
+    }
+}
 
 export { formatters as Formatters };

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -6,7 +6,8 @@ import { xssUtils } from '../../utils/xss';
 * Calculate if a Placeholder is required and its value.
 * @private
 */
-function calculatePlaceholder(placeholder, formattedValue, row, cell, value, col, item) {
+function calculatePlaceholder(formattedValue, row, cell, value, col, item) {
+  let placeholder = col.placeholder;
   if (placeholder && formattedValue === '') {
     const getType = {};
     if (getType.toString.call(placeholder) === '[object Function]') {
@@ -43,7 +44,7 @@ const formatters = {
   },
 
   Placeholder(row, cell, value, col, item) {
-    const placeholder = calculatePlaceholder(col.placeholder, value, row, cell, value, col, item);
+    const placeholder = calculatePlaceholder(value, row, cell, value, col, item);
     if (placeholder !== '') {
       const html = `<span class="is-placeholder">${placeholder}</span>`;
 
@@ -152,7 +153,7 @@ const formatters = {
     let formatted = ((value === null || value === undefined) ? '' : value);
     let isPlaceholder = false;
     
-    const placeholder = calculatePlaceholder(col.placeholder, formatted, row, cell, value, col, item);
+    const placeholder = calculatePlaceholder(formatted, row, cell, value, col, item);
     if (placeholder !== '') {
       isPlaceholder = true;
     }
@@ -189,7 +190,7 @@ const formatters = {
     
     formatted = (formatted === null || formatted === undefined || formatted === 'NaN') ? '' : formatted;
     
-    const placeholder = calculatePlaceholder(col.placeholder, formatted, row, cell, value, col, item);
+    const placeholder = calculatePlaceholder(formatted, row, cell, value, col, item);
     if (placeholder !== '') {
       const html = `<span class="is-placeholder">${placeholder}</span>`;
 
@@ -557,7 +558,7 @@ const formatters = {
       }
     }
     
-    const placeholder = calculatePlaceholder(col.placeholder, formattedValue, row, cell, value, col, item);
+    const placeholder = calculatePlaceholder(formattedValue, row, cell, value, col, item);
     if (placeholder !== '') {
       isPlaceholder = true;
       formattedValue = placeholder;

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -136,27 +136,65 @@ const formatters = {
 
   Lookup(row, cell, value, col, item) {
     let formatted = ((value === null || value === undefined) ? '' : value);
+    let placeholder = col.placeholder;
+    let isPlaceholder = false;
+    
+    if (placeholder && formatted === '') {
+      isPlaceholder = true;
+      const getType = {};
+      if (getType.toString.call(placeholder) === '[object Function]') {
+        placeholder = placeholder(row, cell, value, col, item);
+      } else if (item && placeholder in item) {
+        placeholder = item[placeholder];
+      }
+    }
+    
     if (!col.editor) {
+      if (isPlaceholder) {
+        return `<span class="is-placeholder">${placeholder}</span>`;;
+      }
       return formatted;
     }
 
     if (col.editorOptions && typeof col.editorOptions.field === 'function') {
       formatted = col.editorOptions.field(item, null, null);
+      isPlaceholder = false;
     }
 
     if (formatted === null || formatted === undefined || formatted === '') {
       formatted = '';
+      if (placeholder) {
+        isPlaceholder = true;
+        formatted = placeholder;
+      }
     }
-    return `<span class="trigger ${col.align === 'right' ? 'align-text-right' : ''}">${formatted}</span>${$.createIcon({ icon: 'search-list', classes: ['icon-search-list'] })}`;
+    return `<span class="trigger ${isPlaceholder ? 'is-placeholder' : '' }${col.align === 'right' ? 'align-text-right' : ''}">${formatted}</span>${$.createIcon({ icon: 'search-list', classes: ['icon-search-list'] })}`;
   },
 
-  Decimal(row, cell, value, col) {
+  Decimal(row, cell, value, col, item) {
     let formatted = value;
+    
     if (typeof Locale !== 'undefined' &&
         formatted !== null && formatted !== undefined && formatted !== '') {
       formatted = Locale.formatNumber(value, col.numberFormat);
     }
-    return ((formatted === null || formatted === undefined || formatted === 'NaN') ? '' : formatted);
+    
+    formatted = (formatted === null || formatted === undefined || formatted === 'NaN') ? '' : formatted;
+    
+    if (col.placeholder && formatted === '') {
+      let placeholder = col.placeholder;
+      const getType = {};
+      if (getType.toString.call(placeholder) === '[object Function]') {
+        placeholder = placeholder(row, cell, value, col, item);
+      } else if (item && placeholder in item) {
+        placeholder = item[placeholder];
+      }
+      const html = `<span class="is-placeholder">${placeholder}</span>`;
+
+      return html;
+    }
+    
+    return (formatted);
   },
 
   Integer(row, cell, value, col) {
@@ -496,12 +534,14 @@ const formatters = {
     return markup;
   },
 
-  Dropdown(row, cell, value, col) {
+  Dropdown(row, cell, value, col, item) {
     let formattedValue = value;
     let compareValue;
     let option;
     let optionValue;
-
+    let placeholder = col.placeholder;
+    let isPlaceholder = false;
+    
     if (col.options && value !== undefined) {
       compareValue = col.caseInsensitive && typeof value === 'string' ? value.toLowerCase() : value;
 
@@ -515,8 +555,21 @@ const formatters = {
         }
       }
     }
+    
+    if (placeholder && formattedValue === '') {
+      isPlaceholder = true;
+      const getType = {};
+      if (getType.toString.call(placeholder) === '[object Function]') {
+        placeholder = placeholder(row, cell, value, col, item);
+      } else if (item && placeholder in item) {
+        placeholder = item[placeholder];
+      }
+      
+      formattedValue = placeholder;
+    }
+    
 
-    let html = `<span class="trigger dropdown-trigger">${formattedValue}</span>${$.createIcon({ icon: 'dropdown' })}`;
+    let html = `<span class="trigger dropdown-trigger ${isPlaceholder ? 'is-placeholder' : '' }">${formattedValue}</span>${$.createIcon({ icon: 'dropdown' })}`;
 
     if (col.inlineEditor) {
       html = `<label for="full-dropdown" class="audible">${col.name}</label><select id="datagrid-dropdown${row}" class="dropdown">`;

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -152,8 +152,7 @@ const formatters = {
     let formatted = ((value === null || value === undefined) ? '' : value);
     let isPlaceholder = false;
     
-    const placeholder = calculatePlaceholder(col.placeholder, 
-      formatted, row, cell, value, col, item);
+    const placeholder = calculatePlaceholder(col.placeholder, formatted, row, cell, value, col, item);
     if (placeholder !== '') {
       isPlaceholder = true;
     }
@@ -190,8 +189,7 @@ const formatters = {
     
     formatted = (formatted === null || formatted === undefined || formatted === 'NaN') ? '' : formatted;
     
-    const placeholder = calculatePlaceholder(col.placeholder, 
-      formatted, row, cell, value, col, item);
+    const placeholder = calculatePlaceholder(col.placeholder, formatted, row, cell, value, col, item);
     if (placeholder !== '') {
       const html = `<span class="is-placeholder">${placeholder}</span>`;
 
@@ -559,8 +557,7 @@ const formatters = {
       }
     }
     
-    const placeholder = calculatePlaceholder(col.placeholder, formattedValue, 
-      row, cell, value, col, item);
+    const placeholder = calculatePlaceholder(col.placeholder, formattedValue, row, cell, value, col, item);
     if (placeholder !== '') {
       isPlaceholder = true;
       formattedValue = placeholder;

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -3,6 +3,26 @@ import { Tmpl } from '../tmpl/tmpl';
 import { xssUtils } from '../../utils/xss';
 
 /**
+* Calculate if a Placeholder is required and its value.
+* @private
+*/
+function calculatePlaceholder(placeholder, formattedValue, row, cell, value, col, item) {
+    if (placeholder && formattedValue === '') {
+      const getType = {};
+      if (getType.toString.call(placeholder) === '[object Function]') {
+        placeholder = placeholder(row, cell, value, col, item);
+      } else if (item && placeholder in item) {
+        placeholder = item[placeholder];
+      }
+      
+      return placeholder;
+    } 
+    else {
+      return '';  
+    }
+}
+
+/**
 * A object containing all the supported UI formatters.
 * @private
 */
@@ -25,7 +45,7 @@ const formatters = {
 
   Placeholder(row, cell, value, col, item) {
     const placeholder = calculatePlaceholder(col.placeholder, value, row, cell, value, col, item);
-    if (placeholder  !== '') {
+    if (placeholder !== '') {
       const html = `<span class="is-placeholder">${placeholder}</span>`;
 
       return html;
@@ -134,7 +154,7 @@ const formatters = {
     let isPlaceholder = false;
     
     const placeholder = calculatePlaceholder(col.placeholder, formatted, row, cell, value, col, item);
-    if (placeholder  !== '') {
+    if (placeholder !== '') {
       isPlaceholder = true;
     }
     
@@ -171,7 +191,7 @@ const formatters = {
     formatted = (formatted === null || formatted === undefined || formatted === 'NaN') ? '' : formatted;
     
     const placeholder = calculatePlaceholder(col.placeholder, formatted, row, cell, value, col, item);
-    if (placeholder  !== '') {
+    if (placeholder !== '') {
       const html = `<span class="is-placeholder">${placeholder}</span>`;
 
       return html;
@@ -539,7 +559,7 @@ const formatters = {
     }
     
     const placeholder = calculatePlaceholder(col.placeholder, formattedValue, row, cell, value, col, item);
-    if (placeholder  !== '') {
+    if (placeholder !== '') {
       isPlaceholder = true;
       formattedValue = placeholder;
     }
@@ -664,26 +684,5 @@ const formatters = {
   // Color Picker (Low)
   // Radio
 };
-
-
-/**
-* Calculate if a Placeholder is required and its value.
-* @private
-*/
-function calculatePlaceholder(placeholder, formattedValue, row, cell, value, col, item) {
-    if (placeholder && formattedValue === '') {
-      const getType = {};
-      if (getType.toString.call(placeholder) === '[object Function]') {
-        placeholder = placeholder(row, cell, value, col, item);
-      } else if (item && placeholder in item) {
-        placeholder = item[placeholder];
-      }
-      
-      return placeholder;
-    } 
-    else {
-      return '';  
-    }
-}
 
 export { formatters as Formatters };

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -151,7 +151,7 @@ const formatters = {
     
     if (!col.editor) {
       if (isPlaceholder) {
-        return `<span class="is-placeholder">${placeholder}</span>`;;
+        return `<span class="is-placeholder">${placeholder}</span>`;
       }
       return formatted;
     }
@@ -168,7 +168,7 @@ const formatters = {
         formatted = placeholder;
       }
     }
-    return `<span class="trigger ${isPlaceholder ? 'is-placeholder' : '' }${col.align === 'right' ? 'align-text-right' : ''}">${formatted}</span>${$.createIcon({ icon: 'search-list', classes: ['icon-search-list'] })}`;
+    return `<span class="trigger ${isPlaceholder ? 'is-placeholder' : ''}${col.align === 'right' ? 'align-text-right' : ''}">${formatted}</span>${$.createIcon({ icon: 'search-list', classes: ['icon-search-list'] })}`;
   },
 
   Decimal(row, cell, value, col, item) {
@@ -566,10 +566,9 @@ const formatters = {
       }
       
       formattedValue = placeholder;
-    }
-    
+    }    
 
-    let html = `<span class="trigger dropdown-trigger ${isPlaceholder ? 'is-placeholder' : '' }">${formattedValue}</span>${$.createIcon({ icon: 'dropdown' })}`;
+    let html = `<span class="trigger dropdown-trigger ${isPlaceholder ? 'is-placeholder' : ''}">${formattedValue}</span>${$.createIcon({ icon: 'dropdown' })}`;
 
     if (col.inlineEditor) {
       html = `<label for="full-dropdown" class="audible">${col.name}</label><select id="datagrid-dropdown${row}" class="dropdown">`;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Able to use the placeholder on additional Formatters:
* DropDown
* Lookup
* Decimal

**Related github/jira issue (required)**:
Closes #2408 

**Steps necessary to review your pull request (required)**:
1. goto 'http://localhost:4000/components/datagrid/example-placeholder.html'
2. A placeholder is visible on the additional Formatters

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
