### PR TITLE
2595/2599 - Fix range issues with datepicker [v4.20.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -72,6 +72,8 @@
 - `[Datagrid]` Fixed a bug is the isEditable column callback in editable tree grid where some data was missing in the callback. ([#2357](https://github.com/infor-design/enterprise/issues/2357))
 - `[Datepicker]` Removed the advanceMonths option as the dropdowns for this are no longer there in the new design. ([#970](https://github.com/infor-design/enterprise/issues/970))
 - `[Datepicker]` Fixed an issue where range selection was not working. ([#2569](https://github.com/infor-design/enterprise/issues/2569))
+- `[Datepicker]` Fixed some issue where footer buttons were not working properly with range selection. ([#2595](https://github.com/infor-design/enterprise/issues/2595))
+- `[Datepicker]` Fixed an issue where time was not updating after change on range selection. ([#2599](https://github.com/infor-design/enterprise/issues/2599))
 - `[Datagrid]` Fixed a bug where deselect all would not deselect some rows when using grouping. ([#1796](https://github.com/infor-design/enterprise/issues/1796))
 - `[Datagrid]` Fixed a bug where summary counts in grouping would show even if the group is collapsed. ([#2221](https://github.com/infor-design/enterprise/issues/2221))
 - `[Datagrid]` Fixed issues when using paging (client side) and removeRow. ([#2590](https://github.com/infor-design/enterprise/issues/2590))

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -331,8 +331,9 @@ DatePicker.prototype = {
 
     // Set focus on (opt: next|prev) focusable element
     let focusables = this.popup.find(':focusable');
-    const isMonthViewPane = $(e.currentTarget).is('.monthview-monthyear-pane, #btn-monthyear-pane') ||
-      $(e.currentTarget).closest('.is-monthyear.is-monthonly').length > 0;
+    const target = $(e.currentTarget);
+    const isMonthViewPane = target.is('.monthview-monthyear-pane, #btn-monthyear-pane') ||
+      target.closest('.is-monthyear.is-monthonly').length > 0;
     if (isMonthViewPane) {
       focusables = this.popup.find(':focusable').not('td').not('.picklist-item a').add('.picklist-item.is-selected a:visible, .picklist-item.up a:visible, .picklist-item.down a:visible');
     }
@@ -782,18 +783,30 @@ DatePicker.prototype = {
       }
 
       if (btn.hasClass('is-today')) {
-        self.setToday();
-        if (!s.range.useRange) {
+        if (s.range.useRange) {
+          self.setToday(true);
+          if (!s.range.second || (s.range.second && !s.range.second.date)) {
+            e.preventDefault();
+            return;
+          }
+        } else {
+          self.setToday();
           self.closeCalendar();
         }
       }
 
       if (btn.hasClass('is-select')) {
-        if (s.range.useRange) {
-          if (s.range.first && s.range.first.date &&
-            s.range.second && s.range.second.date) {
-            self.closeCalendar();
-          }
+        const status = self.calendarAPI.setRangeSelByClick();
+        if (status === 1) {
+          self.closeCalendar();
+        } else if (status === 2) {
+          self.element
+            .trigger('change', [s.range.data])
+            .trigger('input', [s.range.data]);
+          self.closeCalendar();
+        } else if (status === 3) {
+          e.preventDefault();
+          return;
         } else {
           self.insertSelectedDate();
           self.closeCalendar();
@@ -854,7 +867,7 @@ DatePicker.prototype = {
   closeCalendar() {
     // Remove range entries
     const cell = this.calendarAPI && this.calendarAPI.days.length ? this.calendarAPI.days.find('td.is-selected') : null;
-    this.resetRange(cell);
+    this.resetRange({ cell });
 
     // Close timepicker
     if (this.settings.showTime && this.timepickerControl && this.timepickerControl.isOpen()) {
@@ -868,6 +881,10 @@ DatePicker.prototype = {
     const popoverAPI = this.trigger.data('tooltip');
     if (popoverAPI) {
       popoverAPI.destroy();
+    }
+
+    if (this.calendarAPI) {
+      delete this.calendarAPI.datepickerApi;
     }
 
     if (this.element.hasClass('is-active')) {
@@ -907,6 +924,7 @@ DatePicker.prototype = {
       this.popup.removeClass('is-hidden');
     }
     this.calendarAPI.activeTabindex(this.calendar.find('td.is-selected'), true);
+    this.calendarAPI.datepickerApi = this;
   },
 
   /**
@@ -1073,7 +1091,7 @@ DatePicker.prototype = {
       let row = cell.closest('tr');
 
       if (s.range.second) {
-        this.resetRange(cell);
+        this.resetRange({ cell });
       }
 
       const time = {};
@@ -1093,7 +1111,7 @@ DatePicker.prototype = {
         (s.range.selectForward && time.date < time.firstdate) ||
         ((s.range.maxDays > 0) && (time.date > time.max.aftertime) ||
         (time.date < time.max.beforetime))) {
-        this.resetRange(cell);
+        this.resetRange({ cell });
         this.setRangeFirstPart(date);
         value = this.getRangeValue();
         this.setPlaceholder();
@@ -1135,7 +1153,8 @@ DatePicker.prototype = {
     } else {
       s.range.data = {
         value,
-        dates: this.calendarAPI.getDateRange(s.range.first.date, s.range.second.date),
+        dates: !this.calendarAPI ? [s.range.first.date] :
+          this.calendarAPI.getDateRange(s.range.first.date, s.range.second.date),
         startDate: s.range.first.date,
         start: formatDate(s.range.first.date),
         endDate: s.range.second.date,
@@ -1153,24 +1172,31 @@ DatePicker.prototype = {
   /**
    * Reset range values
    * @private
-   * @param {object} cell to keep selection.
+   * @param {object} options cell: to keep selection, isData: to delete the data
    * @returns {void}
    */
-  resetRange(cell) {
+  resetRange(options) {
+    options = options || {};
     if (this.settings.range.useRange) {
       delete this.settings.range.first;
       delete this.settings.range.second;
       delete this.settings.range.extra;
+      if (options.isData) {
+        delete this.settings.range.data;
+      }
       if (this.calendarAPI) {
         delete this.calendarAPI.settings.range.first;
         delete this.calendarAPI.settings.range.second;
         delete this.calendarAPI.settings.range.extra;
+        if (options.isData) {
+          delete this.calendarAPI.settings.range.data;
+        }
       }
       if (this.calendarAPI && this.calendarAPI.days.length) {
         this.calendarAPI.days.find('td').removeClass('range range-next range-prev range-selection end-date is-selected');
       }
-      if (cell) {
-        cell.addClass('is-selected');
+      if (options.cell) {
+        options.cell.addClass('is-selected');
       }
     }
   },
@@ -1275,8 +1301,7 @@ DatePicker.prototype = {
     this.setCurrentCalendar();
 
     if (s.range.useRange && this.element.val().trim() === '') {
-      delete s.range.data;
-      this.resetRange();
+      this.resetRange({ isData: true });
     }
 
     if (s.range.useRange && ((this.element.val().trim() !== '') ||
@@ -1350,9 +1375,12 @@ DatePicker.prototype = {
       }, false));
     }
 
-    if (s.range.useRange && s.range.first && s.range.first.date
-      && s.range.second && !s.range.second.date) {
-      this.setRangeToElem(this.currentDate, true);
+    if (s.range.useRange && s.range.first && s.range.first.date && s.range.second) {
+      if (s.range.second.date) {
+        this.element.val(this.getRangeValue());
+      } else {
+        this.setRangeToElem(this.currentDate, true);
+      }
     }
   },
 
@@ -1393,9 +1421,10 @@ DatePicker.prototype = {
   /**
    * Set to todays date in current format.
    * @private
+   * @param {boolean} keepFocus if true keep focus on calendar
    * @returns {void}
    */
-  setToday() {
+  setToday(keepFocus) {
     const s = this.settings;
     this.currentDate = new Date();
 
@@ -1422,16 +1451,39 @@ DatePicker.prototype = {
       this.currentDateIslamic = islamicDateParts;
     }
 
+    const currentDate = this.isIslamic ? this.currentDateIslamic : this.currentDate;
+
     if (this.isOpen()) {
-      this.insertDate(this.isIslamic ? this.currentDateIslamic : this.currentDate, true);
+      if (s.range.useRange) {
+        if (!s.range.first || (s.range.first && !s.range.first.date)) {
+          this.calendarAPI.days.find('td:visible')
+            .removeClass('is-selected').removeAttr('aria-selected');
+          this.insertDate(currentDate, true);
+          if (keepFocus && this.calendarAPI) {
+            const cell = this.calendarAPI.dayMap.filter(d => d.elem.is('.is-selected'));
+            if (cell && cell.length) {
+              setTimeout(() => {
+                cell[0].elem.focus();
+              }, 0);
+            }
+          }
+        } else if (s.range.first && s.range.first.date &&
+          (!s.range.second || (s.range.second && !s.range.second.date))) {
+          this.setRangeToElem(currentDate, false);
+        } else if (s.range.first && s.range.first.date &&
+          s.range.second && s.range.second.date) {
+          this.resetRange({ isData: true });
+          this.insertDate(currentDate, true);
+        }
+      } else {
+        this.insertDate(currentDate, true);
+      }
     } else {
       if (s.range.useRange) {
         this.setRangeToElem(this.currentDate);
       } else {
         const options = { pattern: this.pattern, locale: this.locale.name };
-        const islamicDateText =
-          Locale.formatDate(this.isIslamic ?
-            this.currentDateIslamic : this.currentDate, options);
+        const islamicDateText = Locale.formatDate(currentDate, options);
         this.element.val(islamicDateText);
       }
       /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed some range issues with datepicker.

**Related github/jira issue (required)**:
Closes #2595
Closes #2599

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datepicker/example-range.html

Issue: 1
1. Open picker `Range - No Initial value`
2. Today's date should be highlighted with blue background
3. Click on footer button `Select`
4. See it should be able to select this date
5. Picker still open till you pick the 2nd date

Issue: 2
1. Refresh the page
2. Open picker `Range - No Initial value`
3. Click on any date and it will select the date
4. Now use arrow key or hover to any date
5. You will see this highlighted dated gray background
6. Use key `tab` or mouse to click on footer button `Select`
7. See it should be able select this highlighted date as 2nd date

Issue: 3
1. Refresh the page
2. Open picker `Range - No Initial value`
3. Click on footer button `Today` and it will select the today's date
4. Click on footer button `Select` to select the 2nd date
5. See it should be able to select this date
6. In this case 1st and 2nd date should be same as today's date

Issue: 4
1. Refresh the page
2. Open picker `Range - No Initial value`
3. Click on footer button `Today` and it will select the today's date
4. Click on any other date to select the 2nd date
5. See it should be able to select this new clicked date as 2nd date and close the picker (if the selected 2nd date smaller then 1st date, it will replace the dates. so always 1st date smaller then 2nd date)
7. If you clicked on same selected date, in this case 1st, 2nd date should be same as today's date and close the picker

Issue: 5
1. Refresh the page
2. Open developer tools
3. Use Keyboard to focus on field `Range - No Initial value`
4. While picker still closed
5. Press key: `t` to enter today's date
6. See console it should not have any js error

Issue: 6
1. Refresh the page
2. Open picker `Range - with Time`
3. Select range August 5 to August 7 (2019)
3. Soon picker close, open it again
4. Now just change the time to 7:40 PM (time dropdowns)
5. Click on footer button `Select` to select
6. See changed time should be applied in the field


**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
