### PR TITLE
2723 - Fix overwritten labels with bar charts

### DIFF
--- a/app/views/components/bar/test-several-on-page.html
+++ b/app/views/components/bar/test-several-on-page.html
@@ -1,0 +1,63 @@
+<div class="row">
+  <div class="two-thirds column">
+    <div class="widget">
+      <div class="widget-header">
+        <h2 class="widget-title">Vertical Bar Chart Title 1</h2>
+      </div>
+      <div class="widget-content">
+        <div id="bar-example1" class="chart-container"></div>
+      </div>
+    </div>
+  </div>
+  <div class="two-thirds column">
+    <div class="widget">
+      <div class="widget-header">
+        <h2 class="widget-title">Vertical Bar Chart Title 2</h2>
+      </div>
+      <div class="widget-content">
+        <div id="bar-example2" class="chart-container"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script id="test-script">
+  $('body').on('initialized', function () {
+
+    var dataset1 = [{
+      data: [{
+        name: 'Category A',
+        value: 373,
+        url: 'test',
+        tooltip: 'Tooltip by Data <br> Component A <br> Information'
+      }, {
+        name: 'Category B',
+        value: 372
+      }, {
+        name: 'Category C',
+        value: 236.35
+      }],
+      name: ''
+    }];
+
+    var dataset2 = [{
+      data: [{
+        name: 'Category D',
+        value: 122,
+        url: 'test',
+        tooltip: 'Tooltip by Data <br> Component A <br> Information'
+      }, {
+        name: 'Category E',
+        value: 122
+      }, {
+        name: 'Category F',
+        value: 122
+      }],
+      name: ''
+    }];
+
+    $('#bar-example1').chart({type: 'bar', dataset: dataset1, animate: false});
+    $('#bar-example2').chart({type: 'bar', dataset: dataset2, animate: false});
+
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### v4.22.0 Fixes
 
+- `[Bar Chart]` Fixed an issue where labels were overwritten when use more then one chart on page. ([#2723](https://github.com/infor-design/enterprise/issues/2723))
+
 ### v4.22.0 Chores & Maintenance
 
 ## v4.21.0

--- a/src/components/bar/bar.js
+++ b/src/components/bar/bar.js
@@ -720,7 +720,7 @@ Bar.prototype = {
       return;
     }
 
-    const elems = document.querySelectorAll('.bar-chart .axis.y .tick text');
+    const elems = this.element[0].querySelectorAll('.bar-chart .axis.y .tick text');
     const dataset = this.settings.dataset;
     for (let i = 0; i < dataset.length; i++) {
       const values = Object.keys(dataset[i]).map(e => dataset[i][e]);

--- a/test/components/bar/bar.e2e-spec.js
+++ b/test/components/bar/bar.e2e-spec.js
@@ -204,3 +204,33 @@ describe('Bar Chart axis formatter tests', () => {
     });
   }
 });
+
+describe('Bar Chart several on page tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/bar/test-several-on-page?layout=nofrills');
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('.axis.y .tick text'))), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should not overwritten labels', async () => {
+    const checkText = async (svgId, tickNum, text) => {
+      expect(await element.all(by.css(`${svgId} .axis.y .tick text`)).get(tickNum).getText()).toEqual(text);
+    };
+
+    expect(await element.all(by.css('.bar-chart svg')).count()).toBe(2);
+    expect(await element.all(by.css('#bar-example1 .axis.y .tick text')).count()).toBe(3);
+    expect(await element.all(by.css('#bar-example2 .axis.y .tick text')).count()).toBe(3);
+
+    await checkText('#bar-example1', 0, 'Category A');
+    await checkText('#bar-example1', 1, 'Category B');
+    await checkText('#bar-example1', 2, 'Category C');
+
+    await checkText('#bar-example2', 0, 'Category D');
+    await checkText('#bar-example2', 1, 'Category E');
+    await checkText('#bar-example2', 2, 'Category F');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed overwritten labels, when use more then one chart on page with bar charts.

**Related github/jira issue (required)**:
Closes #2723

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/bar/test-several-on-page.html
- See the labels of both charts should be different 

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
