### PR TITLE
2800 - Toolbar: Fix toolbar/dropdown menu cut off on iOS device

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## v4.22.0
 
 ### v4.23.0 Fixes
-- `[Toolbar]` Fixed a bug where the dropdown/toolbar menu is being cutoff in iOS device. ([#2800](https://github.com/infor-design/enterprise/issues/2800))
+
+- `[Toolbar]` Fixed a bug where the dropdown/toolbar menu is being cut off on iOS device. ([#2800](https://github.com/infor-design/enterprise/issues/2800))
 
 ### v4.22.0 Deprecation
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # What's New with Enterprise
 
-## v4.22.0
+## v4.23.0
 
 ### v4.23.0 Fixes
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v4.22.0
 
+### v4.23.0 Fixes
+- `[Toolbar]` Fixed a bug where the dropdown/toolbar menu is being cutoff in iOS device. ([#2800](https://github.com/infor-design/enterprise/issues/2800))
+
 ### v4.22.0 Deprecation
 
 - `[Icons]` The alert icons now all have a white background allowing them to appear on colored areas. There was previously a special `-solid` version of the icons created that is now not needed, if you used the `icon-<name>-solid` icon change it to just `icon-<name>`. ([#396](https://github.com/infor-design/design-system/issues/396))

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -244,10 +244,11 @@ Toolbar.prototype = {
     // Setup an Event Listener that will refresh the contents of the More Actions
     // Menu's items each time the menu is opened.
     const isMobile = env.os.name === 'ios';
+    const isSafari = env.browser.name === 'safari';
     const menuButtonSettings = utils.extend({}, this.settings.moreMenuSettings, {
       trigger: 'click',
       menu: this.moreMenu,
-      attachToBody: isMobile
+      attachToBody: isMobile || isSafari
     }, (this.hasDefaultMenuItems ? { predefined: this.defaultMenuItems } : {}));
     if (popupMenuInstance) {
       this.more

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -1,5 +1,6 @@
 import * as debug from '../../utils/debug';
 import { utils } from '../../utils/utils';
+import { Environment as env } from '../../utils/environment';
 import { deprecateMethod } from '../../utils/deprecated';
 import { stringUtils } from '../../utils/string';
 import { Locale } from '../locale/locale';
@@ -242,9 +243,11 @@ Toolbar.prototype = {
 
     // Setup an Event Listener that will refresh the contents of the More Actions
     // Menu's items each time the menu is opened.
+    const isMobile = env.os.name === 'ios';
     const menuButtonSettings = utils.extend({}, this.settings.moreMenuSettings, {
       trigger: 'click',
-      menu: this.moreMenu
+      menu: this.moreMenu,
+      attachToBody: isMobile ? true : false
     }, (this.hasDefaultMenuItems ? { predefined: this.defaultMenuItems } : {}));
     if (popupMenuInstance) {
       this.more

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -247,7 +247,7 @@ Toolbar.prototype = {
     const menuButtonSettings = utils.extend({}, this.settings.moreMenuSettings, {
       trigger: 'click',
       menu: this.moreMenu,
-      attachToBody: isMobile ? true : false
+      attachToBody: isMobile
     }, (this.hasDefaultMenuItems ? { predefined: this.defaultMenuItems } : {}));
     if (popupMenuInstance) {
       this.more


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a problem with dropdown/toolbar menu on iOS device (Safari & Chrome browser) is being cut off when clicking the more button. Adding `attachToBody: true` if the environment is **iOS**.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/2800

**Steps necessary to review your pull request (required)**:
- Pull this branch, then run the app
- Use iOS device or browserstack (Safari and Chrome )
- Navigate to http://localhost:4000/components/toolbar/example-inside-form-tag.html
- Click `...` button
- toolbar menu shouldn't cut off

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
