### PR TITLE
2717 - Fix misaligned short row with datagrid [v4.21.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@
 - `[Datagrid]` Added an announcement of the selection state of a row. ([#2535](https://github.com/infor-design/enterprise/issues/2535))
 - `[Datagrid]` Fixed filtering on time columns when time is a string. ([#2535](https://github.com/infor-design/enterprise/issues/2535))
 - `[Datagrid]` Fixed icon layout issues on the filter row in medium rowHeight mode. ([#2709](https://github.com/infor-design/enterprise/issues/2709))
+- `[Datagrid]` Fixed an issue where short row height was misaligning in Uplift theme. ([#2717](https://github.com/infor-design/enterprise/issues/2717))
 - `[Dropdown]` Fixed an issue where tooltip on all browsers and ellipsis on firefox, ie11 was not showing with long text after update. ([#2534](https://github.com/infor-design/enterprise/issues/2534))
 - `[Editor]` Fixed an issue where clear formatting was causing to break while switch mode on Firefox. ([#2424](https://github.com/infor-design/enterprise/issues/2424))
 - `[Fileupload Advanced]` Added custom errors example page. ([#2620](https://github.com/infor-design/enterprise/issues/2620))

--- a/src/components/datagrid/_datagrid-uplift.scss
+++ b/src/components/datagrid/_datagrid-uplift.scss
@@ -33,12 +33,31 @@
   padding: 1px 0 0 5px;
 }
 
-// Adjust Row Links
-.datagrid td .hyperlink {
-  margin-top: -2px;
-}
+// Main Grid
+.datagrid {
+  td {
+    // Adjust Row Links
+    .hyperlink {
+      margin-top: -2px;
+    }
+  }
 
-// Adjust Tags
-.datagrid.short-rowheight tbody tr td span {
-  line-height: 22px;
+  // Short Row Height
+  &.short-rowheight {
+    tbody {
+      tr {
+        td {
+          // Adjust Tags
+          span {
+            line-height: 22px;
+          }
+
+          // Adjust Row Buttons
+          .row-btn {
+            min-height: 25px;
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed short row height was misaligning in Uplift theme with Datagrid.

**Related github/jira issue (required)**:
Closes #2717

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/example-list.html?theme=uplift&variant=light&colors=0563C2
- Click `...` three dot action button top of grid
- Set row height to Short
- Hover to any row
- See last column `Action Item`
- Should aligned properly

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
