### PR TITLE
2692 - Add e2e test for `noSearchfieldReinvoke` to check for errors

### DIFF
--- a/test/components/toolbar/toolbar-searchfield.e2e-spec.js
+++ b/test/components/toolbar/toolbar-searchfield.e2e-spec.js
@@ -1,0 +1,25 @@
+const { browserStackErrorReporter } = requireHelper('browserstack-error-reporter');
+const config = requireHelper('e2e-config');
+const utils = requireHelper('e2e-utils');
+requireHelper('rejection');
+
+jasmine.getEnv().addReporter(browserStackErrorReporter);
+
+// Searchfield IDs
+const sfId = 'regular-toolbar-searchfield';
+
+describe('Toolbar Searchfield (no-reinvoke)', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/toolbar/test-searchfield-no-reinvoke-update?layout=nofrills');
+    await browser.driver
+      .wait(protractor.ExpectedConditions
+        .presenceOf(element(by.id(sfId))), config.waitsFor);
+  });
+
+  it('can be updated without issues', async () => {
+    await element(by.id('update-toolbar')).click();
+    await browser.driver.sleep(config.sleep);
+
+    await utils.checkForErrors();
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR just adds a quick e2e test that checks a test page for errors.  The Toolbar Searchfield's `noSearchfieldReinvoke` setting has a strange lifecycle that should be checked for errors whenever the Toolbar or Searchfield components are modified, and this provides a quick smoke test.

**Related github/jira issue (required)**:
Closes #2692

**Steps necessary to review your pull request (required)**:
Ensure all the tests on this branch pass

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
