### PR TITLE
2647 - Slider: Colors object uses old theme names

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `[Locale]` Fixed a bug where getCulturePath does not work if the sohoxi.js file name has a hash part. ([#2637](https://github.com/infor-design/enterprise/issues/2637))
 - `[Lookup]` Fixed memory leak issues after destroy. ([#2494](https://github.com/infor-design/enterprise/issues/2494))
 - `[Modal]` Fixed memory leak issues after destroy. ([#2497](https://github.com/infor-design/enterprise/issues/2497))
+- `[Slider]` Updated the color variant logic to match new uplift theming. ([#2647](https://github.com/infor-design/enterprise/issues/2647))
 
 ## v4.20.0
 

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -937,7 +937,7 @@ Slider.prototype = {
         'very-good': '#76b051',
         superior: '#488421'
       },
-      'contrast': {
+      contrast: {
         default: '#000000',
         'very-poor': '#a13030',
         poor: '#d66221',

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -917,7 +917,7 @@ Slider.prototype = {
    * @returns {string} hex value representing a color
    */
   getColorClosestToValue() {
-    const currentTheme = theme.currentTheme.id;
+    const currentVariant = theme.currentTheme.id.split('-')[2];
     const preColors = {
       light: {
         default: '#000000',
@@ -937,7 +937,7 @@ Slider.prototype = {
         'very-good': '#76b051',
         superior: '#488421'
       },
-      'high-contrast': {
+      'contrast': {
         default: '#000000',
         'very-poor': '#a13030',
         poor: '#d66221',
@@ -948,7 +948,7 @@ Slider.prototype = {
       }
     };
 
-    const themeColors = preColors[currentTheme];
+    const themeColors = preColors[currentVariant];
     const val = this.value()[0];
     let highestTickColor;
     let c;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The colors object is using outdated theme names (pre introduction of uplift) and returning undefined.

**Related github/jira issue (required)**:
Closes #2647 

**Steps necessary to review your pull request (required)**:
- Pull branch, build, run app
- Visit http://localhost:4000/components/slider/example-colors-and-ticks.html and http://localhost:4000/components/slider/example-vertical.html
  - ensure the slider demo works as expected

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.