### PR TITLE
419 - Add new design release for 5 new icons

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `[Datepicker]` Moved the today button to the datepicker header and adding a setting to hide it if wanted. ([#2704](https://github.com/infor-design/enterprise/issues/2704))
 - `[Datepicker]` Fixed a bug in datepicker where the destroy method does not readd the masking functionality. [2832](https://github.com/infor-design/enterprise/issues/2832))
 - `[Icons]` Added and updated the following icons: icon-new, icon-calculator, icon-save-new, icon-doc-check. ([#391](https://github.com/infor-design/design-system/issues/391))
+- `[Icons]` Added and updated the following icons: icon-bed, icon-user-clock, icon-phone-filled, icon-phone-empty. ([#419](https://github.com/infor-design/design-system/issues/419))
 - `[Listview]` Fixed an issue where empty message would not be centered if the listview in a flex container. ([#2716](https://github.com/infor-design/enterprise/issues/2716))
 - `[Mask]` Added an example showing how to user percent format with the locale. ([#434](https://github.com/infor-design/enterprise/issues/434))
 - `[Modal]` Fixed an issue where encoded html would not be recoded on the title. ([#246](https://github.com/infor-design/enterprise/issues/246))

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "handlebars-registrar": "^1.5.2",
     "html-loader": "^0.5.5",
     "ids-css": "^1.3.0",
-    "ids-identity": "2.6.13",
+    "ids-identity": "2.6.14",
     "jasmine-core": "^3.4.0",
     "jasmine-jquery": "^2.1.1",
     "jasmine-spec-reporter": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "handlebars-registrar": "^1.5.2",
     "html-loader": "^0.5.5",
     "ids-css": "^1.3.0",
-    "ids-identity": "2.6.12",
+    "ids-identity": "2.6.13",
     "jasmine-core": "^3.4.0",
     "jasmine-jquery": "^2.1.1",
     "jasmine-spec-reporter": "^4.2.1",


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adds 3 new icons for WFM. For this updated the design system release with the new icons.

**Related github/jira issue (required)**:
Addresses #419 (DS)

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/icons/example-index.html
- look at the new icons (both themes)
- `icon-bed`, `icon-phone` and `icon-phone-linear` and `user-clock`and `icon-submit` and `icon-transfer`

**Included in this Pull Request**:
- [x] A note to the change log.