### PR TITLE
2810 - Fix title gets truncated even there's enough space in toolbar flex

### DIFF
--- a/app/views/components/toolbar-flex/test-header-like-title-in-span.html
+++ b/app/views/components/toolbar-flex/test-header-like-title-in-span.html
@@ -1,0 +1,37 @@
+<div class="row top-padding">
+  <div class="twelve columns">
+
+    <!-- BEGIN Toolbar similar to Header Toolbar long title -->
+    <div class="flex-toolbar">
+      <div class="toolbar-section">
+        <button id="show-nav" class="btn-icon application-menu-trigger" type="button">
+          <span class="audible">Show navigation</span>
+          <span class="icon app-header">
+            <span class="one"></span>
+            <span class="two"></span>
+            <span class="three"></span>
+          </span>
+        </button>
+      </div>
+
+      <div class="toolbar-section title">
+        <h1>
+          <span>Toolbar Title - Having a long title here</span>
+        </h1>
+      </div>
+
+      <div class="toolbar-section buttonset">
+        <a id="outbound-link" class="hyperlink" href="#">Outbound Link</a>
+      </div>
+
+      <div class="toolbar-section search">
+        <div class="searchfield-wrapper">
+          <label for="toolbar-searchfield-02" class="audible">Toolbar Search</label>
+          <input id="toolbar-searchfield-02" class="searchfield" placeholder="Search..."/>
+        </div>
+      </div>
+    </div>
+    <!-- END Toolbar similar to Header Toolbar -->
+
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## v4.22.0
 
