### PR TITLE
2345 - Tabs: new tab duplication

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -74,6 +74,7 @@
 - `[Scatter Plot]` Fixed the incorrect color on the tooltips. ([#1066](https://github.com/infor-design/enterprise/issues/1066))
 - `[Stepprocess]` Fixed an issue where a newly enabled step is not shown. ([#2391](https://github.com/infor-design/enterprise/issues/2391))
 - `[Tabs]` Fixed the more tabs button to style as disabled when the tabs component is disabled. ([#2347](https://github.com/infor-design/enterprise/issues/2347))
+- `[Tabs]` Added an independent count for adding new tabs and their associated IDs to prevent duplication. ([#2345](https://github.com/infor-design/enterprise/issues/2345))
 
 ### v4.20.0 Chores & Maintenance
 

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -55,8 +55,6 @@ const tabContainerTypes = ['horizontal', 'vertical', 'module-tabs', 'header-tabs
  * @param {object} [settings.sourceArguments={}] If a source method is defined, this
  * flexible object can be passed into the source method, and augmented with
  * parameters specific to the implementation.
- * @param {integer} [settings.startIdCounter] An independent number to maintain an incremental
- * count for adding new tabs and their respective IDs.
  * @param {boolean} [settings.tabCounts=false] If true, Displays a modifiable count above each tab.
  * @param {boolean} [settings.verticalResponsive=false] If Vertical Tabs & true, will automatically
  * switch to Horizontal Tabs on smaller breakpoints.
@@ -75,7 +73,6 @@ const TABS_DEFAULTS = {
   moduleTabsTooltips: false,
   source: null,
   sourceArguments: {},
-  startIdCounter: 0,
   tabCounts: false,
   verticalResponsive: false
 };
@@ -1324,16 +1321,10 @@ Tabs.prototype = {
     }
 
     function makeId() {
-      const stringName = 'new-tab';
-      const existing = $(`[id^="${stringName}"]`);
+      self.idCounter = typeof self.idCounter === 'number' ? self.idCounter : -1;
+      self.idCounter++;
 
-      if (!existing.length) {
-        return `${stringName}-0`;
-      }
-
-      self.settings.startIdCounter++;
-
-      return `${stringName}-${self.settings.startIdCounter}`;
+      return `new-tab-${self.idCounter}`;
     }
 
     function makeName(id) {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -55,6 +55,8 @@ const tabContainerTypes = ['horizontal', 'vertical', 'module-tabs', 'header-tabs
  * @param {object} [settings.sourceArguments={}] If a source method is defined, this
  * flexible object can be passed into the source method, and augmented with
  * parameters specific to the implementation.
+ * @param {integer} [settings.startIdCounter] An independent number to maintain an incremental
+ * count for adding new tabs and their respective IDs.
  * @param {boolean} [settings.tabCounts=false] If true, Displays a modifiable count above each tab.
  * @param {boolean} [settings.verticalResponsive=false] If Vertical Tabs & true, will automatically
  * switch to Horizontal Tabs on smaller breakpoints.
@@ -73,6 +75,7 @@ const TABS_DEFAULTS = {
   moduleTabsTooltips: false,
   source: null,
   sourceArguments: {},
+  startIdCounter: 0,
   tabCounts: false,
   verticalResponsive: false
 };
@@ -1313,6 +1316,7 @@ Tabs.prototype = {
    * @returns {boolean|undefined} ?
    */
   handleAddButton() {
+    const self = this;
     const cb = this.settings.addTabButtonCallback;
     if (cb && typeof cb === 'function') {
       const newTabId = cb();
@@ -1326,7 +1330,10 @@ Tabs.prototype = {
       if (!existing.length) {
         return `${stringName}-0`;
       }
-      return `${stringName}-${existing.length}`;
+
+      self.settings.startIdCounter++;
+
+      return `${stringName}-${self.settings.startIdCounter}`;
     }
 
     function makeName(id) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The current code checks for the length of existing tabs and adds a new tab with an ID based off that length. When a tab is deleted, this is not accounted for, thus leaving the function to add a tab susceptible to duplicate tab creation and double focusing. This PR introduces an independent count to alleviate this issue.

This is indicated as a `demo-app-bug`in the original issue but I think it's a legitimate bug.

**Related github/jira issue (required)**:
Closes #2345 .

**Steps necessary to review your pull request (required)**:
- Pull branch, run app
- Visit http://localhost:4000/components/tabs/example-add-tab-button.html
  - Choose the first radio button option
  - Add and delete new tabs at your discretion
  - Ensure none are duplicates

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.