### PR TITLE
2352 - RTL: Colorpicker menu arrows advance oppositely

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,6 @@
 ### v4.20.0 Features
 
 - `[Datagrid]` Added support to resize column widths after a value change via the stretchColumnOnChange setting. ([#2174](https://github.com/infor-design/enterprise/issues/2174))
-- `[Datagrid]` Added a Sort Function to the datagrid column to allow the value to be formatted for the sort. ([#1766](https://github.com/infor-design/enterprise/issues/2274))
 - `[Datagrid]` Added a Sort Function to the datagrid column to allow the value to be formatted for the sort. ([#1766](https://github.com/infor-design/enterprise/issues/2274)))
 - `[Datagrid]` Added placeholder functionality to Lookup, Dropdown, and Decimal Formatrers. ([#2408](https://github.com/infor-design/enterprise/issues/2408)))
 - `[Datagrid]` Added support to restrict the size of a column with minWidth and maxWidth setting on the column. ([#2313](https://github.com/infor-design/enterprise/issues/2313))
@@ -23,6 +22,7 @@
 - `[Alerts]` Removed dirty tracker from the page due to layout issues. ([#1679](https://github.com/infor-design/enterprise/issues/1679))
 - `[Calendar]` Allow Validation of the Calendar Popup. ([#1742](https://github.com/infor-design/enterprise/issues/1742))
 - `[Charts]` Made fixes so all charts change color in uplift theme. ([#2058](https://github.com/infor-design/enterprise/issues/2058))
+- `[Colorpicker]` Fixed colorpicker left and right keys advanced oppositely in right-to-left mode. ([#2352](https://github.com/infor-design/enterprise/issues/2352))
 - `[Datagrid]` Fixed the text width functions for better auto sized columns when using editors and special formatters. ([#2270](https://github.com/infor-design/enterprise/issues/2270))
 - `[Datagrid]` Fixes the alignment of the alert and warning icons on a lookup editor. ([#2175](https://github.com/infor-design/enterprise/issues/2175))
 - `[Datagrid]` Fixes tooltip on the non displayed table errors. ([#2264](https://github.com/infor-design/enterprise/issues/2264))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### v4.20.0 Features
 
 - `[Datagrid]` Added support to resize column widths after a value change via the stretchColumnOnChange setting. ([#2174](https://github.com/infor-design/enterprise/issues/2174))
-- `[Datagrid]` Added a Sort Function to the datagrid column to allow the value to be formatted for the sort. ([#1766](https://github.com/infor-design/enterprise/issues/2274)))
+- `[Datagrid]` Added a Sort Function to the datagrid column to allow the value to be formatted for the sort. ([#2274](https://github.com/infor-design/enterprise/issues/2274)))
 - `[Datagrid]` Added placeholder functionality to Lookup, Dropdown, and Decimal Formatrers. ([#2408](https://github.com/infor-design/enterprise/issues/2408)))
 - `[Datagrid]` Added support to restrict the size of a column with minWidth and maxWidth setting on the column. ([#2313](https://github.com/infor-design/enterprise/issues/2313))
 - `[Datagrid]` Automatically remove nonVisibelCellError when a row is removed. ([#2436](https://github.com/infor-design/enterprise/issues/2436))

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -857,7 +857,7 @@ PopupMenu.prototype = {
 
   handleKeys() {
     const self = this;
-    const isRTL = document.querySelector('html').dir === "rtl";
+    const isRTL = document.querySelector('html').dir === 'rtl';
     // http://access.aol.com/dhtml-style-guide-working-group/#popupmenu
 
     // Handle Events in Anchors

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -857,6 +857,7 @@ PopupMenu.prototype = {
 
   handleKeys() {
     const self = this;
+    const isRTL = document.querySelector('html').dir === "rtl";
     // http://access.aol.com/dhtml-style-guide-working-group/#popupmenu
 
     // Handle Events in Anchors
@@ -1047,7 +1048,7 @@ PopupMenu.prototype = {
         }
 
         // Up on Up
-        if ((!isPicker && key === 38) || (isPicker && key === 37)) {
+        if ((!isPicker && key === 38) || (isPicker && key === (isRTL ? 39 : 37))) {
           e.stopPropagation();
           e.preventDefault();
 
@@ -1085,7 +1086,7 @@ PopupMenu.prototype = {
         }
 
         // Down
-        if ((!isPicker && key === 40) || (isPicker && key === 39 && !isAutocomplete)) {
+        if ((!isPicker && key === 40) || (isPicker && key === (isRTL ? 37 : 39)) && (!isAutocomplete)) {
           e.stopPropagation();
           e.preventDefault();
 

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -1086,7 +1086,10 @@ PopupMenu.prototype = {
         }
 
         // Down
-        if ((!isPicker && key === 40) || (isPicker && key === (isRTL ? 37 : 39)) && (!isAutocomplete)) {
+        if ((!isPicker && key === 40)
+          || (isPicker && key === (isRTL ? 37 : 39))
+          && (!isAutocomplete))
+        {
           e.stopPropagation();
           e.preventDefault();
 

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -4,6 +4,7 @@ import { utils } from '../../utils/utils';
 import { stringUtils } from '../../utils/string';
 import { DOM } from '../../utils/dom';
 import { PlacementObject, Place } from '../place/place';
+import { Locale } from '../locale/locale';
 
 // jQuery Components
 import '../place/place.jquery';

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -1088,8 +1088,7 @@ PopupMenu.prototype = {
         // Down
         if ((!isPicker && key === 40)
           || (isPicker && key === (isRTL ? 37 : 39))
-          && (!isAutocomplete))
-        {
+          && (!isAutocomplete)) {
           e.stopPropagation();
           e.preventDefault();
 

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -857,7 +857,6 @@ PopupMenu.prototype = {
 
   handleKeys() {
     const self = this;
-    const isRTL = document.querySelector('html').dir === 'rtl';
     // http://access.aol.com/dhtml-style-guide-working-group/#popupmenu
 
     // Handle Events in Anchors
@@ -1048,7 +1047,7 @@ PopupMenu.prototype = {
         }
 
         // Up on Up
-        if ((!isPicker && key === 38) || (isPicker && key === (isRTL ? 39 : 37))) {
+        if ((!isPicker && key === 38) || (isPicker && key === (Locale.isRTL() ? 39 : 37))) {
           e.stopPropagation();
           e.preventDefault();
 
@@ -1087,7 +1086,7 @@ PopupMenu.prototype = {
 
         // Down
         if ((!isPicker && key === 40)
-          || (isPicker && key === (isRTL ? 37 : 39))
+          || (isPicker && key === (Locale.isRTL() ? 37 : 39))
           && (!isAutocomplete)) {
           e.stopPropagation();
           e.preventDefault();

--- a/test/components/colorpicker/colorpicker.e2e-spec.js
+++ b/test/components/colorpicker/colorpicker.e2e-spec.js
@@ -410,3 +410,24 @@ describe('Colorpicker sizes tests', () => {
     });
   }
 });
+
+describe('Colorpicker RTL left and right keys test', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/colorpicker/example-index?locale=ar-EG&layout=nofrills');
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should pick correct color from picker on keyboard enter', async () => {
+    const colorInputEl = await element(by.id('background-color'));
+    await colorInputEl.click();
+    await colorInputEl.sendKeys(protractor.Key.ARROW_DOWN);
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.id('colorpicker-menu'))), config.waitsFor);
+    await browser.driver.actions().sendKeys(protractor.Key.ARROW_RIGHT).perform();
+    await browser.driver.actions().sendKeys(protractor.Key.ENTER).perform();
+    expect(await element(by.id('background-color')).getAttribute('value')).toEqual('#AD4242');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
When in RTL, the colorpicker left and right arrows advance opposite to their native direction. This PR fixes that issue by adding a RTL check and swapping the key events appropriately.

**Related github/jira issue (required)**:
Closes #2352 .

**Steps necessary to review your pull request (required)**:
- Pull branch, run app
- Visit http://localhost:4000/components/colorpicker/example-index.html & http://localhost:4000/components/colorpicker/example-index.html?locale=ar-EG (RTL)
  - Open colorpicker, focus into colorpicker menu, ensure left and right arrows advance correctly (left is left and right is right)

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
