### PR TITLE
2490 - Add custom separator support with export to csv

### DIFF
--- a/app/views/components/datagrid/test-export-custom-separator.html
+++ b/app/views/components/datagrid/test-export-custom-separator.html
@@ -1,0 +1,102 @@
+<div class="row top-padding">
+  <div class="twelve columns">
+    <h3>Export To Csv</h3>
+    <p>Shows how to expose the export to csv functionality with custom separator.</p>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+    <p><strong>Default Separator</strong></p>
+    <ul>
+      <li>1) Add `sep=,` to first line</li>
+      <li>2) Change document seperator to char `,`</li>
+    </ul>
+    <br>
+    <pre><code>exportToCsv('Filename-1', data);</code></pre><br>
+    <button class="btn-secondary" type="button" id="export-default">Default</button>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+    <p><strong>Separator with Cusrom String</strong></p>
+    <ul>
+      <li>1) Add `sep=;` to first line</li>
+      <li>2) Change document seperator to char `;`</li>
+    </ul>
+    <br>
+    <pre><code>exportToCsv('Filename-2', data, 'sep=;');</code></pre><br>
+    <button class="btn-secondary" type="button" id="export-cusrom-string">Cusrom String</button>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+    <p><strong>Separator with Cusrom String Char Only</strong></p>
+    <ul>
+      <li>1) Add `sep=;` to first line</li>
+      <li>2) Change document seperator to char `;`</li>
+    </ul>
+    <br>
+    <pre><code>exportToCsv('Filename-3', data, ';');</code></pre><br>
+    <button class="btn-secondary" type="button" id="export-cusrom-string-char-only">Cusrom String Char Only</button>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+    <p><strong>Separator with Cusrom Object Type</strong></p>
+    <ul>
+      <li>1) NOT add anything to first line</li>
+      <li>2) Change document seperator to char `;`</li>
+    </ul>
+    <pre style="white-space: pre-line;"><code>
+      var separator = { firstLine: false, char: ';' };
+      exportToCsv('Filename-4', data, separator);
+    </code></pre><br>
+    <button class="btn-secondary" type="button" id="export-cusrom-object">Cusrom Object Type</button>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    var data = '';
+    var url = '{{basepath}}api/tasks';
+
+    // Set Data
+    $.getJSON(url, function(res) {
+      res.splice(0, 0, {id: ' ID', escalated: 'Escalated', taskName: 'Task Name', desc: 'Description', comments: 'Comments'});
+      data = res;
+    });
+
+    // Default separator *****************************************
+    // 1) Add `sep=,` to first line
+    // 2) Change document seperator to char `,`
+    $('#export-default').on('click', function () {
+      Soho.excel.exportToCsv('Filename-1', data);
+    });
+
+    // Separator with cusrom string, this will *******************
+    // 1) Add `sep=;` to first line
+    // 2) Change document seperator to char `;`
+    $('#export-cusrom-string').on('click', function () {
+      Soho.excel.exportToCsv('Filename-2', data, 'sep=;');
+    });
+
+    // Separator with cusrom string Char only, this will *********
+    // 1) Add `sep=;` to first line
+    // 2) Change document seperator to char `;`
+    $('#export-cusrom-string-char-only').on('click', function () {
+      Soho.excel.exportToCsv('Filename-3', data, ';');
+    });
+
+    // Separator with cusrom Object type, this will **************
+    // 1) NOT add anything to first line
+    // 2) Change document seperator to char `;`
+    $('#export-cusrom-object').on('click', function () {
+      var separator = { firstLine: false, char: ';' };
+      Soho.excel.exportToCsv('Filename-4', data, separator);
+    });
+ });
+</script>

--- a/app/views/components/datagrid/test-export-custom-separator.html
+++ b/app/views/components/datagrid/test-export-custom-separator.html
@@ -1,4 +1,4 @@
-<div class="row top-padding">
+custom<div class="row top-padding">
   <div class="twelve columns">
     <h3>Export To Csv</h3>
     <p>Shows how to expose the export to csv functionality with custom separator.</p>
