### PR TITLE
2598/2597 - Fix range picker mask showing 'loc' and title placement [v4.20.x]

### DIFF
--- a/app/views/components/datepicker/test-placeholder.html
+++ b/app/views/components/datepicker/test-placeholder.html
@@ -1,0 +1,23 @@
+<div class="row">
+  <div class="twelve columns">
+    <h2 class="fieldset-title">Date Picker - With Placeholder</h2>
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="field">
+      <label for="date-field" class="label">Date Field with Legend</label>
+      <input id="date-field" data-init="false" class="datepicker" name="date-field" type="text" />
+    </div>
+
+  </div>
+</div>
+
+<script>
+  $('#date-field').datepicker({
+    placeholder: true,
+    dateFormat: 'yyyy-MM-DD'
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,8 @@
 - `[Datagrid]` Fixed a bug that the selected event would fire when no rows are deselected and on initial load. ([#2472](https://github.com/infor-design/enterprise/issues/2472))
 - `[Datagrid]` Removed a white background from the colorpicker editor in high contrast theme. ([#1574](https://github.com/infor-design/enterprise/issues/1574))
 - `[Datepicker]` Made the showMonthYearPicker option true by default and added a newly designed panel to select the year and day. ([#1958](https://github.com/infor-design/enterprise/issues/1958))
+- `[Datepicker]` Fixed a layout issue in IE 11 with the datepicker title. ([#2598](https://github.com/infor-design/enterprise/issues/2598))
+- `[Datepicker]` Fixed issues with the mask when using the range picker. ([#2597](https://github.com/infor-design/enterprise/issues/2597))
 - `[Dropdown]` Fixed an issue where ellipsis was not working when use firefox new tab. ([#2236](https://github.com/infor-design/enterprise/issues/2236))
 - `[Form Compact]` Added checkboxes/radios, and improved visual style. ([#2193](https://github.com/infor-design/enterprise/issues/2193))
 - `[Images]` Created an additional image class to apply focus state without coercing width and height. ([#2025](https://github.com/infor-design/enterprise/issues/2025))

--- a/src/components/datepicker/_datepicker.scss
+++ b/src/components/datepicker/_datepicker.scss
@@ -185,3 +185,9 @@ html[dir='rtl'] {
     }
   }
 }
+
+.ie-edge {
+  .monthview .btn-monthyear-pane {
+    margin-left: 10px;
+  }
+}

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -198,9 +198,7 @@ DatePicker.prototype = {
     this.conversions = this.currentCalendar.conversions;
     this.isFullMonth = this.settings.dateFormat.indexOf('MMMM') > -1;
     this.setFormat();
-    if (this.element.data('mask') === undefined) {
-      this.mask();
-    }
+    this.mask();
   },
 
   /**
@@ -404,7 +402,7 @@ DatePicker.prototype = {
 
     if (this.isFullMonth) {
       this.pattern = this.settings.dateFormat;
-    } else {
+    } else if (this.element.data('mask') === undefined) {
       this.element.mask(maskOptions);
     }
 

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -198,7 +198,9 @@ DatePicker.prototype = {
     this.conversions = this.currentCalendar.conversions;
     this.isFullMonth = this.settings.dateFormat.indexOf('MMMM') > -1;
     this.setFormat();
-    this.mask();
+    if (this.element.data('mask') === undefined) {
+      this.mask();
+    }
   },
 
   /**
@@ -364,6 +366,7 @@ DatePicker.prototype = {
 
     if (s.dateFormat === 'locale') {
       this.pattern = localeDateFormat + (s.showTime ? ` ${(s.timeFormat || localeTimeFormat)}` : '');
+      s.dateFormat = this.pattern;
     } else {
       this.pattern = s.dateFormat + (s.showTime && s.timeFormat ? ` ${s.timeFormat}` : '');
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes two issue in datepicker, one is an IE Edge placement issue with the title. The second is a mask issue on the range date picker.

**Related github/jira issue (required)**:
Fixes #2598 
Fixes #2597 

**Steps necessary to review your pull request (required)**:
2598
- go to http://localhost:4000/components/datepicker/example-index on IE edge and/or IE 11
- Look at the title (month year) layout should look similar to chrome
- also test http://localhost:4000/components/datepicker/test-no-month-year-picker.html

2597
- go to http://localhost:4000/components/datepicker/example-range on IE edge or IE 11
- in the first range picker "Range - No Initial value" select any range
- click out of the field -> should not show loc
- go to http://localhost:4000/components/datepicker/example-range in chrome
- in the first range picker "Range - No Initial value" select any range
- attempt to type a character like "l" at the end of the selected range (nothing should happen)

**Included in this Pull Request**:
- [x] A note to the change log.
