### PR TITLE
2900 - Enable usage of chevron icons on all levels of Accordion headers

### DIFF
--- a/app/views/components/accordion/test-all-chevrons.html
+++ b/app/views/components/accordion/test-all-chevrons.html
@@ -1,0 +1,353 @@
+<div class="row">
+  <div class="six columns">
+    <p>In this test, all the expandable headers contain a "chevron" icon in their expander buttons.</p>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="six columns">
+    <div data-init="false" id="test-accordion" class="accordion panel alternate">
+      <!-- Level 1 -->
+      <div class="accordion-header">
+        <a href="#"><span>Level 1</span></a>
+      </div>
+      <div class="accordion-pane">
+
+        <!-- Level 2 -->
+        <div class="accordion-header">
+          <a href="#"><span>Level 2</span></a>
+        </div>
+        <div class="accordion-pane">
+
+          <!-- Level 3 -->
+          <div class="accordion-header">
+            <a href="#"><span>Level 3</span></a>
+          </div>
+          <div class="accordion-pane">
+
+            <!-- Level 4 -->
+            <div class="accordion-header">
+              <a href="#"><span>Level 4</span></a>
+            </div>
+            <div class="accordion-pane">
+
+              <!-- Level 5 -->
+              <div class="accordion-header">
+                <a href="#"><span>Level 5</span></a>
+              </div>
+              <div class="accordion-pane">
+
+                <!-- Level 6 -->
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6</span></a>
+                </div>
+                <div class="accordion-pane">
+                  <div class="accordion-content">
+                    <h3>You've reached the bottom</h3>
+                    <p>Nice work</p>
+                  </div>
+                </div>
+
+                <div class="accordion-header list-item">
+                  <a href="#"><span>Level 6 List-Item Header</span></a>
+                </div>
+
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Header Only</span></a>
+                </div>
+
+              </div>
+
+              <!-- Level 5 -->
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 (No Children with Icons)</span></a>
+              </div>
+              <div class="accordion-pane">
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Item #1</span></a>
+                </div>
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Item #2</span></a>
+                </div>
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Item #3</span></a>
+                </div>
+              </div>
+
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Content</span></a>
+              </div>
+              <div class="accordion-pane">
+                <div class="accordion-content">
+                  <h3>Level 5 Content Pane</h3>
+                  <p>Nothing to see here</p>
+                </div>
+              </div>
+
+              <div class="accordion-header list-item">
+                <a href="#"><span>Level 5 List-Item Header</span></a>
+              </div>
+
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Header Only</span></a>
+              </div>
+
+            </div>
+
+            <!-- Level 4 -->
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 (No Children with Icons)</span></a>
+            </div>
+            <div class="accordion-pane">
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Item #1</span></a>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Item #2</span></a>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Item #3</span></a>
+              </div>
+            </div>
+
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Content</span></a>
+            </div>
+            <div class="accordion-pane">
+              <div class="accordion-content">
+                <h3>Level 4 Content Pane</h3>
+                <p>Nothing to see here</p>
+              </div>
+            </div>
+
+            <div class="accordion-header list-item">
+              <a href="#"><span>Level 4 List-Item Header</span></a>
+            </div>
+
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Header Only</span></a>
+            </div>
+
+          </div>
+
+          <!-- Level 3 -->
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 (No Children with Icons)</span></a>
+          </div>
+          <div class="accordion-pane">
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Item #1</span></a>
+            </div>
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Item #2</span></a>
+            </div>
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Item #3</span></a>
+            </div>
+          </div>
+
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Content</span></a>
+          </div>
+          <div class="accordion-pane">
+            <div class="accordion-content">
+              <h3>Level 3 Content Pane</h3>
+              <p>Nothing to see here</p>
+            </div>
+          </div>
+
+          <div class="accordion-header list-item">
+            <a href="#"><span>Level 3 List-Item Header</span></a>
+          </div>
+
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Header Only</span></a>
+          </div>
+
+        </div>
+
+        <!-- Level 2 -->
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 (No Children with Icons)</span></a>
+        </div>
+        <div class="accordion-pane">
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Item #1</span></a>
+          </div>
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Item #2</span></a>
+          </div>
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Item #3</span></a>
+          </div>
+        </div>
+
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Content</span></a>
+        </div>
+        <div class="accordion-pane">
+          <div class="accordion-content">
+            <h3>Level 2 Content Pane</h3>
+            <p>Nothing to see here</p>
+          </div>
+        </div>
+
+        <div class="accordion-header list-item">
+          <a href="#"><span>Level 2 List-Item Header</span></a>
+        </div>
+
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Header Only</span></a>
+        </div>
+
+      </div>
+
+      <!-- Level 1 -->
+      <div class="accordion-header">
+        <a href="#"><span>Level 1 Outbound Links</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="accordion-content">
+          <h3>Level 2 Accordion Subheaders with Links</h3>
+          <p>All of the subheaders within this pane that are not expandable will have outbound links.</p>
+        </div>
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Outbound Link #1</span></a>
+        </div>
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Outbound Link #2</span></a>
+        </div>
+
+        <div class="accordion-header list-item">
+          <a href="#"><span>Level 2 List-Item Header</span></a>
+        </div>
+
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Header</span></a>
+        </div>
+        <div class="accordion-pane">
+          <div class="accordion-content">
+            <h3>Level 3 Accordion Subheaders with Links</h3>
+            <p>All of the subheaders within this pane that are not expandable will have outbound links.</p>
+          </div>
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Outbound Link #1</span></a>
+          </div>
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Outbound Link #2</span></a>
+          </div>
+
+          <div class="accordion-header list-item">
+            <a href="#"><span>Level 3 List-Item Header</span></a>
+          </div>
+
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Header</span></a>
+          </div>
+          <div class="accordion-pane">
+            <div class="accordion-content">
+              <h3>Level 4 Accordion Subheaders with Links</h3>
+              <p>All of the subheaders within this pane that are not expandable will have outbound links.</p>
+            </div>
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Outbound Link #1</span></a>
+            </div>
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Outbound Link #2</span></a>
+            </div>
+
+            <div class="accordion-header list-item">
+              <a href="#"><span>Level 4 List-Item Header</span></a>
+            </div>
+
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Header</span></a>
+            </div>
+            <div class="accordion-pane">
+              <div class="accordion-content">
+                <h3>Level 5 Accordion Subheaders with Links</h3>
+                <p>All of the subheaders within this pane that are not expandable will have outbound links.</p>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Outbound Link #1</span></a>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Outbound Link #2</span></a>
+              </div>
+
+              <div class="accordion-header list-item">
+                <a href="#"><span>Level 5 List-Item Header</span></a>
+              </div>
+
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Header</span></a>
+              </div>
+              <div class="accordion-pane">
+                <div class="accordion-content">
+                  <h3>Level 6 Accordion Subheaders with Links</h3>
+                  <p>All of the subheaders within this pane will have outbound links.</p>
+                </div>
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Outbound Link #1</span></a>
+                </div>
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Outbound Link #2</span></a>
+                </div>
+
+                <div class="accordion-header list-item">
+                  <a href="#"><span>Level 6 List-Item Header</span></a>
+                </div>
+
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Header</span></a>
+                </div>
+                <div class="accordion-pane">
+                  <div class="accordion-content">
+                    <h3>You've reached the bottom!</h3>
+                    <p>Nice Work</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Level 1 -->
+      <div class="accordion-header">
+        <a href="#"><span>Level 1 (No Children with Icons)</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Item #1</span></a>
+        </div>
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Item #2</span></a>
+        </div>
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Item #3</span></a>
+        </div>
+      </div>
+
+      <div class="accordion-header">
+        <a href="#"><span>Level 1 Content</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="accordion-content">
+          <h3>Level 1 Content Pane</h3>
+          <p>Nothing to see here</p>
+        </div>
+      </div>
+
+      <div class="accordion-header">
+        <a href="#"><span>Level 1 Header Only</span></a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script id="test-script">
+  $('#test-accordion').accordion({
+    expanderDisplay: 'chevron'
+  });
+</script>

