### PR TITLE
2097 - Fix tooltip with bar and column charts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,7 +27,7 @@
 ### v4.20.0 Fixes
 
 - `[Alerts]` Removed dirty tracker from the page due to layout issues. ([#1679](https://github.com/infor-design/enterprise/issues/1679))
-- `[Bar Chart]` Fixes an issue where tooltip not show. ([#2097](https://github.com/infor-design/enterprise/issues/2097))
+- `[Bar Chart]` Fixed an issue where the tooltip would not show. ([#2097](https://github.com/infor-design/enterprise/issues/2097))
 - `[Calendar]` Added more information to the onMonthRendered callback. ([#2419](https://github.com/infor-design/enterprise/issues/2419))
 - `[Calendar]` Changed updated method so it can reinit the calendar with new data. ([#2419](https://github.com/infor-design/enterprise/issues/2419))
 - `[Calendar]` Fixed stack exceeded error in angular using updated and legend. ([#2419](https://github.com/infor-design/enterprise/issues/2419))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,7 +37,7 @@
 - `[Charts]` Made fixes so all charts change color in uplift theme. ([#2058](https://github.com/infor-design/enterprise/issues/2058))
 - `[Charts]` Fixes dynamic tooltips on a bar chart. ([#2447](https://github.com/infor-design/enterprise/issues/2447))
 - `[Colorpicker]` Fixed colorpicker left and right keys advanced oppositely in right-to-left mode. ([#2352](https://github.com/infor-design/enterprise/issues/2352))
-- `[Column Chart]` Fixes an issue where tooltip not show. ([#2097](https://github.com/infor-design/enterprise/issues/2097))
+- `[Column Chart]` Fixed an issue where the tooltip would not show. ([#2097](https://github.com/infor-design/enterprise/issues/2097))
 - `[Datagrid]` Fixed the text width functions for better auto sized columns when using editors and special formatters. ([#2270](https://github.com/infor-design/enterprise/issues/2270))
 - `[Datagrid]` Fixes the alignment of the alert and warning icons on a lookup editor. ([#2175](https://github.com/infor-design/enterprise/issues/2175))
 - `[Datagrid]` Fixes tooltip on the non displayed table errors. ([#2264](https://github.com/infor-design/enterprise/issues/2264))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### v4.20.0 Fixes
 
 - `[Alerts]` Removed dirty tracker from the page due to layout issues. ([#1679](https://github.com/infor-design/enterprise/issues/1679))
+- `[Bar Chart]` Fixes an issue where tooltip not show. ([#2097](https://github.com/infor-design/enterprise/issues/2097))
 - `[Calendar]` Added more information to the onMonthRendered callback. ([#2419](https://github.com/infor-design/enterprise/issues/2419))
 - `[Calendar]` Changed updated method so it can reinit the calendar with new data. ([#2419](https://github.com/infor-design/enterprise/issues/2419))
 - `[Calendar]` Fixed stack exceeded error in angular using updated and legend. ([#2419](https://github.com/infor-design/enterprise/issues/2419))
@@ -36,6 +37,7 @@
 - `[Charts]` Made fixes so all charts change color in uplift theme. ([#2058](https://github.com/infor-design/enterprise/issues/2058))
 - `[Charts]` Fixes dynamic tooltips on a bar chart. ([#2447](https://github.com/infor-design/enterprise/issues/2447))
 - `[Colorpicker]` Fixed colorpicker left and right keys advanced oppositely in right-to-left mode. ([#2352](https://github.com/infor-design/enterprise/issues/2352))
+- `[Column Chart]` Fixes an issue where tooltip not show. ([#2097](https://github.com/infor-design/enterprise/issues/2097))
 - `[Datagrid]` Fixed the text width functions for better auto sized columns when using editors and special formatters. ([#2270](https://github.com/infor-design/enterprise/issues/2270))
 - `[Datagrid]` Fixes the alignment of the alert and warning icons on a lookup editor. ([#2175](https://github.com/infor-design/enterprise/issues/2175))
 - `[Datagrid]` Fixes tooltip on the non displayed table errors. ([#2264](https://github.com/infor-design/enterprise/issues/2264))

--- a/src/components/bar/bar.js
+++ b/src/components/bar/bar.js
@@ -566,11 +566,11 @@ Bar.prototype = {
         } else {
           content = tooltipDataCache[i] || tooltipData || content || '';
           if (!tooltipDataCache[i] && d.tooltip !== false &&
-            (typeof d.tooltip !== 'undefined' || d.tooltip !== null)) {
+            typeof d.tooltip !== 'undefined' && d.tooltip !== null) {
             if (typeof d.tooltip === 'function') {
               setCustomTooltip(d.tooltip);
             } else {
-              content = d.tooltip;
+              content = d.tooltip.toString();
               replaceMatchAndSetType();
               tooltipDataCache[i] = content;
             }

--- a/src/components/bar/bar.js
+++ b/src/components/bar/bar.js
@@ -14,7 +14,7 @@ const COMPONENT_NAME = 'bar';
  * with heights or lengths proportional to the values that they represent. This is adapated from
  * http://jsfiddle.net/datashaman/rBfy5/2/
  * @class Bar
- * @param {string} element The plugin element for the constuctor
+ * @param {string} element The plugin element for the constuctor.
  * @param {string} [settings] The settings element.
  * @param {array} [settings.dataset=[]] The data to use in the line/area/bubble.
  * @param {boolean} [settings.isStacked=true] Default is a single or stacked chart.

--- a/src/components/column/column.js
+++ b/src/components/column/column.js
@@ -843,11 +843,11 @@ Column.prototype = {
         } else {
           content = tooltipDataCache[i] || tooltipData || content || '';
           if (!tooltipDataCache[i] && d.tooltip !== false &&
-            (typeof d.tooltip !== 'undefined' || d.tooltip !== null)) {
+            typeof d.tooltip !== 'undefined' && d.tooltip !== null) {
             if (typeof d.tooltip === 'function') {
               setCustomTooltip(d.tooltip);
             } else {
-              content = d.tooltip;
+              content = d.tooltip.toString();
               replaceMatchAndSetType();
               tooltipDataCache[i] = content;
             }

--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -191,6 +191,10 @@ Personalize.prototype = {
     colors.darker = colors.inactive;
     colors.darkest = colors.horizontalBorder;
 
+    const tooltipContrast = colorUtils.getContrastColor(colors.darkest);
+    defaultColors.tooltipText = tooltipContrast === 'white' ? 'ffffff' : '000000';
+    colors.tooltipText = colorUtils.validateHex(colors.tooltipText || defaultColors.tooltipText);
+
     return personalizeStyles(colors);
   },
 

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -528,6 +528,12 @@ function personalizeStyles(colors) {
 .tooltip.is-personalizable .chart-swatch .swatch-row div {
   border-bottom-color: ${colors.darkest};
 }
+.tooltip.is-personalizable,
+.tooltip.is-personalizable p,
+.tooltip.is-personalizable .chart-swatch .swatch-row span,
+.tooltip.is-personalizable .chart-swatch .swatch-row b {
+  color: ${colors.tooltipText};
+}
 .tooltip.is-personalizable.top .arrow::after {
   border-top-color: ${colors.darkest};
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
There was Failed QA because tooltip for bar chart was stop working with some other change, so this PR will fix it and contrast color for tooltip text.

**Related github/jira issue (required)**:
Closes #2097

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/homepage/example-hero-widget.html
- Click top right `...` action button to change theme/colors
- See tooltip should show with bar chart
- See the tooltip text color should be easy readable

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
