### PR TITLE
1796 - Fix select all on 2nd page with groupable datagrid

### DIFF
--- a/app/views/components/datagrid/example-grouping-paging.html
+++ b/app/views/components/datagrid/example-grouping-paging.html
@@ -70,7 +70,9 @@
         },
         toolbar: {title: 'Accounts', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: false}
       }).on('click', function (e, args) {
-          console.log('Row Click ',args)
+        if (args) {
+          console.log('Row Click ', args);
+        }
       });
  });
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -6586,7 +6586,7 @@ Datagrid.prototype = {
     const dataset = this.getDataset();
 
     for (let i = 0, l = dataset.length; i < l; i++) {
-      const idx = this.pagingRowIndex(i);
+      const idx = this.settings.groupable ? i : this.pagingRowIndex(i);
       if (this.filterRowRendered ||
         (this.filterExpr && this.filterExpr[0] && this.filterExpr[0].keywordSearch)) {
         if (!dataset[i].isFiltered) {
@@ -6627,7 +6627,7 @@ Datagrid.prototype = {
     this.dontSyncUi = true;
     // Unselect each row backwards so the indexes are correct
     for (let i = this._selectedRows.length - 1; i >= 0; i--) {
-      const idx = this.pagingRowIndex(this._selectedRows[i].idx);
+      const idx = this.settings.groupable ? i : this.pagingRowIndex(this._selectedRows[i].idx);
       this.unselectRow(idx, true, true);
     }
     // Sync the Ui and call the events
@@ -7698,7 +7698,7 @@ Datagrid.prototype = {
       let handled = false;
       const target = $(e.target);
       const isRTL = Locale.isRTL();
-      const node = self.activeCell.node;
+      let node = self.activeCell.node;
       const rowNode = $(this).parent();
       const prevRow = rowNode.prevAll(':not(.is-hidden, .datagrid-expandable-row)').first();
       const nextRow = rowNode.nextAll(':not(.is-hidden, .datagrid-expandable-row)').first();
@@ -7715,6 +7715,11 @@ Datagrid.prototype = {
         }
         return self.dataRowIndex(visibleRow);
       };
+
+      if (!node.length) {
+        self.activeCell.node = self.cellNode(row, cell);
+        node = self.activeCell.node;
+      }
 
       const getGroupCell = function (currentCell, lastCell, prev) {
         const n = self.activeCell.groupNode || node;

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -6628,7 +6628,8 @@ Datagrid.prototype = {
     this.dontSyncUi = true;
     // Unselect each row backwards so the indexes are correct
     for (let i = this._selectedRows.length - 1; i >= 0; i--) {
-      const idx = this.settings.groupable ? i : this.pagingRowIndex(this._selectedRows[i].idx);
+      const idx = this.settings.groupable ?
+        this._selectedRows[i].idx : this.pagingRowIndex(this._selectedRows[i].idx);
       this.unselectRow(idx, true, true);
     }
     // Sync the Ui and call the events


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed method selectAll() was not working on 2nd page with groupable datagrid.

**Related github/jira issue (required)**:
Closes #1796

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/example-grouping-paging.html
- Go to 2nd page
- Click on `Select all` checkbox in header to select all
- See it should select all rows on this page
