### PR TITLE
2620 - Add custom errors example page with fileupload advanced

### DIFF
--- a/app/views/components/fileupload-advanced/test-custom-errors.html
+++ b/app/views/components/fileupload-advanced/test-custom-errors.html
@@ -1,0 +1,27 @@
+<div class="row top-padding">
+  <div class="six columns">
+
+    <h3>Fileupload Advanced</h3>
+    <p><br><strong>Custom Errors</strong><br>This example shows how to use the custom error strings thru api settings</p><br>
+    <p>
+      <strong>Allowed File Types</strong>:
+      &quot;Only files can be upload (.jpg, .png or .gif)&quot;
+      <br>
+      <strong>Max File Size</strong>:
+      &quot;(2 MB) Max file size allow to be upload&quot;
+      <br>
+      <strong>Max Files In Process</strong>:
+      &quot;Max (3) files can be process at once&quot;
+    </p>
+  <br>
+  </div>
+</div>
+
+<div class="row">
+  <div class="four columns">
+
+    <div class="fileupload-advanced" data-options="{allowedTypes: 'jpg|png|gif', errorAllowedTypes: 'Only files can be upload (.jpg, .png or .gif)', maxFileSize: '2000000', errorMaxFileSize: '(2 MB) Max file size allow to be upload', maxFilesInProcess: '3', errorMaxFilesInProcess: 'Max (3) files can be process at once'}">
+    </div>
+
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Contextual Action Panel]` Fixed an issue where if the title is longer, there will be an overflow causing a white space on the right on mobile view. ([#2605](https://github.com/infor-design/enterprise/issues/2605))
 - `[Datagrid]` Fixed a bug where the value would clear when using a lookup editor with a mask on new rows. ([#2305](https://github.com/infor-design/enterprise/issues/2305))
+- `[Fileupload Advanced]` Added custom errors example page. ([#2620](https://github.com/infor-design/enterprise/issues/2620))
 
 ## v4.20.0
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added custom errors example page with fileupload advanced.

**Related github/jira issue (required)**:
Closes #2620

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/fileupload-advanced/test-custom-errors.html
- Try to create the errors and see the error strings as
- Allowed File Types: `Only files can be upload (.jpg, .png or .gif)` 
- Max File Size: `(2 MB) Max file size allow to be upload` 
- Max Files In Process: `Max (3) files can be process at once`

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