@@ -7,46 +7,46 @@
 
 <div class="row top-padding">
   <div class="twelve columns">
-    <p><strong>Default Separator</strong></p>
+    <p><strong>Default Separator</strong></p><br/>
     <ul>
       <li>1) Add `sep=,` to first line</li>
       <li>2) Change document seperator to char `,`</li>
     </ul>
-    <br>
-    <pre><code>exportToCsv('Filename-1', data);</code></pre><br>
+    <br/>
+    <pre><code>exportToCsv('Filename-1', data);</code></pre><br/>
     <button class="btn-secondary" type="button" id="export-default">Default</button>
   </div>
 </div>
 
 <div class="row top-padding">
   <div class="twelve columns">
-    <p><strong>Separator with Cusrom String</strong></p>
+    <p><strong>Separator with Custom String</strong></p><br/>
     <ul>
       <li>1) Add `sep=;` to first line</li>
       <li>2) Change document seperator to char `;`</li>
     </ul>
-    <br>
-    <pre><code>exportToCsv('Filename-2', data, 'sep=;');</code></pre><br>
-    <button class="btn-secondary" type="button" id="export-cusrom-string">Cusrom String</button>
+    <br/>
+    <pre><code>exportToCsv('Filename-2', data, 'sep=;');</code></pre><br/>
+    <button class="btn-secondary" type="button" id="export-custom-string">Custom String</button>
   </div>
 </div>
 
 <div class="row top-padding">
   <div class="twelve columns">
-    <p><strong>Separator with Cusrom String Char Only</strong></p>
+    <p><strong>Separator with Custom String Char Only</strong></p><br/>
     <ul>
       <li>1) Add `sep=;` to first line</li>
       <li>2) Change document seperator to char `;`</li>
     </ul>
-    <br>
-    <pre><code>exportToCsv('Filename-3', data, ';');</code></pre><br>
-    <button class="btn-secondary" type="button" id="export-cusrom-string-char-only">Cusrom String Char Only</button>
+    <br/>
+    <pre><code>exportToCsv('Filename-3', data, ';');</code></pre><br/>
+    <button class="btn-secondary" type="button" id="export-custom-string-char-only">Custom String Char Only</button>
   </div>
 </div>
 
 <div class="row top-padding">
   <div class="twelve columns">
-    <p><strong>Separator with Cusrom Object Type</strong></p>
+    <p><strong>Separator with Custom Object Type</strong></p><br/>
     <ul>
       <li>1) NOT add anything to first line</li>
       <li>2) Change document seperator to char `;`</li>
@@ -54,8 +54,8 @@
     <pre style="white-space: pre-line;"><code>
       var separator = { firstLine: false, char: ';' };
       exportToCsv('Filename-4', data, separator);
-    </code></pre><br>
-    <button class="btn-secondary" type="button" id="export-cusrom-object">Cusrom Object Type</button>
+    </code></pre><br/>
+    <button class="btn-secondary" type="button" id="export-custom-object">Custom Object Type</button>
   </div>
 </div>
 
@@ -77,24 +77,24 @@
       Soho.excel.exportToCsv('Filename-1', data);
     });
 
-    // Separator with cusrom string, this will *******************
+    // Separator with custom string, this will *******************
     // 1) Add `sep=;` to first line
     // 2) Change document seperator to char `;`
