### PR TITLE
2765 - Field Options: Fix misaligned option menu in full length input field

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `[Datagrid]` Fixed keyword search so that it will again work with client side paging. ([#2797](https://github.com/infor-design/enterprise/issues/2797))
 - `[Datepicker]` Moved the today button to the datepicker header and adding a setting to hide it if wanted. ([#2704](https://github.com/infor-design/enterprise/issues/2704))
 - `[Datepicker]` Fixed a bug in datepicker where the destroy method does not readd the masking functionality. [2832](https://github.com/infor-design/enterprise/issues/2832))
+- `[Field Options]` Fixed an issue where the option menu is misaligned in full length input field in uplift theme. ([#2765](https://github.com/infor-design/enterprise/issues/2765))
 - `[Icons]` Added and updated the following icons: icon-new, icon-calculator, icon-save-new, icon-doc-check. ([#391](https://github.com/infor-design/design-system/issues/391))
 - `[Icons]` Added and updated the following icons: icon-bed, icon-user-clock, icon-phone-filled, icon-phone-empty. ([#419](https://github.com/infor-design/design-system/issues/419))
 - `[Listview]` Fixed an issue where empty message would not be centered if the listview in a flex container. ([#2716](https://github.com/infor-design/enterprise/issues/2716))

--- a/src/components/field-options/_field-options-uplift.scss
+++ b/src/components/field-options/_field-options-uplift.scss
@@ -36,6 +36,10 @@
     }
   }
 
+  .field-options {
+    width: calc(100% - 45px);
+  }
+
   [data-clearable='true'] ~ .icon.close.is-empty ~ .btn-actions {
     left: -12px;
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adjusting the width of input field large to align the option menu in uplift theme only. SoHo theme seems looks fine.

**Related github/jira issue (required)**:
Closes: https://github.com/infor-design/enterprise/issues/2765

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the app
- Navigate to http://localhost:4000/components/contextmenu/example-field-options.html?theme=uplift&variant=light&colors=0563C2
- Hover the input full field to show the action menu
- Input full field and action menu should align in a single row

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
