### PR TITLE
2745 - Tabs Searchfield x-button and text overlap FAILED QA

### DIFF
--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -848,7 +848,7 @@ html[dir='rtl'] {
       &.has-go-button {
         > .icon {
           &.close {
-            right: 60px;
+            right: 50px;
           }
         }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Text is overlapping the close icon in the searchfield in the toolbar at phone screen size. This PR reduces the right position of the close icon when responding to phonedown screen width.

**Related github/jira issue (required)**:
Closes #2745 

**Steps necessary to review your pull request (required)**:
- Pull branch, build, run app.
- Visit localhost:4000/components/tabs-module/example-category-searchfield-go-button.html
- Reduce screen size to phone and type lots of characters in the searchfield and ensure text does not overlap the close button.

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
~- [ ] A note to the change log.~