### PR TITLE
fixes #2493 dropdown memory leak issue

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,6 +66,7 @@
 - `[Datagrid]` Fixed a bug is the isEditable column callback in editable tree grid where some data was missing in the callback. ([#2357](https://github.com/infor-design/enterprise/issues/2357))
 - `[Datagrid]` Fixed a bug where deselect all would not deselect some rows when using grouping. ([#1796](https://github.com/infor-design/enterprise/issues/1796))
 - `[Datagrid]` Fixed a bug where summary counts in grouping would show even if the group is collapsed. ([#2221](https://github.com/infor-design/enterprise/issues/2221))
+- `[Dropdown]` Fix light text on custom colors with personalization ([#2476](https://github.com/infor-design/enterprise/issues/2476))
 - `[Editor]` Fixed a bug where tab or shift tab would break out of the editor when doing an indent/outdent. ([#2421](https://github.com/infor-design/enterprise/issues/2421))
 - `[Fieldfilter]` Fixed an issue where fields were getting wrap to second line on iPhone SE. ([#1861](https://github.com/infor-design/enterprise/issues/1861))
 - `[Fieldfilter]` Fixed an issue where Dropdown was not switching mode on example page. ([#2288](https://github.com/infor-design/enterprise/issues/2288))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,7 +66,7 @@
 - `[Datagrid]` Fixed a bug is the isEditable column callback in editable tree grid where some data was missing in the callback. ([#2357](https://github.com/infor-design/enterprise/issues/2357))
 - `[Datagrid]` Fixed a bug where deselect all would not deselect some rows when using grouping. ([#1796](https://github.com/infor-design/enterprise/issues/1796))
 - `[Datagrid]` Fixed a bug where summary counts in grouping would show even if the group is collapsed. ([#2221](https://github.com/infor-design/enterprise/issues/2221))
-- `[Dropdown]` Fix light text on custom colors with personalization ([#2476](https://github.com/infor-design/enterprise/issues/2476))
+- `[Dropdown]` Fixed a memory leak when calling destroy. ([#2493](https://github.com/infor-design/enterprise/issues/2493))
 - `[Editor]` Fixed a bug where tab or shift tab would break out of the editor when doing an indent/outdent. ([#2421](https://github.com/infor-design/enterprise/issues/2421))
 - `[Fieldfilter]` Fixed an issue where fields were getting wrap to second line on iPhone SE. ([#1861](https://github.com/infor-design/enterprise/issues/1861))
 - `[Fieldfilter]` Fixed an issue where Dropdown was not switching mode on example page. ([#2288](https://github.com/infor-design/enterprise/issues/2288))

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -2931,6 +2931,9 @@ Dropdown.prototype = {
     this.wrapper.remove();
     this.listfilter.destroy();
     this.element.removeAttr('style');
+    this.element.closest('form').off('reset.dropdown');
+    this.element.off();
+    this.label.off();
 
     const list = document.body.querySelector('#dropdown-list');
     if (list && this.isOpen()) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This fixes memory leaks in dropdown caused by event listeners left open. Screenshot below shows a heap comparison with the original vs this fix and you'll notice a bunch of other objects aside from Dropdown and detached elements now being GC'd properly.
![image](https://user-images.githubusercontent.com/11013464/61539387-ff20af00-aa6d-11e9-9466-d25ffdb0e03e.png)


**Related github/jira issue (required)**:
Closes #2493 

**Steps necessary to review your pull request (required)**:

1. Go to http://localhost:4000/components/dropdown/test-destroy.html
2. Open the Memory tab in Chrome Developer Tools
3. Click on 'Destroy Dropdown One' and 'Destroy Dropdown Two'
4. Click the 'Collect garbage' button to make sure the browser has collected garbage
5. Click the 'Take snapshot' button to see the memory heap.
6. Repeat steps 1-5 against changes included in this PR
7. Compare the two heap snapshots

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
