### PR TITLE
NG-594 - Improvements to Toolbar/Icon for Angular CAP Lifecycle

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@
 - `[Flex Toolbar]` Fixed a lifecycle problem that was preventing Menu Buttons with a `removeOnDestroy` setting from opening. ([#2664](https://github.com/infor-design/enterprise/issues/2664))
 - `[Homepage]` Fixed an issue where dynamically added widget was not positioning correctly. ([#2425](https://github.com/infor-design/enterprise/issues/2425))
 - `[Icons]` Fixed an issue with partially invisible empty messages in uplift theme. ([#2474](https://github.com/infor-design/enterprise/issues/2474))
+- `[Icons (Component)]` Fixed a bug where it was possible to store a full base-tag prefixed URL in the `use` setting, which shouldn't be possible. ([PR#2738](https://github.com/infor-design/enterprise/pull/2738))
 - `[Locale]` Fixed a bug where getCulturePath does not work if the sohoxi.js file name has a hash part. ([#2637](https://github.com/infor-design/enterprise/issues/2637))
 - `[Locale]` Fixed a bug found when using NG8 that the default us locale causes issues. It is now an official requirement that you set a locale for all components that require locale information. ([#2640](https://github.com/infor-design/enterprise/issues/2640))
 - `[Locale]` Fixed an occurrence where an nonstandard locale filename was not correctly processed. ([#2684](https://github.com/infor-design/enterprise/issues/2684))
@@ -48,6 +49,7 @@
 - `[Slider]` Updated the color variant logic to match new uplift theming. ([#2647](https://github.com/infor-design/enterprise/issues/2647))
 - `[Tabs]` Fixed a memory leak caused by removing a tab. ([#2686](https://github.com/infor-design/enterprise/issues/2686))
 - `[Toast]` Fixed memory leak issues after destroy. ([#2634](https://github.com/infor-design/enterprise/issues/2634))
+- `[Toolbar]` Fixed the conditions for when `noSearchfieldReinvoke` destroys an inner Searchfield that's been previously invoked. ([PR#2738](https://github.com/infor-design/enterprise/pull/2738))
 - `[Uplift Theme]` Various improvements to the Dark/Contrast variants, with a focus on passing WCAG ([#2541](https://github.com/infor-design/enterprise/issues/2541)) ([#2588](https://github.com/infor-design/enterprise/issues/2588))
 
 ### v4.21.0 Chores & Maintenance

--- a/src/components/icons/icons.js
+++ b/src/components/icons/icons.js
@@ -102,8 +102,15 @@ Icon.prototype = {
       return this;
     }
 
-    const xlinkHref = useTag.attr('xlink:href');
-    this.settings.use = xlinkHref.replace('#icon-', '');
+    // Store the icon's name under the `use` setting.
+    // Strip out all extraneous items including the `base` URL.
+    let xlinkHref = useTag.attr('xlink:href');
+    const baseUrl = base.url;
+    if (base.element.length && baseUrl.length) {
+      xlinkHref = xlinkHref.replace(baseUrl, '');
+    }
+    xlinkHref = xlinkHref.replace('#icon-', '');
+    this.settings.use = xlinkHref;
 
     return this;
   },

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -1505,7 +1505,7 @@ Toolbar.prototype = {
       // this flag is set in `updated()` if the setting `noSearchfieldReinvoke` is set
       // to `true` before an update is performed. The Searchfield will stay in-tact for
       // one update cycle, or until the setting is reset to `true`.
-      if (!this.settings.noSearchfieldReinvoke || !this.keepSearchfield) {
+      if (!this.settings.noSearchfieldReinvoke && !this.keepSearchfield) {
         const searchFields = this.buttonset.children('.searchfield-wrapper').children('.searchfield');
         if (searchFields.data('searchfield')) {
           searchFields.data('searchfield').destroy();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR makes a few tweaks to the Toolbar and Icon components that better suit the SPA-nature of Angular components.  Specifically, these tweaks fix the Contextual Action Panel bugs found in the Angular wrapper for that component.
- The Icon component was changed to prevent the storage of a full URL on the `use` setting when coupled with a base tag.
- The Toolbar component was changed to fix the condition that makes the conditions for destroying an invoked Searchfield to work better in an SPA lifecycle.

**Related github/jira issue (required)**:
- Related to infor-design/enterprise-ng#594
- infor-design/enterprise-ng#604 depends on this PR.

**Steps necessary to review your pull request (required)**:
NOTE TO Q/A - this issue requires testing on the NG side.  Nothing has changed on the EP side.

- Install the [`enterprise-ng` project](https://github.com/infor-design/enterprise-ng)
- Pull this branch and build with `npm run build`
- `npm link` or symlink the dist folder in EP to the `node_modules/ids-enterprise/dist` folder in NG.
- Build/serve NG
- Navigate to http://localhost:4200/ids-enterprise-ng-demo/contextual-action-panel
- Click the button that says "Panel with Searchfield".  Ensure there is a fully functioning Searchfield present in the CAP toolbar that contains visible icons.
- Close that CAP and click the button that says "Panel with Searchfield in Flex Toolbar".  Ensure there is a fully functioning Searchfield present in the CAP toolbar, that it's right aligned, and that there are not two toolbars present inside the CAP.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

----

paging @anhallbe