### PR TITLE
N/A - Fix vertical centering of Flex Toolbar contained by header components [v4.20.x]

### DIFF
--- a/src/components/contextualactionpanel/_contextualactionpanel.scss
+++ b/src/components/contextualactionpanel/_contextualactionpanel.scss
@@ -27,6 +27,7 @@
   }
 
   .flex-toolbar {
+    height: inherit;
     margin: 0 auto;
     padding: 0 5px;
   }

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -194,6 +194,7 @@ $subheader-height: 60px;
   }
 
   .flex-toolbar {
+    height: inherit;
     max-height: $header-height;
     padding: 0 1.3rem;
 

--- a/src/components/masthead/_masthead.scss
+++ b/src/components/masthead/_masthead.scss
@@ -106,6 +106,10 @@
     }
   }
 
+  .flex-toolbar {
+    height: inherit;
+  }
+
   .toolbar,
   .flex-toolbar {
     .toolbar-section.logo {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds some CSS rules for the height of a Flex Toolbar when contained by Headers, Mastheads, and Contextual Action Panels.  A previous change to fix a height-related bug in Flex Toolbars caused them to become misaligned in these cases.  The fix provided satisfies the original fix and makes vertical centering work again.

**Related github/jira issue (required)**:
N/A

**Steps necessary to review your pull request (required)**:
Pull this branch, run the app, and check the Toolbars on the following pages to ensure they appear vertically-centered within their containers:
- http://localhost:4000/components/contextualactionpanel/example-workspaces.html
- http://localhost:4000/components/header/example-flex-toolbar.html
- http://localhost:4000/components/masthead/example-index.html?flextoolbar=true