### PR TITLE
2428 - Improve a fix for re-measuring datagrid columns (2)

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -808,12 +808,14 @@ Datagrid.prototype = {
       this.restoreUserSettings();
       this.renderRows();
       this.renderHeader();
-    } else if (['first', 'next', 'prev', 'last'].indexOf(pagerInfo.type) >= 0) {
-      this.clearHeaderCache();
-      this.renderRows();
-      this.syncColGroups();
     } else {
-      this.renderRows();
+      if (this.headerContainer.find('.datagrid-filter-wrapper .is-open').length === 0) {
+        this.clearHeaderCache();
+        this.renderRows();
+        this.syncColGroups();
+      } else {
+        this.renderRows();
+      }
     }
 
     // Setup focus on the first cell

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -808,14 +808,13 @@ Datagrid.prototype = {
       this.restoreUserSettings();
       this.renderRows();
       this.renderHeader();
+    } else if (this.headerContainer.find('.datagrid-filter-wrapper .is-open').length === 0) {
+      this.clearHeaderCache();
+      this.renderRows();
+      this.syncColGroups();
     } else {
-      if (this.headerContainer.find('.datagrid-filter-wrapper .is-open').length === 0) {
-        this.clearHeaderCache();
-        this.renderRows();
-        this.syncColGroups();
-      } else {
-        this.renderRows();
-      }
+      // Filter field is open so do not resize
+      this.renderRows();
     }
 
     // Setup focus on the first cell


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
#2429 was closed before I was able to review and the fix missed some other situation not put on the initial ticket, (sorting and filtering).

This is a rework of #2404 , so that it will do just what it intended, not to resize the columns when the multi-select dropdown is opened.

**Related github/jira issue (required):**
Fixes #2428

**Steps necessary to review your pull request (required):**

retest #2404 
But specifically go to http://localhost:4000/components/datagrid/test-editor-dropdown-source
open the header multiselect and pick some items -> the columns should not change size when selecting
go to http://localhost:4000/components/datagrid/test-paging-select-indeterminate-single.html
Sort the Product name descending
note the width of the product name column
go to last page -> the product name column should adjust in size to the text


**Included in this Pull Request:**

 An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
