### PR TITLE
2421 - Fix a bug using tab to indent in editor

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@
 - `[Datagrid]` Fixed an issue where source would not fire on sorting. ([#2390](https://github.com/infor-design/enterprise/issues/2390))
 - `[Datagrid]` Fixes the styling of non editable checkbox cells so they look disabled. ([#2340](https://github.com/infor-design/enterprise/issues/2340))
 - `[Datagrid]` Changed the dynamic column tooltip function to pass the row and more details. This changes the order of parameters but since this feature is new did not consider this a breaking change. If you are using this please take note. ([#2333](https://github.com/infor-design/enterprise/issues/2333))
+- `[Editor]` Fixed a bug where tab or shift tab would break out of the editor when doing an indent/outdent. ([#2421](https://github.com/infor-design/enterprise/issues/2421))
 - `[Fieldfilter]` Fixed an issue where Dropdown was not switching mode on example page. ([#2288](https://github.com/infor-design/enterprise/issues/2288))
 - `[Field Options]` Fixed an issue where input example was not working. ([#2348](https://github.com/infor-design/enterprise/issues/2348))
 - `[Fieldfilter]` Fixed an issue where Dropdown was not switching mode on example page. ([#2288](https://github.com/infor-design/enterprise/issues/2288))

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -264,6 +264,7 @@ Editor.prototype = {
         }
         // Tab to indent list structures!
         if (tag === 'li') {
+          e.preventDefault();
           // If Shift is down, outdent, otherwise indent
           document.execCommand((e.shiftKey ? 'outdent' : 'indent'), e);
         }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
When using the tab key to indent in the editor the cursor will break out of the editor after doing the indent. This fixes that issue.

**Related github/jira issue (required)**:
Fixes #2421 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/editor/example-index.html
- put cursor at the bottom and click the number list icon
- type something and hit enter
- hit tab to do an indent (the editor used to loose focus here)

**Included in this Pull Request**:
- [x] A note to the change log.
