### PR TITLE
2590  - Fixing paging and removeRow in datagrid [v4.20.x]

### DIFF
--- a/app/views/components/datagrid/example-paging-client-side.html
+++ b/app/views/components/datagrid/example-paging-client-side.html
@@ -43,7 +43,7 @@
           dataset: res.data,
           selectable: 'multiple',
           paging: true,
-          pagesize: 15,
+          pagesize: 10,
           toolbar: {title: 'Compressors', results: true, keywordFilter: true, actions: true, rowHeight: true}
           }).on('selected', function (e, args) {
             console.log(args);
@@ -52,7 +52,9 @@
           });
       });
 
-
+      $('#datagrid-remove-btn').on('click', function() {
+        $('#datagrid').data('datagrid').removeSelected();
+      });
   });
 
 

--- a/app/views/components/datagrid/example-paging.html
+++ b/app/views/components/datagrid/example-paging.html
@@ -1,17 +1,6 @@
 
 <div class="row">
   <div class="twelve columns">
-    <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">0 Selected</div>
-      <div class="buttonset">
-        <button id="datagrid-remove-btn" class="btn" type="button">
-          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-            <use xlink:href="#icon-delete"></use>
-          </svg>
-          <span>Remove</span>
-        </button>
-      </div>
-    </div>
     <div id="datagrid">
     </div>
   </div>

--- a/app/views/components/datagrid/example-paging.html
+++ b/app/views/components/datagrid/example-paging.html
@@ -75,14 +75,5 @@
         console.log('Removed:', args);
       });
 
-      $('#datagrid-remove-btn').on('click', function() {
-        // Will trigger `rowremove` with every row removed for more then one selected rows
-        $('#datagrid').data('datagrid').removeSelected();
-
-        // Will trigger `rowremove` one time only for more then one selected rows
-        // If passed the `boolean:true` to catch all the removed rows at once
-        // $('#datagrid').data('datagrid').removeSelected(true);
-      });
-
   });
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -73,6 +73,7 @@
 - `[Datepicker]` Removed the advanceMonths option as the dropdowns for this are no longer there in the new design. ([#970](https://github.com/infor-design/enterprise/issues/970))
 - `[Datagrid]` Fixed a bug where deselect all would not deselect some rows when using grouping. ([#1796](https://github.com/infor-design/enterprise/issues/1796))
 - `[Datagrid]` Fixed a bug where summary counts in grouping would show even if the group is collapsed. ([#2221](https://github.com/infor-design/enterprise/issues/2221))
+- `[Datagrid]` Fixed issues when using paging (client side) and removeRow. ([#2590](https://github.com/infor-design/enterprise/issues/2590))
 - `[Demoapp]` When displaying Uplift theme, now shows the correct alternate fonts for some locales when switching via the `locale` query string. ([#2365](https://github.com/infor-design/enterprise/issues/2365))
 - `[Dropdown]` Fixed a memory leak when calling destroy. ([#2493](https://github.com/infor-design/enterprise/issues/2493))
 - `[Editor]` Fixed a bug where tab or shift tab would break out of the editor when doing an indent/outdent. ([#2421](https://github.com/infor-design/enterprise/issues/2421))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -488,9 +488,10 @@ Datagrid.prototype = {
   /**
   * Refresh the pager based on the current page and dataset.
   * @private
-  * @param {object} location Deprecated - Can be set to 'top' or left off for bottom pager.
+  * @param {object} location Can be set to 'top' or left off for bottom pager.
+  * @param {boolean} savePage if true the activate page will be restored.
   */
-  pagerRefresh(location) {
+  pagerRefresh(location, savePage) {
     if (!this.pagerAPI) {
       return;
     }
@@ -506,6 +507,10 @@ Datagrid.prototype = {
     if (!this.settings.source) {
       pagingInfo.total = this.settings.dataset.length;
       pagingInfo.pagesize = this.settings.pagesize;
+    }
+    if (savePage) {
+      pagingInfo.activePage = this.settings.pagesize * this.pager.activePage >
+        this.settings.dataset.length ? 1 : this.pager.activePage;
     }
     this.renderPager(pagingInfo, true);
   },
@@ -529,7 +534,7 @@ Datagrid.prototype = {
     this.preventSelection = true;
     if (!noSync) {
       this.setRowGrouping();
-      this.pagerRefresh();
+      this.pagerRefresh('top', true);
       this.renderRows();
     }
 

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -2021,7 +2021,6 @@ describe('Datagrid paging serverside multi select tests 2nd page', () => {
     await browser.actions().click(checkboxTd).perform();
 
     expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(10);
-    expect(await element.all(by.css('.contextual-toolbar .title.selection-count')).getText()).toEqual(['10 Selected']);
     expect(await element(by.css('#datagrid .datagrid-header th .datagrid-checkbox.is-checked.is-partial')).isPresent()).toBeFalsy();
     expect(await element(by.css('#datagrid .datagrid-header th .datagrid-checkbox.is-checked')).isPresent()).toBeTruthy();
 
@@ -2029,7 +2028,6 @@ describe('Datagrid paging serverside multi select tests 2nd page', () => {
     await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(2) td:nth-child(1)')).click();
 
     expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(8);
-    expect(await element.all(by.css('.contextual-toolbar .title.selection-count')).getText()).toEqual(['8 Selected']);
     expect(await element(by.css('#datagrid .datagrid-header th .datagrid-checkbox.is-checked.is-partial')).isPresent()).toBeTruthy();
     expect(await element(by.css('#datagrid .datagrid-header th .datagrid-checkbox.is-checked')).isPresent()).toBeTruthy();
   });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

QA found some regressions with paging and remove row and i fixed the behavior. For serverside paging removeRow wont work so removed the clear from it but made it work on the other client side examples.

**Related github/jira issue (required)**:
Fixed #2590 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-editable.html
- select and remove row 4
- go to page 2
- select and remove row 7
- will now go to page one
- go to http://localhost:4000/components/datagrid/example-paging
- select a row(s) -> there is now no Contextual toolbar you cannot clear here
- http://localhost:4000/components/datagrid/example-paging-client-side
- select some rows on random pages and delete them -> the pager will stay on the page and the rows will recalulate to pagesize

**Included in this Pull Request**:
- [x] A note to the change log.
