### PR TITLE
2678 - Fix scrollable content behind modal

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@
 - `[Listview]` Fixed an issue where empty message would not be centered if the listview in a flex container. ([#2716](https://github.com/infor-design/enterprise/issues/2716))
 - `[Mask]` Added an example showing how to user percent format with the locale. ([#434](https://github.com/infor-design/enterprise/issues/434))
 - `[Modal]` Fixed an issue where encoded html would not be recoded on the title. ([#246](https://github.com/infor-design/enterprise/issues/246))
+- `[Modal]` Fixed an issue where the content behind was still scrollable while modal window open with IOS devices. ([#2678](https://github.com/infor-design/enterprise/issues/2678))
 - `[Swaplist]` Fixed an issue where passed data for searched items were not syncing for beforeswap event. ([#2819](https://github.com/infor-design/enterprise/issues/2819))
 - `[Tabs]` Add more padding to the count styles. ([#2744](https://github.com/infor-design/enterprise/issues/2744))
 - `[Tabs]` Fixed the disabled tab color. ([#396](https://github.com/infor-design/design-system/issues/396))

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -526,3 +526,12 @@ html[dir='rtl'] {
     }
   }
 }
+
+.ios {
+  .has-modal-open {
+    [aria-hidden='true'],
+    [aria-hidden='true'] * {
+      overflow: hidden;
+    }
+  }
+}

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1,4 +1,5 @@
 import * as debug from '../../utils/debug';
+import { Environment as env } from '../../utils/environment';
 import { warnAboutDeprecation } from '../../utils/deprecated';
 import { breakpoints } from '../../utils/breakpoints';
 import { renderLoop, RenderLoopItem } from '../../utils/renderloop';
@@ -775,6 +776,10 @@ Modal.prototype = {
       let focusElem = thisElem.element.find(':focusable').not('.modal-header .searchfield').first();
       thisElem.keepFocus();
 
+      if (env.os.name === 'ios') {
+        $('body').addClass('has-modal-open');
+      }
+
       /**
       * Fires when the modal opens.
       * @event open
@@ -1023,6 +1028,10 @@ Modal.prototype = {
       $('body').removeClass('modal-engaged');
       $('body > *').not(this.element.closest('.modal-page-container')).removeAttr('aria-hidden');
       $('.overlay').remove();
+    }
+
+    if (env.os.name === 'ios') {
+      $('body').removeClass('has-modal-open');
     }
 
     // Fire Events


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the content behind was still scrollable while modal window open with IOS devices.

**Related github/jira issue (required)**:
Closes #2678

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Use iPhone
- Navigate to http://localhost:4000/components/modal/test-body-scroll.html
- Scroll down and click on button `Add Context` to open modal window
- Drag one finger up/down outside of the modal window
- The content that is outside the modal window should not scroll

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
