### PR TITLE
2547 - fix modal scrolling

### DIFF
--- a/src/components/modal/_modal-uplift.scss
+++ b/src/components/modal/_modal-uplift.scss
@@ -1,12 +1,6 @@
 // Uplift Modal
 //================================================== //
 
-.modal-content {
-  .modal-body-wrapper {
-    overflow: inherit;
-  }
-}
-
 .modal-buttonset {
   button {
     line-height: normal;

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -443,6 +443,15 @@
   }
 }
 
+// Fix scrollbar in IE on single-line Message Modals
+.ie {
+  .modal-content {
+    .modal-body-wrapper {
+      padding: 2px 20px;
+    }
+  }
+}
+
 // RTL Styles
 html[dir='rtl'] {
   .modal-buttonset {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR makes a better change to Modals that consist of single line messages.  The previous changes -- part of #2318 -- mistakenly broke scrolling on all modals.  This PR reverses that change and adds a bit of padding to prevent the scrollbar's appearance unless it's necessary.

**Related github/jira issue (required)**:
- Related to #2318 
- Closes #2547 

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the app.
- Open http://localhost:4000/components/modal/test-full-content-buttons.html?theme=uplift
- Shrink the browser window so that the inner contents of the modal are scrollable.  The modal contents should scroll up and down as expected.
- Open http://localhost:4000/components/message/example-index in IE11
- Click the "Success Example" button.
- Ensure there is no scrollbar on the success message.
