### PR TITLE
2470 - Fix a bug to prevent the selected event from firing on load

### DIFF
--- a/app/views/components/datagrid/example-mixed-selection.html
+++ b/app/views/components/datagrid/example-mixed-selection.html
@@ -85,7 +85,7 @@
 
       //Init The Header Grid
       var headerGrid = $('#datagrid-header').datagrid({
-        dataset: res,
+        dataset: [],
         columns: columnsHeader,
         editable: false,
         selectable: 'mixed',
@@ -103,6 +103,9 @@
       }).on('selected', function (e, args) {
         console.log(args);
       }).data('datagrid');
+
+      headerGrid.loadData(res);
+      headerGrid.unSelectAllRows();
 
       $('#activate-selected-row').on('click', function(e) {
         if (!headerGrid.selectedRows()[0]) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `[Datagrid]` Automatically remove nonVisibelCellError when a row is removed. ([#2436](https://github.com/infor-design/enterprise/issues/2436))
 - `[Datagrid]` Add a fix to show ellipsis text on lookups in the datagrid filter. ([#2122](https://github.com/infor-design/enterprise/issues/2122))
 - `[Datagrid]` Changed the beforeCommitCellEdit event into a function on the column that is synchronous. ([#2442](https://github.com/infor-design/enterprise/issues/2442))
+- `[Datagrid]` Fixed a bug that the selected event would fire when no rows are deselected and on initial load. ([#2472](https://github.com/infor-design/enterprise/issues/2472))
 - `[Dropdown]` Fixed an issue where ellipsis was not working when use firefox new tab. ([#2236](https://github.com/infor-design/enterprise/issues/2236))
 - `[Images]` Created an additional image class to apply focus state without coercing width and height. ([#2025](https://github.com/infor-design/enterprise/issues/2025))
 - `[ListFilter]` Added `phraseStartsWith` filterMode for only matching a search term against the beginning of a string. ([#1606](https://github.com/infor-design/enterprise/issues/1606))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -6619,12 +6619,17 @@ Datagrid.prototype = {
   * Deselect all rows that are currently selected.
   */
   unSelectAllRows() {
+    // Nothing to do
+    if (!this._selectedRows || this._selectedRows.length === 0) {
+      return;
+    }
     this.dontSyncUi = true;
-
+    // Unselect each row backwards so the indexes are correct
     for (let i = this._selectedRows.length - 1; i >= 0; i--) {
       const idx = this.pagingRowIndex(this._selectedRows[i].idx);
       this.unselectRow(idx, true, true);
     }
+    // Sync the Ui and call the events
     this.dontSyncUi = false;
     this.syncSelectedUI();
     this.element.triggerHandler('selected', [this._selectedRows, 'deselectall']);

--- a/test/components/calendar/calendar-api.func-spec.js
+++ b/test/components/calendar/calendar-api.func-spec.js
@@ -18,7 +18,7 @@ const settings = {
   year: 2018
 };
 
-fdescribe('Calendar API', () => { //eslint-disable-line
+describe('Calendar API', () => {
   beforeEach(() => {
     calendarEl = null;
     calendarObj = null;

--- a/test/components/datagrid/datagrid-selection.func-spec.js
+++ b/test/components/datagrid/datagrid-selection.func-spec.js
@@ -477,7 +477,7 @@ describe('Datagrid Selection API', () => {
     done();
   });
 
-  it('Should be able to veto selection with onBeforeSelect', () => {
+  it('Should not fire selected event on load or when no rows are selected', () => {
     datagridObj.destroy();
     datagridObj = new Datagrid(datagridEl, { dataset: [], columns, selectable: 'mixed' });
 

--- a/test/components/datagrid/datagrid-selection.func-spec.js
+++ b/test/components/datagrid/datagrid-selection.func-spec.js
@@ -476,4 +476,16 @@ describe('Datagrid Selection API', () => {
     expect(datagridObj.selectedRows().length).toEqual(0);
     done();
   });
+
+  it('Should be able to veto selection with onBeforeSelect', () => {
+    datagridObj.destroy();
+    datagridObj = new Datagrid(datagridEl, { dataset: [], columns, selectable: 'mixed' });
+
+    const spyEvent = spyOnEvent($(datagridEl), 'selected');
+
+    datagridObj.loadData(data);
+    datagridObj.unSelectAllRows();
+
+    expect(spyEvent).not.toHaveBeenTriggered();
+  });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The selected event fires when the loadData method is called because unSelectAllRows is called to deselect rows. This caused issues as the event is "false". This PR fixes that.

Also removed a fdescribe from my last pr.

**Related github/jira issue (required)**:
Fixes #2470 

**Steps necessary to review your pull request (required)**:
- This is covered by a functional tests
- Added a manual simple test:
- open console
- open page http://localhost:4000/components/datagrid/example-mixed-selection.html
- should not see any selected events in the console
- try to select rows (should see the event)
- unselect all (should see the event)

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
