### PR TITLE
2058 - Fix theme color issues in charts

### DIFF
--- a/app/src/index.scss
+++ b/app/src/index.scss
@@ -13,10 +13,6 @@
 @import '../../src/core/config';
 @import '../../src/core/mixins';
 
-// Enterprise color palette
-@import '../../src/components/colors/colorpalette';
-@import '../../src/components/colors/colors';
-
 // Layout styles
 @import 'sass/layouts/nofrills';
 @import 'sass/layouts/embedded';

--- a/src/components/bar/bar.js
+++ b/src/components/bar/bar.js
@@ -759,6 +759,9 @@ Bar.prototype = {
       });
     }
 
+    $('html').on(`themechanged.${COMPONENT_NAME}`, () => {
+      this.updated();
+    });
     return this;
   },
 
@@ -836,6 +839,7 @@ Bar.prototype = {
   teardown() {
     this.element.off(`updated.${COMPONENT_NAME}`);
     $('body').off(`resize.${COMPONENT_NAME}`);
+    $('html').off(`themechanged.${COMPONENT_NAME}`);
     return this;
   },
 

--- a/src/components/column/column.js
+++ b/src/components/column/column.js
@@ -1155,6 +1155,9 @@ Column.prototype = {
       });
     }
 
+    $('html').on(`themechanged.${COMPONENT_NAME}`, () => {
+      this.updated();
+    });
     return this;
   },
 
@@ -1230,6 +1233,7 @@ Column.prototype = {
   teardown() {
     this.element.off(`updated.${COMPONENT_NAME}`);
     $('body').off(`resize.${COMPONENT_NAME}`);
+    $('html').off(`themechanged.${COMPONENT_NAME}`);
     return this;
   },
 

--- a/src/components/line/line.js
+++ b/src/components/line/line.js
@@ -761,6 +761,9 @@ Line.prototype = {
       });
     }
 
+    $('html').on(`themechanged.${COMPONENT_NAME}`, () => {
+      this.updated();
+    });
     return this;
   },
 
@@ -838,6 +841,7 @@ Line.prototype = {
   teardown() {
     this.element.off(`updated.${COMPONENT_NAME}`);
     $('body').off(`resize.${COMPONENT_NAME}`);
+    $('html').off(`themechanged.${COMPONENT_NAME}`);
     return this;
   },
 

--- a/src/components/pie/pie.js
+++ b/src/components/pie/pie.js
@@ -630,6 +630,9 @@ Pie.prototype = {
       });
     }
 
+    $('html').on(`themechanged.${COMPONENT_NAME}`, () => {
+      this.updated();
+    });
     return this;
   },
 
@@ -785,6 +788,7 @@ Pie.prototype = {
   teardown() {
     this.element.off(`updated.${COMPONENT_NAME}`);
     $('body').off(`resize.${COMPONENT_NAME}`);
+    $('html').off(`themechanged.${COMPONENT_NAME}`);
     return this;
   },
 

--- a/src/components/radar/radar.js
+++ b/src/components/radar/radar.js
@@ -105,11 +105,9 @@ Radar.prototype = {
    */
   init() {
     this.width = 0;
-    if (!this.settings.colors) {
-      this.settings.colors = charts.colorRange();
-    }
 
     this
+      .setupColors()
       .build()
       .handleEvents();
 
@@ -133,6 +131,19 @@ Radar.prototype = {
   build() {
     this.updateData(this.settings.dataset);
     this.setInitialSelected();
+    return this;
+  },
+
+  /**
+   * Sets up the internal colors.
+   * @returns {object} The component prototype for chaining.
+   * @private
+   */
+  setupColors() {
+    if (!this.settings.colors || this.useBuiltInColors) {
+      this.settings.colors = charts.colorRange();
+      this.useBuiltInColors = true;
+    }
     return this;
   },
 
@@ -489,6 +500,9 @@ Radar.prototype = {
       });
     }
 
+    $('html').on(`themechanged.${COMPONENT_NAME}`, () => {
+      this.updated();
+    });
     return this;
   },
 
@@ -579,6 +593,7 @@ Radar.prototype = {
 
     this.element.empty();
     return this
+      .setupColors()
       .build();
   },
 
@@ -590,6 +605,7 @@ Radar.prototype = {
   teardown() {
     this.element.off(`updated.${COMPONENT_NAME}`);
     $('body').off(`resize.${COMPONENT_NAME}`);
+    $('html').off(`themechanged.${COMPONENT_NAME}`);
     return this;
   },
 

--- a/src/components/treemap/treemap.js
+++ b/src/components/treemap/treemap.js
@@ -85,7 +85,17 @@ Treemap.prototype = {
    * @private
    */
   build() {
-    if (!this.settings.colors) {
+    this.setupColors();
+    this.updateData(this.settings.dataset);
+    return this;
+  },
+
+  /**
+   * Generate internal color variables.
+   * @private
+   */
+  setupColors() {
+    if (!this.settings.colors || this.useBuiltInColors) {
       const palette = theme.themeColors().palette;
       this.settings.colors = [
         palette.azure['100'].value,
@@ -117,10 +127,8 @@ Treemap.prototype = {
         palette.turquoise['30'].value,
         palette.turquoise['20'].value
       ];
+      this.useBuiltInColors = true;
     }
-
-    this.updateData(this.settings.dataset);
-    return this;
   },
 
   /**
@@ -216,6 +224,9 @@ Treemap.prototype = {
       });
     }
 
+    $('html').on(`themechanged.${COMPONENT_NAME}`, () => {
+      this.updated();
+    });
     return this;
   },
 
@@ -250,6 +261,7 @@ Treemap.prototype = {
       this.settings.dataset = settings.dataset;
     }
 
+    this.setupColors();
     this.element.empty();
     return this
       .build();
@@ -263,6 +275,7 @@ Treemap.prototype = {
   teardown() {
     this.element.off(`updated.${COMPONENT_NAME}`);
     $('body').off(`resize.${COMPONENT_NAME}`);
+    $('html').off(`themechanged.${COMPONENT_NAME}`);
     return this;
   },
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When i first fixed #2058 things worked but https://github.com/infor-design/enterprise/pull/2373/files#diff-bc5de2d974df82ad6e9bc8bc7933773dR17 added an extra set of variables that caused the colors to be wrong. Fixed this. Also fixed that the theme change in the switcher didnt work.

**Related github/jira issue (required)**:
Fixes #2058 

**Steps necessary to review your pull request (required)**:
- pull this branch
- clean the `app/dist` folder
- stop server and run `npm run quickstart` so the demo app is generated properly
- `npm run start` again
- go to http://localhost:4000/components/bar-stacked/example-index.html?theme=uplift and make sure that the legend color is correct
- go to http://localhost:4000/components/bar-stacked/example-index.html and then change theme in the switcher to uplift and notice the colors changed
- NOTE: the theme switcher wont be correctly set  if you have url params this is fixed on https://github.com/infor-design/enterprise/pull/2438
- test demo app by going to http://localhost:4000/components/bar-stacked/xxx and http://localhost:4000/components/bar-stacked ect
