### PR TITLE
2578 - Searchfield: Close icon [v4.20.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -104,6 +104,7 @@
 - `[Popupmenu]` Added a type-check during building/rebuilding of submenus that prevents an error when a submenu `<ul>` tag is not present. ([#2458](https://github.com/infor-design/enterprise/issues/2458))
 - `[Scatter Plot]` Fixed the incorrect color on the tooltips. ([#1066](https://github.com/infor-design/enterprise/issues/1066))
 - `[Stepprocess]` Fixed an issue where a newly enabled step is not shown. ([#2391](https://github.com/infor-design/enterprise/issues/2391))
+- `[Searchfield]` Fixed an issue where the close icon on a searchfield is inoperable. ([#2578](https://github.com/infor-design/enterprise/issues/2578))
 - `[Tabs]` Fixed the more tabs button to style as disabled when the tabs component is disabled. ([#2347](https://github.com/infor-design/enterprise/issues/2347))
 - `[Tabs]` Added the select method inside the hide method to ensure proper focusing of the selected tab. ([#2346](https://github.com/infor-design/enterprise/issues/2346))
 - `[Tabs]` Added an independent count for adding new tabs and their associated IDs to prevent duplication. ([#2345](https://github.com/infor-design/enterprise/issues/2345))

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -301,7 +301,7 @@ $toolbarsearchfield-category-empty-width: 51px;
 
     &.show-category {
       .searchfield {
-        padding-left: 0;
+        padding-left: 5px;
       }
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The close icon in a toolbar searchfield defers pointer events when the class `is-open` is not present. This PR changes the class for this rule to `active` to ensure all toolbar searchfield close icons are considered and also changes the approach to `display: none;` from `pointer-events: none;` to ensure there is no display of the close icon that is potentially uninteractable.

Also tested the pages on this PR as this is where the rule in question was created.
https://github.com/infor-design/enterprise/pull/2086


**Related github/jira issue (required)**:
Closes #2578 .

**Steps necessary to review your pull request (required)**:
- Pull branch, build and run app
- Visit http://localhost:4000/components/tabs-module/example-category-searchfield-go-button-home.html
  - Ensure the close icon is operable after typing text in searchfield, clicking away to unfocus, clicking back in searchfield.
  - Ensure close icon operates as expected when performing the above test on all searchfield pages.

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [ ] A note to the change log.