### PR TITLE
2809 - Fix bubbling destroy event with popupmenu

### DIFF
--- a/app/views/components/colorpicker/test-modal.html
+++ b/app/views/components/colorpicker/test-modal.html
@@ -41,6 +41,8 @@
         validate: false,
         isDefault: true
       }]
+    }).on('destroy', function() {
+      console.log('destroy fired');
     });
   });
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### v4.23.0 Fixes
 
 - `[Contextual Action Panel]` Fixed an issue where the CAP close but beforeclose event not fired. ([#2826](https://github.com/infor-design/enterprise/issues/2826))
-- `[Popupmenu]` Fixed an issue where the destroy event was bubbling. ([#2809](https://github.com/infor-design/enterprise/issues/2809))
+- `[Popupmenu]` Fixed an issue where the destroy event was bubbling up to other parent components. ([#2809](https://github.com/infor-design/enterprise/issues/2809))
 
 ### v4.23.0 Chores & Maintenance
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### v4.23.0 Fixes
 
 - `[Contextual Action Panel]` Fixed an issue where the CAP close but beforeclose event not fired. ([#2826](https://github.com/infor-design/enterprise/issues/2826))
+- `[Popupmenu]` Fixed an issue where the destroy event was bubbling. ([#2809](https://github.com/infor-design/enterprise/issues/2809))
 
 ### v4.23.0 Chores & Maintenance
 

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -2354,7 +2354,7 @@ PopupMenu.prototype = {
     this.teardown();
 
     // In some cases, the menu needs to be completely removed on `destroy`.
-    this.menu.trigger('destroy');
+    this.menu.triggerHandler('destroy');
     if (this.settings.removeOnDestroy && this.menu && this.menu.length) {
       this.menu.off().remove();
       delete this.menu;

--- a/test/components/popupmenu/popupmenu-updates-events.func-spec.js
+++ b/test/components/popupmenu/popupmenu-updates-events.func-spec.js
@@ -60,4 +60,10 @@ describe('Popupmenu Events', () => {
       done();
     }, 600);
   });
+
+  it('Should not bubble "destroy" event', () => {
+    const spyEvent = spyOnEvent('.field', 'destroy');
+    popupmenuObj.destroy();
+    expect(spyEvent).not.toHaveBeenTriggered();
+  });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed bubbling destroy event with popupmenu.

**Related github/jira issue (required)**:
Closes #2809

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/colorpicker/test-modal.html
- Open developer tools
- Open modal
- Open color picker popup menu and pick any color
- Color picker popup menu should close
- See console should not fire destroy event

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
