### PR TITLE
2424 - Fix clear formatting on firefox with editor

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `[Datagrid]` Added a more descriptive aria-label to checkboxes if the required descriptors exist. ([#2031](https://github.com/infor-design/enterprise-ng/issues/2031))
 - `[Datagrid]` Added an announcement of the selection state of a row. ([#2535](https://github.com/infor-design/enterprise/issues/2535))
 - `[Dropdown]` Fixed an issue where tooltip on all browsers and ellipsis on firefox, ie11 was not showing with long text after update. ([#2534](https://github.com/infor-design/enterprise/issues/2534))
+- `[Editor]` Fixed an issue where clear formatting was causing to break while switch mode on Firefox. ([#2424](https://github.com/infor-design/enterprise/issues/2424))
 - `[Fileupload Advanced]` Added custom errors example page. ([#2620](https://github.com/infor-design/enterprise/issues/2620))
 - `[Homepage]` Fixed an issue where dynamically added widget was not positioning correctly. ([#2425](https://github.com/infor-design/enterprise/issues/2425))
 - `[Icons]` Fixed an issue with partially invisible empty messages in uplift theme. ([#2474](https://github.com/infor-design/enterprise/issues/2474))

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -2081,8 +2081,12 @@ Editor.prototype = {
       } else if (/ul|ol/.test(parentTag)) {
         normalizeList(parentEl);
       } else {
-        const lists = [].slice.call(parentEl.parentNode.querySelectorAll('ul, ol'));
-        lists.forEach(list => normalizeList(list));
+        const setEl = () => ($(parentEl).closest('.editor').length ? parentEl.parentNode : null);
+        const elem = parentEl.classList.contains('editor') ? parentEl : setEl();
+        if (elem) {
+          const lists = [].slice.call(elem.querySelectorAll('ul, ol'));
+          lists.forEach(list => normalizeList(list));
+        }
       }
     };
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed clear formatting was causing to break while switch mode on Firefox with Editor.

**Related github/jira issue (required)**:
Closes #2424

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Use Firefox
- Navigate to http://localhost:4000/components/editor/test-source-formatter.html
- Editor should open in source mode
- Click button `VISUAL` to go to visual mode
- Select all then click button `Clear Formatting`
- Click button `HTML` to go back to source mode
- See content, should have proper indentation

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
