### PR TITLE
2576 - Fix Vertical Tabs test samples that demonstrate outbound links

### DIFF
--- a/app/views/components/tabs-vertical/example-outbound-links-page1.html
+++ b/app/views/components/tabs-vertical/example-outbound-links-page1.html
@@ -19,26 +19,24 @@
     <div class="page-container no-scroll">
 
       <!-- Vertical Tabs inside of a tab panel -->
-      <div id="tabs-vertical" class="vertical tab-container scrollable">
+      <div id="tabs-vertical" class="vertical tab-container scrollable" data-options='{ "lazyLoad": false }'>
 
         <div class="tab-list-container">
 
           <ul class="tab-list">
-            <li class="tab is-selected"><a href="{{basepath}}components/tabs-vertical/outbound-links-page1">Page 1</a></li>
-            <li class="tab"><a href="{{basepath}}components/tabs-vertical/outbound-links-page2">Page 2</a></li>
+            <li class="tab is-selected"><a href="#outbound-links-page-1">Page 1</a></li>
+            <li class="tab"><a href="{{basepath}}components/tabs-vertical/example-outbound-links-page2">Page 2</a></li>
           </ul>
 
         </div>
         <div class="tab-panel-container">
-
-          <div class="tab-panel">
+          <div id="outbound-links-page-1" class="tab-panel">
             <div class="row">
               <div class="twelve columns">
                 <p>Page 1 Is Showing</p>
               </div>
             </div>
           </div>
-
         </div>
       </div>
 

--- a/app/views/components/tabs-vertical/example-outbound-links-page2.html
+++ b/app/views/components/tabs-vertical/example-outbound-links-page2.html
@@ -19,19 +19,16 @@
     <div class="page-container no-scroll">
 
       <!-- Vertical Tabs inside of a tab panel -->
-      <div id="tabs-vertical" class="vertical tab-container scrollable">
+      <div id="tabs-vertical" class="vertical tab-container scrollable" data-options='{ "lazyLoad": false }'>
 
         <div class="tab-list-container">
-
           <ul class="tab-list">
-            <li class="tab"><a href="{{basepath}}components/tabs-vertical/outbound-links-page1">Page 1</a></li>
-            <li class="tab is-selected"><a href="{{basepath}}components/tabs-vertical/outbound-links-page2">Page 2</a></li>
+            <li class="tab"><a href="{{basepath}}components/tabs-vertical/example-outbound-links-page1">Page 1</a></li>
+            <li class="tab is-selected"><a href="#outbound-links-page-2">Page 2</a></li>
           </ul>
-
         </div>
         <div class="tab-panel-container">
-
-          <div class="tab-panel">
+          <div id="outbound-links-page-2" class="tab-panel">
             <div class="row">
               <div class="twelve columns">
                 <p>Page 2 Is Showing</p>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a demoapp bug where a set of vertical tabs samples that demonstrate how to use the component's tab list as simple outbound links was previously not working.  It appears that this stopped working after we added the lazy-loading tab feature.

**Related github/jira issue (required)**:
Closes #2576 

**Steps necessary to review your pull request (required)**:
- Pull this branch, run app
- Open http://localhost:4000/components/tabs-vertical/example-outbound-links-page1.  In the tab panel area, there should be text present saying "Page 1 is Showing".
- Click the link in the tab list for Page 2.  This should navigate the browser to http://localhost:4000/components/tabs-vertical/example-outbound-links-page2.
- In the tab panel area, there should be text present saying "Page 2 is Showing".
- Click the link in the tab list for Page 1.  This should navigate the browser back to http://localhost:4000/components/tabs-vertical/example-outbound-links-page1.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