-### v4.23.0 Fixes
-- `[Toolbar Flex]` Fixed a bug in toolbar flex where the title is getting truncated even there's enough space for it. ([#2810](https://github.com/infor-design/enterprise/issues/2810))
-
 ### v4.22.0 Deprecation
 
 - `[Icons]` The alert icons now all have a white background allowing them to appear on colored areas. There was previously a special `-solid` version of the icons created that is now not needed, if you used the `icon-<name>-solid` icon change it to just `icon-<name>`. ([#396](https://github.com/infor-design/design-system/issues/396))
@@ -40,6 +37,7 @@
 - `[Tabs]` Fixed the disabled tab color. ([#396](https://github.com/infor-design/design-system/issues/396))
 - `[Tabs-Module]` Fixed styling and appearance issues on an example page demonstrating the Go Button alongside a Searchfield with Categories. ([#2745](https://github.com/infor-design/enterprise/issues/2745))
 - `[Tabs-Multi]` Fixed an issue where tooltip was not showing when hovering a tab with cut-off text. ([#2747](https://github.com/infor-design/enterprise/issues/2747))
+- `[Toolbar Flex]` Fixed a bug in toolbar flex where the title is getting truncated even there's enough space for it. ([#2810](https://github.com/infor-design/enterprise/issues/2810))
 - `[Validation]` Fixed an issue where if the mask is set to use a time other than the default time for the locale, this was not taken into account in validation. ([#2821](https://github.com/infor-design/enterprise/issues/2821))
 
 ### v4.22.0 Chores & Maintenance

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,7 +37,7 @@
 - `[Tabs]` Fixed the disabled tab color. ([#396](https://github.com/infor-design/design-system/issues/396))
 - `[Tabs-Module]` Fixed styling and appearance issues on an example page demonstrating the Go Button alongside a Searchfield with Categories. ([#2745](https://github.com/infor-design/enterprise/issues/2745))
 - `[Tabs-Multi]` Fixed an issue where tooltip was not showing when hovering a tab with cut-off text. ([#2747](https://github.com/infor-design/enterprise/issues/2747))
-- `[Toolbar Flex]` Fixed a bug in toolbar flex where the title is getting truncated even there's enough space for it. ([#2810](https://github.com/infor-design/enterprise/issues/2810))
+- `[Toolbar Flex]` Fixed a bug in toolbar flex where the title is getting truncated even if there's enough space for it. ([#2810](https://github.com/infor-design/enterprise/issues/2810))
 - `[Validation]` Fixed an issue where if the mask is set to use a time other than the default time for the locale, this was not taken into account in validation. ([#2821](https://github.com/infor-design/enterprise/issues/2821))
 
 ### v4.22.0 Chores & Maintenance

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v4.22.0
 
+### v4.23.0 Fixes
+- `[Toolbar Flex]` Fixed a bug in toolbar flex where the title is getting truncated even there's enough space for it.
+
 ### v4.22.0 Deprecation
 
 - `[Icons]` The alert icons now all have a white background allowing them to appear on colored areas. There was previously a special `-solid` version of the icons created that is now not needed, if you used the `icon-<name>-solid` icon change it to just `icon-<name>`. ([#396](https://github.com/infor-design/design-system/issues/396))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v4.22.0
 
 ### v4.23.0 Fixes
-- `[Toolbar Flex]` Fixed a bug in toolbar flex where the title is getting truncated even there's enough space for it.
+- `[Toolbar Flex]` Fixed a bug in toolbar flex where the title is getting truncated even there's enough space for it. ([#2810](https://github.com/infor-design/enterprise/issues/2810))
 
 ### v4.22.0 Deprecation
 

--- a/src/components/contextualactionpanel/_contextualactionpanel.scss
+++ b/src/components/contextualactionpanel/_contextualactionpanel.scss
@@ -29,6 +29,20 @@
       .toolbar-section {
         &.title {
           padding-left: 15px;
+
+          span {
+            @media (min-width: $breakpoint-big-phone + 1) {
+              width: 150px;
+            }
+      
+            @media (min-width: $breakpoint-phablet + 1) {
+              width: 250px;
+            }
+
+            @media (max-width: $breakpoint-big-phone) {
+              display: none;
+            }
+          }
         }
       }
     }

--- a/src/components/contextualactionpanel/_contextualactionpanel.scss
+++ b/src/components/contextualactionpanel/_contextualactionpanel.scss
@@ -31,6 +31,12 @@
           padding-left: 15px;
 
           span {
+            display: inline-block;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            vertical-align: middle;
+            white-space: nowrap;
+
             @media (min-width: $breakpoint-big-phone + 1) {
               width: 150px;
             }

--- a/src/components/contextualactionpanel/_contextualactionpanel.scss
+++ b/src/components/contextualactionpanel/_contextualactionpanel.scss
@@ -40,7 +40,7 @@
             @media (min-width: $breakpoint-big-phone + 1) {
               width: 150px;
             }
-      
+
             @media (min-width: $breakpoint-phablet + 1) {
               width: 250px;
             }

--- a/src/components/toolbar-flex/_toolbar-flex.scss
+++ b/src/components/toolbar-flex/_toolbar-flex.scss
@@ -52,14 +52,6 @@
       display: inline;
     }
 
-    span {
-      display: inline-block;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      vertical-align: middle;
-      white-space: nowrap;
-    }
-
     .page-title,
     .section-title {
       display: block;

--- a/src/components/toolbar-flex/_toolbar-flex.scss
+++ b/src/components/toolbar-flex/_toolbar-flex.scss
@@ -58,18 +58,6 @@
       text-overflow: ellipsis;
       vertical-align: middle;
       white-space: nowrap;
-
-      @media (min-width: $breakpoint-big-phone - 1) and (max-width: $breakpoint-wide-tablet) {
-        width: 150px;
-      }
-
-      @media (min-width: $breakpoint-wide-tablet + 1) {
-        width: 250px;
-      }
-
-      @media (max-width: $breakpoint-big-phone) {
-        display: none;
-      }
     }
 
     .page-title,


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The css rule for the toolbar flex title was for the Contextual Action Panel title. Thus, the solution will target the `.modal.contextual-action-panel` as it's parent. The toolbar flex title shouldn't be truncated anymore.

I created a test page for this issue.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/2810
Relates https://github.com/infor-design/enterprise/issues/2605

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the app
- Navigate to http://localhost:4000/components/toolbar-flex/test-header-like-title-in-span.html
- The title text shouldn't be truncated anymore.

Additional Testing (For Contextual Action Panel Title)
- Navigate to http://localhost:4000/components/contextualactionpanel/example-workspaces.html
- Resize the browser to mobile or use mobile device.
- The title should be truncated when the text is long.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
