### PR TITLE
1322 - Fix custom build errors when including files with extra punctuation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### v4.21.0 Fixes
 
 - `[Contextual Action Panel]` Fixed an issue where if the title is longer, there will be an overflow causing a white space on the right on mobile view. ([#2605](https://github.com/infor-design/enterprise/issues/2605))
+- `[Custom Builds]` Fixed a problem where including components with extra punctuation (periods, etc) may cause a build to fail. ([#1322](https://github.com/infor-design/enterprise/issues/1322))
 - `[Datagrid]` Fixed a bug where the value would clear when using a lookup editor with a mask on new rows. ([#2305](https://github.com/infor-design/enterprise/issues/2305))
 - `[Fileupload Advanced]` Added custom errors example page. ([#2620](https://github.com/infor-design/enterprise/issues/2620))
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -179,6 +179,7 @@ const customLocations = {
   '_multi-tabs': 'complex',
   '_tabs-module': 'complex',
   '_tabs-header': 'complex',
+  'toolbar-flex.item': '',
   validation: 'rules',
   'validation.utils': '',
   validator: 'foundational'

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -138,9 +138,6 @@ const filePaths = {
   }
 };
 
-addDynamicCssThemePaths(`${SRC_DIR}/themes`, true)
-
-
 // These search terms are used when scanning existing index files to determine
 // a component's placement in a generated file.
 const searchTerms = {
@@ -270,12 +267,12 @@ function addDynamicCssThemePaths() {
       filePaths.src.sass.themes[fileName] = srcPath;
       filePaths.target.sass.themes[fileName] = targetPath;
     }
-  }
+  };
 
-  IDS_THEMES.forEach(theme => {
+  IDS_THEMES.forEach((theme) => {
     tryAddPath(theme.name, theme.base.name);
 
-    theme.variants.forEach(variant => {
+    theme.variants.forEach((variant) => {
       tryAddPath(theme.name, variant.name);
     });
   });
@@ -983,6 +980,9 @@ if (!commandLineArgs.components) {
 } else {
   requestedComponents = commandLineArgs.components.split(',');
 }
+
+// Add all existing CSS theme paths dynamically.
+addDynamicCssThemePaths(`${SRC_DIR}/themes`, true);
 
 cleanAll(true).then(() => {
   if (!normalBuild) {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -288,13 +288,13 @@ function addDynamicCssThemePaths() {
 function replaceDashesWithCaptials(str) {
   str = capitalize(str);
 
-  const matches = str.match(/(-\w)+/g);
+  const matches = str.match(/([-|\.]\w)+/g);
   if (!matches) {
     return str;
   }
 
   matches.forEach((match) => {
-    str = str.replace(match, capitalize(match.replace('-', '')));
+    str = str.replace(match, capitalize(match.replace(/[-|\.]/, '')));
   });
   return str;
 }

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -17,17 +17,15 @@
   box-shadow: 0 3px 5px 0 rgba($searchfield-context-box-shadow-color, 0.7);
 }
 
-$cubic-bezier-ease: cubic-bezier(0.17, 0.04, 0.03, 0.94);
-
 .searchfield-wrapper {
   display: inline-block;
   margin-bottom: 20px;
   position: relative;
 
-  @include transition(width 300ms $cubic-bezier-ease,
-  left 300ms $cubic-bezier-ease,
-  right 300ms $cubic-bezier-ease,
-  box-shadow 300ms $cubic-bezier-ease);
+  @include transition(width 300ms $cubic-ease,
+  left 300ms $cubic-ease,
+  right 300ms $cubic-ease,
+  box-shadow 300ms $cubic-ease);
 
   > .icon {
     background-color: rgba($theme-color-palette-white, 0); // IE 10
@@ -70,8 +68,8 @@ $cubic-bezier-ease: cubic-bezier(0.17, 0.04, 0.03, 0.94);
     padding-left: 34px;
     padding-right: 10px;
 
-    @include transition(background-color 300ms $cubic-bezier-ease,
-    border-color 300ms $cubic-bezier-ease);
+    @include transition(background-color 300ms $cubic-ease,
+    border-color 300ms $cubic-ease);
   }
 
   // This variation is used on white-backgrounds (usually in list-detail, listviews, or builder pattern)
@@ -243,7 +241,7 @@ $cubic-bezier-ease: cubic-bezier(0.17, 0.04, 0.03, 0.94);
 
   // Buttons inside of searchfields
   .btn {
-    @include transition(border 300ms $cubic-bezier-ease); // Matches the one on inputs
+    @include transition(border 300ms $cubic-ease); // Matches the one on inputs
 
     background-color: transparent;
     border-bottom-right-radius: 0;

--- a/src/components/toolbar-flex/_toolbar-flex.scss
+++ b/src/components/toolbar-flex/_toolbar-flex.scss
@@ -16,7 +16,7 @@
 }
 
 .toolbar-section {
-  @include transition(width 100ms $cubic-bezier-ease, padding 100ms $cubic-bezier-ease);
+  @include transition(width 100ms $cubic-ease, padding 100ms $cubic-ease);
 
   white-space: nowrap;
   width: auto;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a bug in the Custom Builder that renders it unable to complete a build when including files with more than one period in the filename, such as `toolbar-flex.item.js`.

**Related github/jira issue (required)**:
Closes #1322 

**Steps necessary to review your pull request (required)**:
- Pull this branch
- Run a custom build in "dry-run" mode that only includes Autocomplete and Flex Toolbar.  Do this  by running the following command:
```sh
npm run build -- --components=autocomplete,toolbar-flex --dry-run
```
- Inspect the output of the file `temp/components.js` file.  Make sure it correctly includes the export for Flex Toolbar, but not the Flex Toolbar Item:
```js
// Foundational ====/

// Mid ====/
export { Autocomplete } from '../src/components/autocomplete/autocomplete';
export { ToolbarFlex } from '../src/components/toolbar-flex/toolbar-flex';

// Complex ====/
```
- Re-run the custom build without the `--dry-run` flag and ensure that Rollup and Node-Sass both complete successfully:
```sh
npm run build -- --components=autocomplete,toolbar-flex
```
- Open the file `dist/js/sohoxi.js` in a code editor and search for `$.fn.toolbarflexitem`.  This should be included because it's a dependency of the main Flex Toolbar component.

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