--- a/app/views/components/accordion/test-all-plus-minus.html
+++ b/app/views/components/accordion/test-all-plus-minus.html
@@ -1,0 +1,353 @@
+<div class="row">
+  <div class="six columns">
+    <p>In this test, all the expandable headers contain a "plus-minus" icon in their expander buttons.</p>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="six columns">
+    <div data-init="false" id="test-accordion" class="accordion panel alternate">
+      <!-- Level 1 -->
+      <div class="accordion-header">
+        <a href="#"><span>Level 1</span></a>
+      </div>
+      <div class="accordion-pane">
+
+        <!-- Level 2 -->
+        <div class="accordion-header">
+          <a href="#"><span>Level 2</span></a>
+        </div>
+        <div class="accordion-pane">
+
+          <!-- Level 3 -->
+          <div class="accordion-header">
+            <a href="#"><span>Level 3</span></a>
+          </div>
+          <div class="accordion-pane">
+
+            <!-- Level 4 -->
+            <div class="accordion-header">
+              <a href="#"><span>Level 4</span></a>
+            </div>
+            <div class="accordion-pane">
+
+              <!-- Level 5 -->
+              <div class="accordion-header">
+                <a href="#"><span>Level 5</span></a>
+              </div>
+              <div class="accordion-pane">
+
+                <!-- Level 6 -->
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6</span></a>
+                </div>
+                <div class="accordion-pane">
+                  <div class="accordion-content">
+                    <h3>You've reached the bottom</h3>
+                    <p>Nice work</p>
+                  </div>
+                </div>
+
+                <div class="accordion-header list-item">
+                  <a href="#"><span>Level 6 List-Item Header</span></a>
+                </div>
+
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Header Only</span></a>
+                </div>
+
+              </div>
+
+              <!-- Level 5 -->
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 (No Children with Icons)</span></a>
+              </div>
+              <div class="accordion-pane">
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Item #1</span></a>
+                </div>
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Item #2</span></a>
+                </div>
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Item #3</span></a>
+                </div>
+              </div>
+
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Content</span></a>
+              </div>
+              <div class="accordion-pane">
+                <div class="accordion-content">
+                  <h3>Level 5 Content Pane</h3>
+                  <p>Nothing to see here</p>
+                </div>
+              </div>
+
+              <div class="accordion-header list-item">
+                <a href="#"><span>Level 5 List-Item Header</span></a>
+              </div>
+
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Header Only</span></a>
+              </div>
+
+            </div>
+
+            <!-- Level 4 -->
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 (No Children with Icons)</span></a>
+            </div>
+            <div class="accordion-pane">
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Item #1</span></a>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Item #2</span></a>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Item #3</span></a>
+              </div>
+            </div>
+
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Content</span></a>
+            </div>
+            <div class="accordion-pane">
+              <div class="accordion-content">
+                <h3>Level 4 Content Pane</h3>
+                <p>Nothing to see here</p>
+              </div>
+            </div>
+
+            <div class="accordion-header list-item">
+              <a href="#"><span>Level 4 List-Item Header</span></a>
+            </div>
+
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Header Only</span></a>
+            </div>
+
+          </div>
+
+          <!-- Level 3 -->
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 (No Children with Icons)</span></a>
+          </div>
+          <div class="accordion-pane">
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Item #1</span></a>
+            </div>
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Item #2</span></a>
+            </div>
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Item #3</span></a>
+            </div>
+          </div>
+
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Content</span></a>
+          </div>
+          <div class="accordion-pane">
+            <div class="accordion-content">
+              <h3>Level 3 Content Pane</h3>
+              <p>Nothing to see here</p>
+            </div>
+          </div>
+
+          <div class="accordion-header list-item">
+            <a href="#"><span>Level 3 List-Item Header</span></a>
+          </div>
+
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Header Only</span></a>
+          </div>
+
+        </div>
+
+        <!-- Level 2 -->
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 (No Children with Icons)</span></a>
+        </div>
+        <div class="accordion-pane">
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Item #1</span></a>
+          </div>
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Item #2</span></a>
+          </div>
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Item #3</span></a>
+          </div>
+        </div>
+
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Content</span></a>
+        </div>
+        <div class="accordion-pane">
+          <div class="accordion-content">
+            <h3>Level 2 Content Pane</h3>
+            <p>Nothing to see here</p>
+          </div>
+        </div>
+
+        <div class="accordion-header list-item">
+          <a href="#"><span>Level 2 List-Item Header</span></a>
+        </div>
+
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Header Only</span></a>
+        </div>
+
+      </div>
+
+      <!-- Level 1 -->
+      <div class="accordion-header">
+        <a href="#"><span>Level 1 Outbound Links</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="accordion-content">
+          <h3>Level 2 Accordion Subheaders with Links</h3>
+          <p>All of the subheaders within this pane that are not expandable will have outbound links.</p>
+        </div>
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Outbound Link #1</span></a>
+        </div>
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Outbound Link #2</span></a>
+        </div>
+
+        <div class="accordion-header list-item">
+          <a href="#"><span>Level 2 List-Item Header</span></a>
+        </div>
+
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Header</span></a>
+        </div>
+        <div class="accordion-pane">
+          <div class="accordion-content">
+            <h3>Level 3 Accordion Subheaders with Links</h3>
+            <p>All of the subheaders within this pane that are not expandable will have outbound links.</p>
+          </div>
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Outbound Link #1</span></a>
+          </div>
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Outbound Link #2</span></a>
+          </div>
+
+          <div class="accordion-header list-item">
+            <a href="#"><span>Level 3 List-Item Header</span></a>
+          </div>
+
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Header</span></a>
+          </div>
+          <div class="accordion-pane">
+            <div class="accordion-content">
+              <h3>Level 4 Accordion Subheaders with Links</h3>
+              <p>All of the subheaders within this pane that are not expandable will have outbound links.</p>
+            </div>
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Outbound Link #1</span></a>
+            </div>
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Outbound Link #2</span></a>
+            </div>
+
+            <div class="accordion-header list-item">
+              <a href="#"><span>Level 4 List-Item Header</span></a>
+            </div>
+
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Header</span></a>
+            </div>
+            <div class="accordion-pane">
+              <div class="accordion-content">
+                <h3>Level 5 Accordion Subheaders with Links</h3>
+                <p>All of the subheaders within this pane that are not expandable will have outbound links.</p>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Outbound Link #1</span></a>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Outbound Link #2</span></a>
+              </div>
+
+              <div class="accordion-header list-item">
+                <a href="#"><span>Level 5 List-Item Header</span></a>
+              </div>
+
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Header</span></a>
+              </div>
+              <div class="accordion-pane">
+                <div class="accordion-content">
+                  <h3>Level 6 Accordion Subheaders with Links</h3>
+                  <p>All of the subheaders within this pane will have outbound links.</p>
+                </div>
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Outbound Link #1</span></a>
+                </div>
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Outbound Link #2</span></a>
+                </div>
+
+                <div class="accordion-header list-item">
+                  <a href="#"><span>Level 6 List-Item Header</span></a>
+                </div>
+
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Header</span></a>
+                </div>
+                <div class="accordion-pane">
+                  <div class="accordion-content">
+                    <h3>You've reached the bottom!</h3>
+                    <p>Nice Work</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Level 1 -->
+      <div class="accordion-header">
+        <a href="#"><span>Level 1 (No Children with Icons)</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Item #1</span></a>
+        </div>
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Item #2</span></a>
+        </div>
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Item #3</span></a>
+        </div>
+      </div>
+
+      <div class="accordion-header">
+        <a href="#"><span>Level 1 Content</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="accordion-content">
+          <h3>Level 1 Content Pane</h3>
+          <p>Nothing to see here</p>
+        </div>
+      </div>
+
+      <div class="accordion-header">
+        <a href="#"><span>Level 1 Header Only</span></a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script id="test-script">
+  $('#test-accordion').accordion({
+    expanderDisplay: 'plus-minus'
+  });
+</script>

