### PR TITLE
2447 - Bar: Unable to use the {{value}} expression in the tooltip

### DIFF
--- a/app/views/components/bar/test-custom-tooltips.html
+++ b/app/views/components/bar/test-custom-tooltips.html
@@ -12,6 +12,8 @@
   </div>
 </div>
 
+{{={{{ }}}=}}
+
 <script>
 $('body').on('initialized', function () {
 
@@ -20,7 +22,7 @@ $('body').on('initialized', function () {
           name: 'Category A',
           value: 373,
           url: 'test',
-          tooltip: 'Custom Tooltip One'
+          tooltip: 'Custom Tooltip One - {{value}}'
       }, {
           name: 'Category B',
           value: 372,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - `[Alerts]` Removed dirty tracker from the page due to layout issues. ([#1679](https://github.com/infor-design/enterprise/issues/1679))
 - `[Charts]` Made fixes so all charts change color in uplift theme. ([#2058](https://github.com/infor-design/enterprise/issues/2058))
+- `[Charts]` Fixes dynamic tooltips on a bar chart. ([#2447](https://github.com/infor-design/enterprise/issues/2447))
 - `[Datagrid]` Fixed the text width functions for better auto sized columns when using editors and special formatters. ([#2270](https://github.com/infor-design/enterprise/issues/2270))
 - `[Datagrid]` Fixes the alignment of the alert and warning icons on a lookup editor. ([#2175](https://github.com/infor-design/enterprise/issues/2175))
 - `[Datagrid]` Fixes tooltip on the non displayed table errors. ([#2264](https://github.com/infor-design/enterprise/issues/2264))

--- a/src/components/bar/bar.js
+++ b/src/components/bar/bar.js
@@ -448,6 +448,57 @@ Bar.prototype = {
           }
         };
 
+        // Replace matched pattern in given string
+        const replaceMatch = (str, callback, expr) => {
+          if (typeof expr === 'undefined' || expr === null) {
+            expr = /{{(\w+)}}/g;
+          } else if (typeof expr === 'string') {
+            expr = new RegExp(expr, 'g');
+          }
+          if (typeof str === 'string' && typeof callback === 'function' && expr instanceof RegExp) {
+            let max = 9999;
+            while (expr.test(str) && max > 0) {
+              str = str.replace(expr, (match, key) => callback(match, key));
+              max--;
+            }
+          }
+          return str;
+        };
+
+        // Replace key/value and set type as string
+        const replaceMatchAndSetType = () => {
+          if (typeof content === 'string') {
+            content = replaceMatch(content, (match, key) => format(d[key]));
+          } else if (typeof content === 'number') {
+            content = content.toString();
+          }
+        };
+
+        // Set custom tooltip callback method
+        const setCustomTooltip = (method) => {
+          content = '';
+          const args = { index: i, data: d };
+          const req = (res) => {
+            if (typeof res === 'string' || typeof res === 'number') {
+              content = res;
+              replaceMatchAndSetType();
+              tooltipDataCache[i] = content;
+            }
+          };
+          let runInterval = true;
+          tooltipInterval = setInterval(() => {
+            if (runInterval) {
+              runInterval = false;
+              method(req, args);
+            }
+
+            if (content !== '') {
+              clearInterval(tooltipInterval);
+              show();
+            }
+          }, 10);
+        };
+
         if (dataset.length === 1) {
           content = `<p><b>${d.y} </b>${d.x}</p>`;
         } else {
@@ -509,8 +560,20 @@ Bar.prototype = {
             }
           }, 10);
         } else {
-          content = tooltipDataCache[i] || tooltipData || d.tooltip || content || '';
-          show(xPosS, yPosS, isTooltipBottom);
+          content = tooltipDataCache[i] || tooltipData || content || '';
+          if (!tooltipDataCache[i] && d.tooltip !== false &&
+            (typeof d.tooltip !== 'undefined' || d.tooltip !== null)) {
+            if (typeof d.tooltip === 'function') {
+              setCustomTooltip(d.tooltip);
+            } else {
+              content = d.tooltip;
+              replaceMatchAndSetType();
+              tooltipDataCache[i] = content;
+            }
+          }
+          if (typeof content === 'string' && content !== '') {
+            show(xPosS, yPosS, isTooltipBottom);
+          }
 
           // set inline colors
           if (self.settings.isStacked) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Add the same tooltip dynamic functionality to the bar chart type

**Related github/jira issue (required)**:
Closes #2447

**Steps necessary to review your pull request (required)**:
Goto 'http://localhost:4000/components/bar/test-custom-tooltips.html'
Hover on the first item, as the custom tip will show the value.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
