### PR TITLE
2415 - Fix both the undefined error on tooltip and an new bug on focus tooltips [v4.19.x]

### DIFF
--- a/app/views/components/tooltip/test-chart-ajax-tooltip-bar.html
+++ b/app/views/components/tooltip/test-chart-ajax-tooltip-bar.html
@@ -28,7 +28,8 @@ $('body').on('initialized', function () {
       }, {
           name: 'Category C',
           value: 236.35
-      }]
+      }],
+      name: ''
     }];
 
   // $('#bar-example').chart({type: 'bar', dataset: dataset});

--- a/app/views/components/tooltip/test-chart-ajax-tooltip-column.html
+++ b/app/views/components/tooltip/test-chart-ajax-tooltip-column.html
@@ -60,15 +60,14 @@ $('body').on('initialized', function () {
 
   $('#column-bar-example').chart({type: 'column', dataset: dataset, tooltip: 'Tooltip by attribute'});
 
-  // $('#column-bar-example').chart({type: 'column', dataset: dataset,
-  //   tooltip: function(response) {
-  //     //Ajax Call or async op
-  //     setTimeout(function () {
-  //       response('<strong>Tooltips Provide <br> Interesting Information</strong>');
-  //     }, 400);
-  //   }
-  // });
-
+  $('#column-bar-example').chart({type: 'column', dataset: dataset,
+    tooltip: function(response) {
+       // Ajax Call or async op
+       setTimeout(function () {
+         response('<strong>Tooltips Provide <br> Interesting Information</strong>');
+       }, 400);
+     }
+  });
 
 });
 </script>

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -442,10 +442,6 @@ Tooltip.prototype = {
     const tooltip = this.tooltip[0];
     let classes = 'tooltip is-hidden';
 
-    if (!contentArea) {
-      return;
-    }
-
     if (extraClass) {
       classes += ` ${extraClass}`;
     }
@@ -455,7 +451,7 @@ Tooltip.prototype = {
       titleArea.style.display = 'none';
     }
 
-    if (!contentArea.previousElementSibling.classList.contains('arrow')) {
+    if (contentArea && !contentArea.previousElementSibling.classList.contains('arrow')) {
       contentArea.insertAdjacentHTML('beforebegin', '<div class="arrow"></div>');
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The fix to #2405 caused a minor regression on the focus tooltips. This fixes both issues

**Related github/jira issue (required)**:
Fixes #2415 
Caused by #2405

**Steps necessary to review your pull request (required)**:
- re-test #2405 (nothing to test really the fix was verified by @pwpatton )
- go to http://localhost:4000/components/tooltip/example-trigger-focus.html
- click the button 
- tooltip should show because the button is focused , note that there is no focus state on click by design
- tab into the button
- tooltip should show as well
