### PR TITLE
246 - Fix incorrect xss removal on modal

### DIFF
--- a/app/views/components/message/test-escaped-title.html
+++ b/app/views/components/message/test-escaped-title.html
@@ -14,17 +14,15 @@ $('#show-message').on('click.test', function () {
       buttons: [{
           id: 'id-cancel',
           text: 'Cancel',
-          click: function() {
-            console.log('You Cancelled');
-            $(this).data('modal').close();
+          click: function(e, modal) {
+            modal.close();
           },
           isLink: true,
           isDefault: true
         },{
           text: 'Remove',
-          click: function() {
-            console.log('Remove It');
-            $(this).data('modal').close();
+          click: function(e, modal) {
+            modal.close();
           }
         }]
     };

--- a/app/views/components/message/test-escaped-title.html
+++ b/app/views/components/message/test-escaped-title.html
@@ -1,0 +1,51 @@
+<div class="row">
+  <div class="twelve columns">
+    <button id="show-message" class="btn-secondary" type="button">Show Message</button>
+  </div>
+</div>
+
+<script>
+$('#show-message').on('click.test', function () {
+    var opts = $(this).attr('data-message');
+
+    opts = {
+      title: '&lt;script&gt;alert(&quot;menuXSS&quot;)&lt;/script&gt;',
+      message: '<span class="longer-message">Are you sure you want to delete this page?</span>',
+      buttons: [{
+          id: 'id-cancel',
+          text: 'Cancel',
+          click: function() {
+            console.log('You Cancelled');
+            $(this).data('modal').close();
+          },
+          isLink: true,
+          isDefault: true
+        },{
+          text: 'Remove',
+          click: function() {
+            console.log('Remove It');
+            $(this).data('modal').close();
+          }
+        }]
+    };
+
+    $('body').message(opts)
+    .on('beforeopen', function () {
+      console.log('beforeOpen');
+      //return false;
+    })
+    .on('open', function () {
+      console.log('open');
+    })
+    .on('beforeclose', function () {
+      console.log('beforeclose');
+      //return false;
+    })
+    .on('close', function () {
+      console.log('close');
+    })
+    .on('afterclose', function () {
+      console.log('afterclose');
+    });
+});
+</script>

--- a/app/views/components/modal/test-escaped-title.html
+++ b/app/views/components/modal/test-escaped-title.html
@@ -43,17 +43,15 @@
       buttons: [{
           id: 'id-cancel',
           text: 'Cancel',
-          click: function() {
-            console.log('You Cancelled');
-            $(this).data('modal').close();
+          click: function(e, modal) {
+            modal.close();
           },
           isLink: true,
           isDefault: true
         },{
           text: 'Remove',
-          click: function() {
-            console.log('Remove It');
-            $(this).data('modal').close();
+          click: function(e, modal) {
+            modal.close();
           }
         }]
     };

--- a/app/views/components/modal/test-escaped-title.html
+++ b/app/views/components/modal/test-escaped-title.html
@@ -1,16 +1,45 @@
 <div class="row">
-  <div class="twelve columns">
-    <button id="show-message" class="btn-secondary" type="button">Show Message</button>
+	<div class="twelve columns">
+
+		<button class="btn-secondary" type="button" id="show-modal">Show Modal</button><br/><br/>
+	</div>
+</div>
+
+
+		<!-- Modal Example -->
+<div id="modal-add-context" class="hidden">
+  <div class="form-responsive row no-bottom-margin">
+   <div class="twelve columns">
+			<div class="field">
+				<label for="subject">Problem</label>
+				<input type="text" id="subject" name="subject" />
+			</div>
+
+      <div class="field">
+        <label for="location" class="label">Location</label>
+        <select id="location" name="location" class="dropdown">
+          <option value="N">North</option>
+          <option value="S">South</option>
+          <option value="E">East</option>
+          <option value="W">West</option>
+        </select>
+      </div>
+
+			<div class="field">
+				<label for="notes-max">Notes (maxlength)</label>
+				<textarea id="notes-max" class="textarea" maxlength="90" name="notes-max">Line One</textarea>
+			</div>
+		</div>
   </div>
 </div>
 
 <script>
-$('#show-message').on('click.test', function () {
+  $('#show-modal').on('click.test', function () {
     var opts = $(this).attr('data-message');
-
     opts = {
       title: '&lt;script&gt;alert(&quot;menuXSS&quot;)&lt;/script&gt;',
-      message: '<span class="longer-message">Are you sure you want to delete this page?</span>',
+      id: 'my-id',
+      content: $('#modal-add-context'),
       buttons: [{
           id: 'id-cancel',
           text: 'Cancel',
@@ -29,23 +58,6 @@ $('#show-message').on('click.test', function () {
         }]
     };
 
-    $('body').message(opts)
-    .on('beforeopen', function () {
-      console.log('beforeOpen');
-      //return false;
-    })
-    .on('open', function () {
-      console.log('open');
-    })
-    .on('beforeclose', function () {
-      console.log('beforeclose');
-      //return false;
-    })
-    .on('close', function () {
-      console.log('close');
-    })
-    .on('afterclose', function () {
-      console.log('afterclose');
-    });
-});
+    $('body').modal(opts);
+  });
 </script>

--- a/app/views/components/modal/test-xss.html
+++ b/app/views/components/modal/test-xss.html
@@ -42,13 +42,11 @@ var modals = {
     opt = $.extend({
       buttons: [{
         text: 'Cancel',
-      //  id: 'modal-button-1',
         click: function(e, modal) {
           modal.close();
         }
       }, {
         text: 'Save',
-      //  id: 'modal-button-2',
         click: function(e, modal) {
           modal.close();
         },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[Bar Chart]` Fixed an issue where labels were overwritten when use more then one chart on page. ([#2723](https://github.com/infor-design/enterprise/issues/2723))
 - `[Datagrid]` Fixed an issue where if you have duplicate Id's the columns many become misaligned. ([#2687](https://github.com/infor-design/enterprise/issues/2687))
 - `[Icons]` Added and updated the following icons: icon-new, icon-calculator, icon-save-new, icon-doc-check. ([#391](https://github.com/infor-design/design-system/issues/391))
+- `[Modal]` Fixed an issue where encoded html would not be recoded on the title. ([#246](https://github.com/infor-design/enterprise/issues/246))
 
 ### v4.22.0 Chores & Maintenance
 

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -4,7 +4,7 @@
 .form-responsive {
   input,
   textarea {
-    width: 100%;
+    width: 100% !important;
   }
 
   .colorpicker-container {
@@ -50,6 +50,9 @@
     white-space: nowrap;
   }
 
+  .row.no-bottom-margin {
+    margin-bottom: 0;
+  }
 }
 
 @media (max-width: $breakpoint-phone-to-tablet + 1) {

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -122,9 +122,6 @@ Modal.prototype = {
     this.id = this.element.attr('id') || (parseInt($('.modal').length, 10) + 1);
     this.namespace = `${COMPONENT_NAME}-${this.id}`;
 
-    // Prevent Css on the title
-    this.settings.title = xssUtils.stripTags(this.settings.title, '<div><span><a><small><img><svg><i><b><use><br><strong><em>');
-
     // Find the button or anchor with same dialog ID
     this.trigger = $(`[data-modal="${this.element.attr('id')}"]`);
     if (this.element.is('body')) {
@@ -181,7 +178,7 @@ Modal.prototype = {
 
     this.element = $(`${'<div class="modal">' +
         '<div class="modal-content" style="max-width: '}${this.settings.maxWidth ? this.settings.maxWidth : ''}px${'">' +
-          '<div class="modal-header"><h1 class="modal-title">'}${this.settings.title}</h1></div>` +
+          '<div class="modal-header"><h1 class="modal-title">'}</h1></div>` +
           '<div class="modal-body-wrapper">' +
             '<div class="modal-body"></div>' +
           '</div>' +
@@ -244,7 +241,8 @@ Modal.prototype = {
     }
 
     if (this.settings.title) {
-      this.element.find('.modal-title').text(this.settings.title);
+      // Prevent Css on the title
+      this.element.find('.modal-title')[0].innerHTML = xssUtils.stripTags(this.settings.title, '<div><span><a><small><img><svg><i><b><use><br><strong><em>');
     }
 
     if (!isAppended) {

--- a/test/components/message/message.e2e-spec.js
+++ b/test/components/message/message.e2e-spec.js
@@ -36,3 +36,25 @@ describe('Message tests', () => {
     expect(['hide-focus', 'btn-modal', 'btn-modal hide-focus']).toContain(await modalButtonEl.getAttribute('class'));
   });
 });
+
+describe('Message xss tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/message/test-escaped-title');
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should not be able to tab out of message modal', async () => {
+    const buttonEl = await element(by.id('show-message'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(buttonEl), config.waitsFor);
+    await buttonEl.click();
+
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('.message.modal'))), config.waitsFor);
+
+    expect(await element(by.css('.message.modal .modal-title')).getText()).toEqual('<script>alert("menuXSS")</script>');
+  });
+});

--- a/test/components/modal/modal.e2e-spec.js
+++ b/test/components/modal/modal.e2e-spec.js
@@ -286,3 +286,25 @@ describe('Modal Full Content Tests', () => {
     await element.all(by.css('.modal-buttonset button')).first().click();
   });
 });
+
+describe('Modal xss tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/modal/test-escaped-title');
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should not be able to tab out of message modal', async () => {
+    const buttonEl = await element(by.id('show-modal'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(buttonEl), config.waitsFor);
+    await buttonEl.click();
+
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('.modal'))), config.waitsFor);
+
+    expect(await element(by.css('.modal .modal-title')).getText()).toEqual('<script>alert("menuXSS")</script>');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The original issue #246 only fixed xss on the title for messages not modal. This fixes it for both.

**Related github/jira issue (required)**:
Fixes #246 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/message/test-escaped-title.html
- open the message
- title should say `<script>alert("menuXSS")</script>`
- go to http://localhost:4000/components/modal/test-escaped-title.html
- open the modal
- title should say `<script>alert("menuXSS")</script>`

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
