### PR TITLE
2739 - Fix Uplift App Menu bullet placement in some versions of Android Chrome [v4.22.x]

### DIFF
--- a/src/components/applicationmenu/_applicationmenu-uplift.scss
+++ b/src/components/applicationmenu/_applicationmenu-uplift.scss
@@ -310,6 +310,12 @@
             }
           }
         }
+
+        &.list-item {
+          &::before {
+            font-size: 1rem;
+          }
+        }
       }
 
       &.is-expanded {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes the problem described in [this comment](https://github.com/infor-design/enterprise/issues/2739#issuecomment-538894947) where bullets on App Menu Accordion list items were causing text to shift down.

**Related github/jira issue (required)**:
Closes #2739 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run app
- Open Chrome on an Android device, simulator, browserstack, etc.
- Navigate to http://localhost:4000/components/applicationmenu/test-six-levels.html?theme=uplift
- Expand the app menu, and the "Level 1 Outbound Links" header.  Ensure the text is adjacent to the bullet point on "Level 2 List Header", and is not pushed down beneath it.