### PR TITLE
2347 - Tabs: responsive more tabs button not disabled

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -56,6 +56,7 @@
 - `[Popupmenu]` Fixed a bug on IOS that prevented some submenus from showing. ([#1928](https://github.com/infor-design/enterprise/issues/1928))
 - `[Scatter Plot]` Fixed the incorrect color on the tooltips. ([#1066](https://github.com/infor-design/enterprise/issues/1066))
 - `[Stepprocess]` Fixed an issue where a newly enabled step is not shown. ([#2391](https://github.com/infor-design/enterprise/issues/2391))
+- `[Tabs]` Fixed the more tabs button to style as disabled when the tabs component is disabled. ([#2347](https://github.com/infor-design/enterprise/issues/2347))
 
 ### v4.20.0 Chores & Maintenance
 

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -57,6 +57,10 @@
     .tab {
       cursor: default !important;
     }
+
+    .icon {
+      color: $disabled-color !important;
+    }
   }
 
   > .busy-indicator-container {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The more tabs button is not styled as disabled at responsive breakpoints.

**Related github/jira issue (required)**:
Closes #2347 .

**Steps necessary to review your pull request (required)**:
- Pull branch, run app
- Visit http://localhost:4000/components/tabs/example-enable-disable.html#programmatic-tabs-disabled
- Click the `Disable Entire Tab Control` button
  - ensure at responsive breakpoints that the `.tab-more` button is appropriately styled when tabs are disabled

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.