### PR TITLE
902 - Pie Chart: Legend get cut off on mobile view

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### v4.23.0 Fixes
 
 - `[Contextual Action Panel]` Fixed an issue where the CAP close but beforeclose event not fired. ([#2826](https://github.com/infor-design/enterprise/issues/2826))
+- `[Pie]` Fixed an issue where legends in pie chart gets cut off on mobile view. ([#902](https://github.com/infor-design/enterprise/issues/902))
 
 ### v4.23.0 Chores & Maintenance
 

--- a/src/components/pie/_pie.scss
+++ b/src/components/pie/_pie.scss
@@ -99,14 +99,6 @@
   }
 }
 
-// Slight Nudge
-@include respond-to(phone) {
-  .chart-pie.has-right-legend .chart-legend {
-    margin: 0;
-    width: 27%;
-  }
-}
-
 // RTL Styles
 html[dir='rtl'] {
   .chart-pie.has-right-legend .chart-legend-item-text {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a problem with legends get cut off on mobile view. Remove unnecessary css properties.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/902

**Steps necessary to review your pull request (required)**:
- Pull this branch, run the app
- Use device toolbar on Chrome then use iPhone X, or use browserstack
- Navigate to http://localhost:4000/components/donut/example-index.html
- Legends shouldn't cut off

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
