### PR TITLE
2876 - Fix actions menu with datagrid

### DIFF
--- a/app/views/components/datagrid/test-actions-reload.html
+++ b/app/views/components/datagrid/test-actions-reload.html
@@ -1,0 +1,78 @@
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="toolbar no-actions-button" role="toolbar">
+      <div class="title">
+        Compressors
+        <span class="datagrid-result-count">(N Results)</span>
+      </div>
+      <div class="buttonset">
+        <button type="button" class="btn" id="btn-reload">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-refresh"></use>
+          </svg>
+          <span>Reload</span>
+        </button>
+      </div>
+    </div>
+
+    <div id="datagrid">
+    </div>
+
+  </div>
+</div>
+
+<ul id="grid-actions-menu" class="popupmenu">
+  <li><a href="#">Action One</a></li>
+  <li><a href="#">Action Two</a></li>
+  <li><a href="#">Action Three</a></li>
+</ul>
+
+<script  id="datagrid-script">
+  $('body').one('initialized', function () {
+
+    var grid,
+      columns = [];
+
+    // Define Columns for the Grid.
+    columns.push({ id: 'actions', name: 'Actions', field: '', width: 100, formatter: Formatters.Actions, menuId: 'grid-actions-menu', selected: function(e, link) { console.log(e, link); }});
+    columns.push({ id: 'productId', hideable: false, name: 'Id', field: 'productId', reorderable: true, formatter: Formatters.Text, width: 100 });
+    columns.push({ id: 'productName', name: 'Product Name', field: 'productName', reorderable: true, formatter: Formatters.Hyperlink, width: 200, minWidth: 150 });
+    columns.push({ id: 'activity', name: 'Activity', field: 'activity', reorderable: true });
+    columns.push({ id: 'hidden', hidden: true, name: 'Hidden', field: 'hidden' });
+    columns.push({ id: 'price', align: 'right', name: 'Actual Price', field: 'price', reorderable: true, formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'currency', currencySign: '$' }});
+    columns.push({ id: 'percent', align: 'right', name: 'Actual %', field: 'percent', reorderable: true, formatter: Formatters.Decimal, numberFormat: { minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'percent' }});
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', reorderable: true, formatter: Formatters.Date, dateFormat: 'M/d/yyyy' });
+    columns.push({ id: 'phone', name: 'Phone', field: 'phone', reorderable: true, formatter: Formatters.Text });
+
+    var url = '{{basepath}}api/datagrid-sample-data';
+
+    $.getJSON(url, function(res) {
+      // Init and get the api for the grid
+      grid = $('#datagrid').datagrid({
+        columns: columns,
+        dataset: res,
+        toolbar: { results: true }
+      });
+    });
+
+    // Set reload data
+    var reloadCounter = 0;
+    function setReloadData (data) {
+      data = (data && data.constructor === Array) ? data : [];
+      reloadCounter++;
+      var n = reloadCounter;
+      data[0] = { productId: (1000 + n), productName: 'New Compressor-' + n, activity: 'New-' + n, price: (101.99 + n), percent: 0.1, orderDate: '2018-08-07T06:00:00.000Z', phone: '(000) 111-000' + n };
+      return data;
+    }
+
+    // Handle reload
+    $('#btn-reload').on('click', function () {
+      $.getJSON(url, function(res) {
+        var newData = setReloadData(res);
+        grid.data('datagrid').loadData(newData);
+      });
+    });
+
+ });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `[Datagrid]` Made the text all white on the targeted achievement formatter. ([#2730](https://github.com/infor-design/enterprise/issues/2730))
 - `[Datagrid]` Fixed keyword search so that it will again work with client side paging. ([#2797](https://github.com/infor-design/enterprise/issues/2797))
 - `[Datagrid]` Fixed an issue where the header and cells do not align perfectly. ([#2849](https://github.com/infor-design/enterprise/issues/2849))
+- `[Datagrid]` Fixed an issue where actions menu was not opening after reload the data. ([#2876](https://github.com/infor-design/enterprise/issues/2876))
 - `[Datepicker]` Moved the today button to the datepicker header and adding a setting to hide it if wanted. ([#2704](https://github.com/infor-design/enterprise/issues/2704))
 - `[FieldSet]` Fixed an issue where the fieldset text in chart completion overlap when resizing the browser. ([#2610](https://github.com/infor-design/enterprise/issues/2610))
 - `[Datepicker]` Fixed a bug in datepicker where the destroy method does not readd the masking functionality. [2832](https://github.com/infor-design/enterprise/issues/2832))

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -327,8 +327,8 @@ const formatters = {
   Actions(row, cell, value, col) {
     // Render an Action Formatter
     return (
-      `<button type="button" class="btn-actions" aria-haspopup="true" aria-expanded="false" aria-owns="${col.menuId} +'">
-        <span class="audible">${col.title}</span>
+      `<button type="button" class="btn-actions" aria-haspopup="true" aria-expanded="false" aria-owns="${col.menuId}">
+        <span class="audible">${col.title || Locale.translate('More')}</span>
         ${$.createIcon({ icon: 'more' })}
       </button>`
     );

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -3213,3 +3213,32 @@ describe('Datagrid Personalization tests', () => {
     expect(await element.all(by.css('.modal-content input[type="checkbox"]')).count()).toEqual(8);
   });
 });
+
+describe('Datagrid Actions Popupmenu tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/test-actions-reload?layout=nofrills');
+    const datagridEl = await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(1)'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should open on click', async () => {
+    const selector = '#datagrid .datagrid-body tbody tr:nth-child(2) td:nth-child(1) .btn-actions';
+    let menuBtn = await element(by.css(selector));
+    menuBtn.click();
+
+    expect(await menuBtn.getAttribute('class')).toContain('is-open');
+    await element(by.id('btn-reload')).click();
+    menuBtn = await element(by.css(selector));
+
+    expect(await menuBtn.getAttribute('class')).not.toContain('is-open');
+    menuBtn = await element(by.css(selector));
+    menuBtn.click();
+
+    expect(await menuBtn.getAttribute('class')).toContain('is-open');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed actions menu was not opening after reload the data with Datagrid.

**Related github/jira issue (required)**:
Closes #2876

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/test-actions-reload.html
- Click on any row `...` three dots action button in column `Action`
- Popup menu should open
- Click on top button `Reload` to reload data
- Click again on any row `...` three dots action button in column `Action`
- Popup menu should open

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