--- a/app/views/components/accordion/test-display-chevron-setting.html
+++ b/app/views/components/accordion/test-display-chevron-setting.html
@@ -1,0 +1,353 @@
+<div class="row">
+  <div class="six columns">
+    <p>In this test, the legacy setting `displayChevron: false` should convert all accordion expander buttons to "plus-minus" mode, including top-level expanders.  A warning message should display.</p>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="six columns">
+    <div data-init="false" id="test-accordion" class="accordion panel alternate">
+      <!-- Level 1 -->
+      <div class="accordion-header">
+        <a href="#"><span>Level 1</span></a>
+      </div>
+      <div class="accordion-pane">
+
+        <!-- Level 2 -->
+        <div class="accordion-header">
+          <a href="#"><span>Level 2</span></a>
+        </div>
+        <div class="accordion-pane">
+
+          <!-- Level 3 -->
+          <div class="accordion-header">
+            <a href="#"><span>Level 3</span></a>
+          </div>
+          <div class="accordion-pane">
+
+            <!-- Level 4 -->
+            <div class="accordion-header">
+              <a href="#"><span>Level 4</span></a>
+            </div>
+            <div class="accordion-pane">
+
+              <!-- Level 5 -->
+              <div class="accordion-header">
+                <a href="#"><span>Level 5</span></a>
+              </div>
+              <div class="accordion-pane">
+
+                <!-- Level 6 -->
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6</span></a>
+                </div>
+                <div class="accordion-pane">
+                  <div class="accordion-content">
+                    <h3>You've reached the bottom</h3>
+                    <p>Nice work</p>
+                  </div>
+                </div>
+
+                <div class="accordion-header list-item">
+                  <a href="#"><span>Level 6 List-Item Header</span></a>
+                </div>
+
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Header Only</span></a>
+                </div>
+
+              </div>
+
+              <!-- Level 5 -->
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 (No Children with Icons)</span></a>
+              </div>
+              <div class="accordion-pane">
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Item #1</span></a>
+                </div>
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Item #2</span></a>
+                </div>
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Item #3</span></a>
+                </div>
+              </div>
+
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Content</span></a>
+              </div>
+              <div class="accordion-pane">
+                <div class="accordion-content">
+                  <h3>Level 5 Content Pane</h3>
+                  <p>Nothing to see here</p>
+                </div>
+              </div>
+
+              <div class="accordion-header list-item">
+                <a href="#"><span>Level 5 List-Item Header</span></a>
+              </div>
+
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Header Only</span></a>
+              </div>
+
+            </div>
+
+            <!-- Level 4 -->
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 (No Children with Icons)</span></a>
+            </div>
+            <div class="accordion-pane">
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Item #1</span></a>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Item #2</span></a>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Item #3</span></a>
+              </div>
+            </div>
+
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Content</span></a>
+            </div>
+            <div class="accordion-pane">
+              <div class="accordion-content">
+                <h3>Level 4 Content Pane</h3>
+                <p>Nothing to see here</p>
+              </div>
+            </div>
+
+            <div class="accordion-header list-item">
+              <a href="#"><span>Level 4 List-Item Header</span></a>
+            </div>
+
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Header Only</span></a>
+            </div>
+
+          </div>
+
+          <!-- Level 3 -->
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 (No Children with Icons)</span></a>
+          </div>
+          <div class="accordion-pane">
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Item #1</span></a>
+            </div>
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Item #2</span></a>
+            </div>
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Item #3</span></a>
+            </div>
+          </div>
+
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Content</span></a>
+          </div>
+          <div class="accordion-pane">
+            <div class="accordion-content">
+              <h3>Level 3 Content Pane</h3>
+              <p>Nothing to see here</p>
+            </div>
+          </div>
+
+          <div class="accordion-header list-item">
+            <a href="#"><span>Level 3 List-Item Header</span></a>
+          </div>
+
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Header Only</span></a>
+          </div>
+
+        </div>
+
+        <!-- Level 2 -->
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 (No Children with Icons)</span></a>
+        </div>
+        <div class="accordion-pane">
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Item #1</span></a>
+          </div>
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Item #2</span></a>
+          </div>
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Item #3</span></a>
+          </div>
+        </div>
+
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Content</span></a>
+        </div>
+        <div class="accordion-pane">
+          <div class="accordion-content">
+            <h3>Level 2 Content Pane</h3>
+            <p>Nothing to see here</p>
+          </div>
+        </div>
+
+        <div class="accordion-header list-item">
+          <a href="#"><span>Level 2 List-Item Header</span></a>
+        </div>
+
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Header Only</span></a>
+        </div>
+
+      </div>
+
+      <!-- Level 1 -->
+      <div class="accordion-header">
+        <a href="#"><span>Level 1 Outbound Links</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="accordion-content">
+          <h3>Level 2 Accordion Subheaders with Links</h3>
+          <p>All of the subheaders within this pane that are not expandable will have outbound links.</p>
+        </div>
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Outbound Link #1</span></a>
+        </div>
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Outbound Link #2</span></a>
+        </div>
+
+        <div class="accordion-header list-item">
+          <a href="#"><span>Level 2 List-Item Header</span></a>
+        </div>
+
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Header</span></a>
+        </div>
+        <div class="accordion-pane">
+          <div class="accordion-content">
+            <h3>Level 3 Accordion Subheaders with Links</h3>
+            <p>All of the subheaders within this pane that are not expandable will have outbound links.</p>
+          </div>
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Outbound Link #1</span></a>
+          </div>
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Outbound Link #2</span></a>
+          </div>
+
+          <div class="accordion-header list-item">
+            <a href="#"><span>Level 3 List-Item Header</span></a>
+          </div>
+
+          <div class="accordion-header">
+            <a href="#"><span>Level 3 Header</span></a>
+          </div>
+          <div class="accordion-pane">
+            <div class="accordion-content">
+              <h3>Level 4 Accordion Subheaders with Links</h3>
+              <p>All of the subheaders within this pane that are not expandable will have outbound links.</p>
+            </div>
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Outbound Link #1</span></a>
+            </div>
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Outbound Link #2</span></a>
+            </div>
+
+            <div class="accordion-header list-item">
+              <a href="#"><span>Level 4 List-Item Header</span></a>
+            </div>
+
+            <div class="accordion-header">
+              <a href="#"><span>Level 4 Header</span></a>
+            </div>
+            <div class="accordion-pane">
+              <div class="accordion-content">
+                <h3>Level 5 Accordion Subheaders with Links</h3>
+                <p>All of the subheaders within this pane that are not expandable will have outbound links.</p>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Outbound Link #1</span></a>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Outbound Link #2</span></a>
+              </div>
+
+              <div class="accordion-header list-item">
+                <a href="#"><span>Level 5 List-Item Header</span></a>
+              </div>
+
+              <div class="accordion-header">
+                <a href="#"><span>Level 5 Header</span></a>
+              </div>
+              <div class="accordion-pane">
+                <div class="accordion-content">
+                  <h3>Level 6 Accordion Subheaders with Links</h3>
+                  <p>All of the subheaders within this pane will have outbound links.</p>
+                </div>
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Outbound Link #1</span></a>
+                </div>
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Outbound Link #2</span></a>
+                </div>
+
+                <div class="accordion-header list-item">
+                  <a href="#"><span>Level 6 List-Item Header</span></a>
+                </div>
+
+                <div class="accordion-header">
+                  <a href="#"><span>Level 6 Header</span></a>
+                </div>
+                <div class="accordion-pane">
+                  <div class="accordion-content">
+                    <h3>You've reached the bottom!</h3>
+                    <p>Nice Work</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Level 1 -->
+      <div class="accordion-header">
+        <a href="#"><span>Level 1 (No Children with Icons)</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Item #1</span></a>
+        </div>
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Item #2</span></a>
+        </div>
+        <div class="accordion-header">
+          <a href="#"><span>Level 2 Item #3</span></a>
+        </div>
+      </div>
+
+      <div class="accordion-header">
+        <a href="#"><span>Level 1 Content</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="accordion-content">
+          <h3>Level 1 Content Pane</h3>
+          <p>Nothing to see here</p>
+        </div>
+      </div>
+
+      <div class="accordion-header">
+        <a href="#"><span>Level 1 Header Only</span></a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script id="test-script">
+  $('#test-accordion').accordion({
+    displayChevron: false
+  });
+</script>

