### PR TITLE
2745 - Tabs: Searchfield X button and text overlap

### DIFF
--- a/app/views/components/tabs-module/example-category-searchfield-go-button.html
+++ b/app/views/components/tabs-module/example-category-searchfield-go-button.html
@@ -20,7 +20,7 @@
         </div>
         <div class="buttonset">
           <label for="searchfield-category-go">Searchfield</label>
-          <input id="searchfield-category-go" class="searchfield is-personalizable" data-options='{ "collapsible": false, "showGoButton": true, "categories": [ "Books", "Movies", "Music", "Video Games" ], "showCategoryText": true }'/>
+          <input id="searchfield-category-go" class="searchfield is-personalizable"/>
         </div>
       </div>
     </header>
@@ -54,3 +54,28 @@
       </section>
     </div>
   </div>
+
+  <script>
+    var body = $('body'),
+      sf = $('#searchfield-category-go');
+
+    // Go Button Action
+    function goButtonAction(e, value, categoryData) {
+      var msg = '<p><b>Searchfield Value: </b>'+ value +'</p>' +
+        '<p><b>Category Data</b>'+  JSON.stringify(categoryData) +'</p>';
+
+      body.toast({
+        'title': 'Go Button Clicked',
+        'message': msg
+      });
+    }
+
+    sf.toolbarsearchfield({
+      'collapsible': false,
+      'goButtonAction': goButtonAction,
+      'showGoButton': true,
+      'categories': [ 'Books', 'Movies', 'Music', 'Video Games' ],
+      'showCategoryText': true
+    });
+
+  </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[Datagrid]` Made the text all white on the targeted achievement formatter. ([#2730](https://github.com/infor-design/enterprise/issues/2730))
 - `[Listview]` Fixed an issue where empty message would not be centered if the listview in a flex container. ([#2716](https://github.com/infor-design/enterprise/issues/2716))
 - `[Tabs]` Add more padding to the count styles. ([#2744](https://github.com/infor-design/enterprise/issues/2744))
+- `[Tabs Module]` Fixed styling and appearance issues on an example page demonstrating the Go Button alongside a Searchfield with Categories. ([#2745](https://github.com/infor-design/enterprise/issues/2745))
 - `[Icons]` Added and updated the following icons: icon-new, icon-calculator, icon-save-new, icon-doc-check. ([#391](https://github.com/infor-design/design-system/issues/391))
 
 ### v4.22.0 Chores & Maintenance

--- a/src/components/searchfield/searchfield.js
+++ b/src/components/searchfield/searchfield.js
@@ -412,7 +412,7 @@ SearchField.prototype = {
       if (!this.goButton || !this.goButton.length) {
         this.goButton = $(`
           <button class="btn-secondary go-button">
-            <span>${this.settings.goButtonCopy || Locale.translate('Go')}</span>
+            <span>${this.settings.goButtonCopy || Locale.translate('Go', { showBrackets: false })}</span>
           </button>
         `);
       }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This turned out to be an example issue. Searchfield with categories was acting up and styling incorrectly when options were injected via html attribute data-options. Moved these to a <script>.

**Related github/jira issue (required)**:
Closes #2745 

**Steps necessary to review your pull request (required)**:
- Pull branch, build, run app
- Visit http://localhost:4000/components/tabs-module/example-category-searchfield-go-button.html
- Play around with the Searchfield with Categories and ensure there are nothing overlapping as per the issue description.

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.