### PR TITLE
1928 - Fix popupmenu scrolling and submenus so that they will work on IOS

### DIFF
--- a/app/views/components/popupmenu/example-submenus.html
+++ b/app/views/components/popupmenu/example-submenus.html
@@ -1,0 +1,36 @@
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="field">
+      <button id="menu-trigger" class="btn-menu">
+        <span>Options</span>
+      </button>
+      <ul class="popupmenu">
+        <li><a href="#">Item 1</a></li>
+        <li><a href="#">Item 2</a></li>
+        <li>
+          <a href="#">Submenu 1</a>
+          <ul class="popupmenu">
+            <li><a href="#">Item 1.1</a></li>
+            <li><a href="#">Item 1.2</a></li>
+            <li>
+              <a href="#">Submenu 2</a>
+              <ul class="popupmenu">
+                <li><a href="#">Item 2.1</a></li>
+                <li><a href="#">Item 2.2</a></li>
+                <li>
+                  <a href="#">Submenu 3</a>
+                  <ul class="popupmenu">
+                    <li><a href="#">Item 3.1</a></li>
+                    <li><a href="#">Item 3.2</a></li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+
+  </div>
+</div>

--- a/app/views/components/popupmenu/test-scrolling.html
+++ b/app/views/components/popupmenu/test-scrolling.html
@@ -1,0 +1,31 @@
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="field">
+      <button id="popupmenu-trigger" class="btn-menu">
+        <span>Normal Menu</span>
+        <svg role="presentation" aria-hidden="true" focusable="false" class="icon icon-dropdown">
+          <use xlink:href="#icon-dropdown"></use>
+        </svg>
+      </button>
+      <ul class="popupmenu">
+        <li><a href="#">Menu Option #1</a></li>
+        <li><a href="#">Menu Option #2</a></li>
+        <li><a href="#">Menu Option #3</a></li>
+        <li><a href="#">Menu Option #4</a></li>
+        <li><a href="#">Menu Option #5</a></li>
+        <li><a href="#">Menu Option #6</a></li>
+        <li><a href="#">Menu Option #7</a></li>
+        <li><a href="#">Menu Option #8</a></li>
+        <li><a href="#">Menu Option #9</a></li>
+        <li><a href="#">Menu Option #10</a></li>
+        <li><a href="#">Menu Option #11</a></li>
+        <li><a href="#">Menu Option #12</a></li>
+        <li><a href="#">Menu Option #13</a></li>
+        <li><a href="#">Menu Option #14</a></li>
+        <li><a href="#">Menu Option #15</a></li>
+      </ul>
+    </div>
+
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,8 @@
 - `[Modal]` Fixed an issue where the modal component would disappear if its content had a checkbox in it in RTL. ([#332](https://github.com/infor-design/enterprise-ng/issues/332))
 - `[Popupmenu]` Fixed an issue where js error was showing after removing a menu item. ([#414](https://github.com/infor-design/enterprise-ng/issues/414))
 - `[Popupmenu]` Fixed a layout issue on disabled checkboxes in multiselect popupmenus. ([#2340](https://github.com/infor-design/enterprise/issues/2340))
+- `[Popupmenu]` Fixed a bug on IOS that prevented menu scrolling. ([#645](https://github.com/infor-design/enterprise/issues/645))
+- `[Popupmenu]` Fixed a bug on IOS that prevented some submenus from showing. ([#1928](https://github.com/infor-design/enterprise/issues/1928))
 - `[Scatter Plot]` Fixed the incorrect color on the tooltips. ([#1066](https://github.com/infor-design/enterprise/issues/1066))
 - `[Stepprocess]` Fixed an issue where a newly enabled step is not shown. ([#2391](https://github.com/infor-design/enterprise/issues/2391))
 

--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -193,7 +193,7 @@
   list-style: none;
   margin: 0;
   overflow: auto;
-  -webkit-overflow-scrolling: touch;
+  -webkit-overflow-scrolling: auto;
   padding: 5px 0;
   text-align: left;
 
@@ -579,13 +579,6 @@
         border-left: 1px solid $popover-separator-color;
       }
     }
-  }
-}
-
-//IOS
-.ios {
-  .has-submenu {
-    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

We had some older rules in for IOS workarounds that caused popupmenus to not scroll and submenus to not show on IOS. This issue fixes these things.

**Related github/jira issue (required)**:
Fixes #1928
Fixes #645
Fixes #2362 (duplicate)

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/popupmenu/test-scrolling on an IOS sim or browser stack
- if the menu isnt cut off try and go to landscape mode
- click the button to open the menu
- attempt to scroll the list up and down (will now work)
- go to http://localhost:4000/components/popupmenu/example-submenus.html also  on an IOS sim or browser stack
- click the submenus and they should open now and be visible

**Included in this Pull Request**:
- [x] A note to the change log.