--- a/app/views/components/applicationmenu/test-all-chevrons.html
+++ b/app/views/components/applicationmenu/test-all-chevrons.html
@@ -1,0 +1,85 @@
+{{> includes/head}}
+
+<body class="no-scroll">
+  <a href="#maincontent" class="skip-link" data-translate="text">SkipToMain</a>
+  {{> includes/svg-inline-refs}}
+  {{> includes/applicationmenu-all-chevrons}}
+
+  <div class="page-container scrollable">
+
+      <header class="header is-personalizable has-tabs">
+        <div class="toolbar">
+          <div class="title">
+            <button class="btn-icon application-menu-trigger" type="button">
+              <span class="audible">Show navigation</span>
+              <span class="icon app-header">
+                <span class="one"></span>
+                <span class="two"></span>
+                <span class="three"></span>
+              </span>
+            </button>
+
+            <h1><span data-translate="text">UserProfile</span></h1>
+          </div>
+
+          <div class="buttonset">
+            <button class="btn" type="button">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use xlink:href="#icon-edit"></use>
+              </svg>
+              <span>Update Details</span>
+            </button>
+          </div>
+
+          {{> includes/header-actionbutton}}
+        </div>
+
+        <div class="tab-container" data-options='{ "containerElement": "#maincontent" }'>
+          <ul class="tab-list">
+            <li class="tab"><a href="#header-dos">Dates of Service</a></li>
+            <li class="tab"><a href="#header-pi">Personal Information</a></li>
+            <li class="tab"><a href="#header-mp">My Password</a></li>
+          </ul>
+        </div>
+
+      </header>
+
+    <div id="maincontent" class="page-container scrollable" role="main">
+      <div id="header-dos" class="tab-panel">
+        <div class="row top-padding">
+          <div class="twelve columns">
+            <p>Man bun portland venmo, reprehenderit cillum exercitation culpa adaptogen pitchfork unicorn. Jianbing mlkshk cloud bread id. Qui forage twee meditation hammock commodo heirloom gochujang shaman tattooed. Ethical commodo woke, ea est in artisan farm-to-table asymmetrical four loko ut master cleanse thundercats. Gochujang reprehenderit schlitz cred squid tote bag tempor literally consequat exercitation.
+            </p>
+          </div>
+        </div>
+      </div>
+      <div id="header-pi" class="tab-panel">
+        <div class="row top-padding">
+          <div class="twelve columns">
+            <p>Aute est literally, salvia fam esse dolor. Banh mi scenester velit franzen trust fund esse dolore truffaut XOXO, shabby chic nisi nostrud typewriter cliche. Cray fanny pack blue bottle dreamcatcher, pariatur iPhone cronut vaporware offal franzen. Ennui selvage man bun cronut kombucha aesthetic gastropub.</p>
+          </div>
+        </div>
+      </div>
+      <div id="header-mp" class="tab-panel">
+        <div class="row top-padding">
+          <div class="twelve columns">
+            <p>
+              Kale chips meditation freegan commodo jean shorts, kickstarter vegan. Enim taxidermy austin, forage marfa cillum gluten-free freegan activated charcoal salvia pariatur vape magna. Woke mlkshk bespoke, vaporware roof party squid kitsch green juice labore. Tacos tempor blog, poutine normcore try-hard dolore tattooed celiac deep v ipsum aute tofu pop-up.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {{> includes/footer}}
+
+  <script type="text/javascript">
+    // May need to do more here.
+    $('.application-menu-switcher-panel .accordion').on('selected', function (e, args) {
+      $('body').toast({title: 'Role ' + args.innerText + ' Selected',  message: 'In a real application, you could refresh the app menu with new contents for the selected role.'});
+       $('.application-menu').data('applicationmenu').closeSwitcherPanel();
+    });
+  </script>
+</body>
+</html>

