### PR TITLE
N/A - try to fix Mutliselect e2e test race condition during nightly build

### DIFF
--- a/test/components/multiselect/multiselect.e2e-spec.js
+++ b/test/components/multiselect/multiselect.e2e-spec.js
@@ -302,6 +302,8 @@ describe('Multiselect typeahead-reloading tests', () => {
       await dropdownSearchEl.sendKeys(protractor.Key.ARROW_DOWN);
       await dropdownSearchEl.sendKeys(protractor.Key.ENTER);
 
+      await browser.driver.sleep(config.sleep);
+
       // Arrow down twice and select "New York"
       await dropdownSearchEl.sendKeys(protractor.Key.ARROW_DOWN);
       await dropdownSearchEl.sendKeys(protractor.Key.ARROW_DOWN);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR attempts to make a randomly-failing Multiselect e2e more stable by adding a `sleep()` call.

**Related github/jira issue (required)**:
N/A

**Steps necessary to review your pull request (required)**:
The e2e tests should pass with no issue.  We should probably just run the tests on this PR several times to confirm it works.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.