### PR TITLE
2634 - Fix memory leak with toast

### DIFF
--- a/app/views/components/toast/test-positions.html
+++ b/app/views/components/toast/test-positions.html
@@ -12,34 +12,51 @@
 </div>
 
 <script>
-  var cnt = 1;
+  var counter = 0;
+
+  function getSettings(position) {
+    counter++;
+    return {
+      title: 'Application Offline ('+ counter +')',
+      message: 'This is a Toast message.',
+      position: position
+    };
+  }
 
   $('#show-toast-top-left').on('click', function() {
-      cnt ++;
-      $('body').toast({title: 'Application Offline' + cnt, position: 'top left', message: 'This is a Toast message.'});
+    var settings = getSettings('top left');
+    $('body').toast(settings);
   });
 
   $('#show-toast-top-right').on('click', function() {
-    cnt ++;
-    $('body').toast({title: 'Application Offline' + cnt, position: 'top right', message: 'This is a Toast message.'});
+    var settings = getSettings('top right');
+    $('body').toast(settings);
   });
 
   $('#show-toast-bottom-left').on('click', function() {
-    cnt ++;
-    $('body').toast({title: 'Application Offline' + cnt, position: 'bottom left', message: 'This is a Toast message.'});
+    var settings = getSettings('bottom left');
+    $('body').toast(settings);
   });
 
   $('#show-toast-bottom-right').on('click', function() {
-    cnt ++;
-    $('body').toast({title: 'Application Offline' + cnt, position: 'bottom right', message: 'This is a Toast message.'});
+    var settings = getSettings('bottom right');
+    $('body').toast(settings);
   });
 
   $('#show-toast-big-text').on('click', function() {
-    cnt ++;
-    $('body').toast({title: 'Longer Application Offline' + cnt, position: 'bottom right', message: 'This is a Toast message that is much longer. It is so long it might wrap but that does not cause any issues.'});
+    counter++;
+    var settings = {
+      title: 'Longer Application Offline ('+ counter +')',
+      position: 'bottom right',
+      message: 'This is a Toast message that is much longer. It is so long it might wrap but that does not cause any issues.'
+    };
+    $('body').toast(settings);
   });
 
   $('#toast-destroy').on('click', function() {
-    $('body').data('toast').destroy();
+    var toastApi = $('body').data('toast');
+    if (toastApi) {
+      toastApi.destroy();
+    }
   });
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Lookup]` Fixed memory leak issues after destroy. ([#2494](https://github.com/infor-design/enterprise/issues/2494))
 - `[Modal]` Fixed memory leak issues after destroy. ([#2497](https://github.com/infor-design/enterprise/issues/2497))
 - `[Slider]` Updated the color variant logic to match new uplift theming. ([#2647](https://github.com/infor-design/enterprise/issues/2647))
+- `[Toast]` Fixed memory leak issues after destroy. ([#2634](https://github.com/infor-design/enterprise/issues/2634))
 
 ## v4.20.0
 

--- a/test/components/toast/toast.e2e-spec.js
+++ b/test/components/toast/toast.e2e-spec.js
@@ -40,7 +40,7 @@ describe('Toast example-index tests', () => {
     await element(by.css('#toast-container button.btn-close')).click();
     await browser.driver.sleep(config.sleep);
 
-    expect(await element(by.id('toast-container')).isDisplayed()).toBeFalsy();
+    expect(await element.all(by.id('toast-container')).count()).toEqual(0);
   });
 });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed memory leak issues with Toast control after destroy.

**Related github/jira issue (required)**:
Closes #2634

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/toast/example-index.html
- Open developer tools
- Click on button `Show Toast Message` to open toast
- Wait or click `X` for the toast message to be closed (which call the destroy method)
- Click to `Memory` tab in developer tools
- Click the `Collect garbage` garbage bin icon
- It will collect all the garbage from browser
- Click the button `Take snapshot` to see the memory heap
- After the scan completes, filter the result in the snapshot for `toast`
- It should not find any instance for Toast control

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
