### PR TITLE
2743 / 2741 - Fix path to be relative when switching theme

### DIFF
--- a/app/views/includes/head.html
+++ b/app/views/includes/head.html
@@ -76,7 +76,7 @@
 
         if (parts[1] !== shortThemeName) {
           shortThemeName = parts[1];
-          $.get('http://localhost:4000/api/icons?theme=' + shortThemeName, function(htmlStr) {
+          $.get('/api/icons?theme=' + shortThemeName, function(htmlStr) {
             htmlStr = htmlStr.replace('</div>', '');
             htmlStr = htmlStr.replace('<div class="svg-icons">', '');
             $('div.svg.hidden:not(.patterns)').empty().append(htmlStr);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The code i added to change out the icons in the demo app did not work when deployed because i had localhost hardcoded and due to CSP.

**Related github/jira issue (required)**:
Fixes #2743 
Fixes #2741 

**Steps necessary to review your pull request (required)**:
- IMPORTANT: Use your machine name and not localhost , you can find this in system prefs - sharing - edit
- go to http://usmvtmcconechy:4000/components/icons/example-index.html (use your name)
- switch to vibrant theme -> icons should change
- go to http://usmvtmcconechy:4000/components/editor/example-index.html
- switch to vibrant theme -> icons should change
