### PR TITLE
2366 - Lookup: Listbox and browser autocomplete conflict

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -64,6 +64,7 @@
 - `[Homepages]` Fixed an issue where personalize and chart text colors were not working with hero. ([#2097](https://github.com/infor-design/enterprise/issues/2097))
 - `[Images]` Fixed an issue where images were not tabbable or receiving a visual focus state. ([#2025](https://github.com/infor-design/enterprise/issues/2025))
 - `[Listview]` Fixed a bug that caused the listview to run initialize too many times. ([#2179](https://github.com/infor-design/enterprise/issues/2179))
+- `[Lookup]` Added `autocomplete="off"` to lookup input fields to prevent browser interference. ([#2366](https://github.com/infor-design/enterprise/issues/2366))
 - `[Modal]` Fixed an issue where the modal component would disappear if its content had a checkbox in it in RTL. ([#332](https://github.com/infor-design/enterprise-ng/issues/332))
 - `[Personalization]` Updated some of the colors to more readable in contrast mode. ([#2097](https://github.com/infor-design/enterprise/issues/2097))
 - `[Pager]` Added a complete Popupmenu settings object for configuring the Page Size Selector Button, and deprecated the `attachPageSizeMenuToBody` setting in favor of `pageSizeMenuSettings.attachToBody`. ([#2356](https://github.com/infor-design/enterprise/issues/2356))

--- a/src/components/lookup/lookup.js
+++ b/src/components/lookup/lookup.js
@@ -162,6 +162,8 @@ Lookup.prototype = {
     }
 
     this.addAria();
+
+    if (lookup.attr('autocomplete') === undefined) lookup.attr('autocomplete', 'off');
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The browser autocomplete is interfering with the lookup. This PR adds `autocomplete="off"` to the lookup input field to prevent it from appearing and interfering.

**Related github/jira issue (required)**:
Closes #2366 .
Relates to #2364 which will be resolved in a separate PR.

**Steps necessary to review your pull request (required)**:
- Pull branch, build, run app
- Visit http://localhost:4000/components/lookup/example-index.html and any related lookup example pages
  - Ensure `autocomplete="off"` is present in the markup of all lookup inputs.

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
