### PR TITLE
1476- Add some warnings for future deprecated components

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### v4.20.0 Deprecation
 
 - `[ListFilter]` Deprecated `startsWith` in favor of `wordStartsWith`, due to the addition of the `phraseStartsWith` filterMode. ([#1606](https://github.com/infor-design/enterprise/issues/1606))
-- `[Popdown]` Deprecated `Popdown` in favor of `Popover` both components have similar functionality and we want to trim the code logic down. ([#2468](https://github.com/infor-design/enterprise/issues/2468))
+- `[Popdown]` Deprecated `Popdown` in favor of `Popover`. Both components have similar functionality and we want to trim the code logic down. ([#2468](https://github.com/infor-design/enterprise/issues/2468))
 - `[StepProcess]` Deprecated `StepProcess` as the component is no longer commonly used. We will remove it in 3-6 versions. ([#1476](https://github.com/infor-design/enterprise/issues/1476))
 - `[CompositeForm]` Deprecated `CompositeForm` as the component is no longer commonly used. We will remove it in 3-6 versions. ([#1476](https://github.com/infor-design/enterprise/issues/1476))
 - `[FieldOptions]` Deprecated `FieldOptions` as the component is no longer commonly used. We will remove it in 3-6 versions. ([#1476](https://github.com/infor-design/enterprise/issues/1476))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### v4.20.0 Deprecation
 
 - `[ListFilter]` Deprecated `startsWith` in favor of `wordStartsWith`, due to the addition of the `phraseStartsWith` filterMode. ([#1606](https://github.com/infor-design/enterprise/issues/1606))
+- `[Popdown]` Deprecated `Popdown` in favor of `Popover` both components have similar functionality and we want to trim the code logic down. ([#2468](https://github.com/infor-design/enterprise/issues/2468))
+- `[StepProcess]` Deprecated `StepProcess` as the component is no longer commonly used. We will remove it in 3-6 versions. ([#1476](https://github.com/infor-design/enterprise/issues/1476))
+- `[CompositeForm]` Deprecated `CompositeForm` as the component is no longer commonly used. We will remove it in 3-6 versions. ([#1476](https://github.com/infor-design/enterprise/issues/1476))
+- `[FieldOptions]` Deprecated `FieldOptions` as the component is no longer commonly used. We will remove it in 3-6 versions. ([#1476](https://github.com/infor-design/enterprise/issues/1476))
 
 ### v4.20.0 Features
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,7 @@
 - `[Popdown]` Deprecated `Popdown` in favor of `Popover`. Both components have similar functionality and we want to trim the code logic down. ([#2468](https://github.com/infor-design/enterprise/issues/2468))
 - `[StepProcess]` Deprecated `StepProcess` as the component is no longer commonly used. We will remove it within 3-6 versions. ([#1476](https://github.com/infor-design/enterprise/issues/1476))
 - `[CompositeForm]` Deprecated `CompositeForm` as the component is no longer commonly used. We will remove it within 3-6 versions. ([#1476](https://github.com/infor-design/enterprise/issues/1476))
-- `[FieldOptions]` Deprecated `FieldOptions` as the component is no longer commonly used. We will remove it in 3-6 versions. ([#1476](https://github.com/infor-design/enterprise/issues/1476))
+- `[FieldOptions]` Deprecated `FieldOptions` as the component is no longer commonly used. We will remove it within 3-6 versions. ([#1476](https://github.com/infor-design/enterprise/issues/1476))
 
 ### v4.20.0 Features
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - `[ListFilter]` Deprecated `startsWith` in favor of `wordStartsWith`, due to the addition of the `phraseStartsWith` filterMode. ([#1606](https://github.com/infor-design/enterprise/issues/1606))
 - `[Popdown]` Deprecated `Popdown` in favor of `Popover`. Both components have similar functionality and we want to trim the code logic down. ([#2468](https://github.com/infor-design/enterprise/issues/2468))
-- `[StepProcess]` Deprecated `StepProcess` as the component is no longer commonly used. We will remove it in 3-6 versions. ([#1476](https://github.com/infor-design/enterprise/issues/1476))
+- `[StepProcess]` Deprecated `StepProcess` as the component is no longer commonly used. We will remove it within 3-6 versions. ([#1476](https://github.com/infor-design/enterprise/issues/1476))
 - `[CompositeForm]` Deprecated `CompositeForm` as the component is no longer commonly used. We will remove it in 3-6 versions. ([#1476](https://github.com/infor-design/enterprise/issues/1476))
 - `[FieldOptions]` Deprecated `FieldOptions` as the component is no longer commonly used. We will remove it in 3-6 versions. ([#1476](https://github.com/infor-design/enterprise/issues/1476))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@
 - `[ListFilter]` Deprecated `startsWith` in favor of `wordStartsWith`, due to the addition of the `phraseStartsWith` filterMode. ([#1606](https://github.com/infor-design/enterprise/issues/1606))
 - `[Popdown]` Deprecated `Popdown` in favor of `Popover`. Both components have similar functionality and we want to trim the code logic down. ([#2468](https://github.com/infor-design/enterprise/issues/2468))
 - `[StepProcess]` Deprecated `StepProcess` as the component is no longer commonly used. We will remove it within 3-6 versions. ([#1476](https://github.com/infor-design/enterprise/issues/1476))
-- `[CompositeForm]` Deprecated `CompositeForm` as the component is no longer commonly used. We will remove it in 3-6 versions. ([#1476](https://github.com/infor-design/enterprise/issues/1476))
+- `[CompositeForm]` Deprecated `CompositeForm` as the component is no longer commonly used. We will remove it within 3-6 versions. ([#1476](https://github.com/infor-design/enterprise/issues/1476))
 - `[FieldOptions]` Deprecated `FieldOptions` as the component is no longer commonly used. We will remove it in 3-6 versions. ([#1476](https://github.com/infor-design/enterprise/issues/1476))
 
 ### v4.20.0 Features

--- a/src/components/compositeform/compositeform.js
+++ b/src/components/compositeform/compositeform.js
@@ -2,6 +2,7 @@ import * as debug from '../../utils/debug';
 import { utils } from '../../utils/utils';
 import { Locale } from '../locale/locale';
 import { breakpoints } from '../../utils/breakpoints';
+import { warnAboutRemoval } from '../../utils/deprecated';
 
 // jQuery Components
 import '../expandablearea/expandablearea.jquery';
@@ -12,6 +13,7 @@ const COMPONENT_NAME = 'compositeform';
 /**
 * CompositeForm is a specialized responsive form component.
 * @class CompositeForm
+* @deprecated as of v4.20.0. This component is no longer supported by the IDS team.
 * @constructor
 * @param {jQuery[]|HTMLElement} element The component element.
 * @param {object} [settings] The component settings.
@@ -33,6 +35,7 @@ function CompositeForm(element, settings) {
   debug.logTimeStart(COMPONENT_NAME);
   this.init();
   debug.logTimeEnd(COMPONENT_NAME);
+  warnAboutRemoval('CompositeForm');
 }
 
 // Component API

--- a/src/components/field-options/field-options.js
+++ b/src/components/field-options/field-options.js
@@ -1,6 +1,7 @@
 import * as debug from '../../utils/debug';
 import { utils } from '../../utils/utils';
 import { Environment as env } from '../../utils/environment';
+import { warnAboutRemoval } from '../../utils/deprecated';
 
 // Component Name
 const COMPONENT_NAME = 'fieldoptions';
@@ -8,6 +9,7 @@ const COMPONENT_NAME = 'fieldoptions';
 /**
 * A control bind next to another component to add some extra functionality.
 * @class FieldOptions
+* @deprecated as of v4.20.0. This component is no longer supported by the IDS team.
 * @constructor
 *
 * @param {jQuery[]|HTMLElement} element The component element.
@@ -22,6 +24,7 @@ function FieldOptions(element, settings) {
   debug.logTimeStart(COMPONENT_NAME);
   this.init();
   debug.logTimeEnd(COMPONENT_NAME);
+  warnAboutRemoval('FieldOptions');
 }
 
 // FieldOptions Methods

--- a/src/components/popdown/popdown.js
+++ b/src/components/popdown/popdown.js
@@ -2,6 +2,7 @@ import * as debug from '../../utils/debug';
 import { utils } from '../../utils/utils';
 import { DOM } from '../../utils/dom';
 import { Locale } from '../locale/locale';
+import { warnAboutDeprecation } from '../../utils/deprecated';
 
 // jQuery Components
 
@@ -12,7 +13,7 @@ const COMPONENT_NAME = 'popdown';
  * The Popdown Component can be used to open an animated popdown from a button. This may in the future
  * be deprecated to one thing. Popup vs Popdown vs Tooltip.
  * @class Popdown
- * @deprecated
+ * @deprecated as of v4.20.0. Please use the `Popover` component instead.
  * @param {object} element The component element.
  * @param {object} [settings] The component settings.
  * @property {boolean} [settings.keepOpen = false] If true, will keep the Popdown open after clicking out until the Trigger
@@ -30,6 +31,7 @@ function Popdown(element, settings) {
   debug.logTimeStart(COMPONENT_NAME);
   this.init();
   debug.logTimeEnd(COMPONENT_NAME);
+  warnAboutDeprecation('Popover', 'Popdown');
 }
 
 Popdown.prototype = {

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -451,7 +451,7 @@ Tooltip.prototype = {
       titleArea.style.display = 'none';
     }
 
-    if (contentArea && !contentArea.previousElementSibling.classList.contains('arrow')) {
+    if (contentArea && contentArea.previousElementSibling && !contentArea.previousElementSibling.classList.contains('arrow')) {
       contentArea.insertAdjacentHTML('beforebegin', '<div class="arrow"></div>');
     }
 

--- a/src/patterns/stepprocess/stepprocess.js
+++ b/src/patterns/stepprocess/stepprocess.js
@@ -1,6 +1,7 @@
 import * as debug from '../../utils/debug';
 import { utils } from '../../utils/utils';
 import { Locale } from '../../components/locale/locale';
+import { warnAboutRemoval } from '../../utils/deprecated';
 
 // Jquery Imports
 import '../../utils/animations';
@@ -25,8 +26,8 @@ const STEPPROCESS_DEFAULTS = {
 
 /**
  * A Stepprocess/wizard control
- *
  * @class Stepprocess
+ * @deprecated as of v4.20.0. This component is no longer supported by the IDS team.
  * @param {string} element The component element.
  * @param {string} [settings] The component settings.
  * @param {boolean} [settings.linearProgression = false] The Main Application Name to display
@@ -51,6 +52,7 @@ function Stepprocess(element, settings) {
   debug.logTimeStart(COMPONENT_NAME);
   this.init();
   debug.logTimeEnd(COMPONENT_NAME);
+  warnAboutRemoval('Stepprocess');
 }
 
 // Stepprocess Methods

--- a/src/utils/deprecated.js
+++ b/src/utils/deprecated.js
@@ -39,6 +39,18 @@ function warnAboutDeprecation(newMethod, oldMethod) {
 }
 
 /**
+ * Warns about upcomming removal of a piece of code with no replacement.
+ * @param {function|string} removedName the name of the removed code
+ * @returns {void}
+ */
+function warnAboutRemoval(removedName) {
+  if (typeof console !== 'object') {
+    return;
+  }
+  console.warn(`IDS Enterprise: "${removedName}" is deprecated and will be later removed. Please adjust your code accordingly.`);
+}
+
+/**
  * Deprecates a method in the codebase
  * @param {function} newMethod the new method to call
  * @param {function} oldMethod the name of the old method
@@ -55,4 +67,4 @@ function deprecateMethod(newMethod, oldMethod) {
   return wrapper;
 }
 
-export { warnAboutDeprecation, deprecateMethod };
+export { warnAboutDeprecation, deprecateMethod, warnAboutRemoval };

--- a/src/utils/deprecated.js
+++ b/src/utils/deprecated.js
@@ -39,7 +39,7 @@ function warnAboutDeprecation(newMethod, oldMethod) {
 }
 
 /**
- * Warns about upcomming removal of a piece of code with no replacement.
+ * Warns about an upcoming removal of a piece of code with no replacement.
  * @param {function|string} removedName the name of the removed code
  * @returns {void}
  */


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Add a warning and change log entry and console log note for some components we hope to remove and deprecate. Added a new `warnAboutRemoval` function for better explanation. Also found a bug that cropped up on tests so added a safety check.

**Related github/jira issue (required)**:
Fixes part of #1476 

**Steps necessary to review your pull request (required)**:
- open http://localhost:4000/components/field-options/example-index.html  and look for the warning in the console
- open http://localhost:4000/patterns/stepprocess and look for the warning in the console
- open http://localhost:4000/components/popdown/example-index.html and look for the warning in the console
- open http://localhost:4000/components/compositeform/example-index.html and look for the warning in the console
- review the change log

**Included in this Pull Request**:
- [x] A note to the change log.

