### PR TITLE
2539 - Fix some personalization text colors [v4.20.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -83,6 +83,7 @@
 - `[Listview]` Fixed a bug that caused the listview to run initialize too many times. ([#2179](https://github.com/infor-design/enterprise/issues/2179))
 - `[Lookup]` Added `autocomplete="off"` to lookup input fields to prevent browser interference. ([#2366](https://github.com/infor-design/enterprise/issues/2366))
 - `[Modal]` Fixed an issue where the modal component would disappear if its content had a checkbox in it in RTL. ([#332](https://github.com/infor-design/enterprise-ng/issues/332))
+- `[Personalization]` Fixes an issue where text color was too dark to more readable in contrast mode. ([#2539](https://github.com/infor-design/enterprise/issues/2539))
 - `[Personalization]` Updated some of the colors to more readable in contrast mode. ([#2097](https://github.com/infor-design/enterprise/issues/2097))
 - `[Personalization]` Fixes an issue where text color was too dark. ([#2476](https://github.com/infor-design/enterprise/issues/2476))
 - `[Pager]` Added a complete Popupmenu settings object for configuring the Page Size Selector Button, and deprecated the `attachPageSizeMenuToBody` setting in favor of `pageSizeMenuSettings.attachToBody`. ([#2356](https://github.com/infor-design/enterprise/issues/2356))

--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -145,20 +145,24 @@ Personalize.prototype = {
       header: '2578A9'
     };
 
-    // Force to be light text on custom colors
+    // Force to be light text on custom colors { color: ['soho', 'uplift'] }
     const forceToBeLightTextOn = {
-      '#db7726': 'amber',
-      '#9279a6': 'amethyst',
-      '#2578a9': 'azure',
-      '#56932e': 'emerald',
-      '#5c5c5c': 'graphite',
-      '#941e1e': 'ruby',
-      '#50535a': 'slate',
-      '#206b62': 'turquoise'
+      amber: ['#db7726', '#9b3300'],
+      amethyst: ['#9279a6', '#7834dd'],
+      azure: ['#2578a9', '#0563c2'],
+      emerald: ['#56932e', '#0a834b'],
+      graphite: ['#5c5c5c', '#808080'],
+      ruby: ['#941e1e', '#7b0f11'],
+      slate: ['#50535a', '#98949e'],
+      turquoise: ['#206b62', '#248b8f']
     };
+    let foundColor = false;
     let isDark = `${colors.header || defaultColors.header}`.toLowerCase();
     isDark = colorUtils.validateHex(isDark);
-    isDark = forceToBeLightTextOn[isDark] ? 'white' : null;
+    Object.keys(forceToBeLightTextOn).forEach((color) => {
+      foundColor = foundColor || forceToBeLightTextOn[color].indexOf(isDark) > -1;
+    });
+    isDark = foundColor ? 'white' : null;
 
     const lightest = colorUtils.validateHex(colors.lightest ||
       colorUtils.getLuminousColorShade((colors.header || defaultColors.header), 0.3));

--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -150,7 +150,11 @@ Personalize.prototype = {
       '#db7726': 'amber',
       '#9279a6': 'amethyst',
       '#2578a9': 'azure',
-      '#56932e': 'emerald'
+      '#56932e': 'emerald',
+      '#5c5c5c': 'graphite',
+      '#941e1e': 'ruby',
+      '#50535a': 'slate',
+      '#206b62': 'turquoise'
     };
     let isDark = `${colors.header || defaultColors.header}`.toLowerCase();
     isDark = colorUtils.validateHex(isDark);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
There was Failed QA because some dark text color, so this PR will update some of the personalization colors.

**Related github/jira issue (required)**:
Closes #2539

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/list?theme=uplift
- Click top right `...` action button to change theme/colors
- Inspect text color should be light and readable for Turquoise, Slate, and Graphite

**Included in this Pull Request**:
- [x] A note to the change log.

