### PR TITLE
2414 - Fix set filter conditions only for multiselect with datagrid

### DIFF
--- a/app/views/components/datagrid/test-editor-dropdown-source-prior-filter.html
+++ b/app/views/components/datagrid/test-editor-dropdown-source-prior-filter.html
@@ -1,0 +1,166 @@
+<div class="row">
+  <div class="six columns">
+    <h2>Datagrid Test: Dropdown Editor Uses Source with Multiselect with prior filter</h2>
+    <p>
+      <a class="hyperlink" href="https://github.com/infor-design/enterprise/issues/2383" target="_blank">GIT #2383</a>.<br />
+    </p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+    <div role="toolbar" class="toolbar">
+      <div class="title">
+        <span>Dropdown Editor Source Example</span>
+        <span class="datagrid-result-count">(N Results)</span>
+      </div>
+      <div class="buttonset"></div>
+    </div>
+    <div id="datagrid"></div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    var gridApi,
+      columns = [],
+      dataAll = [],
+      dataPOH = [],
+      dataSS = [],
+      dataCC = [],
+      dataRR = [];
+
+    var LOW_RANGE_LOW_NUMBER = 0,
+        LOW_RANGE_HIGH_NUMBER = 150,
+        HIGH_RANGE_LOW_NUMBER = 151,
+        HIGH_RANGE_HIGH_NUMBER = 9999;
+
+    // Define all possible "Action" column options for the grid
+    var actionOptions = [
+      { label: 'Place On-Hold', value: 'poh' },
+      { label: 'Request Review', value: 'rr' },
+      { label: 'Send to Shipping', value: 'ss' },
+      { label: 'Contact Client', value: 'cc' }
+    ];
+
+    // Some Sample Data
+    dataAll.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  '<svg/onload=alert(1)>', quantity: 1, price: 210.99, orderDate:  new Date(2016, 2, 15, 12, 30, 36), portable: false, action: 'poh', description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning' });
+    dataAll.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false, action: 'poh', description: 'The kit has an air blow gun that can be used for cleaning' });
+    dataAll.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity:  'Inspect and Repair', portable: true, quantity: 1, price: 120.992, orderDate: new Date(2014, 6, 3), action: 'ss' });
+    dataAll.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', portable: true, quantity: 3, price: null, orderDate: new Date(2015, 3, 3), action: 'ss', description: 'Compressor comes with with air tool kit' });
+    dataAll.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, orderDate: new Date(2015, 5, 5), action: 'rr' });
+    dataAll.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', portable: false, quantity: 41, price: 120.99, orderDate: new Date(2014, 6, 9), action: 'cc' });
+    dataAll.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', portable: true, quantity: 41, price: 123.99, orderDate: new Date(2014, 6, 9), action: 'ss' });
+
+    dataPOH.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  '<svg/onload=alert(1)>', quantity: 1, price: 210.99, orderDate:  new Date(2016, 2, 15, 12, 30, 36), portable: false, action: 'poh', description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning' });
+    dataPOH.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false, action: 'poh', description: 'The kit has an air blow gun that can be used for cleaning' });
+
+    dataSS.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity:  'Inspect and Repair', portable: true, quantity: 1, price: 120.992, orderDate: new Date(2014, 6, 3), action: 'ss' });
+    dataSS.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', portable: true, quantity: 3, price: null, orderDate: new Date(2015, 3, 3), action: 'ss', description: 'Compressor comes with with air tool kit' });
+    dataSS.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', portable: true, quantity: 41, price: 123.99, orderDate: new Date(2014, 6, 9), action: 'ss' });
+
+    dataRR.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, orderDate: new Date(2015, 5, 5), action: 'rr' });
+
+    dataCC.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', portable: false, quantity: 41, price: 120.99, orderDate: new Date(2014, 6, 9), action: 'cc' });
+
+    var dropDownFormatter = function (row, cell, value, col) {
+      for (var index = 0, len = actionOptions.length; index < len; index++) {
+        var item = actionOptions[ index ];
+        if (value === item.value) {
+          return item.label;
+        }
+      }
+      return '';
+    };
+
+    var dropDownSource = function (response, term, gridArgs) {
+      setTimeout(function () {
+        response(actionOptions);
+      }, 1);
+    };
+
+    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center' });
+    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input });
+    columns.push({ id: 'status', name: 'Status', field: 'price', formatter: Formatters.Alert, readonly: true, ranges: [{ 'min': LOW_RANGE_LOW_NUMBER, 'max': LOW_RANGE_HIGH_NUMBER, 'classes': 'success', text: 'Confirmed' }, { 'min': HIGH_RANGE_LOW_NUMBER, 'max': HIGH_RANGE_HIGH_NUMBER, 'classes': 'error', text: 'Error' }] });
+    columns.push({ id: 'price', name: 'Price', field: 'price', align: 'right', formatter: Formatters.Decimal, numberFormat: { minimumFractionDigits: 3, maximumFractionDigits: 3 }, editor: Editors.Input, mask: '###.000' });
+    columns.push({ id: 'action', name: 'Action', field: 'action', formatter: dropDownFormatter, filterType: 'multiselect', options:  [{ label: ' ', value: ' ' }], editor: Editors.Dropdown, editorOptions: { editable: false, source: dropDownSource }});
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date });
+
+    //Init and get the api for the grid
+    $('#datagrid').datagrid({
+      cellNavigation: true,
+      columns: columns,
+      dataset: dataAll,
+      disableClientSort: true,
+      disableClientFilter: true,
+      filterWhenTyping: true,
+      editable: true,
+      clickToSelect: false,
+      redrawOnResize: false,
+      isList: true,
+      menuId: 'datagrid',
+      selectable: 'multiple',
+      filterable: true,
+      enableTooltips: true,
+      toolbar: { keywordFilter: true, results: true },
+      actionableMode: true,
+      showDirty: true,
+      emptyMessage: null,
+      rowHeight: 'short',
+      saveUserSettings: {
+        columns: false,
+        rowHeight: false,
+        sortOrder: false,
+        pagesize: false,
+        activePage: false,
+        filter: false
+      },
+    }).on('activecellchange', function (e, args) {
+      console.log('e', e);
+      console.log('args', args);
+    }).on('cellchange', function (e, args) {
+      console.log(e, args);
+    }).on('rowadd', function (e, args) {
+      console.log(e, args);
+    }).on('rowremove', function (e, args) {
+      console.log(e, args);
+    })
+    .on('filtered', function (e, args) {
+      console.log('filtered', args);
+
+      if (gridApi && args && args.conditions) {
+        if (args.conditions.length === 0) {
+          gridApi.loadData(dataAll);
+        } else {
+          let results = [];
+          for (let value of args.conditions[0].value) {
+            switch(value) {
+              case 'poh':
+                results = $.merge(results, dataPOH);
+                break;
+              case 'rr':
+                results = $.merge(results, dataRR);
+                break;
+              case 'ss':
+                results = $.merge(results, dataSS);
+                break;
+              case 'cc':
+                results = $.merge(results, dataCC);
+                break;
+              case 'blank':
+                break;
+            }
+          }
+          gridApi.loadData(results);
+        }
+      }
+    });
+
+    gridApi = $('#datagrid').data('datagrid');
+    if (gridApi) {
+      gridApi.setFilterConditions([
+        { columnId: 'action', operator: 'equals', value: ['poh', 'rr'] }
+      ]);
+    }
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -52,7 +52,7 @@
 - `[Datagrid]` Fixes the alignment of the alert and warning icons on a lookup editor. ([#2175](https://github.com/infor-design/enterprise/issues/2175))
 - `[Datagrid]` Fixes tooltip on the non displayed table errors. ([#2264](https://github.com/infor-design/enterprise/issues/2264))
 - `[Datagrid]` Fixes an issue with alignment when toggling the filter row. ([#2332](https://github.com/infor-design/enterprise/issues/2332))
-- `[Datagrid]` Fixes an issue where method setFilterConditions() was not working for multiselect filter. ([#2414](https://github.com/infor-design/enterprise/issues/2414))
+- `[Datagrid]` Fixes an issue where method setFilterConditions() were not working for multiselect filter. ([#2414](https://github.com/infor-design/enterprise/issues/2414))
 - `[Datagrid]` Fixes an error on tree grid when using server-side paging. ([#2132](https://github.com/infor-design/enterprise/issues/2132))
 - `[Datagrid]` Fixed an issue where autocompletes popped up on cell editors. ([#1575](https://github.com/infor-design/enterprise/issues/1575))
 - `[Datagrid]` Fixes reset columns to set the correct hidden status. ([#2315](https://github.com/infor-design/enterprise/issues/2315))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -52,6 +52,7 @@
 - `[Datagrid]` Fixes the alignment of the alert and warning icons on a lookup editor. ([#2175](https://github.com/infor-design/enterprise/issues/2175))
 - `[Datagrid]` Fixes tooltip on the non displayed table errors. ([#2264](https://github.com/infor-design/enterprise/issues/2264))
 - `[Datagrid]` Fixes an issue with alignment when toggling the filter row. ([#2332](https://github.com/infor-design/enterprise/issues/2332))
+- `[Datagrid]` Fixes an issue where method setFilterConditions() was not working for multiselect filter. ([#2414](https://github.com/infor-design/enterprise/issues/2414))
 - `[Datagrid]` Fixes an error on tree grid when using server-side paging. ([#2132](https://github.com/infor-design/enterprise/issues/2132))
 - `[Datagrid]` Fixed an issue where autocompletes popped up on cell editors. ([#1575](https://github.com/infor-design/enterprise/issues/1575))
 - `[Datagrid]` Fixes reset columns to set the correct hidden status. ([#2315](https://github.com/infor-design/enterprise/issues/2315))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -2319,10 +2319,17 @@ Datagrid.prototype = {
       input.val(conditions[i].value);
 
       if (input.is('select')) {
+        const firstVal = conditions[i].value instanceof Array ?
+          conditions[i].value[0] : conditions[i].value;
         if (conditions[i].innerHTML) {
           input[0].innerHTML = conditions[i].innerHTML;
         }
-        if (conditions[i].value instanceof Array && !conditions[i].selectedOptions) {
+        if (!input.find(`option[value="${firstVal}"]`).length) {
+          const dropdownApi = input.data('dropdown');
+          if (dropdownApi) {
+            dropdownApi.setCode(conditions[i].value);
+          }
+        } else if (conditions[i].value instanceof Array && !conditions[i].selectedOptions) {
           for (let j = 0; j < conditions[i].value.length; j++) {
             input.find(`option[value="${conditions[i].value[j]}"]`).prop('selected', true);
           }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed method setFilterConditions() was not working for multiselect filter with datagrid.

**Related github/jira issue (required)**:
Closes #2414

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/test-editor-dropdown-source-prior-filter.html
- On page load see the filter for column `Action`
- Should be populated (`Place On-Hold, Request Review`)
- And grid rows should not be filtered because the setting disableClientFilter is on.

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
