### PR TITLE
2826 - Fix beforeclose event with contextual action panel

### DIFF
--- a/app/views/components/contextualactionpanel/test-beforeclose.html
+++ b/app/views/components/contextualactionpanel/test-beforeclose.html
@@ -1,0 +1,141 @@
+
+<div class="row">
+  <div class="six columns">
+
+    <button type="button" class="btn-secondary contextual-action-panel-trigger">
+      Contextual Action Panel
+    </button>
+    <div class="contextual-action-panel">
+      <div class="toolbar">
+        <div class="title">Company Information</div>
+        <div class="buttonset">
+          <button class="btn" type="button">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use xlink:href="#icon-save"></use>
+            </svg>
+            <span>Save</span>
+          </button>
+          <div class="separator"></div>
+          <button name="close" class="btn" type="button">
+            <svg class="icon icon-close" focusable="false" aria-hidden="true" role="presentation">
+              <use xlink:href="#icon-close"></use>
+            </svg>
+            <span>Close</span>
+          </button>
+        </div>
+      </div>
+      <div class="row">
+        <div class="twelve columns">
+          <div class="field">
+            <p style="padding-bottom: 10px;"><strong>Close this panel by click on (X Close) or by press (Escape key)</strong> Will update this preference on event `beforeclose`.</p>
+            <button type="button" class="btn-secondary" id="can-close">
+              Toggle to set close (<span id="can-close-text">False</span>)
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div class="row top-padding">
+        <div class="six columns">
+
+          <div class="field">
+            <label for="company-name">Company Name</label>
+            <select id="company-name" name="company-name" class="dropdown">
+              <option value="">None</option>
+              <option value="jawbone" selected>Jawbone, Inc.</option>
+              <option value="infor">Infor</option>
+            </select>
+          </div>
+
+          <div class="field">
+            <label for="purchase-form">Purchase Form</label>
+            <select id="purchase-form" name="purchase-form" class="dropdown">
+              <option value="">None</option>
+              <option value="3567" selected>3567</option>
+              <option value="3568">3568</option>
+              <option value="3569">3569</option>
+            </select>
+          </div>
+
+          <div class="field">
+            <label for="template">Template</label>
+            <select id="template" name="template" class="dropdown">
+              <option value="" selected>None</option>
+              <option value="1">Template #1</option>
+              <option value="2">Template #2</option>
+            </select>
+          </div>
+
+          <div class="field">
+            <label for="notes">Notes</label>
+            <textarea id="notes" name="notes"></textarea>
+          </div>
+
+        </div>
+        <div class="six columns">
+
+          <div class="field">
+            <label for="ship-terms">Ship Terms</label>
+            <select id="ship-terms" name="ship-terms" class="dropdown">
+              <option value="">None</option>
+              <option value="default" selected>Default</option>
+              <option value="alternate">Alternate</option>
+            </select>
+          </div>
+
+          <div class="field">
+            <label for="ship-via">Ship Via</label>
+            <select id="ship-via" name="ship-via" class="dropdown">
+              <option value="">None</option>
+              <option value="freight" selected>Freight</option>
+              <option value="air">USPS Air</option>
+            </select>
+          </div>
+
+          <div class="field">
+            <label for="issue-method">Issue Method</label>
+            <select id="issue-method" name="issue-method" class="dropdown">
+              <option value="">None</option>
+              <option value="phone">Telephone</option>
+              <option value="email" selected>E-mail</option>
+              <option value="sms">SMS Message</option>
+            </select>
+          </div>
+
+          <div class="field">
+            <input type="checkbox" id="po-box" name="po-box" class="checkbox" checked/>
+            <label for="po-box" class="checkbox-label">Freight</label>
+          </div>
+
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<script>
+  $('body').on('initialized', function () {
+    var canClose = false;
+    var canCloseText = $('#can-close-text');
+
+    // Set text
+    function setCanCloseText() {
+      canCloseText.text(canClose ? 'True' : 'False');
+    }
+
+    // Set Init text
+    setCanCloseText();
+
+    // Bind can close toggle button
+    $('#can-close').on('click', function() {
+      canClose = !canClose;
+      setCanCloseText();
+    });
+
+    // Bind `beforeclose`
+    $('.contextual-action-panel').on('beforeclose', function() {
+      return canClose;
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # What's New with Enterprise
 
+## v4.23.0
+
+### v4.23.0 Deprecation
+
+### v4.23.0 Features
+
+### v4.23.0 Fixes
+
+- `[Contextual Action Panel]` Fixed an issue where the CAP close but beforeclose event not fired. ([#2826](https://github.com/infor-design/enterprise/issues/2826))
+
+### v4.23.0 Chores & Maintenance
+
 ## v4.22.0
 
 ### v4.22.0 Deprecation

--- a/src/components/contextualactionpanel/contextualactionpanel.js
+++ b/src/components/contextualactionpanel/contextualactionpanel.js
@@ -380,10 +380,6 @@ ContextualActionPanel.prototype = {
         passEvent(e);
         self.panel.removeClass('is-animating');
       })
-      .off('beforeclose.contextualactionpanel')
-      .on('beforeclose.contextualactionpanel', () => {
-        self.panel.addClass('is-animating');
-      })
       .off('close.contextualactionpanel')
       .on('close.contextualactionpanel', (e) => {
         passEvent(e);

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1011,6 +1011,10 @@ Modal.prototype = {
       return false;
     }
 
+    if (this.isCAP) {
+      this.element.addClass('is-animating');
+    }
+
     if (this.mainContent && this.removeNoScroll) {
       this.mainContent.removeClass('no-scroll');
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the case where `beforeclose` event was not working with contextual action panel.

**Related github/jira issue (required)**:
Closes #2826

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Use iPhone
- Navigate to http://localhost:4000/components/contextualactionpanel/test-beforeclose.html
- Click on button `Contextual Action Panel`
- Click on button `Toggle to set close (False/True)`, this will update the preference on event `beforeclose`
- Try to close the panel by click button `X Close` or press `Escape` key
- It should only close if set to `True`

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
