### PR TITLE
NA - Fix slate 08 and colors page [v4.22.x]

### DIFF
--- a/app/views/components/colors/example-index.html
+++ b/app/views/components/colors/example-index.html
@@ -561,24 +561,29 @@
 </div>
 
 <script>
-  const paletteColor = document.querySelectorAll('.palette-color');
-
-  function valueToHex(v) {
-    const hex = v.toString(16);
-    return hex.length === 1 ?  0 + hex : hex;
-  }
-
-  function rgbToHex(r,g,b) {
-    return '#' + valueToHex(parseInt(r)) + valueToHex(parseInt(g)) + valueToHex(parseInt(b));
-  }
-
-  Array.prototype.forEach.call(paletteColor, function(color) {
-    const paletteHex = color.querySelector('.palette-hex');
-    const bgColor = window.getComputedStyle(color, null).getPropertyValue("background-color");
-    const rgbValues = bgColor.match(/\d+/g);
-
-    if (paletteHex !== null) {
-      paletteHex.innerHTML = rgbToHex(rgbValues[0], rgbValues[1], rgbValues[2]);
+  var setColors = function () {
+    const paletteColor = document.querySelectorAll('.palette-color');
+    function valueToHex(v) {
+      const hex = v.toString(16);
+      return hex.length === 1 ?  0 + hex : hex;
     }
-  })
+    function rgbToHex(r,g,b) {
+      return '#' + valueToHex(parseInt(r)) + valueToHex(parseInt(g)) + valueToHex(parseInt(b));
+    }
+    Array.prototype.forEach.call(paletteColor, function(color) {
+      const paletteHex = color.querySelector('.palette-hex');
+      const bgColor = window.getComputedStyle(color, null).getPropertyValue("background-color");
+      const rgbValues = bgColor.match(/\d+/g);
+      if (paletteHex !== null) {
+        paletteHex.innerHTML = rgbToHex(rgbValues[0], rgbValues[1], rgbValues[2]);
+      }
+    })
+  }
+  setColors();
+  // Change color on theme change
+  $('html').on('themechanged', function (e, a) {
+    setTimeout(function () {
+      setColors();
+    }, 250);
+  });
 </script>

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "handlebars-registrar": "^1.5.2",
     "html-loader": "^0.5.5",
     "ids-css": "^1.3.0",
-    "ids-identity": "2.6.14",
+    "ids-identity": "2.6.15",
     "jasmine-core": "^3.4.0",
     "jasmine-jquery": "^2.1.1",
     "jasmine-spec-reporter": "^4.2.1",


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

@kevinwhitedesign pointouted out that slate08 in uplift was not the new value anymore.
I found out that the hex change on this fix/PR https://github.com/infor-design/design-system/pull/405/files#diff-29b10ecab34514390228105c58e01e1dR85 for some reason did not get into IDS. So fixed this.

Also fixed the color page to change.

**Steps necessary to review your pull request (required)**:
- pull this branch
- npm i
- go to http://localhost:4000/components/colors/example-index.html
- slate08 is 313236 in soho/subtle
- use the theme switcher and change to uplift/vibrant
- slate08 is no #5C5861 in soho/subtle (note that before this change the colors didnt 100% get updated)
