### PR TITLE
2305 - Fix lookup so it works when used with mask/datagrid

### DIFF
--- a/app/views/components/datagrid/test-lookup-with-mask.html
+++ b/app/views/components/datagrid/test-lookup-with-mask.html
@@ -1,0 +1,138 @@
+<div class="row">
+  <div class="twelve columns">
+    <div role="toolbar" class="toolbar">
+
+      <div class="title">
+        Example illustrates a mask issue with a lookup when using IE11. Press add row (top), focus the productId cell and then open the lookup and select a value.
+        The value should be shown in the field.
+      </div>
+      <br />
+
+      <div class="buttonset">
+        <button type="button" id="add-row-top" class="btn">
+          <span>Add Row (top)</span>
+        </button>
+        <button type="button" id="add-row-bottom" class="btn">
+          <span>Add Row (bottom)</span>
+        </button>
+      </div>
+    </div>
+
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+  var gridApi = null;
+
+  $('body').one('initialized', function () {
+
+    Locale.set('en-US').done(function () {
+        var grid,
+          data = [],
+          columns = [],
+          maskOptions,
+
+          //lookup data
+          lookupOptions,
+          lookupData = [],
+          lookupColumns = [];
+
+          // Some Sample Data for Lookup
+          lookupData.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+          lookupData.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+          lookupData.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+          lookupData.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+          lookupData.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+          lookupData.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+          lookupData.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+
+          //Define Columns for the Lookup Grid.
+          lookupColumns.push({ id: 'productId', name: 'Product Id', field: 'productId', width: 140});
+          lookupColumns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', width: 250, formatter: Formatters.Hyperlink});
+          lookupColumns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', width: 125});
+          lookupColumns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', width: 125});
+          lookupColumns.push({ id: 'price', name: 'Price', field: 'price', width: 125, formatter: Formatters.Decimal});
+          lookupColumns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+
+          lookupOptions = {
+            // field: 'productId',
+            field: function (row, field, grid) {
+              return row.productId;
+            },
+            match: function (value, row, field, grid) {
+              return (row.productId) === value;
+            },
+            options: {
+              columns: lookupColumns,
+              dataset: lookupData,
+              selectable: 'single', //multiselect or single
+              toolbar: {title: 'Products', results: true, dateFilter: false ,keywordFilter: false, advancedFilter: true, actions: true, views: true , rowHeight: true}
+            }
+          };
+
+        maskOptions = {
+          patternOptions: {
+            allowDecimal: false,
+            allowNegative: false,
+            allowThousandsSeparator: false,
+            decimalLimit: 0,
+            integerLimit: 7,
+            symbols: {
+              decimal: '.',
+              negative: '-',
+              thousands: ','
+            },
+            processOnBlur: false,
+            processOnInitialize: false
+          },
+          process: "number"
+        };
+
+        // Some Sample Data
+        data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  '<svg/onload=alert(1)>', quantity: 1, price: 210.99, status: 'OK', orderDate:  new Date(2016, 2, 15, 12, 30, 36), portable: false, action: 'ac', description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning'});
+        data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, status: '', orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false, action: 'oh', description: 'The kit has an air blow gun that can be used for cleaning'});
+        data.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity:  'Inspect and Repair', portable: true, quantity: 1, price: 120.992, status: null, orderDate: new Date(2014, 6, 3), action: 'ac'});
+        data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', portable: true, quantity: 3, price: null, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'ac', description: 'Compressor comes with with air tool kit'});
+        data.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'oh'});
+        data.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', portable: false, quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'oh'});
+        data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'oh'});
+
+        //Define Columns for the Grid.
+        columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
+        columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Ellipsis, editor: Editors.Input });
+        columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, editorOptions: lookupOptions, maskOptions: maskOptions });
+        columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, align: 'right', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###.000'});
+        columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date5});
+
+        //Init and get the api for the grid
+        grid = $('#datagrid').datagrid({
+          columns: columns,
+          dataset: data,
+          editable: true,
+          toolbar: {keywordFilter: true, results: true},
+          showDirty: true,
+          clickToSelect: false,
+          actionableMode: true,
+          cellNavigation: true,
+          enableTooltips: true,
+          paging: true,
+          pagesize: 10,
+          selectable: 'mixed',
+          rowHeight: 'short'
+        });
+
+        gridApi = $('#datagrid').data('datagrid');
+
+        $('#add-row-top').on('click', function () {
+          gridApi.addRow({ productName: '', productId: '0' });
+        });
+
+        $('#add-row-bottom').on('click', function () {
+          gridApi.addRow({ productName: '', productId: '0' }, 'bottom');
+        });
+    });
+  });
+
+</script>

