### PR TITLE
1876 - Fix saved position with responsive view for toast

### DIFF
--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -161,10 +161,32 @@ Toast.prototype = {
     // Drop container
     const dropContainer = container.parent();
 
+    // Clear inline style
+    container.css({ top: '', left: '', right: '' });
+
     // Create css rules, position from local storage
     const rect = container[0].getBoundingClientRect();
     const lsPosition = this.restorePosition();
-    const posEl = lsPosition || rect;
+    let posEl = rect;
+
+    // Check for stored postion is in viewport
+    if (lsPosition) {
+      posEl = {
+        top: lsPosition.top,
+        left: lsPosition.left,
+        width: toast.outerWidth(),
+        height: toast.outerHeight(),
+      };
+      posEl.right = posEl.left + posEl.width;
+      posEl.bottom = posEl.top + posEl.height;
+
+      // Set to default, if stored postion not in viewport
+      if (!this.isPosInViewport(posEl)) {
+        posEl = rect;
+      }
+    }
+
+    // Compile css rules
     const rules = { top: `${posEl.top}px`, left: `${posEl.left}px` };
 
     // Reset position right rule, if was set in css file
@@ -172,7 +194,7 @@ Toast.prototype = {
       rules.right = 'auto';
     }
 
-    // Apply compile css rules
+    // Apply compiled css rules
     container.css(rules);
     container.addClass('is-draggable');
 
@@ -341,6 +363,21 @@ Toast.prototype = {
       .replace(/%20/g, '-')}-${suffix}`;
 
     return uniqueid.replace(/--/g, '-').replace(/-$/g, '');
+  },
+
+  /**
+   * Check if given postion in the viewport
+   * @private
+   * @param {object} pos The postion to check
+   * @param {object} elem The element to check
+   * @returns {boolean} true if is in the viewport
+   */
+  isPosInViewport(pos) {
+    return (
+      pos.top >= 0 && pos.left >= 0 &&
+      pos.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+      pos.right <= (window.innerWidth || document.documentElement.clientWidth)
+    );
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed issue for toast with responsive view when saved position is in view and after loads while off the page.

**Related github/jira issue (required)**:
Closes #1876

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/toast/example-draggable.html
- Open the browser wider
- Click on button `Show Toast Message` to open toast
- Drag toast to the far right
- Click `X` in toast or wait for time out to close the toast
- Close the browser window and navigate back to same page
- Resize the browser to narrow
- Click on button `Show Toast Message` to open toast
- See toast should open in view area
