### PR TITLE
2589 - Fix circle pager not showing on mobile

### DIFF
--- a/app/views/components/circlepager/example-index.html
+++ b/app/views/components/circlepager/example-index.html
@@ -1,11 +1,9 @@
 <style>
   .example1 .slide-content {
     height: 318px;
+    padding-top: 230px;
     text-align: center;
     width: 100%;
-  }
-  .example1 .slide-content p {
-    padding-top: 230px;
   }
   .example1 .slides .slide:nth-child(1) .slide-content,
   .example1 .slides .slide:nth-child(4) .slide-content,

--- a/app/views/components/circlepager/example-index.html
+++ b/app/views/components/circlepager/example-index.html
@@ -1,9 +1,11 @@
 <style>
   .example1 .slide-content {
     height: 318px;
-    padding: 230px 20px 20px 20px;
     text-align: center;
     width: 100%;
+  }
+  .example1 .slide-content p {
+    padding-top: 230px;
   }
   .example1 .slides .slide:nth-child(1) .slide-content,
   .example1 .slides .slide:nth-child(4) .slide-content,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[Contextual Action Panel]` Fixed an issue where if the title is longer, there will be an overflow causing a white space on the right on mobile view. ([#2605](https://github.com/infor-design/enterprise/issues/2605))
 - `[Datagrid]` Fixed a bug where the value would clear when using a lookup editor with a mask on new rows. ([#2305](https://github.com/infor-design/enterprise/issues/2305))
 - `[Fileupload Advanced]` Added custom errors example page. ([#2620](https://github.com/infor-design/enterprise/issues/2620))
+- `[Pager]` Fixed a bug where the circle pager doesn't show on mobile view. ([#2589](https://github.com/infor-design/enterprise/issues/2589))
 
 ## v4.20.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@
 - `[Contextual Action Panel]` Fixed an issue where if the title is longer, there will be an overflow causing a white space on the right on mobile view. ([#2605](https://github.com/infor-design/enterprise/issues/2605))
 - `[Datagrid]` Fixed a bug where the value would clear when using a lookup editor with a mask on new rows. ([#2305](https://github.com/infor-design/enterprise/issues/2305))
 - `[Fileupload Advanced]` Added custom errors example page. ([#2620](https://github.com/infor-design/enterprise/issues/2620))
-- `[Pager]` Fixed a bug where the circle pager doesn't show on mobile view. ([#2589](https://github.com/infor-design/enterprise/issues/2589))
+- `[Circle Pager]` Fixed a bug where it was not showing on mobile view. ([#2589](https://github.com/infor-design/enterprise/issues/2589))
 
 ## v4.20.0
 

--- a/test/components/circlepager/circlepager.e2e-spec.js
+++ b/test/components/circlepager/circlepager.e2e-spec.js
@@ -38,6 +38,6 @@ describe('Circle pager example-circlepager tests', () => {
   });
 
   it('Should show the circle pager', async () => {
-    expect(await element(by.css('.example1 .slide-content')).isDisplayed()).toBe(true);
+    expect(await element(by.css('.example1 .slide-content')).getCssValue('padding-top')).toEqual('230px');
   });
 });

--- a/test/components/circlepager/circlepager.e2e-spec.js
+++ b/test/components/circlepager/circlepager.e2e-spec.js
@@ -25,3 +25,24 @@ describe('Circle pager example-index tests', () => {
     });
   }
 });
+
+describe('Circle pager example-circlepager tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/pager/example-circlepager');
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('.circlepager'))), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should show the circle pager', async () => {
+    const el = await element(by.css('div[role=main]'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(el), config.waitsFor);
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('.example1 .slide-content p')).getCssValue('padding-top')).toEqual('230px');
+  });
+});

--- a/test/components/circlepager/circlepager.e2e-spec.js
+++ b/test/components/circlepager/circlepager.e2e-spec.js
@@ -38,11 +38,6 @@ describe('Circle pager example-circlepager tests', () => {
   });
 
   it('Should show the circle pager', async () => {
-    const el = await element(by.css('div[role=main]'));
-    await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(el), config.waitsFor);
-    await browser.driver.sleep(config.sleep);
-
     expect(await element(by.css('.example1 .slide-content')).isDisplayed()).toBe(true);
   });
 });

--- a/test/components/circlepager/circlepager.e2e-spec.js
+++ b/test/components/circlepager/circlepager.e2e-spec.js
@@ -43,6 +43,6 @@ describe('Circle pager example-circlepager tests', () => {
       .wait(protractor.ExpectedConditions.presenceOf(el), config.waitsFor);
     await browser.driver.sleep(config.sleep);
 
-    expect(await element(by.css('.example1 .slide-content p')).getCssValue('padding-top')).toEqual('230px');
+    expect(await element(by.css('.example1 .slide-content')).getCssValue('padding-top')).toEqual('230px');
   });
 });

--- a/test/components/circlepager/circlepager.e2e-spec.js
+++ b/test/components/circlepager/circlepager.e2e-spec.js
@@ -43,6 +43,6 @@ describe('Circle pager example-circlepager tests', () => {
       .wait(protractor.ExpectedConditions.presenceOf(el), config.waitsFor);
     await browser.driver.sleep(config.sleep);
 
-    expect(await element(by.css('.example1 .slide-content')).getCssValue('padding-top')).toEqual('230px');
+    expect(await element(by.css('.example1 .slide-content')).isDisplayed()).toBe(true);
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Removed unnecessary `paddings (right, left, bottom)`. Having these paddings has an impact on mobile and it affects the script and tends to iterate. (Check the elements).

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/2589

**Steps necessary to review your pull request (required)**:

- Pull this branch and run the app
- Navigate to http://localhost:4000/components/pager/example-circlepager.html
- Resize the browser to mobile or use mobile device
- You should able to see the circle pager

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
