### PR TITLE
2588 - Pager: Numbers illegible in Uplift Dark theme 

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Contextual Action Panel]` Fixed an issue where if the title is longer, there will be an overflow causing a white space on the right on mobile view. ([#2605](https://github.com/infor-design/enterprise/issues/2605))
 - `[Datagrid]` Fixed a bug where the value would clear when using a lookup editor with a mask on new rows. ([#2305](https://github.com/infor-design/enterprise/issues/2305))
 - `[Fileupload Advanced]` Added custom errors example page. ([#2620](https://github.com/infor-design/enterprise/issues/2620))
+- `[Pager]` Changed pager number font color to be more legible in uplift dark theme. ([#2588](https://github.com/infor-design/enterprise/issues/2588))
 
 ## v4.20.0
 

--- a/src/themes/theme-uplift-dark.scss
+++ b/src/themes/theme-uplift-dark.scss
@@ -348,7 +348,7 @@ $radio-checked-bg-color: $radio-color-checked-initial-background;
 $radio-disabled-checked-bg-color: $radio-color-checked-disabled-background;
 
 // Pager
-$pager-text-color: $theme-color-brand-primary-base;
+$pager-text-color: $theme-color-palette-azure-100;
 $pager-selected-color: $font-color-extrahighcontrast;
 $pager-focus-border-color: $input-color-focus-border;
 $pager-hover-color: $font-color-extrahighcontrast;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The pager numbers are illegible in uplift dark theme.

**Related github/jira issue (required)**:
Closes #2588 

**Steps necessary to review your pull request (required)**:
- Pull branch, build, run app
- Visit localhost:4000/components/pager/example-listview.html?theme=uplift&variant=dark
  - Ensure the pager numbers are legible.

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.