### PR TITLE
2446 - Improve scrolling capability of Homepage container

### DIFF
--- a/app/views/components/homepage/example-hero-widget-scrollable-container.html
+++ b/app/views/components/homepage/example-hero-widget-scrollable-container.html
@@ -5,7 +5,7 @@
   <div class="page-container no-scroll">
     {{> includes/header}}
 
-    <div id="maincontent" class="page-container scrollable" role="main">
+    <div id="maincontent" class="page-container no-scroll" role="main">
 
       <!-- BEGIN: hero-widget -->
       <div class="hero-widget is-personalizable">

--- a/app/views/components/homepage/example-hero-widget-scrollable-container.html
+++ b/app/views/components/homepage/example-hero-widget-scrollable-container.html
@@ -1,0 +1,324 @@
+<body class="no-scroll">
+  <a href="#maincontent" class="skip-link" data-translate="text">SkipToMain</a>
+  {{> includes/svg-inline-refs}}
+
+  <div class="page-container no-scroll">
+    {{> includes/header}}
+
+    <div id="maincontent" class="page-container scrollable" role="main">
+
+      <!-- BEGIN: hero-widget -->
+      <div class="hero-widget is-personalizable">
+
+        <!-- BEGIN: hero-top -->
+        <div class="hero-top">
+
+          <!-- BEGIN: hero-header -->
+          <div class="hero-header" style="height: 45px;">
+            <div id="hero-header-toolbar" class="toolbar" role="toolbar">
+              <div class="title">Oakham Branch Sales Report</div>
+              <div class="buttonset">
+                <button id="hero-header-toolbar-btn-view" class="btn-menu" type="button">
+                  <span>View: Last 6 Months</span>
+                </button>
+                <ul class="popupmenu is-selectable">
+                  <li class="is-checked"><a href="#">Month to Date</a></li>
+                  <li><a href="#">previous Month</a></li>
+                  <li><a href="#">Last 15 days</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <!-- ENDS: hero-header -->
+
+          <!-- BEGIN: hero-content -->
+          <div class="hero-content">
+
+
+            <!-- BEGIN: circlepager -->
+            <div class="circlepager">
+              <!-- BEGIN: slides -->
+              <div class="slides">
+
+                <div class="slide">
+                  <div style="height: 325px; width: 400px;">
+                    <div id="donut-alert1" class="chart-container"></div>
+                  </div>
+                </div>
+                <div class="slide">
+                  <div style="height: 325px; width: 400px;">
+                    <div id="bar-grouped-example" class="chart-container"></div>
+                  </div>
+                </div>
+                <div class="slide">
+                  <div style="height: 300px; width: 400px; margin-top: -15px">
+                    <div id="area-example" class="chart-container"></div>
+                  </div>
+                </div>
+
+              </div>
+              <!-- END: slides -->
+            </div>
+            <!-- END: circlepager -->
+
+
+          </div>
+          <!-- ENDS: hero-content -->
+
+        </div>
+        <!-- ENDS: hero-top -->
+
+        <!-- BEGIN: hero-bottom -->
+        <div class="hero-bottom">
+          <!-- BEGIN: hero-footer -->
+          <div class="hero-footer">
+            <span class="hero-footer-nav-title">My Quick Links</span>
+            <ul class="hero-footer-nav">
+              <li><a class="btn-tertiary" href="#"><span>Start new order</span></a></li>
+              <li><a class="btn-tertiary" href="#"><span>Access credit management</span></a></li>
+              <li><a class="btn-tertiary" href="#"><span>Manage my team</span></a></li>
+            </ul>
+          </div>
+          <!-- ENDS: hero-footer -->
+        </div>
+        <!-- ENDS: hero-bottom -->
+
+      </div>
+      <!-- ENDS: hero-widget -->
+
+
+
+
+
+      <div class="homepage scrollable" data-columns="4">
+        <div class="content">
+
+
+         <div class="widget">
+            <div class="widget-header">
+              <h2 tabindex="0" class="widget-title">Widget 4x1 (Dom Order 1) - A</h2>
+            </div>
+          </div>
+
+          <div class="widget">
+            <div class="widget-header">
+              <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 2) - B</h2>
+            </div>
+          </div>
+
+         <div class="widget">
+            <div class="widget-header">
+              <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 3) - C</h2>
+            </div>
+          </div>
+
+         <div class="widget">
+            <div class="widget-header">
+              <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 4) - D</h2>
+            </div>
+          </div>
+
+          <div class="widget triple-width">
+            <div class="widget-header">
+              <h2 tabindex="0" class="widget-title">Widget 3x1 (Dom Order 5) - E</h2>
+            </div>
+          </div>
+
+      </div>
+    </div>
+
+  </div>
+</div>
+
+
+<script>
+  var palette = Soho.theme.themeColors().palette;
+  var colors = {
+    // default amber amethyst azure emerald graphite ruby slate turquoise
+    '#some-color': 'default',
+    '#db7726': 'amber',
+    '#9279a6': 'amethyst',
+    '#2578a9': 'azure',
+    '#56932e': 'emerald',
+    '#5c5c5c': 'graphite',
+    '#941e1e': 'ruby',
+    '#50535a': 'slate',
+    '#206b62': 'turquoise'
+  };
+  var donutColors = {
+    amber: {
+      neutral: palette.graphite['10'].value
+    },
+    amethyst: {
+      neutral: palette.graphite['10'].value
+    },
+    emerald: {
+      positive: palette.emerald['90'].value,
+      neutral: palette.graphite['10'].value
+    },
+    ruby: {
+      neutral: palette.graphite['10'].value
+    }
+  };
+  var barColors = {
+    amber: {
+      apr: palette.azure['50'].value,
+      may: palette.amber['100'].value
+    },
+    emerald: {
+      feb: palette.emerald['90'].value,
+      apr: palette.amethyst['70'].value
+    },
+    ruby: {
+      mar: palette.ruby['10'].value
+    }
+  };
+  var areaColors = {
+    amber: {
+      metals: palette.amethyst['90'].value,
+      stone: palette.azure['70'].value,
+    },
+    amethyst: {
+      metals: palette.amethyst['90'].value
+    },
+    ruby: {
+      metals: 'good',
+      wood: palette.amethyst['100'].value
+    }
+  };
+
+  var donutData = [{
+    data: [
+      { name: 'Positive', value: 20, color: 'good' },
+      { name: 'Negative', value: 25, color: 'error' },
+      { name: 'Neutral', value: 10, color: 'neutral' }
+    ],
+    centerLabel: 'Reviews'
+  }];
+
+  var barData = [{
+        data: [
+          {name: 'Jan', value: 12, color: 'alertYellow'},
+          {name: 'Feb', value: 11, color: 'good'},
+          {name: 'Mar', value: -5, color: 'error'},
+          {name: 'Apr', value: 10, color: '#7cc0b5'},
+          {name: 'May', value: 14, color: '#ff9426'}
+        ],
+        name: 'Team A'
+      }, {
+        data: [
+          {name: 'Jan', value: 22, color: 'alertYellow'},
+          {name: 'Feb', value: 24, color: 'good'},
+          {name: 'Mar', value: 12, color: 'error'},
+          {name: 'Apr', value: 20, color: '#7cc0b5'},
+          {name: 'May', value: 21, color: '#ff9426'}
+        ],
+        name: 'Team B'
+      }, {
+        data: [
+          {name: 'Jan', value: 32, color: 'alertYellow'},
+          {name: 'Feb', value: 31, color: 'good'},
+          {name: 'Mar', value: 34, color: 'error'},
+          {name: 'Apr', value: 30, color: '#7cc0b5'},
+          {name: 'May', value: 33, color: '#ff9426'}
+        ],
+        name: 'Team C'
+      }];
+
+  var areaData = [{
+    data: [
+      {name: 'Jan', value: 12}, {name: 'Feb', value: 11}, {name: 'Mar', value: 14},
+      {name: 'Apr', value: 10}, {name: 'May', value: 14}, {name: 'Jun', value: 8}],
+    name: 'Metals', color: '#ede3fc'
+  }, {
+    data: [
+      {name: 'Jan', value: 22}, {name: 'Feb', value: 21}, {name: 'Mar', value: 24},
+      {name: 'Apr', value: 20}, {name: 'May', value: 24}, {name: 'Jun', value: 28}],
+    name: 'Stone', color: 'alertYellow'
+  }, {
+    data: [
+      {name: 'Jan', value: 32}, {name: 'Feb', value: 31}, {name: 'Mar', value: 34},
+      {name: 'Apr', value: 30}, {name: 'May', value: 34}, {name: 'Jun', value: 38}],
+    name: 'Wood', color: 'error'
+  }];
+
+  var getDonutData = function (color) {
+    var d = JSON.parse(JSON.stringify(donutData));
+    if (color && donutColors[color]) {
+      for (var i = 0, l = d[0].data.length; i < l; i++) {
+        var item = d[0].data[i];
+        var thisColor = donutColors[color][item.name.toLowerCase()];
+        item.color = thisColor || item.color;
+      }
+    }
+    return d;
+  };
+
+  var getBarData = function (color) {
+    var d = JSON.parse(JSON.stringify(barData));
+    if (color && barColors[color]) {
+      for (var i = 0, l = d.length; i < l; i++) {
+        for (var i2 = 0, l2 = d[i].data.length; i2 < l2; i2++) {
+          var item = d[i].data[i2];
+          var thisColor = barColors[color][item.name.toLowerCase()];
+          item.color = thisColor || item.color;
+        }
+      }
+    }
+    return d;
+  };
+
+  var getAreaData = function (color) {
+    var d = JSON.parse(JSON.stringify(areaData));
+    if (color && areaColors[color]) {
+      for (var i = 0, l = d.length; i < l; i++) {
+        var item = d[i];
+        var thisColor = areaColors[color][item.name.toLowerCase()];
+        item.color = thisColor || item.color;
+      }
+    }
+    return d;
+  };
+
+  $('#donut-alert1').chart({type: 'donut', dataset: getDonutData()});
+  $('#bar-grouped-example').chart({type: 'bar-grouped', dataset: getBarData(), showLegend: false});
+  $('#area-example').chart({type: 'area', dataset: getAreaData()});
+
+  // Wait for initialize
+  $('body').on('initialized', function() {
+    var homepageApi = $('.homepage').data('homepage');
+    var circlepagerApi = $('.circlepager').data('circlepager');
+
+    // Set view type
+    var setView = function(numberOfColumns) {
+      if (numberOfColumns > 2) {
+        circlepagerApi.showExpandedView();
+      } else {
+        circlepagerApi.showCollapsedView();
+      }
+    };
+
+    // Bind resize
+    homepageApi.element.on('resize', function(e, numberOfColumns) {
+      setView(numberOfColumns);
+    });
+
+
+    // Init
+    setView(homepageApi.settings.columns);
+
+    var donutApi = $('#donut-alert1').data('pie');
+    var barApi = $('#bar-grouped-example').data('bar');
+    var areaApi = $('#area-example').data('line');
+
+    $('html')
+      .on('colorschanged themechanged', function (e, a) {
+        if (typeof a.colors !== 'undefined') {
+          var color = colors[a.colors];
+          donutApi.updated({ dataset: getDonutData(color) });
+          barApi.updated({ dataset: getBarData(color) });
+          areaApi.updated({ dataset: getAreaData(color) });
+        }
+      });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -74,6 +74,7 @@
 - `[Fieldfilter]` Fixed an issue where Dropdown was not switching mode on example page. ([#2288](https://github.com/infor-design/enterprise/issues/2288))
 - `[Field Options]` Fixed an issue where input example was not working. ([#2348](https://github.com/infor-design/enterprise/issues/2348))
 - `[Homepages]` Fixed an issue where personalize and chart text colors were not working with hero. ([#2097](https://github.com/infor-design/enterprise/issues/2097))
+- `[Homepages]` Added `height: inherit;` CSS rule to Homepage container element to improve visibility in scrollable layouts. ([#2446](https://github.com/infor-design/enterprise/issues/2446))
 - `[Images]` Fixed an issue where images were not tabbable or receiving a visual focus state. ([#2025](https://github.com/infor-design/enterprise/issues/2025))
 - `[Listview]` Fixed a bug that caused the listview to run initialize too many times. ([#2179](https://github.com/infor-design/enterprise/issues/2179))
 - `[Lookup]` Added `autocomplete="off"` to lookup input fields to prevent browser interference. ([#2366](https://github.com/infor-design/enterprise/issues/2366))

--- a/src/components/homepage/_homepage.scss
+++ b/src/components/homepage/_homepage.scss
@@ -6,6 +6,7 @@
 // Different Widget Heights and Widths
 
 .homepage {
+  height: inherit;
   margin: 0 auto;
   padding: 20px 0;
   position: relative;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds a `height: inherit;` CSS rule to the Homepage container element.  This assists the visibility of the element when it's made scrollable, either by way of adding the `scrollable` CSS class IDS provides, or by adding `overflow` CSS rules manually. 

**Related github/jira issue (required)**:
Closes #2446

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the app.
- Open http://localhost:4000/components/homepage/example-hero-widget.html and ensure that the Homepage widget area is still usable. Resize the browser viewport to various sizes and make sure the entire page still scrolls, and all widgets are visible.
- Open http://localhost:4000/components/homepage/example-hero-widget-scrollable-container.html.  Ensure that the Homepage widget area is scrollable on its own (outside of the hero image area), and that all Homepage widgets can be visible via scrolling.

**Included in this Pull Request**:
- [x] A note to the change log.