### PR TITLE
2732 - Fix a regression in tree expansion [v4.21.x]

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9900,14 +9900,21 @@ Datagrid.prototype = {
             const node = $(this);
             const nodeLevel = parseInt(node.attr('aria-level'), 10);
 
-            if (!node.hasClass('is-filtered')) {
-              node.removeClass('is-hidden');
-            }
+            // Handles that child rows get the right states
+            if (nodeLevel === (lev + 1)) {
+              if (!node.hasClass('is-filtered')) {
+                node.removeClass('is-hidden');
 
-            if (node.is('.datagrid-tree-parent')) {
-              const nodeIsExpanded = node.find('.datagrid-expand-btn.is-expanded').length > 0;
-              if (nodeIsExpanded) {
-                setChildren(node, nodeLevel, !nodeIsExpanded);
+                if (self.settings.frozenColumns) {
+                  const rowindex = node.attr('aria-rowindex');
+                  self.tableBody.find(`[aria-rowindex="${rowindex}"]`).removeClass('is-hidden');
+                }
+              }
+              if (node.is('.datagrid-tree-parent')) {
+                const nodeIsExpanded = node.find('.datagrid-expand-btn.is-expanded').length > 0;
+                if (nodeIsExpanded) {
+                  setChildren(node, nodeLevel, !nodeIsExpanded);
+                }
               }
             }
           });

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -2625,6 +2625,33 @@ describe('Datagrid Tree and Frozen Column tests', () => {
     expect(await element.all(by.css('tr:not(.is-hidden)')).count()).toEqual(12);
   });
 
+  it('Should expand last tree nodes', async () => {
+    expect(await element.all(by.css('tr.is-hidden')).count()).toEqual(20);
+    expect(await element.all(by.css('tr:not(.is-hidden)')).count()).toEqual(26);
+
+    await element(by.css('#datagrid tbody tr:nth-child(15) td:nth-child(1) button')).click();
+
+    expect(await element.all(by.css('tr.is-hidden')).count()).toEqual(6);
+    expect(await element.all(by.css('tr:not(.is-hidden)')).count()).toEqual(40);
+  });
+
+  it('Should expand last tree nodes and restore hidden', async () => {
+    await element(by.css('#datagrid tbody tr:nth-child(15) td:nth-child(1) button')).click();
+    await element(by.css('#datagrid tbody tr:nth-child(18) td:nth-child(1) button')).click();
+
+    expect(await element.all(by.css('tr.is-hidden')).count()).toEqual(14);
+    expect(await element.all(by.css('tr:not(.is-hidden)')).count()).toEqual(32);
+    await element(by.css('#datagrid tbody tr:nth-child(15) td:nth-child(1) button')).click();
+
+    expect(await element.all(by.css('tr.is-hidden')).count()).toEqual(20);
+    expect(await element.all(by.css('tr:not(.is-hidden)')).count()).toEqual(26);
+
+    await element(by.css('#datagrid tbody tr:nth-child(15) td:nth-child(1) button')).click();
+
+    expect(await element.all(by.css('tr.is-hidden')).count()).toEqual(14);
+    expect(await element.all(by.css('tr:not(.is-hidden)')).count()).toEqual(32);
+  });
+
   if (utils.isChrome() && utils.isCI()) {
     it('Should not visual regress', async () => {
       const containerEl = await element(by.className('container'));


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

QA spotted a regression with respect to which rows stay expanded in tree i caused in adding frozen columns + tree.

**Related github/jira issue (required)**:
Fixes #2732 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-tree
- collapse: Follow up action with Acme Canada
- collapse:  Follow up action with Residental New York
- collapse:  Follow up action with Residental Baltimore
- expand:  Follow up action with Residental Baltimore -> Follow up action with Acme Canada and Follow up action with Residental New York should still be collapsed

- retest http://localhost:4000/components/datagrid/test-tree-frozen-columns.html
- specifically expand the very last group and the rows on each side should match 

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
