### PR TITLE
603 - Prevent the redirects in NG on picker [v4.21.x]

### DIFF
--- a/src/components/monthview/monthview.js
+++ b/src/components/monthview/monthview.js
@@ -599,14 +599,14 @@ MonthView.prototype = {
 
     const wideMonths = this.currentCalendar.months.wide;
     wideMonths.map(function (monthMap, i) { // eslint-disable-line
-      monthList += `<li class="picklist-item${(i === month ? ' is-selected ' : '')}"><a ${(i === month ? 'tabindex="0" ' : 'tabindex="-1" ')}data-month="${i}">${monthMap}</a></li>`;
+      monthList += `<li class="picklist-item${(i === month ? ' is-selected ' : '')}"><a href="#" ${(i === month ? 'tabindex="0" ' : 'tabindex="-1" ')}data-month="${i}">${monthMap}</a></li>`;
     });
     monthList += '</ul>';
 
     this.monthYearPane.find('.picklist-section.is-month').empty().append(monthList);
     const years = [];
     let yearList = '<ul class="picklist is-year">';
-    yearList += '<li class="picklist-item up"><a tabindex="0"><svg class="icon" focusable="false" aria-hidden="true" role="presentation"><use xlink:href="#icon-caret-up"></use></svg></a></li>';
+    yearList += '<li class="picklist-item up"><a href="#" tabindex="0"><svg class="icon" focusable="false" aria-hidden="true" role="presentation"><use xlink:href="#icon-caret-up"></use></svg></a></li>';
 
     for (let i = this.settings.yearsBack; i >= 1; i--) {
       years.push(parseInt(year, 10) - i);
@@ -618,7 +618,7 @@ MonthView.prototype = {
 
     // eslint-disable-next-line
     years.map(function (yearMap) {
-      yearList += `<li class="picklist-item${(year === yearMap ? ' is-selected ' : '')}"><a ${(year === yearMap ? 'tabindex="0" ' : 'tabindex="-1" ')}data-year="${yearMap}">${yearMap}</a></li>`;
+      yearList += `<li class="picklist-item${(year === yearMap ? ' is-selected ' : '')}"><a href="#" ${(year === yearMap ? 'tabindex="0" ' : 'tabindex="-1" ')}data-year="${yearMap}">${yearMap}</a></li>`;
     });
     yearList += '<li class="picklist-item down"><a tabindex="0"><svg class="icon" focusable="false" aria-hidden="true" role="presentation"><use xlink:href="#icon-caret-down"></use></svg></a></li>';
     yearList += '</ul>';
@@ -1046,6 +1046,13 @@ MonthView.prototype = {
       .off('click.picklist-month')
       .on('click.picklist-month', '.picklist.is-month li', (e) => {
         setMonthYearPane(e.target, 'is-month');
+        e.preventDefault();
+      });
+
+    this.monthYearPane
+      .off('click.picklist-month-a')
+      .on('click.picklist-month-a', '.picklist.is-month li a', (e) => {
+        e.preventDefault();
       });
 
     this.monthYearPane
@@ -1061,6 +1068,13 @@ MonthView.prototype = {
         }
 
         setMonthYearPane(e.target, 'is-year');
+        e.preventDefault();
+      });
+
+    this.monthYearPane
+      .off('click.picklist-year-a')
+      .on('click.picklist-year-a', '.picklist.is-year li a', (e) => {
+        e.preventDefault();
       });
 
     // Handle behaviors when expanding and collapsing like disabling buttons and setting height


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When clicking links in the new datepicker month/year view the NG app will restart.

**Related github/jira issue (required)**:
Fixes #603 

**Steps necessary to review your pull request (required)**:
- pull the branch and build
- copy the dist files to an ng node_modules/ids-enterprise folder (or use npm link)
- run the NG app to http://localhost:4200/ids-enterprise-ng-demo/datepicker
- open the standard date picker and go into the month/year view
- click links (year and month) and the app should not redirect
- scroll up and down and click links (year and month) and the app should not redirect
- smoke test picker functionality in EP as well http://localhost:4000/components/datepicker/example-index.html