### PR TITLE
466 - Listview: Search not working the same in NG

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -103,7 +103,7 @@
 - `[Tabs]` Added the select method inside the hide method to ensure proper focusing of the selected tab. ([#2346](https://github.com/infor-design/enterprise/issues/2346))
 - `[Tabs]` Added an independent count for adding new tabs and their associated IDs to prevent duplication. ([#2345](https://github.com/infor-design/enterprise/issues/2345))
 - `[Toolbar Flex]` Removed a 100% height on the toolbar which caused issues when nested in some situations. ([#474](https://github.com/infor-design/enterprise-ng/issues/474))
-- `[Listview]` Search not working the same as EP. ([#466](https://github.com/infor-design/enterprise-ng/issues/466))
+- `[Listview]` Fixed search to work when not using templates. ([#466](https://github.com/infor-design/enterprise-ng/issues/466))
 
 ### v4.20.0 Chores & Maintenance
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -103,7 +103,7 @@
 - `[Tabs]` Added the select method inside the hide method to ensure proper focusing of the selected tab. ([#2346](https://github.com/infor-design/enterprise/issues/2346))
 - `[Tabs]` Added an independent count for adding new tabs and their associated IDs to prevent duplication. ([#2345](https://github.com/infor-design/enterprise/issues/2345))
 - `[Toolbar Flex]` Removed a 100% height on the toolbar which caused issues when nested in some situations. ([#474](https://github.com/infor-design/enterprise-ng/issues/474))
-- `[Listview]` Search not working the same as EP.([#466] (https://github.com/infor-design/enterprise-ng/issues/466))
+- `[Listview]` Search not working the same as EP. ([#466](https://github.com/infor-design/enterprise-ng/issues/466))
 
 ### v4.20.0 Chores & Maintenance
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -103,6 +103,7 @@
 - `[Tabs]` Added the select method inside the hide method to ensure proper focusing of the selected tab. ([#2346](https://github.com/infor-design/enterprise/issues/2346))
 - `[Tabs]` Added an independent count for adding new tabs and their associated IDs to prevent duplication. ([#2345](https://github.com/infor-design/enterprise/issues/2345))
 - `[Toolbar Flex]` Removed a 100% height on the toolbar which caused issues when nested in some situations. ([#474](https://github.com/infor-design/enterprise-ng/issues/474))
+- `[Listview]` Search not working the same as EP.([#466] (https://github.com/infor-design/enterprise-ng/issues/466))
 
 ### v4.20.0 Chores & Maintenance
 

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -358,14 +358,24 @@ ListView.prototype = {
         }
 
         if (self.settings.showCheckboxes) {
-          // For mixed selection mode primarily append a checkbox object
-          item.prepend(`<label class="listview-selection-checkbox l-vertical-center inline inline-checkbox">
-            <input tabindex="-1" type="checkbox" class="checkbox">
-            <span class="label-text" role="presentation">
-              <span class="audible">${Locale.translate('Checkbox')} ${Locale.translate('NotSelected')}.</span>
-            </span>
-          </label>`);
+          // Only need one checkbox 
+          if(item.children('.listview-selection-checkbox').length === 0) {
+            // For mixed selection mode primarily append a checkbox object
+            item.prepend(`<label class="listview-selection-checkbox l-vertical-center inline inline-checkbox">
+              <input tabindex="-1" type="checkbox" class="checkbox">
+              <span class="label-text" role="presentation">
+                <span class="audible">${Locale.translate('Checkbox')} ${Locale.translate('NotSelected')}.</span>
+              </span>
+            </label>`);
+          } 
         }
+      }
+
+      // Hide filtered items
+      const n = firstRecordIdx + i;
+      if (n < self.settings.dataset.length) {
+      	const data = self.settings.dataset[n];
+      	item.css('display', (data.isFiltered === undefined || data.isFiltered) ? '' : 'none');
       }
 
       // Add Aria
@@ -659,12 +669,26 @@ ListView.prototype = {
 
     // Make sure there is a search term...and its not the
     // same as the previous term
-    if (searchFieldVal.length < 2 || this.searchTerm === searchFieldVal) {
+    if (searchFieldVal.length < 2) {
+      this.searchTerm = '';  
+      this.element.unhighlight();
+      return;
+    }
+
+    if (this.searchTerm === searchFieldVal) {
       return;
     }
 
     // Set a global "searchTerm" and get the list of elements
     this.searchTerm = searchFieldVal;
+
+    // Clean highlight marks before new filter action
+    this.element.unhighlight();
+
+    // Reset filter status
+    this.settings.dataset.forEach(function(item) {
+      item.isFiltered = false;
+    });
 
     // Filter the results and highlight things
     let results = this.listfilter.filter(this.settings.dataset, this.searchTerm);

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -344,7 +344,7 @@ ListView.prototype = {
     }
 
     // When DOM items are not rendered with "mustache" template, filtered items 
-    // have to be hiden specifically.  
+    // have to be hidden specifically.  
     const hideFlag = items.length > displayedDataset.length;
 
     items.each(function (i) {

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -363,7 +363,7 @@ ListView.prototype = {
 
         if (self.settings.showCheckboxes) {
           // Only need one checkbox 
-          if(item.children('.listview-selection-checkbox').length === 0) {
+          if (item.children('.listview-selection-checkbox').length === 0) {
             // For mixed selection mode primarily append a checkbox object
             item.prepend(`<label class="listview-selection-checkbox l-vertical-center inline inline-checkbox">
               <input tabindex="-1" type="checkbox" class="checkbox">
@@ -379,8 +379,8 @@ ListView.prototype = {
       if (hideFlag) {
         const n = firstRecordIdx + i;
         if (n < self.settings.dataset.length) {
-            const data = self.settings.dataset[n];
-           item.css('display', (data.isFiltered === undefined || data.isFiltered) ? '' : 'none');
+          const data = self.settings.dataset[n];
+          item.css('display', (data.isFiltered === undefined || data.isFiltered) ? '' : 'none');
         }
       }
 
@@ -691,10 +691,9 @@ ListView.prototype = {
     this.element.unhighlight();
 
     // Reset filter status
-    this.settings.dataset.forEach(function(item) {
+    this.settings.dataset.forEach(function (item) {
       item.isFiltered = false;
     });
-    
 
     // Filter the results and highlight things
     let results = this.listfilter.filter(this.settings.dataset, this.searchTerm);

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -319,7 +319,7 @@ ListView.prototype = {
         DOM.append(this.element, this.emptyMessageContainer[0].outerHTML, '<div><svg><use><span><b>');
       } else if (displayedDataset.length === 0) {
         this.element.html(renderedTmpl || '<ul></ul>');
-      }
+      }      
     }
 
     // Add Aria
@@ -341,6 +341,10 @@ ListView.prototype = {
     if (!this.settings.selectable && first.find('a').length === 1) {
       first.removeAttr('tabindex');
     }
+
+    // When DOM items are not rendered with "mustache" template, filtered items 
+    // have to be hiden specifically.  
+    const hideFlag = items.length > displayedDataset.length;
 
     items.each(function (i) {
       const item = $(this);
@@ -372,10 +376,12 @@ ListView.prototype = {
       }
 
       // Hide filtered items
-      const n = firstRecordIdx + i;
-      if (n < self.settings.dataset.length) {
-      	const data = self.settings.dataset[n];
-      	item.css('display', (data.isFiltered === undefined || data.isFiltered) ? '' : 'none');
+      if (hideFlag) {
+        const n = firstRecordIdx + i;
+        if (n < self.settings.dataset.length) {
+            const data = self.settings.dataset[n];
+           item.css('display', (data.isFiltered === undefined || data.isFiltered) ? '' : 'none');
+        }
       }
 
       // Add Aria
@@ -670,8 +676,7 @@ ListView.prototype = {
     // Make sure there is a search term...and its not the
     // same as the previous term
     if (searchFieldVal.length < 2) {
-      this.searchTerm = '';  
-      this.element.unhighlight();
+      this.resetSearch();
       return;
     }
 
@@ -689,12 +694,14 @@ ListView.prototype = {
     this.settings.dataset.forEach(function(item) {
       item.isFiltered = false;
     });
+    
 
     // Filter the results and highlight things
     let results = this.listfilter.filter(this.settings.dataset, this.searchTerm);
     if (!results.length) {
       results = [];
     }
+    
     pagingInfo.filteredTotal = results.length;
     pagingInfo.searchActivePage = 1;
     results.forEach((result) => {

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -65,7 +65,8 @@ const LISTVIEW_DEFAULTS = {
   pagerSettings: {
     showFirstButton: false,
     showLastButton: false
-  }
+  },
+  searchTermMinSize: 0
 };
 
 function ListView(element, settings) {
@@ -319,7 +320,7 @@ ListView.prototype = {
         DOM.append(this.element, this.emptyMessageContainer[0].outerHTML, '<div><svg><use><span><b>');
       } else if (displayedDataset.length === 0) {
         this.element.html(renderedTmpl || '<ul></ul>');
-      }      
+      }
     }
 
     // Add Aria
@@ -371,7 +372,7 @@ ListView.prototype = {
                 <span class="audible">${Locale.translate('Checkbox')} ${Locale.translate('NotSelected')}.</span>
               </span>
             </label>`);
-          } 
+          }
         }
       }
 
@@ -382,6 +383,8 @@ ListView.prototype = {
           const data = self.settings.dataset[n];
           item.css('display', (data.isFiltered === undefined || data.isFiltered) ? '' : 'none');
         }
+      } else {
+        item.css('display', '');
       }
 
       // Add Aria
@@ -675,7 +678,7 @@ ListView.prototype = {
 
     // Make sure there is a search term...and its not the
     // same as the previous term
-    if (searchFieldVal.length < 2) {
+    if (searchFieldVal.length <= this.settings.searchTermMinSize) {
       this.resetSearch();
       return;
     }
@@ -700,7 +703,7 @@ ListView.prototype = {
     if (!results.length) {
       results = [];
     }
-    
+
     pagingInfo.filteredTotal = results.length;
     pagingInfo.searchActivePage = 1;
     results.forEach((result) => {
@@ -728,6 +731,13 @@ ListView.prototype = {
    * @returns {void}
    */
   resetSearch() {
+    this.element.unhighlight();
+
+    //reset filter status
+    this.settings.dataset.forEach(function (item) {
+      delete item.isFiltered;
+    });
+
     if (this.filteredDataset) {
       delete this.filteredDataset;
     }
@@ -1318,10 +1328,10 @@ ListView.prototype = {
         }
 
         if ((!isSelect) &&
-            (!item.hasClass('is-disabled')) &&
-            (self.settings.selectOnFocus) &&
-            (self.settings.selectable !== 'multiple') &&
-            (self.settings.selectable !== 'mixed')) {
+          (!item.hasClass('is-disabled')) &&
+          (self.settings.selectOnFocus) &&
+          (self.settings.selectable !== 'multiple') &&
+          (self.settings.selectable !== 'mixed')) {
           self.select(item);
           isSelect = true;
           isFocused = true;

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -703,7 +703,6 @@ ListView.prototype = {
     if (!results.length) {
       results = [];
     }
-
     pagingInfo.filteredTotal = results.length;
     pagingInfo.searchActivePage = 1;
     results.forEach((result) => {
@@ -733,7 +732,7 @@ ListView.prototype = {
   resetSearch() {
     this.element.unhighlight();
 
-    //reset filter status
+    // reset filter status
     this.settings.dataset.forEach(function (item) {
       delete item.isFiltered;
     });

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -43,6 +43,7 @@ const COMPONENT_NAME = 'listview';
  * @param {boolean} [settings.showPageSizeSelector=false] If true the page size select will be shown when paging.
  * @param {object} [settings.listFilterSettings=null] If defined as an object, passes settings into the internal ListFilter component
  * @param {object} [settings.pagerSettings=null] If defined as an object, passes settings into the internal Pager component
+ * @param {object} [settings.searchTermMinSize=1] The search term will trigger filtering only when its length is greater than or equals to the value.
  */
 const LISTVIEW_DEFAULTS = {
   dataset: [],
@@ -66,7 +67,7 @@ const LISTVIEW_DEFAULTS = {
     showFirstButton: false,
     showLastButton: false
   },
-  searchTermMinSize: 0
+  searchTermMinSize: 1
 };
 
 function ListView(element, settings) {
@@ -678,7 +679,7 @@ ListView.prototype = {
 
     // Make sure there is a search term...and its not the
     // same as the previous term
-    if (searchFieldVal.length <= this.settings.searchTermMinSize) {
+    if (searchFieldVal.length < this.settings.searchTermMinSize) {
       this.resetSearch();
       return;
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
update render function to reflect filtered status of items
highlight marks should be cleaned before new filter action, otherwise, new filter action would fail.

**Related github/jira issue (required)**:
Fixes #infor-design/enterprise-ng/issues/466 

**Steps necessary to review your pull request (required)**:
1. build sohoxi.js
1. update node_modules\ids-enterprise\dist\js\sohoxi.js in enterprise-ng
1. run command: npm start
1. open http://loalhost:4200 in a browser, and open ListView page, enter 063003 in search box, make sure only item with text 063003  would be displayed, other items are not displayed.
1. then change 063003 to 0, make sure all items are displayed and also highlight marks are cleaned
1. then change 0 to 06, make sure all items with 06 are displayed, and 06 are highlighted.
1. test listview in EP a bit

![image](https://user-images.githubusercontent.com/39074182/62338398-f8347a80-b50a-11e9-81c0-71e211527781.png)

**Included in this Pull Request**:
- [x] A note to the change log.

