### PR TITLE
2709 - Fix a serious filter row issue [v4.21.x]

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "release:rc": "release-it --preRelease=rc --no-github.release",
     "release:final": "release-it",
     "test": "npm run mdlint && npm run eslint && npm run stylelint && npm run functional:ci && npm run e2e:ci",
-    "node-version-check": "npx check-node-version --node 10.16"
+    "node-version-check": "npx check-node-version --node 10.16",
+    "//postinstall": "npm run node-version-check"
   },
   "dependencies": {
     "d3": "^4.13.0",
@@ -104,7 +105,7 @@
     "front-matter": "^2.3.0",
     "grunt": "^1.0.4",
     "grunt-bump": "^0.8.0",
-    "grunt-chokidar": "^1.0.1",
+    "grunt-chokidar": "1.0.1",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-compress": "^1.5.0",
     "grunt-contrib-copy": "^1.0.0",

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -2337,8 +2337,6 @@ Dropdown.prototype = {
     this.toggleTooltip();
 
     this.element.trigger('change').triggerHandler('selected');
-
-    self.applyFilter(null, 'selected');
   },
 
   /**

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -2226,7 +2226,7 @@ PopupMenu.prototype = {
     this.menu.off('dragstart.popupmenu');
 
     // Remove the wrapper, if applicable
-    if (!this.preExistingWrapper) {
+    if (!this.preExistingWrapper && this.menu.parent().is('.popupmenu-wrapper')) {
       this.menu.unwrap();
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes an issue where the layout broke when closing filter row popdowns (maybe similar problems elsewhere).

Also added the contents of https://github.com/infor-design/enterprise/pull/2727 so we do not have this issue on the 4.21.x branch.

**Related github/jira issue (required)**:
Fixes #2709 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-filter.html
- open any filter row dropdown and close it
- layout should be ok and filter should work
- For good measure test the following as well for the same issue:
http://localhost:4000/components/datagrid/test-editable-time has error
http://localhost:4000/components/datagrid/example-filter.html
http://localhost:4000/components/datagrid/test-filter-short-rowheight
http://localhost:4000/components/datagrid/test-filter-medium-rowheight
