### PR TITLE
474- Fix an issue with height 100% in flex toolbar

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -83,6 +83,7 @@
 - `[Tabs]` Fixed the more tabs button to style as disabled when the tabs component is disabled. ([#2347](https://github.com/infor-design/enterprise/issues/2347))
 - `[Tabs]` Added the select method inside the hide method to ensure proper focusing of the selected tab. ([#2346](https://github.com/infor-design/enterprise/issues/2346))
 - `[Tabs]` Added an independent count for adding new tabs and their associated IDs to prevent duplication. ([#2345](https://github.com/infor-design/enterprise/issues/2345))
+- `[Toolbar Flex]` Removed a 100% height on the toolbar which caused issues when nested in some situations. ([#474](https://github.com/infor-design/enterprise-ng/issues/474))
 
 ### v4.20.0 Chores & Maintenance
 

--- a/src/components/toolbar-flex/_toolbar-flex.scss
+++ b/src/components/toolbar-flex/_toolbar-flex.scss
@@ -12,7 +12,6 @@
   align-items: center;
   display: flex;
   flex-flow: row nowrap;
-  height: 100%;
   justify-content: space-between;
 }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The flex toolbar has an `height: 100%` that caused some issues in some layouts. Removed this without negative effects.

**Related github/jira issue (required)**:
Fixes infor-design/enterprise-ng#474

**Steps necessary to review your pull request (required)**:
- pull this branch and build
- restest http://localhost:4000/components/toolbar-flex for issues
- can also test https://github.com/infor-design/enterprise-ng/pull/549

**Included in this Pull Request**:
- [x] A note to the change log.
