### PR TITLE
2612 - Fix text/icon alignment on Spinbox fields [v4.20.x]

### DIFF
--- a/src/components/spinbox/_spinbox-uplift.scss
+++ b/src/components/spinbox/_spinbox-uplift.scss
@@ -1,17 +1,30 @@
 // Uplift Spinbox
 //================================================== //
 
+.spinbox-wrapper {
+  height: 38px;
+}
+
+input.spinbox,
+.spinbox-control {
+  height: inherit;
+}
+
 // `+` and `-` in Source Sans Pro are not lined up by default.
 // This fixes the alignment.
 .spinbox-control {
-  padding: 6px 10px;
+  padding: 7px 10px;
 
   &.down {
-    padding: 5px 10px 7px;
+    padding: 6px 10px;
   }
 }
 
 .field-short {
+  .spinbox-wrapper {
+    height: auto;
+  }
+
   .spinbox-control {
     padding: 4px 10px;
 
@@ -22,6 +35,10 @@
 }
 
 .is-firefox {
+  .spinbox-wrapper {
+    height: 36px;
+  }
+
   .field-short {
     .spinbox {
       padding: 4px;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes styling [problems discovered](https://github.com/infor-design/enterprise/issues/2612#issuecomment-519470284) while doing Q/A on #2612

**Related github/jira issue (required)**:
Closes #2612 

**Steps necessary to review your pull request (required)**:
- Pull branch, build, run app
- Open http://localhost:4000/components/input/test-comparison-of-fields.html?theme=uplift on various browsers.  Also try `rtl` by adding `&locale=ar-EG` to the end of the URL.
- Ensure the Spinbox's vertical text and button alignment in the field appears to match the others.