### PR TITLE
2610 - Fieldset: Fix overlapping labels when resizing the browser

### DIFF
--- a/app/views/components/fieldset/example-index.html
+++ b/app/views/components/fieldset/example-index.html
@@ -1,83 +1,105 @@
-
 <div class="row">
-  <div class="six columns">
-
-    <!-- Variation One -->
-    <fieldset>
-      <legend>Company Information</legend>
-      <div class="summary-form">
-
-        <div class="row">
-          <div class="one-half column">
-
-            <div class="field">
-              <span class="label">Company Name</span>
-              <span class="data">Building Suppliers</span>
+    <div class="six columns">
+  
+      <!-- Variation One -->
+      <fieldset>
+        <legend>Company Information</legend>
+        <div class="summary-form">
+  
+          <div class="row">
+            <div class="one-half column">
+  
+              <div class="field">
+                <span class="label">Company Name</span>
+                <span class="data">Building Suppliers</span>
+              </div>
+  
+              <div class="field">
+                <span class="label">Company Type</span>
+                <span class="data">Contractor</span>
+              </div>
+  
+              <div class="field">
+                <span class="label">Company Address</span>
+                <span class="data">4209 Industrial Avenue <br>Los Angeles, California 90001 USA</span>
+              </div>
+  
             </div>
-
-            <div class="field">
-              <span class="label">Company Type</span>
-              <span class="data">Contractor</span>
-            </div>
-
-            <div class="field">
-              <span class="label">Company Address</span>
-               <span class="data">4209 Industrial Avenue <br>Los Angeles, California 90001 USA</span>
-            </div>
-
-          </div>
-
-          <div class="one-half column">
-
+  
+            <div class="one-half column">
+  
               <div class="field">
                 <span class="label">Phone Number</span>
                 <span class="data">(999) 810-2604</span>
               </div>
-
+  
               <div class="field">
                 <span class="label">Website</span>
                 <span class="data">www.buildings.com</span>
               </div>
-
+  
               <div class="field">
                 <span class="label">Estimated Delivery</span>
                 <span class="data">June 21, 2015 <i> (4 days)</i></span>
               </div>
-
+  
+            </div>
+  
           </div>
-
+  
         </div>
-
-      </div>
-
-    </fieldset>
-
-    <!-- Variation Two -->
-    <div class="fieldset">
+  
+      </fieldset>
+  
+      <!-- Variation Two -->
+      <div class="fieldset">
         <h2 class="fieldset-title">Credit Information</h2>
-
-        <span class="label" id="prbc-label1">Available Credit <span class="l-pull-right">$95,000</span></span>
-        <div class="chart-completion-target" id="chart-progressbar1" aria-labelledby="prbc-label1">
-          <div class="target">
-            <span aria-hidden="true">$10,000 <br/> Pending</span>
-          </div>
-          <div class="completed">
-            <span aria-hidden="true">$50,000 <br/> Spent</span>
-          </div>
-        </div>
-
-    </div>
-
-    <div class="fieldset">
+        <div id="container-1" class="char-container"></div>
+      </div>
+  
+      <div class="fieldset">
         <h2 class="fieldset-title">Delivery Addresses</h2>
-
+  
         <div class="summary-form">
           <div class="field">
             <span class="data">4209 Industrial Avenue Los Angeles, California 90001 USA<br>
-            Default Shipping Address</span>
+              Default Shipping Address</span>
           </div>
         </div>
+      </div>
+  
     </div>
-
   </div>
-</div>
+  
+  <script>
+    $('body').on('initialized', function () {
+      var container = [{
+        data: [{
+          name: {
+            text: 'Available Credit'
+          },
+          completed: {
+            text: 'Spent',
+            value: 50000,
+            format: '$,.0f'
+          },
+          remaining: {
+            text: 'Pending',
+            value: 10000,
+            format: '$,.0f'
+          },
+          total: {
+            value: 95000,
+            format: '$,.0f'
+          },
+        }]
+      }];
+  
+      $('#container-1').chart({
+        dataset: container,
+        type: 'completion-target'
+      }).data('chart');
+    });
+  
+  </script>
+  

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `[Datagrid]` Made the text all white on the targeted achievement formatter. ([#2730](https://github.com/infor-design/enterprise/issues/2730))
 - `[Datagrid]` Fixed keyword search so that it will again work with client side paging. ([#2797](https://github.com/infor-design/enterprise/issues/2797))
 - `[Datepicker]` Moved the today button to the datepicker header and adding a setting to hide it if wanted. ([#2704](https://github.com/infor-design/enterprise/issues/2704))
+- `[FieldSet]` Fixed an issue where the fieldset text in chart completion overlap when resizing the browser. ([#2610](https://github.com/infor-design/enterprise/issues/2610))
 - `[Datepicker]` Fixed a bug in datepicker where the destroy method does not readd the masking functionality. [2832](https://github.com/infor-design/enterprise/issues/2832))
 - `[Icons]` Added and updated the following icons: icon-new, icon-calculator, icon-save-new, icon-doc-check. ([#391](https://github.com/infor-design/design-system/issues/391))
 - `[Icons]` Added and updated the following icons: icon-bed, icon-user-clock, icon-phone-filled, icon-phone-empty. ([#419](https://github.com/infor-design/design-system/issues/419))


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The example page with chart is not being initialized. Change the example page by initializing the chart component.

**Related github/jira issue (required)**:
Closes: https://github.com/infor-design/enterprise/issues/2610

**Steps necessary to review your pull request (required)**:
- Pull this branch and run the app
- Navigate to http://localhost:4000/components/fieldset/example-index.html?theme=uplift&variant=light&colors=0563C2
- Resize the browser and check the completion chart labels
- Completion chart labels shouldn't overlapping each other

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

