### PR TITLE
2613 - Allow the user to type on Input Fields coupled with a Context Menu (iOS)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # What's New with Enterprise
 
+## v4.23.0
+
+### v4.23.0 Deprecation
+
+### v4.23.0 Features
+
+### v4.23.0 Fixes
+
+`[Popupmenu]` In mobile settings (specifically iOS), input fields will now allow for text input when also being assigned a context menu. ([#2613](https://github.com/infor-design/enterprise/issues/2613))
+
+### v4.22.0 Chores & Maintenance
+
 ## v4.22.0
 
 ### v4.22.0 Deprecation

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 `[Popupmenu]` In mobile settings (specifically iOS), input fields will now allow for text input when also being assigned a context menu. ([#2613](https://github.com/infor-design/enterprise/issues/2613))
 
-### v4.22.0 Chores & Maintenance
+### v4.23.0 Chores & Maintenance
 
 ## v4.22.0
 

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -817,7 +817,7 @@ PopupMenu.prototype = {
     }
 
     function contextMenuHandler(e, isLeftClick) {
-      e.preventDefault();
+
 
       if (self.keydownThenClick) {
         delete self.keydownThenClick;
@@ -862,7 +862,8 @@ PopupMenu.prototype = {
           this.element
             .on('touchstart.popupmenu', (e) => {
               // iOS needs this prevented to prevent its own longpress feature in Safari
-              if (env.os.name === 'ios') {
+              // NOTE: this should not interfere with normal text input on form fields.
+              if (env.os.name === 'ios' && e.target.tagName !== 'INPUT') {
                 e.preventDefault();
               }
               $(e.target)

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -817,8 +817,6 @@ PopupMenu.prototype = {
     }
 
     function contextMenuHandler(e, isLeftClick) {
-
-
       if (self.keydownThenClick) {
         delete self.keydownThenClick;
         return;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a problem in iOS environments where it was not previously possible to type with a keyboard on input fields that also had a context menu assigned to them.

**Related github/jira issue (required)**:
Closes #2613 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run app
- Open a browser on an iPhone/iPad, simulator, BrowserStack, etc.
- Navigate to localhost:4000/components/input/example-contextmenu.html
- Focus the input field with a tap.  It should now allow the user to type or perform selection on the text.
- Press and hold on the input field.  After a longpress, a context menu should appear as expected.

**Included in this Pull Request**:
- [x] A note to the change log.
