### PR TITLE
2444 - Fix an issue where filtering will only run every second time [v4.19.x]

### DIFF
--- a/app/views/components/datagrid/example-keyword-search.html
+++ b/app/views/components/datagrid/example-keyword-search.html
@@ -42,7 +42,8 @@
         dataset: data,
         frozenColumns: {left: ['productId']},
         toolbar: {title: 'Data Grid Header Title', collapsibleFilter: true, results: true, keywordFilter: true, actions: true, rowHeight: true}
+      }).on('filtered', function () {
+        console.log('Filter Ran');
       });
-
  });
 </script>

--- a/app/views/components/datagrid/test-editor-dropdown-source.html
+++ b/app/views/components/datagrid/test-editor-dropdown-source.html
@@ -84,7 +84,7 @@
     };
 
     columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
-    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input});
+    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input, filterType: 'text'});
     columns.push({ id: 'status', name: 'Status', field: 'price', formatter: Formatters.Alert, readonly: true, ranges: [{'min': LOW_RANGE_LOW_NUMBER, 'max': LOW_RANGE_HIGH_NUMBER, 'classes': 'success', text: 'Confirmed'}, {'min': HIGH_RANGE_LOW_NUMBER, 'max': HIGH_RANGE_HIGH_NUMBER, 'classes': 'error', text: 'Error'}]});
     columns.push({ id: 'price', name: 'Price', field: 'price', align: 'right', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###.000'});
     columns.push({ id: 'action', name: 'Action', field: 'action', formatter: dropDownFormatter, filterType: 'multiselect', options:  [ { label: ' ', value: ' '} ], editor: Editors.Dropdown, editorOptions: {editable: false, source: dropDownSource} });
@@ -95,12 +95,12 @@
       cellNavigation: true,
       columns: columns,
       dataset: dataAll,
-      disableClientSort:    true,
-      disableClientFilter:  true,
-      filterWhenTyping: true,
+      disableClientSort: true,
+      disableClientFilter: true,
+      filterWhenTyping: false,
       editable: true,
       clickToSelect: false,
-      redrawOnResize:       false,
+      redrawOnResize: false,
       isList: true,
       menuId: 'datagrid',
       selectable: 'multiple',
@@ -130,6 +130,7 @@
       console.log(e, args);
     })
     .on('filtered', function (e, args) {
+      $('body').toast({ title: 'Filtered Event', message: 'Filter Event Triggered' });
       console.log('filtered', args);
 
       if (args.conditions.length === 0) {

--- a/app/views/components/datagrid/test-timezone-formats.html
+++ b/app/views/components/datagrid/test-timezone-formats.html
@@ -11,24 +11,24 @@
       var columns = [],
         data = [];
 
-      data.push({id: 1, productId: 2445201, orderDate: new Date(2019, 3, 3) });
-      data.push({id: 2, productId: 2445202, orderDate: new Date(2019, 3, 3) });
-      data.push({id: 3, productId: 2445203, orderDate: new Date(2019, 3, 3) });
-      data.push({id: 4, productId: 2445204, orderDate: new Date(2019, 3, 3) });
-      data.push({id: 5, productId: 2445205, orderDate: new Date(2019, 3, 3) });
-      data.push({id: 6, productId: 2445206, orderDate: new Date(2019, 3, 3) });
-      data.push({id: 7, productId: 2445207, orderDate: new Date(2019, 3, 3) });
-      data.push({id: 8, productId: 2445208, orderDate: new Date(2019, 3, 3) });
-      data.push({id: 9, productId: 2445209, orderDate: new Date(2019, 3, 3) });
+      data.push({id: 1, productId: 2445201, orderDate: new Date(2019, 3, 3, 0, 0, 0) });
+      data.push({id: 2, productId: 2445202, orderDate: new Date(2019, 3, 3, 0, 0, 0) });
+      data.push({id: 3, productId: 2445203, orderDate: new Date(2019, 3, 3, 0, 0, 0) });
+      data.push({id: 4, productId: 2445204, orderDate: new Date(2019, 3, 3, 0, 0, 0) });
+      data.push({id: 5, productId: 2445205, orderDate: new Date(2019, 3, 3, 0, 0, 0) });
+      data.push({id: 6, productId: 2445206, orderDate: new Date(2019, 3, 3, 0, 0, 0) });
+      data.push({id: 7, productId: 2445207, orderDate: new Date(2019, 3, 3, 0, 0, 0) });
+      data.push({id: 8, productId: 2445208, orderDate: new Date(2019, 3, 3, 0, 0, 0) });
+      data.push({id: 9, productId: 2445209, orderDate: new Date(2019, 3, 3, 0, 0, 0) });
 
-      //Define Columns for the Grid.
+      // Define Columns for the Grid.
       columns.push({ id: 'orderDate', name: 'Default Format', field: 'orderDate', formatter: Soho.Formatters.Date});
       columns.push({ id: 'orderDate', name: 'Short Timezone (Locale)', field: 'orderDate', formatter: Soho.Formatters.Date, dateFormat: { date: 'timezone' }});
       columns.push({ id: 'orderDate', name: 'Long Timezone (Locale)', field: 'orderDate', formatter: Soho.Formatters.Date, dateFormat: { date: 'timezoneLong' }});
       columns.push({ id: 'orderDate', name: 'Short Timezone (Custom)', field: 'orderDate', formatter: Soho.Formatters.Date, dateFormat: 'dd-MM-yyyy HH:mm zz'});
       columns.push({ id: 'orderDate', name: 'Long Timezone (Custom)', field: 'orderDate', formatter: Soho.Formatters.Date, dateFormat: 'dd-MM-yyyy HH:mm zz'});
 
-      //Init and get the api for the grid
+      // Init and get the api for the grid
       grid = $('#datagrid').datagrid({
         columns: columns,
         dataset: data,

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -796,7 +796,6 @@ Datagrid.prototype = {
       this.restoreFilter = true;
       this.restoreSortOrder = true;
       this.savedFilter = this.filterConditions();
-      this.restoreFilterClientSide = true;
     }
 
     // Resize and re-render if have a new dataset
@@ -1627,7 +1626,6 @@ Datagrid.prototype = {
       elem.find('select.multiselect').each(function () {
         const multiselect = $(this);
         multiselect.multiselect(col.editorOptions).on('selected.datagrid', () => {
-          self.restoreFilterClientSide = false;
           self.applyFilter(null, 'selected');
         });
 
@@ -1883,7 +1881,7 @@ Datagrid.prototype = {
       this.filterExpr = [];
     }
 
-    if (JSON.stringify(conditions) !== JSON.stringify(this.filterExpr)) {
+    if (this.pagerAPI && JSON.stringify(conditions) !== JSON.stringify(this.filterExpr)) {
       this.filterExpr = conditions;
       filterChanged = true;
     }
@@ -2184,22 +2182,17 @@ Datagrid.prototype = {
         type: 'filtered'
       });
     }
-
-    if (this.restoreFilterClientSide) {
-      this.restoreFilterClientSide = false;
-    } else {
-      /**
-      * Fires after a filter action ocurs
-      * @event filtered
-      * @memberof Datagrid
-      * @property {object} event The jquery event object
-      * @property {object} args Object with the arguments
-      * @property {number} args.op The filter operation, this can be 'apply', 'clear'
-      * @property {object} args.conditions An object with all the condition data.
-      * @property {string} args.trigger Info on what was the triggering action. May be render, select or key
-      */
-      this.element.trigger('filtered', { op: 'apply', conditions, trigger });
-    }
+    /**
+    * Fires after a filter action ocurs
+    * @event filtered
+    * @memberof Datagrid
+    * @property {object} event The jquery event object
+    * @property {object} args Object with the arguments
+    * @property {number} args.op The filter operation, this can be 'apply', 'clear'
+    * @property {object} args.conditions An object with all the condition data.
+    * @property {string} args.trigger Info on what was the triggering action. May be render, select or key
+    */
+    this.element.trigger('filtered', { op: 'apply', conditions, trigger });
     this.saveUserSettings();
   },
 

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -601,7 +601,6 @@ const Locale = {  // eslint-disable-line
    */
   getTimeZone(date, timeZoneName) {
     const currentLocale = Locale.currentLocale.name || 'en-US';
-    const time = date.toLocaleTimeString(currentLocale);
     let name = '';
 
     if (env.browser.name === 'ie' && env.browser.version === '11') {
@@ -613,14 +612,14 @@ const Locale = {  // eslint-disable-line
         currentLocale,
         { timeZoneName: 'long' }
       );
-      return name.replace(`${time} `, '');
+      return name.split(' ')[1];
     }
 
     name = date.toLocaleTimeString(
       currentLocale,
       { timeZoneName: 'short' }
     );
-    return name.replace(`${time} `, '');
+    return name.split(' ')[1];
   },
 
   /**

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -612,14 +612,15 @@ const Locale = {  // eslint-disable-line
         currentLocale,
         { timeZoneName: 'long' }
       );
-      return name.split(' ')[1];
+    } else {
+      name = date.toLocaleTimeString(
+        currentLocale,
+        { timeZoneName: 'short' }
+      );
     }
 
-    name = date.toLocaleTimeString(
-      currentLocale,
-      { timeZoneName: 'short' }
-    );
-    return name.split(' ')[1];
+    const timezoneParts = name.replace(/[0-9:AMP]/g, '').split(' ');
+    return timezoneParts.join(' ').trimStart();
   },
 
   /**

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -917,6 +917,20 @@ describe('Datagrid editor dropdown source tests', () => {
 
     expect(await element.all(by.css('#datagrid tbody tr')).count()).toEqual(4);
   });
+
+  it('Should filter twice in a row and filter', async () => {
+    expect(await element.all(by.css('#datagrid tbody tr')).count()).toEqual(7);
+    const inputEl = await element(by.id('test-editor-dropdown-source-datagrid-1-header-filter-1'));
+    await inputEl.click();
+    await inputEl.sendKeys('Com');
+    await inputEl.sendKeys(protractor.Key.ENTER);
+    await inputEl.sendKeys('Com');
+    await inputEl.sendKeys(protractor.Key.ENTER);
+    await inputEl.sendKeys('');
+    await inputEl.sendKeys(protractor.Key.ENTER);
+
+    expect(await element.all(by.css('.toast-title')).count()).toEqual(3);
+  });
 });
 
 describe('Datagrid Header Alignment With Ellipsis', () => {
@@ -1807,18 +1821,18 @@ describe('Datagrid timezone tests', () => {
       expect(await element(by.css('.datagrid tr:nth-child(1) td:nth-child(1)')).getText()).toEqual('03-04-2019');
       let text = await element(by.css('.datagrid tr:nth-child(1) td:nth-child(2)')).getText();
 
-      expect(['03-04-2019 00:00 GMT-5', '03-04-2019 00:00 GMT-4']).toContain(text);
+      expect(['03-04-2019 00:00 GMT-5', '03-04-2019 00:00 GMT-4', '03-04-2019 00:00 EDT']).toContain(text);
       text = await element(by.css('.datagrid tr:nth-child(1) td:nth-child(3)')).getText();
 
       expect(['03-04-2019 00:00 Eastern-standaardtijd', '03-04-2019 00:00 Eastern-zomertijd']).toContain(text);
 
       text = await element(by.css('.datagrid tr:nth-child(1) td:nth-child(4)')).getText();
 
-      expect(['03-04-2019 00:00 GMT-5', '03-04-2019 00:00 GMT-4']).toContain(text);
+      expect(['03-04-2019 00:00 GMT-5', '03-04-2019 00:00 GMT-4', '03-04-2019 00:00 EDT']).toContain(text);
 
       text = await element(by.css('.datagrid tr:nth-child(1) td:nth-child(5)')).getText();
 
-      expect(['03-04-2019 00:00 GMT-5', '03-04-2019 00:00 GMT-4']).toContain(text);
+      expect(['03-04-2019 00:00 GMT-5', '03-04-2019 00:00 GMT-4', '03-04-2019 00:00 EDT']).toContain(text);
     });
   }
 });

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -948,7 +948,7 @@ describe('Locale API', () => {
     expect(Locale.formatDate('00000000')).toEqual('');
   });
 
-  xit('Should format dates with short timezones', () => {
+  it('Should format dates with short timezones', () => {
     Locale.set('en-US');
 
     expect(['3/22/2018 8:11 PM EST', '3/22/2018 8:11 PM EDT']).toContain(Locale.formatDate(new Date(2018, 2, 22, 20, 11, 12), { date: 'timezone' }));


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
It was found that the filter would only run every second time do to some bad flag logic. Found this code wasn't needed so removed to fix. While running tests I found there was a time-bomb bug in the timezone code so fixed this (when running at certain times (8:58 fx).

**Related github/jira issue (required)**:
Fixes #2444 

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/datagrid/test-timezone-formats?layout=nofrills&locale=nl-NL
- page should show timezones at 00:00

http://localhost:4000/components/datagrid/test-editor-dropdown-source
- in the text field type com then enter and should see a toast
- in the text field type "" then enter and should see a toast again (this wasnt working)

http://localhost:4000/components/datagrid/example-filter
http://localhost:4000/components/datagrid/example-keyword-search.html
- test for good measure

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
