### PR TITLE
2436 - Remove nonVisibleCellErrors when rowRemove is called

### DIFF
--- a/app/views/components/datagrid/test-editable-paging-validation.html
+++ b/app/views/components/datagrid/test-editable-paging-validation.html
@@ -1,5 +1,18 @@
 <div class="row">
   <div class="twelve columns">
+
+    <div class="contextual-toolbar toolbar is-hidden">
+      <div class="title selection-count">1 Selected</div>
+      <div class="buttonset">
+        <button class="btn-icon" type="button" id="remove-btn">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-delete"></use>
+          </svg>
+          <span class="audible">Remove</span>
+        </button>
+      </div>
+    </div>
+  
     <div id="datagrid">
 
     </div>
@@ -75,8 +88,10 @@
             });
 
             $('#datagrid').on('page', function(e, pi) {
-              var gridApi = $(this).data('datagrid');	              if (pi && pi.type === 'afterpaging') {
-              gridApi.validateAll();	                return;
+              var gridApi = $(this).data('datagrid');	              
+              if (pi && pi.type === 'afterpaging') {
+                gridApi.validateAll();
+                return;
               }
               var self = $(this).data('datagrid');
               if (pi && pi.type === 'next' || pi.type === 'prev') {
@@ -97,8 +112,14 @@
                 self.validateAll();
               }
             });
-
+            
+            //Add Code for Add and icon-delete
+            $('#remove-btn').on('click', function () {
+              $('#datagrid').data('datagrid').removeSelected();
+            });
         });
+        
+        
 
   });
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[Datagrid]` Added a Sort Function to the datagrid column to allow the value to be formatted for the sort. ([#1766](https://github.com/infor-design/enterprise/issues/2274)))
 - `[Datagrid]` Added placeholder functionality to Lookup, Dropdown, and Decimal Formatrers. ([#2408](https://github.com/infor-design/enterprise/issues/2408)))
 - `[Datagrid]` Added support to restrict the size of a column with minWidth and maxWidth setting on the column. ([#2313](https://github.com/infor-design/enterprise/issues/2313))
+- `[Datagrid]` Automatically remove nonVisibelCellError when a row is removed. ([#2436](https://github.com/infor-design/enterprise/issues/2436))
 - `[Dropdown]` Fixed an issue where ellipsis was not working when use firefox new tab. ([#2236](https://github.com/infor-design/enterprise/issues/2236))
 - `[ListFilter]` Added `phraseStartsWith` filterMode for only matching a search term against the beginning of a string. ([#1606](https://github.com/infor-design/enterprise/issues/1606))
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -580,6 +580,10 @@ Datagrid.prototype = {
     this.settings.dataset.splice(row, 1);
     this.preventSelection = true;
     this.renderRows();
+    if (this.nonVisibleCellErrors.length !== 0) {
+      this.nonVisibleCellErrors = $.grep(this.nonVisibleCellErrors, error => error.row !== row);
+      this.showNonVisibleCellErrors();
+    }
     delete this.preventSelection;
     this.syncSelectedUI();
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Remove the row error information if the row has been removed.

**Related github/jira issue (required)**:
Closes #2436

**Steps necessary to review your pull request (required)**:
1. Go to 'http://localhost:4000/components/datagrid/test-editable-paging-validation.html'
2. Select a row and also remove the Product Name 
3. Page to the next page, so that the nonVisibleCellErrors created and visible
4. Click on the remove button to remove the row 

You can test creating multiple error and only removing some on another page.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