--- a/app/views/includes/applicationmenu-all-chevrons.html
+++ b/app/views/includes/applicationmenu-all-chevrons.html
@@ -1,0 +1,216 @@
+<nav id="application-menu" class="application-menu is-open is-personalizable" data-options='{ "filterable": true, "dismissOnClickMobile": true }'>
+
+  <div class="flex-wrapper">
+    <div class="application-menu-header expandable-area-header">
+      <img src="/images/11.jpg" class="icon avatar" alt="Photo of Richard Fairbanks"/>
+      <button type="button" class="btn application-menu-switcher-trigger expandable-area-trigger" id="trigger-btn">
+        <span>Employee</span>
+        <svg class="icon icon-closed" focusable="false" aria-hidden="true" role="presentation">
+          <use xlink:href="#icon-caret-down"></use>
+        </svg>
+        <svg class="icon icon-opened" focusable="false" aria-hidden="true" role="presentation">
+          <use xlink:href="#icon-caret-up"></use>
+        </svg>
+      </button>
+      <div class="expandable-area">
+        <div class="expandable-pane application-menu-switcher-panel">
+          <div class="content">
+            <div class="accordion panel inverse">
+              <div class="accordion-header">
+                <a href="#"><span>Manager</span></a>
+              </div>
+              <div class="accordion-header is-selected">
+                <a href="#"><span>Recruiter</span></a>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>Admin</span></a>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>Example Role Thats Really Really Long So Long that it flows into an ellipsis just really long, maybe too long?</span></a>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>Example Role</span></a>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>Example Role</span></a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <span class="name-xl">Richard <br /> Fairbanks</span>
+      <div class="application-menu-toolbar">
+        <div class="flex-toolbar">
+          <div class="toolbar-section buttonset center-text">
+            <button class="btn-icon" title="Download My Profile">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use xlink:href="#icon-download"></use>
+              </svg>
+              <span class="audible">Download</span>
+            </button>
+            <button class="btn-icon" title="Print My Profile">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use xlink:href="#icon-print"></use>
+              </svg>
+              <span class="audible">Print</span>
+            </button>
+            <button class="btn-icon" title="Show Purchasing Info">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use xlink:href="#icon-purchasing"></use>
+              </svg>
+              <span class="audible">Purchasing</span>
+            </button>
+            <button class="btn-icon" title="Show Notification Info">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use xlink:href="#icon-notification"></use>
+              </svg>
+              <span class="audible">Notification</span>
+            </button>
+            <button class="btn-icon" title="Show Inventory Info">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use xlink:href="#icon-inventory"></use>
+              </svg>
+              <span class="audible">Inventory</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="application-menu-content">
+    <div class="searchfield-wrapper">
+      <label class="audible" for="application-menu-searchfield">Search</label>
+      <input id="application-menu-searchfield" class="searchfield" data-options='{ "clearable": true }' placeholder="Look up menu items"/>
+    </div>
+
+    <div class="accordion panel inverse" data-options="{'allowOnePane': false, 'expanderDisplay': 'chevron'}" >
+      <div class="accordion-header">
+        <a href="#"><span>Home</span></a>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Profile</span></a>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Pay</span></a>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Benefits</span></a>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Time Off</span></a>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Growth</span></a>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Engagements</span></a>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Resources</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="accordion-header">
+          <a href="#"><span>2nd Level Menu Item</span></a>
+        </div>
+        <div class="accordion-pane">
+          <div class="accordion-header">
+            <a href="#"><span>3rd Level Menu Item</span></a>
+          </div>
+          <div class="accordion-pane">
+            <div class="accordion-header">
+              <a href="#"><span>4th Level Menu Item</span></a>
+            </div>
+            <div class="accordion-pane">
+              <div class="accordion-header">
+                <a href="#"><span>5th Level Menu Item</span></a>
+              </div>
+              <div class="accordion-pane">
+                <div class="accordion-header is-expanded">
+                  <a href="#"><span>6th Level Menu Item</span></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="accordion-header">
+          <a href="#"><span>2nd Level Menu Item</span></a>
+        </div>
+        <div class="accordion-pane">
+          <div class="accordion-header">
+            <a href="#"><span>3rd Level Menu Item</span></a>
+          </div>
+          <div class="accordion-pane">
+            <div class="accordion-header">
+              <a href="#"><span>4th Level Menu Item</span></a>
+            </div>
+            <div class="accordion-pane">
+              <div class="accordion-header">
+                <a href="#"><span>5th Level Menu Item</span></a>
+              </div>
+              <div class="accordion-pane">
+                <div class="accordion-header is-expanded">
+                  <a href="#"><span>6th Level Menu Item</span></a>
+                </div>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>5th Level Menu Item</span></a>
+              </div>
+            </div>
+            <div class="accordion-header">
+              <a href="#"><span>4th Level Menu Item</span></a>
+            </div>
+          </div>
+          <div class="accordion-header">
+            <a href="#"><span>3rd Level Menu Item</span></a>
+          </div>
+        </div>
+        <div class="accordion-header">
+          <a href="#"><span>2nd Level Menu Item</span></a>
+        </div>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>The Next Level One Menu Item</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="accordion-header">
+          <a href="#"><span>2nd Level Menu item</span></a>
+        </div>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Proxy</span></a>
+      </div>
+    </div>
+  </div>
+
+  <div class="application-menu-footer">
+    <div class="application-menu-toolbar">
+      <div class="flex-toolbar">
+        <div class="toolbar-section buttonset">
+          <button class="btn" type="button" title="Show Settings">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use xlink:href="#icon-settings"></use>
+            </svg>
+            <span>Settings</span>
+          </button>
+          <button class="btn-icon" type="button" title="Proxy as user">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use xlink:href="#icon-employee-directory"></use>
+            </svg>
+          </button>
+          <button class="btn-icon" type="button" title="About this App">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use xlink:href="#icon-info-linear"></use>
+            </svg>
+          </button>
+          <button class="btn-icon" type="button" title="Log Out">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use xlink:href="#icon-logout"></use>
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</nav>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### v4.23.0 Features
 
