### PR TITLE
434 - Add Percent Locale examples

### DIFF
--- a/app/views/components/mask/test-percent-locale.html
+++ b/app/views/components/mask/test-percent-locale.html
@@ -1,0 +1,26 @@
+<div class="row">
+  <div class="six columns">
+    <h2>Mask using currency and locale</h2>
+    <p>Test this page with ar-SA, tr-TR and en-US</p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="six columns">
+    <div class="field">
+      <label for="percentage-field">Percentage Field</label>
+      <input id="percentage-field" />
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').on('initialized', function(locale, args) {
+    $('#percentage-field').mask({
+      pattern: Locale.currentLocale.data.numbers.percentFormat,
+      patternOptions: {
+        allowDecimal: false
+      }
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[Datepicker]` Moved the today button to the datepicker header and adding a setting to hide it if wanted. ([#2704](https://github.com/infor-design/enterprise/issues/2704))
 - `[Icons]` Added and updated the following icons: icon-new, icon-calculator, icon-save-new, icon-doc-check. ([#391](https://github.com/infor-design/design-system/issues/391))
 - `[Listview]` Fixed an issue where empty message would not be centered if the listview in a flex container. ([#2716](https://github.com/infor-design/enterprise/issues/2716))
+- `[Mask]` Added an example showing how to user percent format with the locale. ([#434](https://github.com/infor-design/enterprise/issues/434))
 - `[Modal]` Fixed an issue where encoded html would not be recoded on the title. ([#246](https://github.com/infor-design/enterprise/issues/246))
 - `[Tabs]` Add more padding to the count styles. ([#2744](https://github.com/infor-design/enterprise/issues/2744))
 - `[Tabs-Module]` Fixed styling and appearance issues on an example page demonstrating the Go Button alongside a Searchfield with Categories. ([#2745](https://github.com/infor-design/enterprise/issues/2745))

--- a/test/components/mask/mask.e2e-spec.js
+++ b/test/components/mask/mask.e2e-spec.js
@@ -1,0 +1,48 @@
+const { browserStackErrorReporter } = requireHelper('browserstack-error-reporter');
+const config = requireHelper('e2e-config');
+const utils = requireHelper('e2e-utils');
+requireHelper('rejection');
+
+jasmine.getEnv().addReporter(browserStackErrorReporter);
+
+const inputId = 'percentage-field';
+
+describe('Mask Percent Format Tests', () => {
+  it('Should be type in en-US', async () => {
+    await utils.setPage('/components/mask/test-percent-locale');
+    const inputEl = await element(by.id(inputId));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(inputEl), config.waitsFor);
+
+    await inputEl.clear();
+    await inputEl.sendKeys('100');
+
+    expect(await inputEl.getAttribute('value')).toEqual('100 %');
+  });
+
+  it('Should be type in tr-TR', async () => {
+    await utils.setPage('/components/mask/test-percent-locale?locale=tr-TR');
+    const inputEl = await element(by.id(inputId));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(inputEl), config.waitsFor);
+    await browser.driver.sleep(config.sleepShort);
+
+    await inputEl.clear();
+    await inputEl.sendKeys('100');
+
+    expect(await inputEl.getAttribute('value')).toEqual('%100');
+  });
+
+  it('Should be type in ar-SA', async () => {
+    await utils.setPage('/components/mask/test-percent-locale?locale=ar-SA');
+    const inputEl = await element(by.id(inputId));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(inputEl), config.waitsFor);
+    await browser.driver.sleep(config.sleepShort);
+
+    await inputEl.clear();
+    await inputEl.sendKeys('100');
+
+    expect(await inputEl.getAttribute('value')).toEqual('100 ٪');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The logic was already in place for 434 so added an example and some tests.

**Related github/jira issue (required)**:
Closes #434 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/mask/test-percent-locale
- type: 100
- should show to the en-US format: `100 %`
- http://localhost:4000/components/mask/test-percent-locale?locale=ar-SA
- type: 100
- should show to the ar-SA format: `٪ 100`
- http://localhost:4000/components/mask/test-percent-locale?locale=tr-TR
- type: 100
- should show to the tr-TR format: `%100`

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
