### PR TITLE
2767 - Fix some accordion issues for NG [v4.21.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 - `[Application Menu]` Fixed an indentation issue with child elements in an accordion in the Angular application (enterprise-ng). ([#2616](https://github.com/infor-design/enterprise/issues/2616))
 - `[AppMenu/Accordion]` Improved performance on Angular by not calling siftFor. ([#2767](https://github.com/infor-design/enterprise/issues/2767))
-- `[AppMenu/Accordion]` Fixed a bug that the buys indicator would immediately shut. ([#2767](https://github.com/infor-design/enterprise/issues/2767))
+- `[AppMenu/Accordion]` Fixed a bug where the busy indicator would immediately close. ([#2767](https://github.com/infor-design/enterprise/issues/2767))
 - `[Button]` Fixed an issue where updated method was not teardown and re-init. ([#2304](https://github.com/infor-design/enterprise/issues/2304))
 - `[Circle Pager]` Fixed a bug where it was not showing on mobile view. ([#2589](https://github.com/infor-design/enterprise/issues/2589))
 - `[Contextual Action Panel]` Fixed an issue where if the title is longer, there will be an overflow causing a white space on the right on mobile view. ([#2605](https://github.com/infor-design/enterprise/issues/2605))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,7 @@
 ### v4.21.0 Fixes
 
 - `[Application Menu]` Fixed an indentation issue with child elements in an accordion in the Angular application (enterprise-ng). ([#2616](https://github.com/infor-design/enterprise/issues/2616))
-- `[AppMenu/Accordion]` Improved performance on Angular by not calling siftFor. ([#2767](https://github.com/infor-design/enterprise/issues/2767))
+- `[AppMenu/Accordion]` Improved performance on Angular by not calling siftFor on the app menu build. ([#2767](https://github.com/infor-design/enterprise/issues/2767))
 - `[AppMenu/Accordion]` Fixed a bug where the busy indicator would immediately close. ([#2767](https://github.com/infor-design/enterprise/issues/2767))
 - `[Button]` Fixed an issue where updated method was not teardown and re-init. ([#2304](https://github.com/infor-design/enterprise/issues/2304))
 - `[Circle Pager]` Fixed a bug where it was not showing on mobile view. ([#2589](https://github.com/infor-design/enterprise/issues/2589))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,8 @@
 ### v4.21.0 Fixes
 
 - `[Application Menu]` Fixed an indentation issue with child elements in an accordion in the Angular application (enterprise-ng). ([#2616](https://github.com/infor-design/enterprise/issues/2616))
+- `[AppMenu/Accordion]` Improved performance on Angular by not calling siftFor. ([#2767](https://github.com/infor-design/enterprise/issues/2767))
+- `[AppMenu/Accordion]` Fixed a bug that the buys indicator would immediately shut. ([#2767](https://github.com/infor-design/enterprise/issues/2767))
 - `[Button]` Fixed an issue where updated method was not teardown and re-init. ([#2304](https://github.com/infor-design/enterprise/issues/2304))
 - `[Circle Pager]` Fixed a bug where it was not showing on mobile view. ([#2589](https://github.com/infor-design/enterprise/issues/2589))
 - `[Contextual Action Panel]` Fixed an issue where if the title is longer, there will be an overflow causing a white space on the right on mobile view. ([#2605](https://github.com/infor-design/enterprise/issues/2605))

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -224,7 +224,7 @@ Accordion.prototype = {
 
       if (!self.isExpanded(header)) {
         pane.data('ignore-animation-once', true);
-        self.collapse(header);
+        self.collapse(header, false);
       }
     });
 
@@ -835,10 +835,11 @@ Accordion.prototype = {
   /**
   * Collapse the given Panel on the Accordion.
   * @param {object} header The jquery header element.
+  * @param {boolean} closeChildren If true closeChildren elements that may be on the page. Skip for performance.
   * @returns {$.Deferred} resolved on the completion of an Accordion pane's
   *  collapse animation (or immediately, if animation is disabled).
   */
-  collapse(header) {
+  collapse(header, closeChildren = true) {
     if (!header || !header.length) {
       return;
     }
@@ -860,8 +861,12 @@ Accordion.prototype = {
       expander.children('.audible').text(Locale.translate('Expand'));
     }
 
-    pane.removeClass('is-expanded').closeChildren();
+    pane.removeClass('is-expanded');
     a.attr('aria-expanded', 'false');
+
+    if (closeChildren) {
+      pane.closeChildren();
+    }
 
     /**
     *  Fires when collapsed a pane is initiated.

--- a/src/utils/lifecycle.js
+++ b/src/utils/lifecycle.js
@@ -1,6 +1,6 @@
 // Lifecycle Methods for jQuery Controls
 // Recursive methods that "globally" call certain methods on large groups of controls
-const EXCLUDED_FROM_CLOSE_CHILDREN = ['.expandable-area', '.accordion', ['soho-busyindicator'], '.busyindicator'];
+const EXCLUDED_FROM_CLOSE_CHILDREN = ['.expandable-area', '.accordion', '[soho-busyindicator]', '.busy-indicator-container'];
 const EXCLUDED_FROM_HANDLE_RESIZE = [];
 
 // Used by several of these plugins to detect whether or not the "data" property in question


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixed two bugs seen in landmark:
1) The busy indicator would immediate close in angular / landmark when the app menu loads
2) The siftFor doing a expensive body selector would call once per accordion pane in the menu (180 times) which was slow on IE. Fixed this by adding a new parameter so its not called on app menu build.

**Related github/jira issue (required)**:
Fixes #2767 

**Steps necessary to review your pull request (required)**:
- test in landmark
- retest page http://localhost:4000/components/accordion/test-close-children-on-collapse.html
- pull this done and npm link or copy the dist to node_modules in ids-enterprise
- put a debug on the `siftFor` function and load http://localhost:4200/ids-enterprise-ng-demo/
- should no longer go in here once per menu items

**Included in this Pull Request**:
- [x] A note to the change log.