+- [`Accordion`] Added a new setting `expanderDisplay` that can display all expander button icons in the classic style, or with all "chevron" or "plus-minus"-style icons.  Deprecated the legacy `displayChevron` setting in favor of this change. ([#2900](https://github.com/infor-design/enterprise/issues/2900))
+
 ### v4.23.0 Fixes
 
 - `[Popupmenu]` In mobile settings (specifically iOS), input fields will now allow for text input when also being assigned a context menu. ([#2613](https://github.com/infor-design/enterprise/issues/2613))

--- a/src/components/accordion/_accordion-mixins.scss
+++ b/src/components/accordion/_accordion-mixins.scss
@@ -50,21 +50,24 @@
 //================================================== //
 @mixin right-align-cascade-styles-header($a-padding, $icon-margin, $width, $li-padding) {
   > a {
+    padding-left: 0;
     padding-right: $a-padding;
   }
 
   > .icon,
   > [class^='btn'] {
+    margin-left: auto;
     margin-right: $icon-margin;
 
     + a {
-      padding-right: auto;
+      padding-right: 0;
       width: calc(100% - #{$width});
     }
   }
 
   &.list-item {
     &::before {
+      padding-left: 0;
       padding-right: $li-padding;
     }
 
@@ -77,15 +80,18 @@
 
 @mixin right-align-cascade-styles-pane($rightPadding, $iconLinkPadding, $iconContentPadding) {
   .accordion-content {
+    padding-left: 0;
     padding-right: $rightPadding;
   }
 
   &.has-icons {
     .accordion-header.no-icon > a {
+      padding-left: 0;
       padding-right: $iconLinkPadding;
     }
 
     .accordion-content {
+      padding-left: 0;
       padding-right: $iconContentPadding;
     }
   }

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -756,6 +756,16 @@
       background-color: $accordion-disabled-pane-bg-color !important;
       border-bottom-color: $accordion-disabled-pane-bg-color !important;
     }
+
+    // Subheaders can now have chevrons as of v4.23.x
+    &:not(.has-chevron) {
+      .icon.chevron {
+        height: 16px;
+        left: -8px;
+        top: -1px;
+        width: 16px;
+      }
+    }
   }
 
   // Level 2 Accordion Pane

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -32,6 +32,7 @@ const expanderDisplayModes = ['classic', 'plus-minus', 'chevron'];
  * @param {boolean} [settings.displayChevron=true] (deprecated in v4.23.0) Displays a "Chevron" icon that sits off to the right-most
  * side of a top-level accordion header. Used in place of an Expander (+/-) if enabled.  Use `settings.expanderDisplay` instead.
  * @param {boolean} [settings.enableTooltips=true] If false, does not run logic to apply tooltips to elements with truncated text.
+ * @param {string} [settings.expanderDisplay='classic'] Changes the iconography used in accordion header expander buttons. By default, top level expanders will be chevrons, and sub-header expanders will be "plus-minus" style.  This setting can also be "plus-minus" or "chevron" to force the same icons throughout the accordion.
  * @param {string} [settings.rerouteOnLinkClick=true]  Can be set to false if routing is externally handled
  * @param {boolean} [settings.source=null]  A callback function that when implemented provided a call back for "ajax loading" of tab contents on open.
  */

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -3,6 +3,7 @@ import * as debug from '../../utils/debug';
 import { utils } from '../../utils/utils';
 import { xssUtils } from '../../utils/xss';
 import { Locale } from '../locale/locale';
+import { warnAboutDeprecation } from '../../utils/deprecated';
 
 // jQuery components
 import '../icons/icons.jquery';
@@ -11,6 +12,12 @@ import '../../utils/behaviors';
 
 // Component Name
 const COMPONENT_NAME = 'accordion';
+
+// Expander Button Display Modes
+// In some cases, expander buttons can be all "plus-minus" icons, or all "chevron" icons.
+// "Classic" is the original mode, with Chevrons at the top level, and Plus-minus style on all subheaders.
+// "Plus-minus" mode is the replacement setting for the deprecated setting `displayChevron`
+const expanderDisplayModes = ['classic', 'plus-minus', 'chevron'];
 
 /**
  * The Accordion is a grouped set of collapsible panels used to navigate sections of
@@ -21,24 +28,39 @@ const COMPONENT_NAME = 'accordion';
  * @param {object} element The component element.
  * @param {object} [settings] The component settings.
  * @param {string} [settings.allowOnePane=true] If set to true, allows only one pane of the Accordion to be open at a
- * time.  If an Accordion pane is open, and that pane contains sub-headers only one of the pane's sub-headers can be open at a time. (default true)
- * @param {string} [settings.displayChevron=true]  Displays a "Chevron" icon that sits off to the right-most
+ * time. If an Accordion pane is open, and that pane contains sub-headers only one of the pane's sub-headers can be open at a time. (default true)
+ * @param {boolean} [settings.displayChevron=true] (deprecated in v4.23.0) Displays a "Chevron" icon that sits off to the right-most
+ * side of a top-level accordion header. Used in place of an Expander (+/-) if enabled.  Use `settings.expanderDisplay` instead.
  * @param {boolean} [settings.enableTooltips=true] If false, does not run logic to apply tooltips to elements with truncated text.
- * side of a top-level accordion header. Used in place of an Expander (+/-) if enabled.
  * @param {string} [settings.rerouteOnLinkClick=true]  Can be set to false if routing is externally handled
  * @param {boolean} [settings.source=null]  A callback function that when implemented provided a call back for "ajax loading" of tab contents on open.
  */
 const ACCORDION_DEFAULTS = {
   allowOnePane: true,
-  displayChevron: true,
+  expanderDisplay: expanderDisplayModes[0],
   enableTooltips: true,
   rerouteOnLinkClick: true,
   source: null
 };
 
+// Handles the conversion of deprecated settings to current settings
+function handleDeprecatedSettings(settings) {
+  if (settings.displayChevron !== undefined) {
+    warnAboutDeprecation('expanderDisplay setting', 'displayChevron setting');
+    if (settings.displayChevron === false) {
+      settings.expanderDisplay = expanderDisplayModes[1]; // plus-minus
+    } else {
+      settings.expanderDisplay = expanderDisplayModes[0]; // classic
+    }
+    delete settings.displayChevron;
+  }
+  return settings;
+}
+
 function Accordion(element, settings) {
   this.element = $(element);
   this.settings = utils.mergeSettings(this.element[0], settings, ACCORDION_DEFAULTS);
+  this.settings = handleDeprecatedSettings(this.settings);
 
   debug.logTimeStart(COMPONENT_NAME);
   this.init();
@@ -152,7 +174,7 @@ Accordion.prototype = {
         expander = $('<button class="btn" type="button"></button>');
 
         let method = 'insertBefore';
-        if (self.settings.displayChevron && isTopLevel) {
+        if (self.settings.expanderDisplay !== 'plus-minus' && isTopLevel) {
           header.addClass('has-chevron');
           method = 'insertAfter';
         }
@@ -164,13 +186,14 @@ Accordion.prototype = {
       expander.hideFocus();
 
       // If Chevrons are turned off and an icon is present, it becomes the expander
-      if (outerIcon.length && !self.settings.displayChevron) {
+      if (outerIcon.length && (self.settings.expanderDisplay === 'classic' || self.settings.expanderDisplay === 'chevron')) {
         outerIcon.appendTo(expander);
       }
 
       let expanderIcon = expander.children('.icon, .svg, .plus-minus');
       if (!expanderIcon.length) {
-        if (self.settings.displayChevron && isTopLevel) {
+        if ((self.settings.expanderDisplay === 'classic' && isTopLevel) ||
+          self.settings.expanderDisplay === 'chevron') {
           expanderIcon = $.createIconElement({ icon: 'caret-down', classes: ['chevron'] });
         } else {
           const isActive = self.isExpanded(header) ? ' active' : '';
@@ -188,7 +211,8 @@ Accordion.prototype = {
       expanderIcon.attr(expanderIconOpts);
 
       // Move around the Expander depending on whether or not it's a chevron
-      if (expanderIcon.is('.chevron')) {
+      // ONLY do this if the chevron is top-level.
+      if (expanderIcon.is('.chevron') && isTopLevel) {
         header.addClass('has-chevron');
         expander.insertAfter(header.children('a'));
       } else {
@@ -198,7 +222,7 @@ Accordion.prototype = {
 
       // Double check to see if we have left-aligned expanders or icons present,
       // so we can add classes that do alignment
-      if (!self.settings.displayChevron && isTopLevel) {
+      if (self.settings.expanderDisplay !== 'plus-minus' && isTopLevel) {
         headersHaveIcons = true;
       }
       checkIfIcons();
@@ -1318,6 +1342,7 @@ Accordion.prototype = {
 
     if (settings) {
       this.settings = utils.mergeSettings(this.element[0], settings, this.settings);
+      this.settings = handleDeprecatedSettings(this.settings);
     }
 
     let currentFocus = $(document.activeElement);

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -187,7 +187,7 @@ Accordion.prototype = {
       expander.hideFocus();
 
       // If Chevrons are turned off and an icon is present, it becomes the expander
-      if (outerIcon.length && (self.settings.expanderDisplay === 'classic' || self.settings.expanderDisplay === 'chevron')) {
+      if (outerIcon.length && (self.settings.expanderDisplay === 'plus-minus')) {
         outerIcon.appendTo(expander);
       }
 
@@ -223,7 +223,7 @@ Accordion.prototype = {
 
       // Double check to see if we have left-aligned expanders or icons present,
       // so we can add classes that do alignment
-      if (self.settings.expanderDisplay !== 'plus-minus' && isTopLevel) {
+      if (self.settings.expanderDisplay === 'plus-minus' && isTopLevel) {
         headersHaveIcons = true;
       }
       checkIfIcons();

--- a/src/components/applicationmenu/_applicationmenu-uplift.scss
+++ b/src/components/applicationmenu/_applicationmenu-uplift.scss
@@ -639,7 +639,6 @@ html[dir='rtl'] {
 
                 &.no-icon {
                   > a {
-                    padding-left: 0;
                     padding-right: 150px;
                   }
                 }
@@ -658,12 +657,10 @@ html[dir='rtl'] {
     .accordion.has-icons {
       .accordion-header {
         > a {
-          padding-left: 0;
           padding-right: 54px;
         }
 
         > .icon + a {
-          padding-left: 0;
           padding-right: 0;
         }
       }
@@ -713,7 +710,6 @@ html[dir='rtl'] {
 
                   &.no-icon {
                     > a {
-                      padding-left: 0;
                       padding-right: 182px;
                     }
                   }

--- a/src/components/applicationmenu/_applicationmenu-uplift.scss
+++ b/src/components/applicationmenu/_applicationmenu-uplift.scss
@@ -316,6 +316,13 @@
             font-size: 1rem;
           }
         }
+
+        &:not(.has-chevron) {
+          .icon.chevron {
+            left: -5px;
+            width: 13px;
+          }
+        }
       }
 
       &.is-expanded {
@@ -428,6 +435,17 @@ html[dir='rtl'] {
     .searchfield-wrapper {
       .icon:not(.close) {
         right: 8px;
+      }
+    }
+
+    .accordion.panel.inverse {
+      .accordion-pane {
+        .accordion-header:not(.has-chevron) {
+          .icon.chevron {
+            left: auto;
+            right: -5px;
+          }
+        }
       }
     }
   }
@@ -621,7 +639,7 @@ html[dir='rtl'] {
 
                 &.no-icon {
                   > a {
-                    padding-left: auto;
+                    padding-left: 0;
                     padding-right: 150px;
                   }
                 }
@@ -640,12 +658,12 @@ html[dir='rtl'] {
     .accordion.has-icons {
       .accordion-header {
         > a {
-          padding-left: auto;
+          padding-left: 0;
           padding-right: 54px;
         }
 
         > .icon + a {
-          padding-left: auto;
+          padding-left: 0;
           padding-right: 0;
         }
       }
@@ -695,7 +713,7 @@ html[dir='rtl'] {
 
                   &.no-icon {
                     > a {
-                      padding-left: auto;
+                      padding-left: 0;
                       padding-right: 182px;
                     }
                   }

--- a/test/components/accordion/accordion-api.func-spec.js
+++ b/test/components/accordion/accordion-api.func-spec.js
@@ -5,18 +5,15 @@ const accordionHTML = require('../../../app/views/components/accordion/example-i
 const svg = require('../../../src/components/icons/svg.html');
 
 let accordionEl;
-let svgEl;
 let accordionObj;
 
 describe('Accordion API', () => {
   beforeEach(() => {
     accordionEl = null;
-    svgEl = null;
     accordionObj = null;
     document.body.insertAdjacentHTML('afterbegin', svg);
     document.body.insertAdjacentHTML('afterbegin', accordionHTML);
     accordionEl = document.body.querySelector('.accordion');
-    svgEl = document.body.querySelector('.svg-icons');
     accordionObj = new Accordion(accordionEl);
   });
 
@@ -110,12 +107,10 @@ describe('Accordion API', () => {
 describe('Accordion API (settings)', () => {
   beforeEach(() => {
     accordionEl = null;
-    svgEl = null;
     accordionObj = null;
     document.body.insertAdjacentHTML('afterbegin', svg);
     document.body.insertAdjacentHTML('afterbegin', accordionHTML);
     accordionEl = document.body.querySelector('.accordion');
-    svgEl = document.body.querySelector('.svg-icons');
   });
 
   afterEach(() => {
@@ -138,7 +133,7 @@ describe('Accordion API (settings)', () => {
   });
 
   // `displayChevron` deprecated as of v4.23.x
-  it('Converts the legacy setting `displayChevron: false` to `expanderDisplay: \'plus-minus\'`', () => {
+  it('Converts the legacy setting `displayChevron: true` to `expanderDisplay: \'classic\'`', () => {
     accordionObj = new Accordion(accordionEl, {
       displayChevron: true
     });

--- a/test/components/accordion/accordion-api.func-spec.js
+++ b/test/components/accordion/accordion-api.func-spec.js
@@ -1,4 +1,5 @@
 import { Accordion } from '../../../src/components/accordion/accordion';
+import { cleanup } from '../../helpers/func-utils';
 
 const accordionHTML = require('../../../app/views/components/accordion/example-index.html');
 const svg = require('../../../src/components/icons/svg.html');
@@ -21,30 +22,34 @@ describe('Accordion API', () => {
 
   afterEach(() => {
     accordionObj.destroy();
-    svgEl.parentNode.removeChild(svgEl);
+    cleanup([
+      '.accordion',
+      '.svg-icons',
+      '.row',
+    ]);
   });
 
-  it('Should be defined', () => {
+  it('should be defined', () => {
     expect(accordionObj).toEqual(jasmine.any(Object));
   });
 
-  it('Should be visible', () => {
+  it('should be visible', () => {
     expect(document.body.querySelector('.accordion')).toBeTruthy();
   });
 
-  it('Should be able to destroy it', () => {
+  it('can be destroyed', () => {
     accordionObj.destroy();
 
     expect(document.body.querySelector('.btn.hide-focus')).toBeFalsy();
   });
 
-  it('Should be able to collapse all accordion', () => {
+  it('can collapse all its headers', () => {
     accordionObj.collapseAll();
 
     expect(document.body.querySelector('.accordion.is-expanded')).toBeFalsy();
   });
 
-  it('Should be able to enable and disable it', () => {
+  it('can be disabled and enabled', () => {
     accordionObj.disable();
 
     expect(document.body.querySelector('.accordion.is-disabled')).toBeTruthy();
@@ -57,17 +62,17 @@ describe('Accordion API', () => {
     expect(document.body.querySelector('.accordion.is-disabled')).toBeFalsy();
   });
 
-  it('Should accordion have headers', () => {
+  it('should contain a reference to all its headers', () => {
     expect(accordionObj.headers).toBeTruthy();
   });
 
-  it('Should check if expanded', () => {
+  it('can describe whether or not a header is currently expanded', () => {
     const isExpanded = accordionObj.isExpanded(accordionObj.headers[0]);
 
     expect(isExpanded).toBeFalsy();
   });
 
-  it('Should fire selected event on click', () => {
+  it('fires a `selected` event on click', () => {
     const linkSelector = '.accordion a';
     const spyEvent = spyOnEvent($(linkSelector), 'click');
     document.body.querySelector(linkSelector).click();
@@ -75,7 +80,7 @@ describe('Accordion API', () => {
     expect(spyEvent).toHaveBeenTriggered();
   });
 
-  it('Should be able to expandAll and collapseAll', (done) => {
+  it('can expand and collapse all of its headers at once', (done) => {
     expect(accordionObj.isExpanded(accordionObj.headers[0])).toBeFalsy();
     expect(accordionObj.isExpanded(accordionObj.headers[1])).toBeFalsy();
     expect(accordionObj.isExpanded(accordionObj.headers[2])).toBeFalsy();
@@ -99,5 +104,46 @@ describe('Accordion API', () => {
         done();
       }, 300);
     }, 300);
+  });
+});
+
+describe('Accordion API (settings)', () => {
+  beforeEach(() => {
+    accordionEl = null;
+    svgEl = null;
+    accordionObj = null;
+    document.body.insertAdjacentHTML('afterbegin', svg);
+    document.body.insertAdjacentHTML('afterbegin', accordionHTML);
+    accordionEl = document.body.querySelector('.accordion');
+    svgEl = document.body.querySelector('.svg-icons');
+  });
+
+  afterEach(() => {
+    accordionObj.destroy();
+    cleanup([
+      '.accordion',
+      '.svg-icons',
+      '.row',
+    ]);
+  });
+
+  // `displayChevron` deprecated as of v4.23.x
+  it('Converts the legacy setting `displayChevron: false` to `expanderDisplay: \'plus-minus\'`', () => {
+    accordionObj = new Accordion(accordionEl, {
+      displayChevron: false
+    });
+
+    expect(accordionObj.settings.displayChevron).not.toBeDefined();
+    expect(accordionObj.settings.expanderDisplay).toEqual('plus-minus');
+  });
+
+  // `displayChevron` deprecated as of v4.23.x
+  it('Converts the legacy setting `displayChevron: false` to `expanderDisplay: \'plus-minus\'`', () => {
+    accordionObj = new Accordion(accordionEl, {
+      displayChevron: true
+    });
+
+    expect(accordionObj.settings.displayChevron).not.toBeDefined();
+    expect(accordionObj.settings.expanderDisplay).toEqual('classic');
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds a setting to the Accordion component, `expanderDisplay` that enables changing the expander button icon.  By default, the accordion uses the "chevron"-style icon on its top-level headers, and uses "plus-minus" style icons on its subheaders.  This PR fulfills a feature request that allows for the usage of all chevron-style icons throughout a nested accordion stack.

Additionally, the `displayChevron` setting, which allows for the conversion of all icons to the "plus-minus" style, was deprecated in favor of the new setting, which handles all display modes.  Deprecation warnings have been added for this setting, and a test demonstrating internal conversion of the setting has been added.

**Related github/jira issue (required)**:
Closes #2900

**Steps necessary to review your pull request (required)**:
- Pull branch, build, run demoapp
- Open http://localhost:4000/components/accordion/test-all-chevrons.html and open the accordion panes.  See that the expandable subheaders are using Chevron-style icons.
- Open http://localhost:4000/components/accordion/test-all-plus-minus.html.  Notice the top-level accordion headers are all using "plus-minus" style icons.  This test uses the new setting to do so.
- Open http://localhost:4000/components/accordion/test-display-chevron-setting.html.  If you open a dev tools console on this page, you will see an IDS Enterprise deprecation warning about using the old setting.  The expander buttons on the top-level should be using the "plus-minus" icon style.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.