### PR TITLE
2356/2484 - Deprecate Pager setting for attachToBody, fix Pager memory leak

### DIFF
--- a/app/views/components/pager/example-standalone.html
+++ b/app/views/components/pager/example-standalone.html
@@ -83,7 +83,6 @@
       enableNextButton: true,
       showLastButton: true,
       enableLastButton: true,
-      attachPageSizeMenuToBody: false,
       onFirstPage: function (elem, args) {
         $('body').toast({title: 'onFirstPage Callback Fired', message: ''});
       },
@@ -133,7 +132,9 @@
 
     $('#toggle-attach-to-body').on('change.test', function() {
       var isChecked = this.checked;
-      api.updated({attachPageSizeMenuToBody: isChecked});
+      api.updated({pageSizeMenuSettings: {
+        attachToBody: isChecked
+      }});
     });
 
     $('#toggle-small-pagesize').on('change.test', function() {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -65,6 +65,8 @@
 - `[Listview]` Fixed a bug that caused the listview to run initialize too many times. ([#2179](https://github.com/infor-design/enterprise/issues/2179))
 - `[Modal]` Fixed an issue where the modal component would disappear if its content had a checkbox in it in RTL. ([#332](https://github.com/infor-design/enterprise-ng/issues/332))
 - `[Personalization]` Updated some of the colors to more readable in contrast mode. ([#2097](https://github.com/infor-design/enterprise/issues/2097))
+- `[Pager]` Added a complete Popupmenu settings object for configuring the Page Size Selector Button, and deprecated the `attachPageSizeMenuToBody` setting in favor of `pageSizeMenuSettings.attachToBody`. ([#2356])(https://github.com/infor-design/enterprise/issues/2356)
+- `[Pager]` Fixed memory leak when using the `attachToBody` setting to change the menu's render location. ([#2482](https://github.com/infor-design/enterprise/issues/2482))
 - `[Popdown]` Fixed usability issue where the Popdown could close prematurely when attempting to use inner components, such as Dropdowns. ([#2092](https://github.com/infor-design/enterprise/issues/2092))
 - `[Popover]` Correctly align the popover close button. ([#1576](https://github.com/infor-design/enterprise/issues/1576))
 - `[Popover]` Fixed an issue where buttons inside the popover would overflow at smaller screen sizes. ([#2271](https://github.com/infor-design/enterprise/issues/2271))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -65,7 +65,7 @@
 - `[Listview]` Fixed a bug that caused the listview to run initialize too many times. ([#2179](https://github.com/infor-design/enterprise/issues/2179))
 - `[Modal]` Fixed an issue where the modal component would disappear if its content had a checkbox in it in RTL. ([#332](https://github.com/infor-design/enterprise-ng/issues/332))
 - `[Personalization]` Updated some of the colors to more readable in contrast mode. ([#2097](https://github.com/infor-design/enterprise/issues/2097))
-- `[Pager]` Added a complete Popupmenu settings object for configuring the Page Size Selector Button, and deprecated the `attachPageSizeMenuToBody` setting in favor of `pageSizeMenuSettings.attachToBody`. ([#2356])(https://github.com/infor-design/enterprise/issues/2356)
+- `[Pager]` Added a complete Popupmenu settings object for configuring the Page Size Selector Button, and deprecated the `attachPageSizeMenuToBody` setting in favor of `pageSizeMenuSettings.attachToBody`. ([#2356](https://github.com/infor-design/enterprise/issues/2356))
 - `[Pager]` Fixed memory leak when using the `attachToBody` setting to change the menu's render location. ([#2482](https://github.com/infor-design/enterprise/issues/2482))
 - `[Popdown]` Fixed usability issue where the Popdown could close prematurely when attempting to use inner components, such as Dropdowns. ([#2092](https://github.com/infor-design/enterprise/issues/2092))
 - `[Popover]` Correctly align the popover close button. ([#1576](https://github.com/infor-design/enterprise/issues/1576))

--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -66,6 +66,7 @@ const FOCUSABLE_SELECTOR = [
 * @param {boolean} [settings.previousPageTooltip = 'Previous Page'] Tooltip for the first page, defaults to an internally translated tooltip.
 * @param {boolean} [settings.nextPageTooltip = 'Next Page'] Tooltip for the first page, defaults to an internally translated tooltip.
 * @param {boolean} [settings.lastPageTooltip = 'Last Page'] Tooltip for the first page, defaults to an internally translated tooltip.
+* @param {boolean} [settings.pageSizeMenuSettings = {}] customizable popupmenu settings for the Page Size Selector.
 */
 const PAGER_DEFAULTS = {
   componentAPI: undefined,
@@ -96,7 +97,9 @@ const PAGER_DEFAULTS = {
   previousPageTooltip: 'PreviousPage',
   nextPageTooltip: 'NextPage',
   lastPageTooltip: 'LastPage',
-  attachPageSizeMenuToBody: false
+  pageSizeMenuSettings: {
+    attachToBody: false
+  }
 };
 
 function Pager(element, settings) {
@@ -278,6 +281,8 @@ Pager.prototype = {
       this.settings.pagesizes = this.settings.pagesizes.sort(sortNumber);
     }
 
+    this.handleDeprecatedSettings();
+
     const widgetContainer = this.element.parents('.card, .widget');
 
     // Adjust for the possibility of the pager being attached to a Table instead
@@ -363,6 +368,21 @@ Pager.prototype = {
 
         self.pagerBar.appendTo(widgetFooter);
       });
+    }
+  },
+
+  /**
+   * Handle Deprecated Settings
+   * @private
+   * @returns {void}
+   */
+  handleDeprecatedSettings() {
+    // `attachPageSizeMenuToBody` becomes `pageSizeMenuSettings.attachToBody`.
+    // The `pageSizeMenuSettings` object represents a Popupmenu settings object.
+    if (this.settings.attachPageSizeMenuToBody !== undefined) {
+      warnAboutDeprecation('pageSizeMenuSettings.attachToBody (setting)', 'attachPageSizeMenuToBody (setting)');
+      this.settings.pageSizeMenuSettings.attachToBody = this.settings.attachPageSizeMenuToBody;
+      delete this.settings.attachPageSizeMenuToBody;
     }
   },
 
@@ -1016,20 +1036,20 @@ Pager.prototype = {
       }
       const menu = $(`<ul class="popupmenu is-selectable">${menuItems}</ul>`);
       pageSizeButton.after(menu);
-
-      const popupOpts = {
-        placementOpts: {
-          parent: pageSizeButton,
-          parentXAlignment: (Locale.isRTL() ? 'left' : 'right'),
-          strategies: ['flip']
-        },
-        attachToBody: this.settings.attachPageSizeMenuToBody
-      };
-
-      pageSizeButton.popupmenu(popupOpts);
     }
 
-    $(this.pageSizeSelectorButton).on('selected.pager', (e, args) => {
+    const $pageSizeSelectorButton = $(this.pageSizeSelectorButton);
+
+    // Invoke/Update the popupmenu instance with new settings
+    const popupOpts = utils.extend({}, {
+      placementOpts: {
+        parent: $pageSizeSelectorButton,
+        parentXAlignment: (Locale.isRTL() ? 'left' : 'right'),
+        strategies: ['flip']
+      }
+    }, this.settings.pageSizeMenuSettings);
+    $pageSizeSelectorButton.popupmenu(popupOpts);
+    $pageSizeSelectorButton.on('selected.pager', (e, args) => {
       this.changePageSize(args);
     });
   },
@@ -1046,6 +1066,10 @@ Pager.prototype = {
       totalPages = state.filteredPages;
     }
     this.pageCount(totalPages);
+
+    if (this.pageSizeSelectorButton) {
+      this.teardownPageSizeSelector();
+    }
 
     this.renderButtons();
     this.renderPageSelectorInput();
@@ -1249,6 +1273,7 @@ Pager.prototype = {
       pagesize: this.settings.pagesize
     };
 
+    this.handleDeprecatedSettings();
     this.updatePagingInfo(pagingInfo);
     return this;
   },
@@ -1429,13 +1454,28 @@ Pager.prototype = {
 
     if (this.pageSizeSelectorButton) {
       $(this.pageSizeSelectorButton).off(`selected.${COMPONENT_NAME}`);
-      $(this.pageSizeSelectorButton).data('popupmenu').destroy();
+      this.teardownPageSizeSelector();
     }
 
     this.pagerBar[0].innerHTML = '';
 
     delete this.firstPage;
     delete this.lastPage;
+  },
+
+  /**
+   * Tears down the Popupmenu associated with the page size selector.
+   * This happens here because the Popupmenu component does not remove its own
+   * menu markup when being destroyed.
+   * @private
+   * @returns {void}
+   */
+  teardownPageSizeSelector() {
+    const $pageSizeSelectorButton = $(this.pageSizeSelectorButton);
+    const api = $pageSizeSelectorButton.data('popupmenu');
+    const pageSizeSelectorMenu = api.menu;
+    api.destroy();
+    pageSizeSelectorMenu.remove();
   },
 
   /**

--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -1473,6 +1473,11 @@ Pager.prototype = {
   teardownPageSizeSelector() {
     const $pageSizeSelectorButton = $(this.pageSizeSelectorButton);
     const api = $pageSizeSelectorButton.data('popupmenu');
+
+    if (!api || !api.menu) {
+      return;
+    }
+
     const pageSizeSelectorMenu = api.menu;
     api.destroy();
     pageSizeSelectorMenu.remove();

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -2193,9 +2193,11 @@ PopupMenu.prototype = {
 
     this.predefinedItems = $();
 
-    this.menu.parent().off('contextmenu.popupmenu');
+    const parentNode = this.menu.parent();
+    parentNode.find('.arrow').remove();
+    parentNode.off('contextmenu.popupmenu');
     if (this.element.hasClass('btn-actions')) {
-      this.menu.parent().removeClass('bottom').find('.arrow').remove();
+      parentNode.removeClass('bottom');
     }
 
     this.menu.off('dragstart.popupmenu');

--- a/test/components/colorpicker/colorpicker-events.func-spec.js
+++ b/test/components/colorpicker/colorpicker-events.func-spec.js
@@ -1,30 +1,31 @@
 import { ColorPicker } from '../../../src/components/colorpicker/colorpicker';
+import { cleanup } from '../../helpers/func-utils';
 
 const colorpickerHTML = require('../../../app/views/components/colorpicker/example-index.html');
 const svg = require('../../../src/components/icons/svg.html');
 
 let colorpickerEl;
-let svgEl;
 let colorpickerObj;
 
 describe('ColorPicker Events', () => {
   beforeEach(() => {
     colorpickerEl = null;
-    svgEl = null;
     colorpickerObj = null;
 
     document.body.insertAdjacentHTML('afterbegin', svg);
     document.body.insertAdjacentHTML('afterbegin', colorpickerHTML);
     colorpickerEl = document.body.querySelector('.colorpicker');
-    svgEl = document.body.querySelector('.svg-icons');
     colorpickerEl.classList.add('no-init');
     colorpickerObj = new ColorPicker(colorpickerEl);
   });
 
   afterEach(() => {
     colorpickerObj.destroy();
-    colorpickerEl.parentNode.removeChild(colorpickerEl);
-    svgEl.parentNode.removeChild(svgEl);
+    cleanup([
+      '.svg-icons',
+      '.colorpicker',
+      '.row',
+    ]);
   });
 
   it('Should trigger "change" event', (done) => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a couple of Pager issues:
- We added a Popupmenu-specific setting for the Page Size Selector button in #2354, where it would've been ideal to pass an entire object for Popupmenu settings for the button.  Due to time constraints and infrastructure needed on the NG side, we weren't able to add the full settings object in that previous issue.  This PR adds the full object on the EP side, deprecates the old setting with a warning message, and gracefully handles switching the old setting to the new one internally.  The new setting is also documented on the Pager component docs.
- @fitzorama discovered a memory leak that began occurring with the previous change.  This PR fixes the leak and improves the rendering system for the button and menu when it's required.

**Related github/jira issue (required)**:
Closes #2356 
Closes #2482

**Steps necessary to review your pull request (required)**:

_To test the new setting (#2356):_
- open http://localhost:4000/components/pager/example-standalone
- also open a dev tools console
- check the "Show Page Size Selector" box
- check the "Attach Page Size Menu To Body" box
- ensure the Page Size Selector button actually works
- in the dev tools console, ensure that the last element inside the `<body>` tag is a `.popupmenu-wrapper` element.
- ensure there are no deprecation warnings in the JS console.

_To test the memory leak fix (#2482):_
- open http://localhost:4000/components/pager/example-standalone
- also open a dev tools console
- check the "Show Page Size Selector" box
- check the "Attach Page Size Menu To Body" box
- ensure the Page Size Selector button actually works
- in the dev tools console, ensure that the last element inside the `<body>` tag is a `.popupmenu-wrapper` element.
- uncheck the "Attach Page Size Menu To Body" box.
- ensure the Page Size Selector button still works
- in the dev tools console, ensure that the `.popupmenu-wrapper` element directly inside the `<body>` tag is no longer there.
- inspect the Page Size Selector button.  Ensure the element that follows the button is a single `.popupmenu-wrapper` element.

**Included in this Pull Request**:
- [x] A note to the change log.