### PR TITLE
2797 - Fix keyword search to reset on paging and sort

### DIFF
--- a/app/views/components/datagrid/example-paging.html
+++ b/app/views/components/datagrid/example-paging.html
@@ -66,7 +66,7 @@
             response(res.data, req);
           });
         },
-        toolbar: {title: 'Data Grid Header Title',filterRow: true, personalize: true, results: true, keywordFilter: true, actions: true, rowHeight: true, collapsibleFilter: true}
+        toolbar: {title: 'Data Grid Header Title', filterRow: true, personalize: true, results: true, keywordFilter: false, actions: true, rowHeight: true}
       })
       .on('selected', function (e, args) {
         console.log('Selected: ', args);

--- a/app/views/components/datagrid/test-editable-paging-validation-notoolbar.html
+++ b/app/views/components/datagrid/test-editable-paging-validation-notoolbar.html
@@ -73,9 +73,7 @@
             });
 
             $('#datagrid').on('page', function(e, pi) {
-              var gridApi = $(this).data('datagrid');	              if (pi && pi.type === 'afterpaging') {
-              gridApi.validateAll();	                return;
-              }
+              var gridApi = $(this).data('datagrid');
               var self = $(this).data('datagrid');
               if (pi && pi.type === 'next' || pi.type === 'prev') {
                 var offet = pi.pagesize;

--- a/app/views/components/datagrid/test-editable-paging-validation.html
+++ b/app/views/components/datagrid/test-editable-paging-validation.html
@@ -89,10 +89,6 @@
 
             $('#datagrid').on('page', function(e, pi) {
               var gridApi = $(this).data('datagrid');
-              if (pi && pi.type === 'afterpaging') {
-                gridApi.validateAll();
-                return;
-              }
               var self = $(this).data('datagrid');
               if (pi && pi.type === 'next' || pi.type === 'prev') {
                 var offet = pi.pagesize;

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -745,7 +745,7 @@ Datagrid.prototype = {
 
     if (this.settings.source) {
       // Hide the entire pager bar if we're only showing one page, if applicable
-      if (this.pagerAPI.hidePagerBar(pagingInfo)) {
+      if (this.pagerAPI && this.pagerAPI.hidePagerBar(pagingInfo)) {
         this.element.removeClass('paginated');
       } else {
         this.element.addClass('paginated');

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -701,13 +701,14 @@ Datagrid.prototype = {
       }
 
       /**
-      * Fires after changing paging has completed.
+      * Fires after changing paging has completed for source operations.
       * @event afterpaging
-      * @memberof Pager
+      * @memberof Datagrid
       * @property {object} event - The jquery event object
       * @property {object} pagingInfo - The paging info object
       */
       self.element.trigger('afterpaging', pagingInfo);
+      self.afterPaging(pagingInfo);
     }
 
     if (this.sortColumn && this.sortColumn.sortId) {
@@ -730,6 +731,38 @@ Datagrid.prototype = {
     this.element.trigger('paging', pagingInfo);
 
     this.settings.source(pagingInfo, response);
+  },
+
+  /**
+   * Do some work after changing the page
+   * @param {object} pagingInfo Info about the paging operation
+   * @private
+   */
+  afterPaging(pagingInfo) {
+    if (!this.settings.paging) {
+      return;
+    }
+
+    if (this.settings.source) {
+      // Hide the entire pager bar if we're only showing one page, if applicable
+      if (this.pagerAPI.hidePagerBar(pagingInfo)) {
+        this.element.removeClass('paginated');
+      } else {
+        this.element.addClass('paginated');
+      }
+
+      if (pagingInfo.total) {
+        this.recordCount = pagingInfo.total;
+        this.displayCounts(pagingInfo.total);
+      }
+
+      // Handle row selection across pages
+      this.syncSelectedUI();
+    }
+
+    if (!this.settings.source && this.filterExpr && this.filterExpr[0] && this.filterExpr[0].column === 'all') {
+      this.highlightSearchRows(this.filterExpr[0].value);
+    }
   },
 
   /**
@@ -5681,33 +5714,16 @@ Datagrid.prototype = {
 
     // Handle Paging
     if (this.settings.paging) {
-      this.element.on(`afterpaging.${COMPONENT_NAME}`, (e, args) => {
-      // Hide the entire pager bar if we're only showing one page, if applicable
-        if (self.pagerAPI.hidePagerBar(args)) {
-          self.element.removeClass('paginated');
-        } else {
-          self.element.addClass('paginated');
-        }
-
-        self.recordCount = args.total;
-        self.displayCounts(args.total);
-
-        // Handle row selection across pages
-        self.syncSelectedUI();
-
-        if (self.filterExpr && self.filterExpr[0] && self.filterExpr[0].column === 'all') {
-          self.highlightSearchRows(self.filterExpr[0].value);
-        }
-      });
-
       this.tableBody.on(`page.${COMPONENT_NAME}`, (e, pagingInfo) => {
         if (pagingInfo.type === 'filtered' && this.settings.source) {
           return;
         }
         self.saveUserSettings();
         self.render(null, pagingInfo);
+        self.afterPaging(pagingInfo);
       }).on(`pagesizechange.${COMPONENT_NAME}`, (e, pagingInfo) => {
         self.render(null, pagingInfo);
+        self.afterPaging(pagingInfo);
       });
     }
 
@@ -10169,6 +10185,10 @@ Datagrid.prototype = {
         this.setActiveCell(this.activeCell.row, this.activeCell.cell);
       }
 
+      if (this.filterExpr && this.filterExpr[0] && this.filterExpr[0].column === 'all') {
+        this.highlightSearchRows(this.filterExpr[0].value);
+      }
+
       if (this.settings.source) {
         this.triggerSource({ type: 'sorted' });
       }
@@ -10817,7 +10837,6 @@ Datagrid.prototype = {
 
     // UnBind the pager
     if (this.pagerAPI) {
-      this.pagerAPI.element.off(`afterpaging.${COMPONENT_NAME}`);
       this.tableBody.off(`page.${COMPONENT_NAME} pagesizechange.${COMPONENT_NAME}`);
       this.pagerAPI.destroy();
     }

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -1287,7 +1287,7 @@ ListView.prototype = {
     this.element.off('click.listview', 'li, tr, input[checkbox]');
     this.element.off('keydown.listview', 'li, tr, a');
     this.element.off('focus.listview', 'li, tbody tr');
-    this.element.off('focus.listview click.listview touchend.listview keydown.listview change.selectable-listview afterpaging.listview updated.listview').empty();
+    this.element.off('focus.listview click.listview touchend.listview keydown.listview change.selectable-listview updated.listview').empty();
 
     if (this.filteredDataset) {
       delete this.filteredDataset;

--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -1418,7 +1418,7 @@ Pager.prototype = {
       return true;
     }
 
-    if ((pagingInfo.firstPage === true && pagingInfo.lastPage === true) &&
+    if (pagingInfo && (pagingInfo.firstPage === true && pagingInfo.lastPage === true) &&
       pagingInfo.hideDisabledPagers) {
       return true;
     }

--- a/test/components/blockgrid/blockgrid-api.func-spec.js
+++ b/test/components/blockgrid/blockgrid-api.func-spec.js
@@ -1,7 +1,7 @@
 import { Blockgrid } from '../../../src/components/blockgrid/blockgrid';
 import { cleanup } from '../../helpers/func-utils';
 
-const blockgridHTML = require('../../../app/views/components/blockgrid/example-index.html');
+let blockgridHTML = require('../../../app/views/components/blockgrid/example-index.html');
 const svg = require('../../../src/components/icons/svg.html');
 
 let blockgridEl;
@@ -29,6 +29,7 @@ describe('Blockgrid API', () => {
   beforeEach(() => {
     blockgridEl = null;
     blockgridObj = null;
+    blockgridHTML = blockgridHTML.replace(/{{basepath}}/g, '/');
     document.body.insertAdjacentHTML('afterbegin', svg);
     document.body.insertAdjacentHTML('afterbegin', blockgridHTML);
     blockgridEl = document.body.querySelector('.blockgrid');

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -1027,9 +1027,35 @@ describe('Datagrid paging client side tests', () => {
     await utils.checkForErrors();
   });
 
-  it('Should be able to move to keyword search', async () => {
+  it('Should be able to do a keyword search', async () => {
     await element(by.id('gridfilter')).sendKeys('ressor 2');
     await element(by.id('gridfilter')).sendKeys(protractor.Key.ENTER);
+
+    expect(await element(by.css('.datagrid-result-count')).getText()).toEqual('(111 of 1,000 Results)');
+    expect(await element.all(by.css('.search-mode i')).count()).toEqual(10);
+  });
+
+  it('Should be able to move to keyword search and sort', async () => {
+    await element(by.id('gridfilter')).sendKeys('ressor 1');
+    await element(by.id('gridfilter')).sendKeys(protractor.Key.ENTER);
+    expect(await element(by.css('.datagrid-result-count')).getText()).toEqual('(111 of 1,000 Results)');
+    expect(await element.all(by.css('.search-mode i')).count()).toEqual(10);
+
+    await element(by.css('#datagrid .datagrid-header th:nth-child(2)')).click();
+    await element(by.css('#datagrid .datagrid-header th:nth-child(2)')).click();
+
+    expect(await element(by.css('.datagrid-result-count')).getText()).toEqual('(111 of 1,000 Results)');
+    expect(await element.all(by.css('.search-mode i')).count()).toEqual(10);
+  });
+
+  it('Should be able to move to keyword search and page', async () => {
+    await element(by.id('gridfilter')).sendKeys('ressor 1');
+    await element(by.id('gridfilter')).sendKeys(protractor.Key.ENTER);
+    expect(await element(by.css('.datagrid-result-count')).getText()).toEqual('(111 of 1,000 Results)');
+    expect(await element.all(by.css('.search-mode i')).count()).toEqual(10);
+
+    await element(by.css('.pager-next .btn-icon')).click();
+    await browser.driver.sleep(config.sleep);
 
     expect(await element(by.css('.datagrid-result-count')).getText()).toEqual('(111 of 1,000 Results)');
     expect(await element.all(by.css('.search-mode i')).count()).toEqual(10);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The feature done on 2797 did not work for sorting and filtering. Found that afterpaging did not fire for client side paging (maybe never have actually). Refactored some code to an afterPaging method but kept the event in case it is used.

**Related github/jira issue (required)**:
Fixes #2797 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-paging-client-side
- 0 search for "ssor 1" -> rows will be highlight and filtered
- sort on any sortable column -> rows will remain highlight and filtered
- go to page 2 -> rows will remain highlight and filtered
- retest http://localhost:4000/components/lookup/example-multiselect-paging-serverside.html
- and http://localhost:4000/components/datagrid/example-paging

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
