### PR TITLE
2612 - Improve Uplift Searchfield styles [v4.20.x]

### DIFF
--- a/app/views/components/input/test-comparison-of-fields.html
+++ b/app/views/components/input/test-comparison-of-fields.html
@@ -7,7 +7,7 @@
 
     <div class="field">
       <label for="searchfield">Searchfield</label>
-      <input type="text" class="searchfield" id="searchfield" name="searchfield" placeholder="Keyword Search" data-options="{ clearable: true }"/>
+      <input id="searchfield" data-init="false" type="text" class="searchfield" name="searchfield" placeholder="Keyword Search"/>
     </div>
 
     <div class="field">
@@ -73,6 +73,13 @@
         response(data);
       });
     }
+  });
+
+  $('#searchfield').searchfield({
+    clearable: true,
+    categories: ['Books', 'Movies', 'TV Shows', 'Video Games'],
+    showGoButton: true,
+    showCategoryText: true
   });
 
   $('#datepicker').datepicker({

--- a/app/views/components/input/test-comparison-of-fields.html
+++ b/app/views/components/input/test-comparison-of-fields.html
@@ -1,0 +1,106 @@
+<div class="row">
+  <div class="one-half column">
+    <div class="field">
+      <label for="normal">Normal text Field</label>
+      <input type="text" id="normal" name="normal" placeholder="Normal text Field"/>
+    </div>
+
+    <div class="field">
+      <label for="searchfield">Searchfield</label>
+      <input type="text" class="searchfield" id="searchfield" name="searchfield" placeholder="Keyword Search" data-options="{ clearable: true }"/>
+    </div>
+
+    <div class="field">
+      <label for="colorpicker">Colorpicker</label>
+      <input class="colorpicker" id="colorpicker" type="text" />
+    </div>
+
+    <div class="field">
+      <label for="spinbox">Spinbox</label>
+      <input id="spinbox" name="spinbox" type="text" class="spinbox" value="10" data-options="{min: -1000, max: 1000}"/>
+    </div>
+  </div>
+  <div class="one-half column">
+    <div class="field">
+      <label for="datepicker">Date Picker</label>
+      <input id="datepicker" data-init="false" class="datepicker" name="datepicker" type="text"/>
+    </div>
+
+    <div class="field">
+      <label for="timepicker">Time Picker</label>
+      <input id="timepicker" class="timepicker" name="timepicker" type="text"/>
+    </div>
+
+    <div class="field">
+      <label for="lookup" class="label">Products</label>
+      <input id="lookup" data-init="false" class="lookup" name="lookup" type="text"/>
+    </div>
+
+    <div class="field">
+      <label for="dropdown">Dropdown</label>
+      <select class="dropdown" id="dropdown" name="dropdown" data-init="false"/>
+    </div>
+  </div>
+</div>
+
+<script id="test-script">
+  var grid,
+    columns = [],
+    data = [];
+
+  // Some Sample Data for the Lookup
+  data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+  data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+  data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+  data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+  data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+  data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+  data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+
+  // Define Columns for the Lookup's Datagrid
+  columns.push({ id: 'productId', name: 'Product Id', field: 'productId'});
+  columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink});
+  columns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity'});
+  columns.push({ id: 'quantity', filterType: 'text', name: 'Quantity', field: 'quantity'});
+  columns.push({ id: 'price', name: 'Price', field: 'price', formatter: Formatters.Decimal});
+
+  // ===========================================
+  // Invoke a bunch of components manually
+  // ===========================================
+  $('#dropdown').dropdown({
+    source: function (response, term) {
+      $.getJSON('{{basepath}}api/states', function(data, term) {
+        response(data);
+      });
+    }
+  });
+
+  $('#datepicker').datepicker({
+    dateFormat: 'yyyy/M/d',
+    timeFormat: 'HH:mm',
+    showTime: true
+  });
+
+  grid = $('#lookup').lookup({
+    field: 'lookup',
+    autoApply: true,
+    options: {
+      columns: columns,
+      dataset: data,
+      selectable: 'single',
+      rowNavigation: true,
+      toolbar: {
+        results: true,
+        keywordFilter: true,
+        advancedFilter: false,
+        actions: false,
+        selectable: 'single',
+        filterable: true,
+        views: true,
+        rowHeight: false,
+        collapsibleFilter: false,
+        fullWidth: true
+      }
+    }
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -108,6 +108,7 @@
 - `[Scatter Plot]` Fixed the incorrect color on the tooltips. ([#1066](https://github.com/infor-design/enterprise/issues/1066))
 - `[Stepprocess]` Fixed an issue where a newly enabled step is not shown. ([#2391](https://github.com/infor-design/enterprise/issues/2391))
 - `[Searchfield]` Fixed an issue where the close icon on a searchfield is inoperable. ([#2578](https://github.com/infor-design/enterprise/issues/2578))
+- `[Searchfield]` Fixed strange alignment of text/icons on the Uplift theme. ([#2612](https://github.com/infor-design/enterprise/issues/2612))
 - `[Tabs]` Fixed the more tabs button to style as disabled when the tabs component is disabled. ([#2347](https://github.com/infor-design/enterprise/issues/2347))
 - `[Tabs]` Added the select method inside the hide method to ensure proper focusing of the selected tab. ([#2346](https://github.com/infor-design/enterprise/issues/2346))
 - `[Tabs]` Added an independent count for adding new tabs and their associated IDs to prevent duplication. ([#2345](https://github.com/infor-design/enterprise/issues/2345))

--- a/src/components/datepicker/_datepicker-uplift.scss
+++ b/src/components/datepicker/_datepicker-uplift.scss
@@ -17,6 +17,16 @@
   }
 }
 
+// Firefox needs some help
+html.is-firefox {
+  .datepicker {
+    + .icon,
+    + .tooltip-description + .icon {
+      margin-top: 9px;
+    }
+  }
+}
+
 html[dir='rtl'] {
   .field-short {
     .datepicker {

--- a/src/components/dropdown/_dropdown-uplift.scss
+++ b/src/components/dropdown/_dropdown-uplift.scss
@@ -7,6 +7,7 @@ $dropdown-size-padding-x-r: 30px;
 div.dropdown,
 div.multiselect {
   + .icon {
+    right: 8px;
     top: 3px;
   }
 
@@ -151,6 +152,10 @@ html.is-firefox:not([dir='rtl']) {
 html[dir='rtl'] {
   div.dropdown,
   div.multiselect {
+    + .icon {
+      left: 8px;
+    }
+
     .listoption-icon {
       top: 10px;
     }
@@ -159,6 +164,12 @@ html[dir='rtl'] {
   .dropdown-list {
     > .listoption-icon {
       top: 9px;
+    }
+
+    > .trigger {
+      .icon {
+        margin-right: -24px;
+      }
     }
   }
 

--- a/src/components/lookup/_lookup-uplift.scss
+++ b/src/components/lookup/_lookup-uplift.scss
@@ -11,6 +11,16 @@
   }
 }
 
+html.is-firefox {
+  .lookup-wrapper {
+    .trigger {
+      .icon {
+        top: 6px;
+      }
+    }
+  }
+}
+
 html[dir='rtl'] {
   .field-short {
     .lookup-wrapper {

--- a/src/components/searchfield/_searchfield-uplift.scss
+++ b/src/components/searchfield/_searchfield-uplift.scss
@@ -9,8 +9,19 @@
 
 .searchfield-wrapper {
   > .icon {
+    top: 12px;
+
     &.close {
       right: 8px;
+    }
+  }
+}
+
+// Firefox needs some help
+html.is-firefox {
+  .searchfield-wrapper {
+    > .icon {
+      top: 10px;
     }
   }
 }

--- a/src/components/searchfield/_searchfield-uplift.scss
+++ b/src/components/searchfield/_searchfield-uplift.scss
@@ -13,15 +13,30 @@
 
     &.close {
       right: 8px;
+      top: 13px;
     }
+  }
+
+  .go-button {
+    height: 100%;
+  }
+
+  .searchfield-category-button {
+    height: 38px;
   }
 }
 
 // Firefox needs some help
 html.is-firefox {
   .searchfield-wrapper {
+    height: 34px;
+
     > .icon {
       top: 10px;
+    }
+
+    .searchfield-category-button {
+      height: inherit;
     }
   }
 }
@@ -32,6 +47,24 @@ html[dir='rtl'] {
       &.close {
         left: 8px;
         right: auto;
+      }
+    }
+
+    .searchfield-category-button {
+      height: 39px;
+    }
+  }
+
+  &.is-firefox {
+    .searchfield-wrapper {
+      > .icon {
+        &.close {
+          top: 10px;
+        }
+      }
+
+      .searchfield-category-button {
+        height: inherit;
       }
     }
   }

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -366,6 +366,11 @@ html[dir='rtl'] {
       padding-right: 34px;
     }
 
+    .go-button {
+      margin-left: 0;
+      margin-right: 10px;
+    }
+
     > .icon {
       &:not(.close) {
         left: auto;
@@ -421,6 +426,7 @@ html[dir='rtl'] {
         &.show-category {
           .searchfield {
             border-right: 1px solid $input-color-initial-border;
+            padding-right: 10px;
           }
         }
       }

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -67,7 +67,6 @@ $cubic-bezier-ease: cubic-bezier(0.17, 0.04, 0.03, 0.94);
   }
 
   .searchfield {
-    height: 34px;
     padding-left: 34px;
     padding-right: 10px;
 
@@ -253,7 +252,6 @@ $cubic-bezier-ease: cubic-bezier(0.17, 0.04, 0.03, 0.94);
     border-top-right-radius: 0;
     color: $font-color;
     font-weight: $theme-number-font-weight-base;
-    height: 34px;
     margin: 0;
     min-width: 0;
     padding: 0 0 0 10px;
@@ -349,6 +347,14 @@ $cubic-bezier-ease: cubic-bezier(0.17, 0.04, 0.03, 0.94);
 
   &.alternate {
     background-color: $searchfield-context-alt-bg;
+  }
+}
+
+// Remove the bottom margin when inside of `.field` or `.field-short`
+.field,
+.field-short {
+  .searchfield-wrapper {
+    margin-bottom: 0;
   }
 }
 

--- a/src/components/timepicker/_timepicker-uplift.scss
+++ b/src/components/timepicker/_timepicker-uplift.scss
@@ -1,6 +1,14 @@
 // Uplift Timepicker
 //================================================== //
 
+.timepicker {
+  + .icon,
+  + .tooltip-description + .icon {
+    margin-left: -29px;
+    margin-top: 10px;
+  }
+}
+
 .field-short {
   .timepicker {
     + .icon,
@@ -11,7 +19,24 @@
   }
 }
 
+html.is-firefox {
+  .timepicker {
+    + .icon,
+    + .tooltip-description + .icon {
+      margin-top: 8px;
+    }
+  }
+}
+
 html[dir='rtl'] {
+  .timepicker {
+    + .icon,
+    + .tooltip-description + .icon {
+      margin-left: auto;
+      margin-right: -29px;
+    }
+  }
+
   .field-short {
     .timepicker {
       + .icon,


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a handful of minor text/icon/padding alignments on the Searchfield component.  This PR also adds a test page that implements a Searchfield alongside of other complex components so we can better see it on a "form" environment.

Additionally, there are minor Uplift-centered tweaks to the style of the components included on that test page.

**Related github/jira issue (required)**:
Closes #2612

**Steps necessary to review your pull request (required)**:
- Pull this branch, run app
- Open http://localhost:4000/components/searchfield/example-index?theme=uplift in various browsers.  Ensure the alignment looks good between the icon/text.  Also check RTL.
- Open http://localhost:4000/components/input/test-comparison-of-fields.html?theme=uplift in various browsers.  Ensure styles generally line up.  Also check RTL.

**Included in this Pull Request**:
- [x] A note to the change log.
