### PR TITLE
2458 - Popupmenu: Fix error when submenu wrappers are defined, but submenus are missing

### DIFF
--- a/app/views/components/popupmenu/test-malformed-popupmenu.html
+++ b/app/views/components/popupmenu/test-malformed-popupmenu.html
@@ -1,0 +1,26 @@
+<div class="row">
+  <div class="six columns">
+    <p>This test fixes a type-checking problem discovered in <a class="hyperlink" href="https://github.com/infor-design/enterprise/issues/2458" target="_blank">Enterprise #2458</a>, where a popupmenu with pre-defined wrapper elements missing submenus could throw errors.</p>
+    <p>This test is considered working if the page opens with no errors, and hovering the third menu item also causes no errors. The submenu is missing on purpose, and will not show.</p>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="six columns">
+
+    <button id="open-me" class="btn-menu">
+      <span>Open Me</span>
+    </button>
+    <div class="popupmenu-wrapper">
+      <ul class="popupmenu">
+        <li><a href="#">Item One</a></li>
+        <li><a href="#">Item Two</a></li>
+        <li class="submenu">
+          <a href="#">Item Three (has empty wrapper)</a>
+          <div class="wrapper"></div>
+        </li>
+      </ul>
+    </div>
+
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -69,6 +69,7 @@
 - `[Popupmenu]` Fixed a layout issue on disabled checkboxes in multiselect popupmenus. ([#2340](https://github.com/infor-design/enterprise/issues/2340))
 - `[Popupmenu]` Fixed a bug on IOS that prevented menu scrolling. ([#645](https://github.com/infor-design/enterprise/issues/645))
 - `[Popupmenu]` Fixed a bug on IOS that prevented some submenus from showing. ([#1928](https://github.com/infor-design/enterprise/issues/1928))
+- `[Popupmenu]` Added a type-check during building/rebuilding of submenus that prevents an error when a submenu `<ul>` tag is not present. ([#2458](https://github.com/infor-design/enterprise/issues/2458))
 - `[Scatter Plot]` Fixed the incorrect color on the tooltips. ([#1066](https://github.com/infor-design/enterprise/issues/1066))
 - `[Stepprocess]` Fixed an issue where a newly enabled step is not shown. ([#2391](https://github.com/infor-design/enterprise/issues/2391))
 - `[Tabs]` Fixed the more tabs button to style as disabled when the tabs component is disabled. ([#2347](https://github.com/infor-design/enterprise/issues/2347))

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -592,15 +592,19 @@ PopupMenu.prototype = {
           a.removeAttribute('disabled');
         }
 
-        // menu items that contain submenus
+        // Checks for existing menus, and if present, apply a `.popupmenu` class automatically.
         if (submenu instanceof HTMLElement) {
           submenu.classList.add('popupmenu');
         }
         if (submenuWrapper instanceof HTMLElement) {
           li.className += `${DOM.classNameExists(li) ? ' ' : ''}submenu`;
           submenu = $(submenuWrapper).children('ul')[0];
-          submenu.classList.add('popupmenu');
+          if (submenu instanceof HTMLElement) {
+            submenu.classList.add('popupmenu');
+          }
         }
+
+        // Adds the SVG arrow, etc to submenu items.
         if (DOM.hasClass(li, 'submenu')) {
           // Add a span
           if (!span) {
@@ -612,8 +616,6 @@ PopupMenu.prototype = {
             $a.append($.createIconElement({ classes: ['arrow', 'icon-dropdown'], icon: 'dropdown' }));
           }
           a.setAttribute('aria-haspopup', 'true');
-
-          // Check for existing menus, and if present, apply a `.popupmenu` class automatically.
         }
 
         // is-checked

--- a/test/components/popupmenu/popupmenu.e2e-spec.js
+++ b/test/components/popupmenu/popupmenu.e2e-spec.js
@@ -142,6 +142,31 @@ describe('Popupmenu example-selectable tests', () => {
   }
 });
 
+// NOTE: tests for infor-design/enterprise#2458
+describe('Popupmenu missing submenu tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/popupmenu/test-malformed-popupmenu?layout=nofrills');
+  });
+
+  it('Should have no errors on page load', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should have no errors when hovering an item with a submenu', async () => {
+    await element(by.id('open-me')).click();
+
+    const popupmenuElem = await element(by.css('#open-me + .popupmenu-wrapper > .popupmenu.is-open'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(popupmenuElem), config.waitsFor);
+
+    const thirdItem = await element(by.css('#open-me + .popupmenu-wrapper > .popupmenu.is-open > li.submenu'));
+    await browser.actions().mouseMove(thirdItem).perform();
+    await browser.driver.sleep(config.sleep);
+
+    await utils.checkForErrors();
+  });
+});
+
 describe('Popupmenu example-selectable-multiple tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/popupmenu/example-selectable-multiple?layout=nofrills');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes an error found in the Landmark client where the Popupmenu doesn't gracefully handle a missing `<ul>` element while submenus are being constructed or reconstructed. 

**Related github/jira issue (required)**:
Closes #2458 

**Steps necessary to review your pull request (required)**:
- Pull this branch, run app
- Open http://localhost:4000/components/popupmenu/test-malformed-popupmenu.html
- Examine a dev tools console to ensure there are no JS errors when the page loads.
- Click the "Open me" button.
- Hover your mouse over the lowest menu item in the list (which contains a malformed submenu)
- Ensure there are no JS errors after hovering.

This is also covered by a new set of e2e tests.

**Included in this Pull Request**:
- [x] An e2e test for the bug.
- [x] A note to the change log.
