### PR TITLE
2759 - Fix datagrid pager was not updating with updated method

### DIFF
--- a/app/views/components/datagrid/test-update-settings.html
+++ b/app/views/components/datagrid/test-update-settings.html
@@ -1,0 +1,65 @@
+<div class="row">
+  <div class="twelve columns">
+    <div class="field">
+      <input type="checkbox" class="checkbox" id="is-paging" checked="true"/>
+      <label for="is-paging" class="checkbox-label" >Paging</label>
+    </div>
+    <button class="btn-secondary" type="button" id="btn-update">Update</button>
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    var isPagingEl = $('#is-paging');
+    var gridEl = $('#datagrid');
+    var columns = [];
+    var gridApi = null;
+
+
+    // Get the paging setting
+    var isPaging = function() {
+      return isPagingEl.is(':checked');
+    };
+
+    // Define Columns for the Grid.
+    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, width: 50, formatter: Formatters.SelectionCheckbox, align: 'center' }),
+    columns.push({ id: 'id', name: 'Id', field: 'id', formatter: Formatters.Text});
+    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink});
+    columns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity'});
+    columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity'});
+    columns.push({ id: 'price', name: 'Price', field: 'price', formatter: Formatters.Decimal});
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+
+    // Url to get some data via ajax
+    var url = '{{basepath}}api/compressors?pageNum=1&pageSize=1000';
+
+    // Get data and initialize
+    $.getJSON(url, function(res) {
+      gridEl.datagrid({
+        columns: columns,
+        dataset: res.data,
+        selectable: 'multiple',
+        paging: isPaging(),
+        pagesize: 10,
+        toolbar: { title: 'Compressors', results: true, actions: true, rowHeight: true }
+      });
+
+      gridApi = gridEl.data('datagrid');
+    });
+
+    // Bind update
+    $('#btn-update').on('click', function() {
+      if (gridApi) {
+        gridApi.updated({ paging: isPaging() });
+      }
+    });
+  });
+
+</script>

--- a/app/views/components/datagrid/test-update-settings.html
+++ b/app/views/components/datagrid/test-update-settings.html
@@ -38,7 +38,7 @@
     columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
 
     // Url to get some data via ajax
-    var url = '{{basepath}}api/compressors?pageNum=1&pageSize=1000';
+    var url = '{{basepath}}api/compressors?pageNum=1&pageSize=10';
 
     // Get data and initialize
     $.getJSON(url, function(res) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### v4.23.0 Fixes
 
 - `[Contextual Action Panel]` Fixed an issue where the CAP close but beforeclose event not fired. ([#2826](https://github.com/infor-design/enterprise/issues/2826))
+- `[Datagrid]` Fixed an issue where the pager was not updating with updated method. ([#2759](https://github.com/infor-design/enterprise/issues/2759))
 
 ### v4.23.0 Chores & Maintenance
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10883,6 +10883,10 @@ Datagrid.prototype = {
   updated(settings) {
     this.settings = utils.mergeSettings(this.element, settings, this.settings);
 
+    if (this.pagerAPI && typeof this.pagerAPI.destroy === 'function') {
+      this.pagerAPI.destroy();
+    }
+
     if (settings && settings.frozenColumns) {
       this.headerRow = undefined;
       this.element.empty();
@@ -10898,6 +10902,7 @@ Datagrid.prototype = {
     }
 
     this.render();
+    this.handlePaging();
 
     return this;
   }

--- a/test/components/datagrid/datagrid-api.func-spec.js
+++ b/test/components/datagrid/datagrid-api.func-spec.js
@@ -703,4 +703,14 @@ describe('Datagrid API', () => {
     expect(table[0].querySelectorAll('tr').length).toEqual(2000);
     expect(table[0].querySelector('tr').outerHTML).toEqual('<tr><td><div><span> T100</span></div></td><td><div><a href="#" tabindex="-1" role="presentation" class="hyperlink ">Compressor</a></div></td><td><div>Assemble Paint</div></td><td><div>$#,##0.00</div></td><td><div>10 %</div></td><td><div>8/7/2018</div></td><td><div></div></td></tr>');
   });
+
+  it('Should update paging settings', () => {
+    datagridObj.destroy();
+    datagridObj = new Datagrid(datagridEl, { dataset: data, columns, paging: true, pagesize: 3 });
+
+    expect(document.body.querySelector('.pager-toolbar')).toBeTruthy();
+    datagridObj.updated({ paging: false });
+
+    expect(document.body.querySelector('.pager-toolbar')).toBeFalsy();
+  });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed Datagrid pager was not updating with updated method.

**Related github/jira issue (required)**:
Closes #2759

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/test-update-settings.html
- See the pager below the grid
- Make un/checked paging checkbox on top of grid and click button `Update`
- See the pager below the grid, should show or removed based on checkbox option

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
