### PR TITLE
2851 - Fix focus state on accordion headers that couldn't be cleared in Safari

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 - `[Application Menu]` Fixed an issue where footer toolbar area was overlapping to menu content. ([#2552](https://github.com/infor-design/enterprise/issues/2552))
 - `[Application Menu]` Fixed an issue where tooltip was showing white text on white background which makes text to be unreadable. ([#2811](https://github.com/infor-design/enterprise/issues/2811))
+- `[Accordion]` Fixed a Safari bug where accordion headers would not lose focus when another accordion header was clicked. ([#2851](https://github.com/infor-design/enterprise/issues/2851))
 - `[Bar Chart]` Fixed an issue where labels were overwritten when use more then one chart on page. ([#2723](https://github.com/infor-design/enterprise/issues/2723))
 - `[Buttons]` Adjust the contrast of buttons (tertiary) on uplift theme. ([#396](https://github.com/infor-design/design-system/issues/396))
 - `[Calendar]` Fixed an issue where the upcoming event description was overlapping the upcoming duration when text is too long, adjust width of spinbox count and fixed alignment of all day checkbox in uplift light theme. ([#2778](https://github.com/infor-design/enterprise/issues/2778))

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -345,6 +345,7 @@ Accordion.prototype = {
     // If it's not a real link, try and toggle an expansion pane.
     if (pane.length) {
       self.toggle(header);
+      self.focusOriginalType(header);
       return true;
     }
 
@@ -1182,10 +1183,13 @@ Accordion.prototype = {
   */
   focusOriginalType(header) {
     const btns = header.children('[class*="btn"]');
+    this.headers.not(header).removeClass('is-focused');
+
     if (this.originalSelection.is('[class*="btn"]') && btns.length) {
       btns.first()[0].focus();
     } else {
       header.children('a')[0].focus();
+      header.addClass('is-focused').removeClass('hide-focus');
     }
   },
 
@@ -1457,6 +1461,7 @@ Accordion.prototype = {
         self.originalSelection = target;
       }
 
+      headerElems.not($(this)).removeClass('is-focused');
       if (target.is(':not(.btn)')) {
         $(this).addClass('is-focused').removeClass('hide-focus');
       }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a problem with Accordion headers on Safari where clicking on accordion headers while another header had focus would not allow the focus state to clear.  If all accordion headers were clicked, eventually a focus state would be present on all headers.  This is no longer the case.

**Related github/jira issue (required)**:
Closes #2851 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run app.
- Open http://localhost:4000/components/accordion/example-accordion-panels.html in Mac OSX Safari
- Click multiple top-level headers in the same accordion.  When clicking a new header, the previously-selected header should lose its focus state.

**Included in this Pull Request**:
- [x] A note to the change log.
