### PR TITLE
434- Refix : Improve the percent example

### DIFF
--- a/app/views/components/mask/test-percent-locale.html
+++ b/app/views/components/mask/test-percent-locale.html
@@ -16,10 +16,15 @@
 
 <script>
   $('body').on('initialized', function(locale, args) {
+    const numberInfo = Locale.currentLocale.data.numbers;
+
     $('#percentage-field').mask({
-      pattern: Locale.currentLocale.data.numbers.percentFormat,
+      pattern: numberInfo.percentFormat.replace(numberInfo.percentPrefix, '').replace(numberInfo.percentSuffix, ''),
+      process: 'number',
       patternOptions: {
-        allowDecimal: false
+        allowDecimal: false,
+        prefix: numberInfo.percentPrefix,
+        suffix: numberInfo.percentSuffix
       }
     });
   });

--- a/app/www/test/js/sv-SE.f0r73571n6purp0537051mul473h45h.js
+++ b/app/www/test/js/sv-SE.f0r73571n6purp0537051mul473h45h.js
@@ -51,6 +51,8 @@ Soho.Locale.addCulture('sv-SE', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/app/www/test/js/sv-SE.f0r73571n6purp0537051mul473h45h.js
+++ b/app/www/test/js/sv-SE.f0r73571n6purp0537051mul473h45h.js
@@ -52,7 +52,7 @@ Soho.Locale.addCulture('sv-SE', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/af-ZA.js
+++ b/src/components/locale/cultures/af-ZA.js
@@ -48,6 +48,8 @@ Soho.Locale.addCulture('af-ZA', {
   numbers: {
     percentSign: '%',
     percentFormat: '###%',
+    percentSuffix: '%',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '٫',
     group: ' ',

--- a/src/components/locale/cultures/af-ZA.js
+++ b/src/components/locale/cultures/af-ZA.js
@@ -49,7 +49,7 @@ Soho.Locale.addCulture('af-ZA', {
     percentSign: '%',
     percentFormat: '###%',
     percentSuffix: '%',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '٫',
     group: ' ',

--- a/src/components/locale/cultures/ar-EG.js
+++ b/src/components/locale/cultures/ar-EG.js
@@ -286,6 +286,8 @@ Soho.Locale.addCulture('ar-EG', {
   numbers: {
     percentSign: '٪',
     percentFormat: '### ٪',
+    percentSuffix: ' ٪',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '.',
     group: '٬',

--- a/src/components/locale/cultures/ar-EG.js
+++ b/src/components/locale/cultures/ar-EG.js
@@ -287,7 +287,7 @@ Soho.Locale.addCulture('ar-EG', {
     percentSign: '٪',
     percentFormat: '### ٪',
     percentSuffix: ' ٪',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '.',
     group: '٬',

--- a/src/components/locale/cultures/ar-SA.js
+++ b/src/components/locale/cultures/ar-SA.js
@@ -287,7 +287,7 @@ Soho.Locale.addCulture('ar-SA', {
     percentSign: '٪',
     percentFormat: '### ٪',
     percentSuffix: ' ٪',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '٫',
     group: '٬',

--- a/src/components/locale/cultures/ar-SA.js
+++ b/src/components/locale/cultures/ar-SA.js
@@ -286,6 +286,8 @@ Soho.Locale.addCulture('ar-SA', {
   numbers: {
     percentSign: '٪',
     percentFormat: '### ٪',
+    percentSuffix: ' ٪',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '٫',
     group: '٬',

--- a/src/components/locale/cultures/bg-BG.js
+++ b/src/components/locale/cultures/bg-BG.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('bg-BG', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/bg-BG.js
+++ b/src/components/locale/cultures/bg-BG.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('bg-BG', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/cs-CZ.js
+++ b/src/components/locale/cultures/cs-CZ.js
@@ -48,6 +48,8 @@ Soho.Locale.addCulture('cs-CZ', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/cs-CZ.js
+++ b/src/components/locale/cultures/cs-CZ.js
@@ -49,7 +49,7 @@ Soho.Locale.addCulture('cs-CZ', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/da-DK.js
+++ b/src/components/locale/cultures/da-DK.js
@@ -51,7 +51,7 @@ Soho.Locale.addCulture('da-DK', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/da-DK.js
+++ b/src/components/locale/cultures/da-DK.js
@@ -50,6 +50,8 @@ Soho.Locale.addCulture('da-DK', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/de-DE.js
+++ b/src/components/locale/cultures/de-DE.js
@@ -51,7 +51,7 @@ Soho.Locale.addCulture('de-DE', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/de-DE.js
+++ b/src/components/locale/cultures/de-DE.js
@@ -50,6 +50,8 @@ Soho.Locale.addCulture('de-DE', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/el-GR.js
+++ b/src/components/locale/cultures/el-GR.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('el-GR', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/el-GR.js
+++ b/src/components/locale/cultures/el-GR.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('el-GR', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/en-AU.js
+++ b/src/components/locale/cultures/en-AU.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('en-AU', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/en-AU.js
+++ b/src/components/locale/cultures/en-AU.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('en-AU', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/en-GB.js
+++ b/src/components/locale/cultures/en-GB.js
@@ -50,6 +50,8 @@ Soho.Locale.addCulture('en-GB', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/en-GB.js
+++ b/src/components/locale/cultures/en-GB.js
@@ -51,7 +51,7 @@ Soho.Locale.addCulture('en-GB', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/en-IN.js
+++ b/src/components/locale/cultures/en-IN.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('en-IN', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/en-IN.js
+++ b/src/components/locale/cultures/en-IN.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('en-IN', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/en-NZ.js
+++ b/src/components/locale/cultures/en-NZ.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('en-NZ', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/en-NZ.js
+++ b/src/components/locale/cultures/en-NZ.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('en-NZ', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/en-US.js
+++ b/src/components/locale/cultures/en-US.js
@@ -50,6 +50,8 @@ Soho.Locale.addCulture('en-US', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: null,
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/en-US.js
+++ b/src/components/locale/cultures/en-US.js
@@ -51,7 +51,7 @@ Soho.Locale.addCulture('en-US', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: null,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/en-ZA.js
+++ b/src/components/locale/cultures/en-ZA.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('en-ZA', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/en-ZA.js
+++ b/src/components/locale/cultures/en-ZA.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('en-ZA', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/es-419.js
+++ b/src/components/locale/cultures/es-419.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('es-419', {
   numbers: {
     percentSign: '%',
     percentFormat: '###%',
+    percentSuffix: '%',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/es-419.js
+++ b/src/components/locale/cultures/es-419.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('es-419', {
     percentSign: '%',
     percentFormat: '###%',
     percentSuffix: '%',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/es-AR.js
+++ b/src/components/locale/cultures/es-AR.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('es-AR', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/es-AR.js
+++ b/src/components/locale/cultures/es-AR.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('es-AR', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/es-ES.js
+++ b/src/components/locale/cultures/es-ES.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('es-ES', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/es-ES.js
+++ b/src/components/locale/cultures/es-ES.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('es-ES', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/es-MX.js
+++ b/src/components/locale/cultures/es-MX.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('es-MX', {
   numbers: {
     percentSign: '%',
     percentFormat: '###%',
+    percentSuffix: '%',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/es-MX.js
+++ b/src/components/locale/cultures/es-MX.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('es-MX', {
     percentSign: '%',
     percentFormat: '###%',
     percentSuffix: '%',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/es-US.js
+++ b/src/components/locale/cultures/es-US.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('es-US', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/es-US.js
+++ b/src/components/locale/cultures/es-US.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('es-US', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/et-EE.js
+++ b/src/components/locale/cultures/et-EE.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('et-EE', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/et-EE.js
+++ b/src/components/locale/cultures/et-EE.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('et-EE', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/fi-FI.js
+++ b/src/components/locale/cultures/fi-FI.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('fi-FI', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/fi-FI.js
+++ b/src/components/locale/cultures/fi-FI.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('fi-FI', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/fr-CA.js
+++ b/src/components/locale/cultures/fr-CA.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('fr-CA', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/fr-CA.js
+++ b/src/components/locale/cultures/fr-CA.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('fr-CA', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/fr-FR.js
+++ b/src/components/locale/cultures/fr-FR.js
@@ -48,6 +48,8 @@ Soho.Locale.addCulture('fr-FR', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/fr-FR.js
+++ b/src/components/locale/cultures/fr-FR.js
@@ -49,7 +49,7 @@ Soho.Locale.addCulture('fr-FR', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/he-IL.js
+++ b/src/components/locale/cultures/he-IL.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('he-IL', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/he-IL.js
+++ b/src/components/locale/cultures/he-IL.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('he-IL', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/hi-IN.js
+++ b/src/components/locale/cultures/hi-IN.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('hi-IN', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/hi-IN.js
+++ b/src/components/locale/cultures/hi-IN.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('hi-IN', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/hr-HR.js
+++ b/src/components/locale/cultures/hr-HR.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('hr-HR', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/hr-HR.js
+++ b/src/components/locale/cultures/hr-HR.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('hr-HR', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/hu-HU.js
+++ b/src/components/locale/cultures/hu-HU.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('hu-HU', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/hu-HU.js
+++ b/src/components/locale/cultures/hu-HU.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('hu-HU', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/id-ID.js
+++ b/src/components/locale/cultures/id-ID.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('id-ID', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/id-ID.js
+++ b/src/components/locale/cultures/id-ID.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('id-ID', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/it-IT.js
+++ b/src/components/locale/cultures/it-IT.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('it-IT', {
   numbers: {
     percentSign: '%',
     percentFormat: '###%',
+    percentSuffix: '%',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/it-IT.js
+++ b/src/components/locale/cultures/it-IT.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('it-IT', {
     percentSign: '%',
     percentFormat: '###%',
     percentSuffix: '%',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/ja-JP.js
+++ b/src/components/locale/cultures/ja-JP.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('ja-JP', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/ja-JP.js
+++ b/src/components/locale/cultures/ja-JP.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('ja-JP', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/ko-KR.js
+++ b/src/components/locale/cultures/ko-KR.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('ko-KR', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/ko-KR.js
+++ b/src/components/locale/cultures/ko-KR.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('ko-KR', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/la-IT.js
+++ b/src/components/locale/cultures/la-IT.js
@@ -47,6 +47,8 @@ Soho.Locale.addCulture('la-IT', {
   numbers: {
     percentSign: '%',
     percentFormat: '###%',
+    percentSuffix: '%',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: '.'

--- a/src/components/locale/cultures/la-IT.js
+++ b/src/components/locale/cultures/la-IT.js
@@ -48,7 +48,7 @@ Soho.Locale.addCulture('la-IT', {
     percentSign: '%',
     percentFormat: '###%',
     percentSuffix: '%',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: '.'

--- a/src/components/locale/cultures/lt-LT.js
+++ b/src/components/locale/cultures/lt-LT.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('lt-LT', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/lt-LT.js
+++ b/src/components/locale/cultures/lt-LT.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('lt-LT', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/lv-LV.js
+++ b/src/components/locale/cultures/lv-LV.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('lv-LV', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/lv-LV.js
+++ b/src/components/locale/cultures/lv-LV.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('lv-LV', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/ms-bn.js
+++ b/src/components/locale/cultures/ms-bn.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('ms-bn', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/ms-bn.js
+++ b/src/components/locale/cultures/ms-bn.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('ms-bn', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/ms-my.js
+++ b/src/components/locale/cultures/ms-my.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('ms-MY', {
     percentSign: '%',
     percentFormat: '###%',
     percentSuffix: '%',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/ms-my.js
+++ b/src/components/locale/cultures/ms-my.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('ms-MY', {
   numbers: {
     percentSign: '%',
     percentFormat: '###%',
+    percentSuffix: '%',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/nb-NO.js
+++ b/src/components/locale/cultures/nb-NO.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('nb-NO', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/nb-NO.js
+++ b/src/components/locale/cultures/nb-NO.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('nb-NO', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/nl-NL.js
+++ b/src/components/locale/cultures/nl-NL.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('nl-NL', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/nl-NL.js
+++ b/src/components/locale/cultures/nl-NL.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('nl-NL', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/no-NO.js
+++ b/src/components/locale/cultures/no-NO.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('no-NO', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/no-NO.js
+++ b/src/components/locale/cultures/no-NO.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('no-NO', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/pl-PL.js
+++ b/src/components/locale/cultures/pl-PL.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('pl-PL', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/pl-PL.js
+++ b/src/components/locale/cultures/pl-PL.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('pl-PL', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/pt-BR.js
+++ b/src/components/locale/cultures/pt-BR.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('pt-BR', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/pt-BR.js
+++ b/src/components/locale/cultures/pt-BR.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('pt-BR', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/pt-PT.js
+++ b/src/components/locale/cultures/pt-PT.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('pt-PT', {
   numbers: {
     percentSign: '%',
     percentFormat: '###%',
+    percentSuffix: '%',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/pt-PT.js
+++ b/src/components/locale/cultures/pt-PT.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('pt-PT', {
     percentSign: '%',
     percentFormat: '###%',
     percentSuffix: '%',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/ro-RO.js
+++ b/src/components/locale/cultures/ro-RO.js
@@ -48,6 +48,8 @@ Soho.Locale.addCulture('ro-RO', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/ro-RO.js
+++ b/src/components/locale/cultures/ro-RO.js
@@ -49,7 +49,7 @@ Soho.Locale.addCulture('ro-RO', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/ru-RU.js
+++ b/src/components/locale/cultures/ru-RU.js
@@ -49,7 +49,7 @@ Soho.Locale.addCulture('ru-RU', {
     percentSign: '%',
     percentFormat: '###%',
     percentSuffix: '%',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/ru-RU.js
+++ b/src/components/locale/cultures/ru-RU.js
@@ -48,6 +48,8 @@ Soho.Locale.addCulture('ru-RU', {
   numbers: {
     percentSign: '%',
     percentFormat: '###%',
+    percentSuffix: '%',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/sk-SK.js
+++ b/src/components/locale/cultures/sk-SK.js
@@ -49,7 +49,7 @@ Soho.Locale.addCulture('sk-SK', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/sk-SK.js
+++ b/src/components/locale/cultures/sk-SK.js
@@ -48,6 +48,8 @@ Soho.Locale.addCulture('sk-SK', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/sl-SI.js
+++ b/src/components/locale/cultures/sl-SI.js
@@ -49,7 +49,7 @@ Soho.Locale.addCulture('sl-SI', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/sl-SI.js
+++ b/src/components/locale/cultures/sl-SI.js
@@ -48,6 +48,8 @@ Soho.Locale.addCulture('sl-SI', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/sv-SE.js
+++ b/src/components/locale/cultures/sv-SE.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('sv-SE', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/sv-SE.js
+++ b/src/components/locale/cultures/sv-SE.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('sv-SE', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/th-TH.js
+++ b/src/components/locale/cultures/th-TH.js
@@ -49,7 +49,7 @@ Soho.Locale.addCulture('th-TH', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/th-TH.js
+++ b/src/components/locale/cultures/th-TH.js
@@ -48,6 +48,8 @@ Soho.Locale.addCulture('th-TH', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/tr-TR.js
+++ b/src/components/locale/cultures/tr-TR.js
@@ -48,6 +48,8 @@ Soho.Locale.addCulture('tr-TR', {
   numbers: {
     percentSign: '%',
     percentFormat: '%###',
+    percentSuffix: undefined,
+    percentPrefix: '%',
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/tr-TR.js
+++ b/src/components/locale/cultures/tr-TR.js
@@ -48,7 +48,7 @@ Soho.Locale.addCulture('tr-TR', {
   numbers: {
     percentSign: '%',
     percentFormat: '%###',
-    percentSuffix: undefined,
+    percentSuffix: '',
     percentPrefix: '%',
     minusSign: '-',
     decimal: ',',

--- a/src/components/locale/cultures/uk-UA.js
+++ b/src/components/locale/cultures/uk-UA.js
@@ -48,6 +48,8 @@ Soho.Locale.addCulture('uk-UA', {
   numbers: {
     percentSign: '%',
     percentFormat: '###%',
+    percentSuffix: '%',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/uk-UA.js
+++ b/src/components/locale/cultures/uk-UA.js
@@ -49,7 +49,7 @@ Soho.Locale.addCulture('uk-UA', {
     percentSign: '%',
     percentFormat: '###%',
     percentSuffix: '%',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: ' ',

--- a/src/components/locale/cultures/vi-VN.js
+++ b/src/components/locale/cultures/vi-VN.js
@@ -49,7 +49,7 @@ Soho.Locale.addCulture('vi-VN', {
     percentSign: '%',
     percentFormat: '### %',
     percentSuffix: ' %',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/vi-VN.js
+++ b/src/components/locale/cultures/vi-VN.js
@@ -48,6 +48,8 @@ Soho.Locale.addCulture('vi-VN', {
   numbers: {
     percentSign: '%',
     percentFormat: '### %',
+    percentSuffix: ' %',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: ',',
     group: '.',

--- a/src/components/locale/cultures/zh-CN.js
+++ b/src/components/locale/cultures/zh-CN.js
@@ -49,7 +49,7 @@ Soho.Locale.addCulture('zh-CN', {
     percentSign: '%',
     percentFormat: '###%',
     percentSuffix: '%',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/zh-CN.js
+++ b/src/components/locale/cultures/zh-CN.js
@@ -48,6 +48,8 @@ Soho.Locale.addCulture('zh-CN', {
   numbers: {
     percentSign: '%',
     percentFormat: '###%',
+    percentSuffix: '%',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/zh-Hans.js
+++ b/src/components/locale/cultures/zh-Hans.js
@@ -48,6 +48,8 @@ Soho.Locale.addCulture('zh-Hans', {
   numbers: {
     percentSign: '%',
     percentFormat: '###%',
+    percentSuffix: '%',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/zh-Hans.js
+++ b/src/components/locale/cultures/zh-Hans.js
@@ -49,7 +49,7 @@ Soho.Locale.addCulture('zh-Hans', {
     percentSign: '%',
     percentFormat: '###%',
     percentSuffix: '%',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/zh-Hant.js
+++ b/src/components/locale/cultures/zh-Hant.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('zh-Hant', {
     percentSign: '%',
     percentFormat: '###%',
     percentSuffix: '%',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/zh-Hant.js
+++ b/src/components/locale/cultures/zh-Hant.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('zh-Hant', {
   numbers: {
     percentSign: '%',
     percentFormat: '###%',
+    percentSuffix: '%',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/zh-TW.js
+++ b/src/components/locale/cultures/zh-TW.js
@@ -50,7 +50,7 @@ Soho.Locale.addCulture('zh-TW', {
     percentSign: '%',
     percentFormat: '###%',
     percentSuffix: '%',
-    percentPrefix: undefined,
+    percentPrefix: '',
     minusSign: '-',
     decimal: '.',
     group: ',',

--- a/src/components/locale/cultures/zh-TW.js
+++ b/src/components/locale/cultures/zh-TW.js
@@ -49,6 +49,8 @@ Soho.Locale.addCulture('zh-TW', {
   numbers: {
     percentSign: '%',
     percentFormat: '###%',
+    percentSuffix: '%',
+    percentPrefix: undefined,
     minusSign: '-',
     decimal: '.',
     group: ',',


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Refix the issue for 434 as it was not possible to have the percent show after typing 1 or 10 Only 100% worked.

**Related github/jira issue (required)**:
Fixes #434 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/mask/test-percent-locale
- type: 100
- should show to the en-US format: `100 %`
- clear field and type: 10
- should show to the en-US format: `10 %`
- clear field and type: 1
- should show to the en-US format: `1 %`
- http://localhost:4000/components/mask/test-percent-locale?locale=ar-SA
- type: 100
- should show to the ar-SA format: `٪ 100`
- clear field and type: 10
- should show to the ar-SA format: `٪ 10`
- clear field and type: 1
- should show to the ar-SA format: `٪ 1`
- http://localhost:4000/components/mask/test-percent-locale?locale=tr-TR
- type: 100
- should show to the tr-TR format: `%100`
- clear field and type: 10
- should show to the ar-SA format: `%10`
- clear field and type: 1
- should show to the ar-SA format: `%1`