-    $('#export-cusrom-string').on('click', function () {
+    $('#export-custom-string').on('click', function () {
       Soho.excel.exportToCsv('Filename-2', data, 'sep=;');
     });
 
-    // Separator with cusrom string Char only, this will *********
+    // Separator with custom string Char only, this will *********
     // 1) Add `sep=;` to first line
     // 2) Change document seperator to char `;`
-    $('#export-cusrom-string-char-only').on('click', function () {
+    $('#export-custom-string-char-only').on('click', function () {
       Soho.excel.exportToCsv('Filename-3', data, ';');
     });
 
-    // Separator with cusrom Object type, this will **************
+    // Separator with custom Object type, this will **************
     // 1) NOT add anything to first line
     // 2) Change document seperator to char `;`
-    $('#export-cusrom-object').on('click', function () {
+    $('#export-custom-object').on('click', function () {
       var separator = { firstLine: false, char: ';' };
       Soho.excel.exportToCsv('Filename-4', data, separator);
     });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # What's New with Enterprise
 
+## v4.22.0
+
+### v4.22.0 Deprecation
+
+### v4.22.0 Features
+
+- `[Export]` Added support for separator to use custom string or object type with Export to CSV. ([#2490](https://github.com/infor-design/enterprise/issues/2490))
+
+### v4.22.0 Fixes
+
+### v4.22.0 Chores & Maintenance
+
 ## v4.21.0
 
 ### v4.21.0 Deprecation

--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -342,11 +342,37 @@ excel.exportToExcel = function (fileName, worksheetName, customDs, self) {
  * Export the grid contents to csv
  * @param {string} fileName The desired export filename in the download.
  * @param {string} customDs An optional customized version of the data to use.
- * @param {string} separator (optional) If user's machine is configured for a locale with alternate default seperator.
+ * @param {string|object} sep (optional) If user's machine is configured for a locale with alternate default seperator.
+ * The char double quote `"` is not allowed to be use as seperator char
+ * Can use as custom string `sep=;` or `;` will add to first line and use `;` as seperator
+ * @param {boolean} [sep.firstLine=true] if false will not added to first line `sep=<separator.char>`
+ * @param {string} [sep.char=','] custom separator char
  * @param {string} self The grid api to use (if customDs is not used)
  * @returns {void}
  */
-excel.exportToCsv = function (fileName, customDs, separator = 'sep=,', self) {
+excel.exportToCsv = function (fileName, customDs, sep = 'sep=,', self) {
+  const isObject = v => (v && typeof v === 'object' && v.constructor === Object);
+  const isFalse = v => /^(false|0+|null)$/gi.test(v);
+
+  // Set Separator
+  const separator = { firstLine: true, char: ',' };
+  if (sep !== 'sep=,' && !isFalse(sep)) {
+    const setChar = char => (char !== '"' ? char : separator.char);
+    if (isObject(sep)) {
+      separator.firstLine = !isFalse(sep.firstLine);
+      if (typeof sep.char === 'string' && sep.char.length === 1 && !isFalse(sep.char)) {
+        separator.char = setChar(sep.char);
+      }
+    } else if (typeof sep === 'string') {
+      if (sep.length === 1 && !isFalse(sep)) {
+        separator.char = setChar(sep);
+      } else if (/^sep=.$/.test(sep)) {
+        const char = sep.replace('sep=', '');
+        separator.char = !isFalse(char) ? setChar(char) : separator.char;
+      }
+    }
+  }
+
   const formatCsv = function (table) {
     const csv = [];
     const rows = [].slice.call(table[0].querySelectorAll('tr'));
@@ -354,9 +380,11 @@ excel.exportToCsv = function (fileName, customDs, separator = 'sep=,', self) {
       const rowContent = [];
       const cols = [].slice.call(row.querySelectorAll('td, th'));
       cols.forEach(col => rowContent.push(col.textContent.replace(/\r?\n|\r/g, '').replace(/"/g, '""').trim()));
-      csv.push(rowContent.join('","'));
+      csv.push(rowContent.join(`"${separator.char}"`));
     });
-    csv.unshift([`${separator}`]);
+    if (separator.firstLine) {
+      csv.unshift([`sep=${separator.char}`]);
+    }
     return `"${csv.join('"\n"')}"`;
   };
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added support for separator to use custom string or object type with Export to CSV.

**Related github/jira issue (required)**:
Closes #2490

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/test-export-custom-separator.html
- Click on each button to download CSV file with custom setting
- Open saved file with text editor to review the outcome

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
