### PR TITLE
2025 - Images tabbable .image-auto

### DIFF
--- a/app/views/components/images/example-index.html
+++ b/app/views/components/images/example-index.html
@@ -4,9 +4,7 @@
   <div class="two columns">
     <div class="content">
       <h2>60x60</h2>
-      <div class="image-sm">
-        <img class="image-sm" src="http://placehold.it/60x60/999999/FFFFFF" alt="image-sm 60x60" tabindex="0"/>
-      </div>
+      <img class="image-sm" src="http://placehold.it/60x60/999999/FFFFFF" alt="image-sm 60x60" tabindex="0"/>
       <p>image-sm</p>
       <br /><br />
       <div class="image-sm placeholder">
@@ -22,9 +20,7 @@
   <div class="two columns">
     <div class="content">
       <h2>154x120</h2>
-      <div class="image-md">
-        <img src="http://placehold.it/154x120/999999/FFFFFF" alt="image-md 154x120" tabindex="0"/>
-      </div>
+      <img class="image-md" src="http://placehold.it/154x120/999999/FFFFFF" alt="image-md 154x120" tabindex="0"/>
       <p>image-md</p>
       <br /><br />
       <div class="image-md placeholder">
@@ -40,9 +36,7 @@
   <div class="four columns">
     <div class="content">
       <h2>300x350</h2>
-      <div class="image-lg">
-        <img src="http://placehold.it/300x350/999999/FFFFFF" alt="image-md 300x350" tabindex="0"/>
-      </div>
+      <img  class="image-lg" src="http://placehold.it/300x350/999999/FFFFFF" alt="image-md 300x350" tabindex="0"/>
       <p>image-lg</p>
       <br /><br />
       <div class="image-lg placeholder">
@@ -58,18 +52,8 @@
   <div class="three columns">
     <div class="content">
       <h2>300x350</h2>
-      <div class="image-auto">
-        <img src="http://placehold.it/300x350/999999/FFFFFF" alt="image-auto 300x350" tabindex="0"/>
-      </div>
+      <img class="image-auto" src="http://placehold.it/300x350/999999/FFFFFF" alt="image-auto 300x350" tabindex="0"/>
       <p>image-auto</p>
-      <br /><br />
-      <div class="image-auto placeholder">
-        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-          <use xlink:href="#icon-insert-image"></use>
-        </svg>
-        <span class="audible">Placeholder Image</span>
-      </div>
-      <p>placeholder</p>
     </div>
   </div>
 

--- a/app/views/components/images/example-index.html
+++ b/app/views/components/images/example-index.html
@@ -5,7 +5,7 @@
     <div class="content">
       <h2>60x60</h2>
       <div class="image-sm">
-        <img src="http://placehold.it/60x60/999999/FFFFFF" alt="image-sm 60x60" tabindex="0"/>
+        <img class="image-sm" src="http://placehold.it/60x60/999999/FFFFFF" alt="image-sm 60x60" tabindex="0"/>
       </div>
       <p>image-sm</p>
       <br /><br />
@@ -19,7 +19,7 @@
     </div>
   </div>
 
-  <div class="three columns">
+  <div class="two columns">
     <div class="content">
       <h2>154x120</h2>
       <div class="image-md">
@@ -37,7 +37,7 @@
     </div>
   </div>
 
-  <div class="three columns">
+  <div class="four columns">
     <div class="content">
       <h2>300x350</h2>
       <div class="image-lg">
@@ -46,6 +46,24 @@
       <p>image-lg</p>
       <br /><br />
       <div class="image-lg placeholder">
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use xlink:href="#icon-insert-image"></use>
+        </svg>
+        <span class="audible">Placeholder Image</span>
+      </div>
+      <p>placeholder</p>
+    </div>
+  </div>
+
+  <div class="three columns">
+    <div class="content">
+      <h2>300x350</h2>
+      <div class="image-auto">
+        <img src="http://placehold.it/300x350/999999/FFFFFF" alt="image-auto 300x350" tabindex="0"/>
+      </div>
+      <p>image-auto</p>
+      <br /><br />
+      <div class="image-auto placeholder">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use xlink:href="#icon-insert-image"></use>
         </svg>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Datagrid]` Added support to restrict the size of a column with minWidth and maxWidth setting on the column. ([#2313](https://github.com/infor-design/enterprise/issues/2313))
 - `[Datagrid]` Automatically remove nonVisibelCellError when a row is removed. ([#2436](https://github.com/infor-design/enterprise/issues/2436))
 - `[Dropdown]` Fixed an issue where ellipsis was not working when use firefox new tab. ([#2236](https://github.com/infor-design/enterprise/issues/2236))
+- `[Images]` Created an additional image class to apply focus state without coercing width and height. ([#2025](https://github.com/infor-design/enterprise/issues/2025))
 - `[ListFilter]` Added `phraseStartsWith` filterMode for only matching a search term against the beginning of a string. ([#1606](https://github.com/infor-design/enterprise/issues/1606))
 
 ### v4.20.0 Fixes

--- a/src/components/images/_images.scss
+++ b/src/components/images/_images.scss
@@ -26,6 +26,12 @@ $images-size: (
 
 @each $key, $value in $images-size {
   .image-#{$key} {
+    border: 1px solid transparent; // to prevent jump on focus
+
+    &:focus {
+      @include focus-state();
+    }
+
     img {
       border: 1px solid transparent; // to prevent jump on focus
       max-height: nth($value, 2);
@@ -43,7 +49,14 @@ $images-size: (
 }
 
 .image-auto {
+  border: 1px solid transparent; // to prevent jump on focus
+
+  &:focus {
+    @include focus-state();
+  }
+
   img {
+    border: 1px solid transparent; // to prevent jump on focus
     &:focus {
       @include focus-state();
     }

--- a/src/components/images/_images.scss
+++ b/src/components/images/_images.scss
@@ -42,6 +42,14 @@ $images-size: (
   }
 }
 
+.image-auto {
+  img {
+    &:focus {
+      @include focus-state();
+    }
+  }
+}
+
 .image-round {
   border: 1px solid transparent; // to prevent jump on focus
   border-radius: 50%;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This provides a solution for the desire to have a focus-state on an image where the width and height are not defined by the CSS. Creates a class `.image-auto` for this purpose and places it in the example page for demonstration purposes.
History here: https://github.com/infor-design/enterprise/issues/2025#issuecomment-506010618

**Related github/jira issue (required)**:
Close #2025 . 

**Steps necessary to review your pull request (required)**:
- Pull branch, run app
- Visit http://localhost:4000/components/images/example-index.html
  - Ensure `.image-auto` is focusable.

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.