### PR TITLE
2748 - Fix Uplift Color Issues

### DIFF
--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -210,7 +210,7 @@ div.multiselect {
   background-color: transparent;
   border: 1px solid $dropdown-menu-border-color;
   border-radius: 3px;
-  box-shadow: $dropdown-shadow-initial-boxshadow, $focus-box-shadow;
+  box-shadow: $dropdown-box-shadow-top, $focus-box-shadow;
   font-size: $theme-size-font-base;
   max-height: 340px;
   min-height: 30px;

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -210,7 +210,7 @@ $trigger-disabled-color: $theme-color-brand-secondary-alt;
 $dropdown-menu-border-color: $theme-color-brand-primary-base;
 $dropdown-menu-separator-color: $theme-color-palette-graphite-40;
 $dropdown-menu-separator-border-color: $theme-color-palette-graphite-30;
-$dropdown-box-shadow-top: 0 -5px 5px $drop-shadow-depth;
+$dropdown-box-shadow-top: 0 0 5px $drop-shadow-depth;
 
 //List View
 $listview-bg-color: $theme-color-palette-white;

--- a/src/themes/theme-uplift-contrast.scss
+++ b/src/themes/theme-uplift-contrast.scss
@@ -30,7 +30,7 @@ $header-focus-box-shadow:  0 0 4px 3px rgba(255, 255, 255, 0.3);
 $dropdown-search-bg-color: $theme-color-palette-white;
 $panel-bg-color: $theme-color-palette-white;
 $panel-border-color: $theme-color-palette-graphite-40;
-$drop-shadow-depth: rgba(0, 0, 0, 0.2);
+$drop-shadow-depth: rgba($theme-color-boxshadow-base, 0.2);
 $focus-box-shadow-color: rgba(41, 41, 41, 0.3);
 $focus-box-shadow: 0 0 4px 2px $focus-box-shadow-color;
 

--- a/src/themes/theme-uplift-contrast.scss
+++ b/src/themes/theme-uplift-contrast.scss
@@ -368,7 +368,7 @@ $pager-text-color: $theme-color-brand-primary-base;
 $pager-selected-color: $font-color-highcontrast;
 $pager-focus-border-color: $input-color-focus-border;
 $pager-hover-color: $font-color-extrahighcontrast;
-$pager-disabled-color: $theme-color-brand-secondary-alt;
+$pager-disabled-color: $theme-color-palette-graphite-40;
 
 // Slider
 $slider-bg-color: $theme-color-palette-graphite-60;

--- a/src/themes/theme-uplift-dark.scss
+++ b/src/themes/theme-uplift-dark.scss
@@ -28,7 +28,7 @@ $header-focus-box-shadow:  0 0 4px 3px rgba(255, 255, 255, 0.3);
 $dropdown-search-bg-color: $theme-color-palette-slate-80;
 $panel-bg-color: $theme-color-palette-slate-80;
 $panel-border-color: $theme-color-palette-slate-70;
-$drop-shadow-depth: rgba(0, 0, 0, 0.4);
+$drop-shadow-depth: rgba($theme-color-boxshadow-base, 0.4);
 $focus-box-shadow-color: rgba(141, 201, 230, 0.3);
 $focus-box-shadow: 0 0 4px 2px $focus-box-shadow-color;
 

--- a/src/themes/theme-uplift-light.scss
+++ b/src/themes/theme-uplift-light.scss
@@ -16,6 +16,7 @@
 
 // Uplift Light Overrides
 $body-color-primary-background: $theme-color-palette-white;
+$drop-shadow-depth: rgba($theme-color-boxshadow-base, 0.2);
 
 $application-menu-border-color: $theme-color-palette-slate-90;
 $accordion-inverse-bg-color: $theme-color-palette-slate-90;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a couple of visual bugs in the Uplift theme:
- The box shadow color and placement on Dropdown Lists has been improved.
- The disabled color for icons on pager buttons is now more distinct from other button colors.

**Related github/jira issue (required)**:
Closes #2748 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app.
- Examine the Dropdown List's box shadow colors on all Uplift variants: http://localhost:4000/components/dropdown/example-index.html?theme=uplift
- On that same sample, ensure that when filtering the dropdown, the Search icon is fully visible and not cut off.
- Examine the disabled color on pager buttons on http://localhost:4000/components/pager/example-index.html?theme=uplift&variant=contrast, and ensure it's significantly different from the other buttons.
