### PR TITLE
2778 - Calendar: Fix overlapping calendar upcoming description

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `[Application Menu]` Fixed an issue where tooltip was showing white text on white background which makes text to be unreadable. ([#2811](https://github.com/infor-design/enterprise/issues/2811))
 - `[Bar Chart]` Fixed an issue where labels were overwritten when use more then one chart on page. ([#2723](https://github.com/infor-design/enterprise/issues/2723))
 - `[Buttons]` Adjust the contrast of buttons (tertiary) on uplift theme. ([#396](https://github.com/infor-design/design-system/issues/396))
+- `[Calendar]` Fixed an issue where the upcoming event description was overlapping the upcoming duration when text is too long, adjust width of spinbox count and fixed alignment of all day checkbox in uplift light theme. ([#2778](https://github.com/infor-design/enterprise/issues/2778))
 - `[Datagrid]` Fixed an issue where if you have duplicate Id's the columns many become misaligned. ([#2687](https://github.com/infor-design/enterprise/issues/2687))
 - `[Datagrid]` Made the text all white on the targeted achievement formatter. ([#2730](https://github.com/infor-design/enterprise/issues/2730))
 - `[Datagrid]` Fixed keyword search so that it will again work with client side paging. ([#2797](https://github.com/infor-design/enterprise/issues/2797))

--- a/src/components/calendar/_calendar.scss
+++ b/src/components/calendar/_calendar.scss
@@ -272,9 +272,10 @@
       display: inline-block;
       font-size: $theme-size-font-sm;
       left: 5px;
+      overflow-wrap: break-word;
       position: relative;
       top: -4px;
-      width: 145px;
+      width: 130px;
     }
 
     .calendar-upcoming-status-text {
@@ -408,6 +409,14 @@
 
     &.graphite {
       background-color: $theme-color-palette-graphite-60;
+    }
+  }
+}
+
+.calendar-event-modal {
+  .field {
+    input.spinbox {
+      width: calc(100% - 66px) !important;
     }
   }
 }

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -67,8 +67,8 @@
 // for uplift light theme overrides
 .theme-uplift-light .field .checkbox-label,
 .theme-uplift-light .field .checkbox > label {
-    margin-top: 40px;
-  }
+  margin-top: 40px;
+}
 
 html[dir='rtl'] {
   .form-responsive {

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -64,6 +64,12 @@
   }
 }
 
+// for uplift light theme overrides
+.theme-uplift-light .field .checkbox-label,
+.theme-uplift-light .field .checkbox > label {
+    margin-top: 40px;
+  }
+
 html[dir='rtl'] {
   .form-responsive {
     .colorpicker-container {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fix the overlapping calendar upcoming description to duration when text is too long. 

Additional fixes (UI issues):
-  spinbox count cut off
-  checkbox all day alignment (not the same as the SOHO) in uplift light theme

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/2778

**Steps necessary to review your pull request (required)**:
- Pull this branch
- Navigate to http://localhost:4000/components/calendar/example-index.html
- Create event with name "New Random Event12345"
- Verify the name of the newly created event in the Upcoming panel
- Check it for both SOHO and Uplift theme
- Text should no longer overlap

Additional Testing for UI issues:
- Create and/or edit an Event
- Spinbox count hours should no longer cutoff/break
- Go to Uplift Theme
- Check the all day checkbox
- It should align same as in the SoHo theme

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
