### PR TITLE
Multiselect - Increase difference in color between placeholder and selected items [v4.20.x]

### DIFF
--- a/src/themes/theme-uplift-light.scss
+++ b/src/themes/theme-uplift-light.scss
@@ -34,6 +34,9 @@ $datagrid-list-sort-icon-color: $theme-color-palette-slate-40;
 $listview-border-color: $theme-color-palette-slate-20;
 $panel-border-color: $theme-color-palette-slate-20;
 
+// TODO: remove this when fixed in tokens (infor-design/design-system#393)
+$input-placeholder-color: $theme-color-palette-slate-60;
+
 // Core Uplift Controls
 @import '../core/controls-uplift';
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR further increases the difference in color between an input field's placeholder text and actual text.  In the case of the Multiselect component, this difference can be seen on examples that display placeholder text.

**Related github/jira issue (required)**:
Closes #2528

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run app
- Open http://localhost:4000/components/multiselect/example-placeholder.html?theme=uplift&variant=light&colors=0563C2
- Examine the difference between the "Select A State" placeholder text, and a selected option.  Make sure there is a significant difference between the text colors.
- If you have the `aXe` browser plugin, run a quick scan to verify there are no accessibility issues related to color contrast on the Uplift Light theme on this page.