### PR TITLE
2335 - Fix that makes the theme switcher to reflect whats sent in the url params

### DIFF
--- a/app/views/components/personalize/test-state.html
+++ b/app/views/components/personalize/test-state.html
@@ -36,17 +36,7 @@
 
 <script>
   // component defaults
-  var colors = {
-    header: '2578A9',
-    subheader: '1d5f8a',
-    text: 'ffffff',
-    verticalBorder: '133C59',
-    horizontalBorder: '134D71',
-    inactive: '1d5f8a',
-    hover: '133C59',
-    btnColorHeader: '368AC0',
-    btnColorSubheader: '54a1d3'
-  };
+  var colors = '2578A9';
 
   $('html').personalize({colors: colors});
 

--- a/app/views/includes/head.html
+++ b/app/views/includes/head.html
@@ -60,13 +60,9 @@
     // If Initialize isnt called need to defer this
     $('html')
       .personalize({colors: colors, theme: theme, blockUI: blockUI})
-      .on('colorschanged', function (e, a) {
-        var pageUrl = '?colors=' + a.colors;
-        window.history.pushState('', '', pageUrl);
-      })
-      .on('themechanged', function (e, a) {
+      .on('colorschanged themechanged', function (e, a) {
         const parts = a.theme.split('-');
-        var pageUrl = '?theme=' + parts[1] + '&variant=' + parts[2];
+        var pageUrl = '?theme=' + parts[1] + '&variant=' + parts[2] + '&colors=' + a.colors.replace('#', '');
         window.history.pushState('', '', pageUrl);
       });
   </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,7 +23,7 @@
 - `[Datagrid]` Fixed the text width functions for better auto sized columns when using editors and special formatters. ([#2270](https://github.com/infor-design/enterprise/issues/2270))
 - `[Datagrid]` Fixes the alignment of the alert and warning icons on a lookup editor. ([#2175](https://github.com/infor-design/enterprise/issues/2175))
 - `[Datagrid]` Fixes tooltip on the non displayed table errors. ([#2264](https://github.com/infor-design/enterprise/issues/2264))
-- `[Datagrid]` Fixes an issue with alignment when toggline the filter row. ([#2332](https://github.com/infor-design/enterprise/issues/2332))
+- `[Datagrid]` Fixes an issue with alignment when toggling the filter row. ([#2332](https://github.com/infor-design/enterprise/issues/2332))
 - `[Datagrid]` Fixes an error on tree grid when using server-side paging. ([#2132](https://github.com/infor-design/enterprise/issues/2132))
 - `[Datagrid]` Fixed an issue where autocompletes popped up on cell editors. ([#1575](https://github.com/infor-design/enterprise/issues/1575))
 - `[Datagrid]` Fixes reset columns to set the correct hidden status. ([#2315](https://github.com/infor-design/enterprise/issues/2315))

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -546,6 +546,16 @@ Header.prototype = {
       const color = link.attr('data-rgbcolor');
       personalization.setColors(color);
     });
+
+    // Mark theme as checked
+    const currentTheme = theme.currentTheme;
+    if (currentTheme.id !== 'theme-soho-light') {
+      const themeParts = currentTheme.id.split('-');
+      this.element.find('[data-theme-name]').parent().removeClass('is-checked');
+      this.element.find(`[data-theme-name="${themeParts[0]}-${themeParts[1]}"]`).parent().addClass('is-checked');
+      this.element.find('[data-theme-variant]').parent().removeClass('is-checked');
+      this.element.find(`[data-theme-variant="${themeParts[2]}"]`).parent().addClass('is-checked');
+    }
   },
 
   /**

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -556,6 +556,16 @@ Header.prototype = {
       this.element.find('[data-theme-variant]').parent().removeClass('is-checked');
       this.element.find(`[data-theme-variant="${themeParts[2]}"]`).parent().addClass('is-checked');
     }
+
+    if (personalization.settings.colors) {
+      let colors = typeof personalization.settings.colors === 'object' ?
+        personalization.settings.colors.header :
+        personalization.settings.colors;
+      colors = colors.replace('#', '');
+
+      this.element.find('[data-rgbcolor]').parent().removeClass('is-checked');
+      this.element.find(`[data-rgbcolor="#${colors}"]`).parent().addClass('is-checked');
+    }
   },
 
   /**

--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -221,7 +221,7 @@ Personalize.prototype = {
     */
     this.element.triggerHandler('colorschanged', {
       colors: this.settings.colors.header ||
-        this.settings.colors || theme.themeColors().brand.primary.base.value,
+        this.settings.colors || theme.themeColors().brand.primary.alt.value,
       theme: this.currentTheme || 'theme-soho-light'
     });
     return this;
@@ -338,7 +338,7 @@ Personalize.prototype = {
     */
     this.element.triggerHandler('themechanged', {
       colors: this.settings.colors.header ||
-        this.settings.colors || theme.themeColors().brand.primary.base.value,
+        this.settings.colors || theme.themeColors().brand.primary.alt.value,
       theme: incomingTheme || 'theme-soho-light'
     });
   },

--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -219,7 +219,11 @@ Personalize.prototype = {
     * @property {object} args - The event args
     * @property {string} args.colors - The color(s) changed to.
     */
-    this.element.triggerHandler('colorschanged', { colors });
+    this.element.triggerHandler('colorschanged', {
+      colors: this.settings.colors.header ||
+        this.settings.colors || theme.themeColors().brand.primary.base.value,
+      theme: this.currentTheme || 'theme-soho-light'
+    });
     return this;
   },
 
@@ -332,7 +336,11 @@ Personalize.prototype = {
     * @property {object} args - The event args
     * @property {string} args.theme - The theme id changed to.
     */
-    this.element.triggerHandler('themechanged', { theme: incomingTheme });
+    this.element.triggerHandler('themechanged', {
+      colors: this.settings.colors.header ||
+        this.settings.colors || theme.themeColors().brand.primary.base.value,
+      theme: incomingTheme || 'theme-soho-light'
+    });
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

#2335 was failed because when the url params are used the checkbox in the theme switcher were incorrect. This fixed that.

**Related github/jira issue (required)**:
Fixes #2335 
**Steps necessary to review your pull request (required)**:
- pull this and build normally
- go to a url with the parms such as http://localhost:4000/components/personalize/example-form.html?theme=soho&variant=contrast
- open the theme switcher in the top right and make sure the checkboxes are correct
- try different theme/variant combos