--- a/app/views/components/lookup/example-index.html
+++ b/app/views/components/lookup/example-index.html
@@ -8,6 +8,11 @@
     </div>
 
     <div class="field">
+      <label for="product-mask" class="label required">Products (mask)</label>
+      <input id="product-mask" data-init="false" data-validate="required" class="lookup" name="product-mask" type="text"/>
+    </div>
+
+    <div class="field">
       <label for="lookup-field-small" class="label">Lookup Field (Xtra - Small)</label>
       <input id="lookup-field-small" class="input-xs lookup" name="lookup-field-small" type="text" value="DA"/>
       <span class="data-description">Danonics 123 Group</span>
@@ -43,7 +48,7 @@
     columns.push({ id: 'price', name: 'Price', field: 'price', formatter: Formatters.Decimal});
 
     //Init and get the api for the grid
-    grid = $('#product-lookup').lookup({
+    $('#product-lookup, #product-mask').lookup({
       field: 'productId',
       autoApply: true,
       options: {
@@ -66,4 +71,19 @@
       }
     });
 
+    $('#product-mask').mask({
+      patternOptions: {
+        allowDecimal: false,
+        allowNegative: false,
+        allowThousandsSeparator: false,
+        decimalLimit: 0,
+        integerLimit: 7,
+        symbols: {
+          decimal: '.',
+          negative: '-',
+          thousands: ','
+        }
+      },
+      process: "number"
+    });
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise
 
+## v4.21.0
+
+### v4.21.0 Fixes
+
+- `[Datagrid]` Fixed a bug where the value would clear when using a lookup editor with a mask on new rows. ([#2305](https://github.com/infor-design/enterprise/issues/2305))
+
 ## v4.20.0
 
 ### v4.20.0 Deprecation

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -50,7 +50,7 @@ $datagrid-row-height: 43px;
 $datagrid-medium-header-height: 30px;
 $datagrid-medium-row-height: 33px;
 $datagrid-short-header-height: 25px;
-$datagrid-short-row-height: 25px;
+$datagrid-short-row-height: 26px;
 
 // Main Datagrid Container
 .datagrid-container {
@@ -1163,7 +1163,8 @@ $datagrid-short-row-height: 25px;
             padding-left: 10px;
 
             .trigger {
-              top: -7px;
+              margin-left: -34px;
+              top: -6px;
             }
           }
 

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -50,7 +50,7 @@ $datagrid-row-height: 43px;
 $datagrid-medium-header-height: 30px;
 $datagrid-medium-row-height: 33px;
 $datagrid-short-header-height: 25px;
-$datagrid-short-row-height: 26px;
+$datagrid-short-row-height: 25px;
 
 // Main Datagrid Container
 .datagrid-container {

--- a/src/components/datagrid/datagrid.editors.js
+++ b/src/components/datagrid/datagrid.editors.js
@@ -791,11 +791,8 @@ const editors = {
       }
 
       // Update on change from lookup
-      self.input.on('change', () => {
-        setTimeout(() => {
-          container.parent().focus();
-          grid.quickEditMode = false;
-        }, 1);
+      self.input.on('change.editorlookup', () => {
+        grid.quickEditMode = false;
       });
     };
 

--- a/src/components/lookup/lookup.js
+++ b/src/components/lookup/lookup.js
@@ -683,6 +683,7 @@ Lookup.prototype = {
       * @property {object} selected rows
       */
     this.element.val(value).trigger('change', [this.selectedRows]);
+    this.element.trigger('input', [this.selectedRows]);
     this.applyAutoWidth();
     this.element.focus();
   },

--- a/test/components/bar/bar-grouped.e2e-spec.js
+++ b/test/components/bar/bar-grouped.e2e-spec.js
@@ -29,6 +29,7 @@ describe('Grouped Bar Chart example-index tests', () => {
 
   it('Should highlight when selected', async () => {
     await element(by.css('.series-group:nth-child(-n+3)')).click();
+    await browser.driver.sleep(config.sleepShort);
 
     expect(await element(by.css('.series-group:nth-child(-n+3)')).getAttribute('class')).toContain('is-selected');
   });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

In a very specific example with datagrid, new rows and lookup with a mask. The value is cleared when selected. This issue fixes it. Also added a possible fix for a test i saw fail and an example of a lookup mask to the lookup page for testing, there wasnt any issue with it but i kept it in for reference.

**Related github/jira issue (required)**:
Fixes #2305 

**Steps necessary to review your pull request (required)**:
- open an IE VM
- open http://localhost:4000/components/datagrid/test-lookup-with-mask in IE11
- click add row to top 
- click into the product id cell with zero in it to focus
- click the lookup to open and pick a value (should now select)
- also test lookup editing with keyboard in quick and non quick mode for good measure.

**Included in this Pull Request**:
- [x] A note to the change log.
