### PR TITLE
2236 - Fix ellipsis was not working with dropdown

### DIFF
--- a/app/views/components/dropdown/test-long-text.html
+++ b/app/views/components/dropdown/test-long-text.html
@@ -4,7 +4,8 @@
 
     <div class="field">
       <label for="states" class="label">States</label>
-      <select id="states" name="states" class="dropdown">
+      <select id="states" name="states" class="dropdown dropdown-mm">
+        <option value=" "> </option>
         <option value="AL">Alaska gffgf gf fgf fg f gfg fgfg ff gfg f gf gff g</option>
         <option value="AZ">Arizona bvbcbcbv c cvbcvb cvbcv bcvbcvbccvb vcbcvbcbvcb</option>
         <option value="CA">California vb rtretetgrthrbrrtb rtbrtrtb rbrt brtbrtb rr b</option>
@@ -19,3 +20,12 @@
 
   </div>
 </div>
+
+<script>
+  $('body').on('initialized', function() {
+ 
+    var api = $('#states').data('dropdown');
+    api.element[0].selectedIndex = 2;
+    api.updated();
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Datagrid]` Added a Sort Function to the datagrid column to allow the value to be formatted for the sort. ([#1766](https://github.com/infor-design/enterprise/issues/2274))
 - `[Datagrid]` Added a Sort Function to the datagrid column to allow the value to be formatted for the sort. ([#1766](https://github.com/infor-design/enterprise/issues/2274)))
 - `[Datagrid]` Added support to restrict the size of a column with minWidth and maxWidth setting on the column. ([#2313](https://github.com/infor-design/enterprise/issues/2313))
+- `[Dropdown]` Fixed an issue where ellipsis was not working when use firefox new tab. ([#2236](https://github.com/infor-design/enterprise/issues/2236))
 - `[ListFilter]` Added `phraseStartsWith` filterMode for only matching a search term against the beginning of a string. ([#1606](https://github.com/infor-design/enterprise/issues/1606))
 
 ### v4.20.0 Fixes

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -325,7 +325,10 @@ Dropdown.prototype = {
     this.setDisplayedValues();
     this.setInitial();
     this.setWidth();
-    this.toggleTooltip();
+
+    setTimeout(() => {
+      this.toggleTooltip();
+    }, 0);
 
     this.element.triggerHandler('rendered');
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed ellipsis was not working when use firefox new tab with dropdown.

**Related github/jira issue (required)**:
Closes #2236

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- In Firefox, create a new tab (Ctrl-T)
- Paste http://localhost:4000/components/dropdown/test-long-text.html into the address bar
- Press Enter
- The dropdown should display with ellipsis
- Using F5 to refresh it should keep display with ellipsis

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
