### PR TITLE
536 - Make the onKeydown fire on any type of key

### DIFF
--- a/app/views/components/datagrid/test-editable-onkeydown.html
+++ b/app/views/components/datagrid/test-editable-onkeydown.html
@@ -32,9 +32,9 @@
           saveColumns: false,
           toolbar: {title: 'Compressors', results: true, actions: true, rowHeight: true, personalize: true},
           editable: true,
-          onKeyDown: function(e) {
+          onKeyDown: function(e, args, response) {
             $('body').toast({title: 'onKeyDown Fired!', message: 'You hit '+ e.key + '. Event has been vetoed, so nothing will happen.'});
-            return false;
+            response(false);
           }
         });
       });

--- a/app/views/components/datagrid/test-editable-onkeydown.html
+++ b/app/views/components/datagrid/test-editable-onkeydown.html
@@ -33,7 +33,7 @@
           toolbar: {title: 'Compressors', results: true, actions: true, rowHeight: true, personalize: true},
           editable: true,
           onKeyDown: function(e) {
-            console.log(e);
+            $('body').toast({title: 'onKeyDown Fired!', message: 'You hit '+ e.key + '. Event has been vetoed, so nothing will happen.'});
             return false;
           }
         });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Contextual Action Panel]` Fixed an issue where if the title is longer, there will be an overflow causing a white space on the right on mobile view. ([#2605](https://github.com/infor-design/enterprise/issues/2605))
 - `[Datagrid]` Fixed a bug where calling update rows in the filter callback will cause an infinite loop. ([#2526](https://github.com/infor-design/enterprise/issues/2526))
 - `[Datagrid]` Fixed a bug where the value would clear when using a lookup editor with a mask on new rows. ([#2305](https://github.com/infor-design/enterprise/issues/2305))
+- `[Datagrid]` Changed the onKeyDown callback to fire on any key. ([#536](https://github.com/infor-design/enterprise-ng/issues/536))
 - `[Fileupload Advanced]` Added custom errors example page. ([#2620](https://github.com/infor-design/enterprise/issues/2620))
 - `[Lookup]` Fixed memory leak issues after destroy. ([#2494](https://github.com/infor-design/enterprise/issues/2494))
 - `[Modal]` Fixed memory leak issues after destroy. ([#2497](https://github.com/infor-design/enterprise/issues/2497))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7820,8 +7820,16 @@ Datagrid.prototype = {
       const lastCell = self.settings.columns.length - 1;
 
       if (self.settings.onKeyDown) {
-        const ret = self.settings.onKeyDown(e, { activeCell: self.activeCell, row, cell });
-        if (ret === false) {
+        const response = (isCancelled) => {
+          if (!isCancelled) {
+            e.stopPropagation();
+            e.preventDefault();
+          }
+        };
+
+        const args = { activeCell: self.activeCell, row, cell };
+        const ret = self.settings.onKeyDown(e, args, response);
+        if (ret === false || !response) {
           e.stopPropagation();
           e.preventDefault();
           return;

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -104,6 +104,7 @@ const COMPONENT_NAME = 'datagrid';
  * @param {Function} [settings.onDestroyCell=null] A call back that goes along with onPostRenderCel and will fire when this cell is destroyed and you need noification of that.
  * @param {Function} [settings.onEditCell=null] A callback that fires when a cell is edited, the editor object is passed in to the function
  * @param {Function} [settings.onExpandRow=null] A callback function that fires when expanding rows. To be used. when expandableRow is true. The function gets eventData about the row and grid and a response function callback. Call the response function with markup to append and delay opening the row.
+ * @param {Function} [settings.onKeyDown=null] A callback function that fires when any key is pressed down.
  * @param {boolean}  [settings.searchExpandableRow=true] If true keywordSearch will search in expandable rows (default). If false it will not search expandable rows.
  * @param {object}   [settings.emptyMessage]
  * @param {object}   [settings.emptyMessage.title='No Data Available']
@@ -197,6 +198,7 @@ const DATAGRID_DEFAULTS = {
   onDestroyCell: null,
   onEditCell: null,
   onExpandRow: null,
+  onKeyDown: null,
   emptyMessage: { title: (Locale ? Locale.translate('NoData') : 'No Data Available'), info: '', icon: 'icon-empty-no-data' },
   searchExpandableRow: true,
   allowChildExpandOnMatch: false

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7817,6 +7817,15 @@ Datagrid.prototype = {
       const lastRow = visibleRows.last();
       const lastCell = self.settings.columns.length - 1;
 
+      if (self.settings.onKeyDown) {
+        const ret = self.settings.onKeyDown(e, { activeCell: self.activeCell, row, cell });
+        if (ret === false) {
+          e.stopPropagation();
+          e.preventDefault();
+          return;
+        }
+      }
+
       // Tab, Left, Up, Right and Down arrow keys.
       if ([9, 37, 38, 39, 40].indexOf(key) !== -1) {
         if (target.closest('.code-block').length &&
@@ -7835,15 +7844,6 @@ Datagrid.prototype = {
 
       // Tab, Left and Right arrow keys.
       if ([9, 37, 39].indexOf(key) !== -1) {
-        if (key === 9 && self.settings.onKeyDown) {
-          const ret = self.settings.onKeyDown(e);
-          if (ret === false) {
-            e.stopPropagation();
-            e.preventDefault();
-            return;
-          }
-        }
-
         if (key === 9 && self.editor && self.editor.name === 'input' && col.inlineEditor === true) {
           // Editor.destroy
           self.editor.destroy();

--- a/test/components/datagrid/datagrid-settings.func-spec.js
+++ b/test/components/datagrid/datagrid-settings.func-spec.js
@@ -110,6 +110,7 @@ describe('Datagrid Settings', () => {
       onDestroyCell: null,
       onEditCell: null,
       onExpandRow: null,
+      onKeyDown: null,
       emptyMessage: { title: (Locale ? Locale.translate('NoData') : 'No Data Available'), info: '', icon: 'icon-empty-no-data' },
       searchExpandableRow: true,
       allowChildExpandOnMatch: false

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -1242,6 +1242,33 @@ describe('Datagrid editor dropdown source tests', () => {
   });
 });
 
+describe('Datagrid onKeyDown Tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/test-editable-onkeydown?layout=nofrills');
+
+    const datagridEl = await element(by.css('#datagrid tr:nth-child(1)'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should show toast on keydown', async () => {
+    await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1)')).click();
+
+    const editCellSelector = '.has-editor.is-editing input';
+    const inputEl = await element(by.css(editCellSelector));
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(inputEl), config.waitsFor);
+    await element(by.css(editCellSelector)).sendKeys('j');
+    await element(by.css(editCellSelector)).sendKeys(protractor.Key.TAB);
+
+    expect(await element.all(by.css('#toast-container .toast-message')).first().getText()).toEqual('You hit j. Event has been vetoed, so nothing will happen.');
+    expect(await element.all(by.css('#toast-container .toast-message')).last().getText()).toEqual('You hit Tab. Event has been vetoed, so nothing will happen.');
+  });
+});
+
 describe('Datagrid Header Alignment With Ellipsis', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-ellipsis-header-align?layout=nofrills');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

While addressing 536 is was noted that the datagrid onKeydown event only fired on tab. Expanded this to fire on any key

**Related github/jira issue (required)**:
Fixes #536 (will add a PR for the NG part)

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-editable-onkeydown.html
- click in any cell and type
- any key you type will omit an event shown in the toast and veto (nothing will happen otherwise as the event is vetoed)

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
