### PR TITLE
2845 - Add a better fix for empty message zindex [v4.22.x]

### DIFF
--- a/src/components/emptymessage/_emptymessage.scss
+++ b/src/components/emptymessage/_emptymessage.scss
@@ -21,7 +21,6 @@
 .datagrid {
   &.has-filterable-columns .empty-message {
     top: calc(50% + 32px);
-    z-index: -1;
   }
 
   .empty-message {
@@ -29,5 +28,6 @@
     top: calc(50% + 20px);
     transform: translate(0, -50%);
     width: inherit;
+    z-index: -1;
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The fix i made for empty message did not work with a filter row. This fixes.

**Related github/jira issue (required)**:
Fixes #2845 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-empty-message.html
- make chrome as short as possible
- notice the icon goes under the header
- now in the .. menu - hide filter row
- notice the icon still now goes under the header
