### PR TITLE
2540- Fix a race condition loading messages [v4.20.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -82,6 +82,7 @@
 - `[Images]` Fixed an issue where images were not tabbable or receiving a visual focus state. ([#2025](https://github.com/infor-design/enterprise/issues/2025))
 - `[Listview]` Fixed a bug that caused the listview to run initialize too many times. ([#2179](https://github.com/infor-design/enterprise/issues/2179))
 - `[Lookup]` Added `autocomplete="off"` to lookup input fields to prevent browser interference. ([#2366](https://github.com/infor-design/enterprise/issues/2366))
+- `[Locale]` Fixed race condition when using initialize and loading locales with a parent locale. ([#2540](https://github.com/infor-design/enterprise/issues/2540))
 - `[Modal]` Fixed an issue where the modal component would disappear if its content had a checkbox in it in RTL. ([#332](https://github.com/infor-design/enterprise-ng/issues/332))
 - `[Personalization]` Updated some of the colors to more readable in contrast mode. ([#2097](https://github.com/infor-design/enterprise/issues/2097))
 - `[Personalization]` Fixes an issue where text color was too dark. ([#2476](https://github.com/infor-design/enterprise/issues/2476))

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -269,15 +269,13 @@ const Locale = {  // eslint-disable-line
         this.setCurrentLocale(locale, this.cultures[locale]);
         this.dff[locale].resolve(locale);
       }
-      if (!isCurrent && !parentLocale && this.dff[locale]) {
-        this.dff[locale].resolve(locale);
-      }
-      if (parentLocale) {
+      if (parentLocale && this.dff[parentLocale]) {
         this.setCurrentLocale(locale, this.cultures[locale]);
         this.setCurrentLocale(parentLocale, this.cultures[parentLocale]);
-        setTimeout(() => {
-          this.dff[parentLocale].resolve(parentLocale);
-        }, locale !== parentLocale ? 250 : 0);
+        this.dff[parentLocale].resolve(parentLocale);
+      }
+      if (!isCurrent && !parentLocale && this.dff[locale]) {
+        this.dff[locale].resolve(locale);
       }
     };
 
@@ -313,21 +311,26 @@ const Locale = {  // eslint-disable-line
       this.appendLocaleScript('en-US', false);
     }
 
-    // Also load the default locale for that locale
     const lang = locale.split('-')[0];
-    let resolveToParent = false;
+    let hasParentLocale = false;
     const match = this.defaultLocales.filter(a => a.lang === lang);
     const parentLocale = match[0] || [{ default: 'en-US' }];
     if (parentLocale.default && parentLocale.default !== locale &&
       !this.cultures[parentLocale.default]) {
-      resolveToParent = true;
-      this.appendLocaleScript(parentLocale.default, false, locale);
+      hasParentLocale = true;
     }
 
-    if (locale && !this.cultures[locale] && this.currentLocale.name !== locale) {
+    if (!hasParentLocale && locale && !this.cultures[locale] &&
+      this.currentLocale.name !== locale) {
       this.setCurrentLocale(locale);
       // Fetch the local and cache it
-      this.appendLocaleScript(locale, !resolveToParent, locale);
+      this.appendLocaleScript(locale, true);
+    }
+
+    // Also load the default locale for that locale
+    if (hasParentLocale) {
+      this.appendLocaleScript(parentLocale.default, false, locale);
+      this.appendLocaleScript(locale, false, parentLocale.default);
     }
 
     if (locale && self.currentLocale.data && self.currentLocale.dataName === locale) {

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -275,7 +275,9 @@ const Locale = {  // eslint-disable-line
       if (parentLocale) {
         this.setCurrentLocale(locale, this.cultures[locale]);
         this.setCurrentLocale(parentLocale, this.cultures[parentLocale]);
-        this.dff[parentLocale].resolve(parentLocale);
+        setTimeout(() => {
+          this.dff[parentLocale].resolve(parentLocale);
+        }, locale !== parentLocale ? 250 : 0);
       }
     };
 
@@ -325,7 +327,7 @@ const Locale = {  // eslint-disable-line
     if (locale && !this.cultures[locale] && this.currentLocale.name !== locale) {
       this.setCurrentLocale(locale);
       // Fetch the local and cache it
-      this.appendLocaleScript(locale, !resolveToParent);
+      this.appendLocaleScript(locale, !resolveToParent, locale);
     }
 
     if (locale && self.currentLocale.data && self.currentLocale.dataName === locale) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This fixes a race condition in locale when using a locale that shares strings. For example es-US and ar-SA (sharing es and ar respectively). only way i could fix was a conditional timeout. Originally noted on #2365

**Related github/jira issue (required)**:
Fixes #2540 

**Steps necessary to review your pull request (required)**:
- http://localhost:4000/components/locale/test-translated-strings.html?locale=ar-SA
- http://localhost:4000/components/locale/test-translated-strings.html?locale=es-ES
- http://localhost:4000/components/locale/test-translated-strings.html?locale=es-US
- try loading all these with a fresh cache (CTRL + Reload)
- ensure pages load
- ensure all tests pass

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
