### PR TITLE
2534 - Fix tooltip and ellipsis after update dropdown

### DIFF
--- a/app/views/components/dropdown/test-updating-long-text.html
+++ b/app/views/components/dropdown/test-updating-long-text.html
@@ -1,0 +1,53 @@
+
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="field">
+      <label for="states" class="label">States</label>
+      <select id="states" name="states" class="dropdown dropdown-mm">
+      </select>
+    </div>
+
+    <div class="field">
+      <label for="states-readonly" class="label">States Readonly</label>
+      <select id="states-readonly" name="states-readonly" class="dropdown dropdown-mm" readonly="true" >
+      </select>
+    </div>
+
+    <button id="update-button" type="button" class="btn-secondary">Update</button>
+  </div>
+</div>
+
+<script>
+  $('body').on('initialized', function() {
+    var options = [];
+    options.push('<option value=" "> </option>');
+    options.push('<option value="AL">Alaska gffgf gf fgf fg f gfg fgfg ff gfg f gf gff g</option>');
+    options.push('<option value="AZ">Arizona bvbcbcbv c cvbcvb cvbcv bcvbcvbccvb vcbcvbcbvcb</option>');
+    options.push('<option value="CA">California vb rtretetgrthrbrrtb rtbrtrtb rbrt brtbrtb rr b</option>');
+    options.push('<option value="CO">Colorado  rt gr grt grtrtg rtgrtg r r btrtrtr rtbrb rtrb t</option>');
+    options.push('<option value="MN">Minnesota  h trgbr rtgrtgrtg rtgrthgrt tr hrh hg rttr trh</option>');
+    options.push('<option value="ND">North Dakota  rt hrthrt hrt trtrhrt hrh trhrrt htr hrth rh</option>');
+    options.push('<option value="OR">Oregon y rt r tertert erreer tret rt erretet ert reert ert</option>');
+    options.push('<option value="WA">Washington r  ter tert er re treete t ertreert ertret ert err</option>');
+    options.push('<option value="WY">Wyoming r  re tret ert et re ter tert ret erter terte4ter ter t</option>');
+
+    var optionsString = options.join('');
+
+    $('#update-button').on('click', function () {
+      var states = $('#states, #states-readonly');
+
+
+      for (var index = 0, len = states.length; index < len; index++) {
+        var elem = $(states[index]);
+        var api = elem.data('dropdown');
+
+        elem.empty().append(optionsString);
+
+        api.element[0].selectedIndex = 2;
+        elem.trigger('updated');
+      }
+    });
+  });
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `[Datagrid]` Fixed a bug where horizontal scrolling would not work when in a card/widget. ([#1785](https://github.com/infor-design/enterprise/issues/1785))
 - `[Datagrid]` Fixed an issue where dirty and row status on the same cell would cause a UI issue. ([#2641](https://github.com/infor-design/enterprise/issues/2641))
 - `[Datagrid]` Changed the onKeyDown callback to fire on any key. ([#536](https://github.com/infor-design/enterprise-ng/issues/536))
+- `[Dropdown]` Fixed an issue where tooltip on all browsers and ellipsis on firefox, ie11 was not showing with long text after update. ([#2534](https://github.com/infor-design/enterprise/issues/2534))
 - `[Fileupload Advanced]` Added custom errors example page. ([#2620](https://github.com/infor-design/enterprise/issues/2620))
 - `[Homepage]` Fixed an issue where dynamically added widget was not positioning correctly. ([#2425](https://github.com/infor-design/enterprise/issues/2425))
 - `[Locale]` Fixed a bug where getCulturePath does not work if the sohoxi.js file name has a hash part. ([#2637](https://github.com/infor-design/enterprise/issues/2637))

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -2921,6 +2921,7 @@ Dropdown.prototype = {
     // update the list and set a new value, if applicable
     this.updateList();
     this.setDisplayedValues();
+    this.toggleTooltip();
 
     this.element.trigger('has-updated');
 

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -97,6 +97,7 @@
   p {
     color: $tooltip-color;
     font-size: $theme-size-font-sm;
+    -webkit-text-fill-color: $tooltip-color;
     word-break: normal;
     word-wrap: break-word;
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed tooltip on all browsers and ellipsis on firefox, ie11 was not showing with long text after updating dropdown.

**Related github/jira issue (required)**:
Closes #2534

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/dropdown/test-updating-long-text.html
- Both Dropdowns should render empty
- Click on button `Update`
- Now it should fill with long text
- It should show ellipsis on all browsers
- On hover it should show the tooltip

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
