### PR TITLE
2346 - Tabs: wrong focus after hiding

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -74,6 +74,7 @@
 - `[Scatter Plot]` Fixed the incorrect color on the tooltips. ([#1066](https://github.com/infor-design/enterprise/issues/1066))
 - `[Stepprocess]` Fixed an issue where a newly enabled step is not shown. ([#2391](https://github.com/infor-design/enterprise/issues/2391))
 - `[Tabs]` Fixed the more tabs button to style as disabled when the tabs component is disabled. ([#2347](https://github.com/infor-design/enterprise/issues/2347))
+- `[Tabs]` Added the select method inside the hide method to ensure proper focusing of the selected tab. ([#2346](https://github.com/infor-design/enterprise/issues/2346))
 
 ### v4.20.0 Chores & Maintenance
 

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -2707,6 +2707,9 @@ Tabs.prototype = {
     this.activateAdjacentTab(e, tabId);
 
     tab.addClass('hidden');
+
+    this.select($(this.element.find('li.tab.is-selected')[0]).find('a')[0].hash);
+
     this.focusBar();
     this.positionFocusState();
     return this;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
After removing two tabs at once in the example, a tab selection is not made and the focus remains outside of any "existing" tabs. We now invoke the `select()` method inside the `hide()` method to ensure proper focusing.

**Related github/jira issue (required)**:
Closes #2346 .

**Steps necessary to review your pull request (required)**:
- Pull branch, build, run app
- Visit http://localhost:4000/components/tabs/example-hidden-tabs.html
  - Follow instructions in issue (also below)
    - Click "Show Hidden Tabs" button
    - Click "Tab # 6"
    - Click "Hide Tabs 2 and 5" button
    - Ensure focus remains with "Tab # 6"

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [ ] A note to the change log.