### PR TITLE
2729 - Fix new row and dirty cell with datagrid [v4.21.x]

### DIFF
--- a/app/views/components/datagrid/test-overlaps-row-cell-indicators.html
+++ b/app/views/components/datagrid/test-overlaps-row-cell-indicators.html
@@ -14,6 +14,9 @@
         <button type="button" id="add-row-bottom" class="btn">
           <span>Add Row (bottom)</span>
         </button>
+        <button type="button" id="dirty-rows" class="btn">
+          <span>Dirty Rows</span>
+        </button>
       </div>
     </div>
 
@@ -134,9 +137,14 @@
         $('#add-row-top').on('click', function () {
           gridApi.addRow({ productName: '', productId: '0' });
         });
-        
+
         $('#add-row-bottom').on('click', function () {
           gridApi.addRow({ productName: '', productId: '0' }, 'bottom');
+        });
+
+        $('#dirty-rows').on('click', function () {
+          var dirtyRows = gridApi.dirtyRows();
+          console.log('Number of Dirty Rows: ' + dirtyRows.length);
         });
     });
   });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,7 +33,7 @@
 - `[Datagrid]` Fixed filtering on time columns when time is a string. ([#2535](https://github.com/infor-design/enterprise/issues/2535))
 - `[Datagrid]` Fixed icon layout issues on the filter row in medium rowHeight mode. ([#2709](https://github.com/infor-design/enterprise/issues/2709))
 - `[Datagrid]` Fixed an issue where short row height was misaligning in Uplift theme. ([#2717](https://github.com/infor-design/enterprise/issues/2717))
-- `[Datagrid]` Fixed an issue where new row and dirty cell were not working. ([#2729](https://github.com/infor-design/enterprise/issues/2729))
+- `[Datagrid]` Fixed an issue where new row and dirty cell were not working when combined. ([#2729](https://github.com/infor-design/enterprise/issues/2729))
 - `[Dropdown]` Fixed an issue where tooltip on all browsers and ellipsis on firefox, ie11 was not showing with long text after update. ([#2534](https://github.com/infor-design/enterprise/issues/2534))
 - `[Editor]` Fixed an issue where clear formatting was causing to break while switch mode on Firefox. ([#2424](https://github.com/infor-design/enterprise/issues/2424))
 - `[Fileupload Advanced]` Added custom errors example page. ([#2620](https://github.com/infor-design/enterprise/issues/2620))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `[Datagrid]` Fixed filtering on time columns when time is a string. ([#2535](https://github.com/infor-design/enterprise/issues/2535))
 - `[Datagrid]` Fixed icon layout issues on the filter row in medium rowHeight mode. ([#2709](https://github.com/infor-design/enterprise/issues/2709))
 - `[Datagrid]` Fixed an issue where short row height was misaligning in Uplift theme. ([#2717](https://github.com/infor-design/enterprise/issues/2717))
+- `[Datagrid]` Fixed an issue where new row and dirty cell were not working. ([#2729](https://github.com/infor-design/enterprise/issues/2729))
 - `[Dropdown]` Fixed an issue where tooltip on all browsers and ellipsis on firefox, ie11 was not showing with long text after update. ([#2534](https://github.com/infor-design/enterprise/issues/2534))
 - `[Editor]` Fixed an issue where clear formatting was causing to break while switch mode on Firefox. ([#2424](https://github.com/infor-design/enterprise/issues/2424))
 - `[Fileupload Advanced]` Added custom errors example page. ([#2620](https://github.com/infor-design/enterprise/issues/2620))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1274,6 +1274,11 @@ $datagrid-short-row-height: 25px;
             top: -15px;
           }
 
+          &.is-dirty-cell::before {
+            border-width: 0;
+            margin: 0;
+          }
+
           .icon-rowstatus {
             left: -1px;
             top: 0;

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9400,12 +9400,6 @@ Datagrid.prototype = {
   setDirtyCell(row, cell, dirtyOptions) {
     const cellNode = this.cellNode(row, cell);
 
-    // Do not show dirty indicator on new cells or cells with errors on them
-    if (this.settings.dataset[row] && this.settings.dataset[row].rowStatus &&
-      (this.settings.dataset[row].rowStatus.icon === 'new' || row === 0)) {
-      return;
-    }
-
     if (dirtyOptions) {
       this.addToDirtyArray(row, cell, dirtyOptions);
     }

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -1543,19 +1543,39 @@ describe('Datagrid Dirty and New Row Indicator', () => {
     expect(await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1).is-dirty-cell')).isPresent()).toBe(true);
   });
 
-  it('should not show a dirty indicator on new rows', async () => {
-    await element(by.id('add-row-top')).click();
-    await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1)')).click();
+  it('should not show a dirty indicator on row-status cell with new rows', async () => {
+    const cell = num => `#datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(${num})`;
+    const pseudoScript = sel => `return window.getComputedStyle(document.querySelector('${sel}'), ':before').getPropertyValue('border-width');`;
 
-    const editCellSelector = '.has-editor.is-editing input';
-    const inputEl = await element(by.css(editCellSelector));
+    await element(by.id('add-row-top')).click();
+
+    await element(by.css(cell(1))).click();
+    let editCellSelector = '.has-editor.is-editing input';
+    let inputEl = await element(by.css(editCellSelector));
     await browser.driver.wait(protractor.ExpectedConditions.presenceOf(inputEl), config.waitsFor);
     await element(by.css(editCellSelector)).sendKeys('121');
 
     expect(await element(by.css(editCellSelector)).getAttribute('value')).toEqual('121');
     await element(by.css(editCellSelector)).sendKeys(protractor.Key.ENTER);
 
-    expect(await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(1) td:nth-child(1).is-dirty-cell')).isPresent()).toBe(false);
+    await element(by.css(cell(2))).click();
+    editCellSelector = '.has-editor.is-editing input';
+    inputEl = await element(by.css(editCellSelector));
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(inputEl), config.waitsFor);
+    await element(by.css(editCellSelector)).sendKeys('122');
+
+    expect(await element(by.css(editCellSelector)).getAttribute('value')).toEqual('122');
+    await element(by.css(editCellSelector)).sendKeys(protractor.Key.ENTER);
+
+    expect(await element(by.css(`${cell(1)}.is-dirty-cell`)).isPresent()).toBe(true);
+    await browser.executeScript(pseudoScript(`${cell(1)}.is-dirty-cell`)).then((data) => {
+      expect(data).toEqual('0px');
+    });
+
+    expect(await element(by.css(`${cell(2)}.is-dirty-cell`)).isPresent()).toBe(true);
+    await browser.executeScript(pseudoScript(`${cell(2)}.is-dirty-cell`)).then((data) => {
+      expect(data).toEqual('4px');
+    });
   });
 });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed new row and dirty cell were not working with Datagrid.

**Related github/jira issue (required)**:
Closes #2729

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/test-overlaps-row-cell-indicators.html
- Open developer tools
- Click on toolbar button `Add Row`
- Change cell values on the new row
- See for dirty indicator (yellow triangle) should show in changed cell
- Dirty indicator should not show if new row and first cell, because it has row status icon in this cell
- For this new row and first cell, dirty indicator just visually not showing on browser but it added to dirtyArray as it should
- Click on toolbar button `Dirty Rows`
- See console for `Number of Dirty Rows`

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
