### PR TITLE
2854 - Fix zeroes for text filter with datagrid

### DIFF
--- a/app/views/components/datagrid/test-filter-zero-as-text.html
+++ b/app/views/components/datagrid/test-filter-zero-as-text.html
@@ -1,0 +1,75 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    var data = [];
+    var columns = [];
+
+    // Define Some Sample Data
+    data.push({ id: 1, propertyName: '164525', productName: 'Compressor', inStock: true, activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action', status: 'Error'});
+    data.push({ id: 2, propertyName: '000001', productName: '1 Different Compressor', inStock: true, activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold', status: 'Error'});
+    data.push({ id: 3, propertyName: '0001615', productName: 'Compressor', inStock: true, activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action', status: 'Error'});
+    data.push({ id: 4, propertyName: '160001', productName: '1 Another Compressor', inStock: false, activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action', status: 'Confirmed'});
+    data.push({ id: 5, propertyName: '160002', productName: 'I Love Compressors', inStock: true, activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold', status: 'Confirmed'});
+    data.push({ id: 5, propertyName: '160002', productName: 'Air Compressors', inStock: false, activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', status: 'Error'});
+    data.push({ id: 6, propertyName: '160003', productName: 'Some Compressor', inStock: true, activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', status: 'Confirmed'});
+    data.push({ id: 7, propertyName: '160004', productName: null, activity:  null, quantity: null, price: null, status: null, orderDate: null, action: 'Blank Row', status: 'Confirmed'});
+    data.push({ id: 8, propertyName: '160005', productName: 'Compressor', inStock: true, activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action', status: 'Error'});
+    data.push({ id: 9, propertyName: '160006', productName: '1 Different Compressor', inStock: true, activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold', status: 'Error'});
+    data.push({ id: 10, propertyName: '160007', productName: 'Compressor', inStock: true, activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action', status: 'Error'});
+    data.push({ id: 11, propertyName: '160008', productName: '1 Another Compressor', inStock: false, activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action', status: 'Confirmed'});
+    data.push({ id: 12, propertyName: '160009', productName: 'I Love Compressors', inStock: true, activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold', status: 'Confirmed'});
+    data.push({ id: 13, propertyName: '160010', productName: 'Air Compressors', inStock: false, activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', status: 'Error'});
+    data.push({ id: 14, propertyName: '160011', productName: 'Some Compressor', inStock: true, activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', status: 'Confirmed'});
+    data.push({ id: 15, propertyName: '160305', productName: null, activity:  null, quantity: null, price: null, status: null, orderDate: null, action: 'Blank Row', status: 'Confirmed'});
+    data.push({ id: 16, propertyName: '160805', productName: 'Compressor', inStock: true, activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action', status: 'Error'});
+    data.push({ id: 17, propertyName: '160814', productName: '1 Different Compressor', inStock: true, activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold', status: 'Error'});
+    data.push({ id: 18, propertyName: '160808', productName: 'Compressor', inStock: true, activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action', status: 'Error'});
+    data.push({ id: 19, propertyName: '160815', productName: '1 Another Compressor', inStock: false, activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action', status: 'Confirmed'});
+    data.push({ id: 20, propertyName: '160811', productName: 'I Love Compressors', inStock: true, activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold', status: 'Confirmed'});
+    data.push({ id: 21, propertyName: '160809', productName: 'Air Compressors', inStock: false, activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', status: 'Error'});
+    data.push({ id: 22, propertyName: '160816', productName: 'Some Compressor', inStock: true, activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', status: 'Confirmed'});
+    data.push({ id: 23, propertyName: '160817', productName: null, activity:  null, quantity: null, price: null, status: null, orderDate: null, action: 'Blank Row', status: 'Confirmed'});
+    data.push({ id: 24, propertyName: '161004', productName: 'Compressor', inStock: true, activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action', status: 'Error'});
+    data.push({ id: 25, propertyName: '160911', productName: '1 Different Compressor', inStock: true, activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold', status: 'Error'});
+    data.push({ id: 26, propertyName: '161100', productName: 'Compressor', inStock: true, activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action', status: 'Error'});
+    data.push({ id: 27, propertyName: '161105', productName: '1 Another Compressor', inStock: false, activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action', status: 'Confirmed'});
+    data.push({ id: 28, propertyName: '161106', productName: 'I Love Compressors', inStock: true, activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold', status: 'Confirmed'});
+    data.push({ id: 29, propertyName: '161202', productName: 'Air Compressors', inStock: false, activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', status: 'Error'});
+    data.push({ id: 30, propertyName: '161601', productName: 'Some Compressor', inStock: true, activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', status: 'Confirmed'});
+
+    var statuses = [
+      { id: 'Confirmed', value: 'Confirmed', label: 'Confirmed' },
+      { id: 'Error', value: 'Error', label: 'Error' }
+    ];
+
+    // Define Columns for the Grid.
+    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center' });
+    columns.push({ id: 'id', name: 'Id', field: 'id', formatter: Formatters.Readonly, filterType: 'text', filterDisabled: true });
+    columns.push({ id: 'propertyName', name: 'Property Name Title', field: 'propertyName', formatter: Formatters.Text, filterType: 'text' });
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', align: 'center', formatter: Formatters.Date, dateFormat: 'MM/dd/yyyy', filterType: 'date' });
+    columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink, filterType: 'text' });
+    columns.push({ id: 'inStock', name: 'In Stock', field: 'inStock', formatter: Formatters.Checkbox, align: 'center', filterType: 'checkbox' });
+    columns.push({ id: 'status', name: 'Status', field: 'status', formatter: Formatters.Alert, filterType: 'select', options: statuses, ranges: [{ value:'Confirmed', classes: 'success', text: 'Confirmed' }, { value:'Error', classes: 'error', text: 'Error' }]});
+
+    // Init the grid
+    $('#datagrid').datagrid({
+      columns: columns,
+      dataset: data,
+      clickToSelect: false,
+      selectable: 'multiple',
+      filterable: true,
+      paging: true,
+      pagesize: 7,
+      toolbar: { title: 'Filterable Datagrid', filterRow: true, results: true, dateFilter: false, keywordFilter: false, actions: true, views: false, rowHeight: true, collapsibleFilter: false }
+    });
+
+ });
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `[Contextual Action Panel]` Fixed an issue where the CAP close but beforeclose event not fired. ([#2826](https://github.com/infor-design/enterprise/issues/2826))
 - `[Datagrid]` Fixed an issue where the pager was not updating with updated method. ([#2759](https://github.com/infor-design/enterprise/issues/2759))
+- `[Datagrid]` Fixed an issue where string include zeroes not working with text filter. ([#2854](https://github.com/infor-design/enterprise/issues/2854))
 - `[Dropdown]` Fixed an issue where the dropdown icons are misaligned in IE11 in the Uplift theme. ([#2826](https://github.com/infor-design/enterprise/issues/2912))
 - `[Locale]` Fixed an issue where some culture files does not have a name property in the calendar. ([#2880](https://github.com/infor-design/enterprise/issues/2880))
 - `[Pie]` Fixed an issue where legends in pie chart gets cut off on mobile view. ([#902](https://github.com/infor-design/enterprise/issues/902))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1995,8 +1995,9 @@ Datagrid.prototype = {
           rowValue = (rowValue === null || rowValue === undefined) ? '' : rowValue.toString().toLowerCase();
         }
 
-        if ((typeof rowValue === 'number' || (!isNaN(rowValue) && rowValue !== '') && !(conditions[i].value instanceof Array)) &&
-              columnDef.filterType !== 'date' && columnDef.filterType !== 'time') {
+        if ((typeof rowValue === 'number' || (!isNaN(rowValue) && rowValue !== '') &&
+          !(conditions[i].value instanceof Array)) &&
+            !(/^(date|time|text)$/.test(columnDef.filterType))) {
           rowValue = rowValue === null ? rowValue : parseFloat(rowValue);
           conditionValue = Locale.parseNumber(conditionValue);
         }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed text filter was not working to filter string include zeroes with Datagrid.

**Related github/jira issue (required)**:
Closes #2854

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/test-filter-zero-as-text.html
- Filter column `Property Name Title` with text string `0001`
- Only rows that have `0001` in this column value should be visible (should be 3 matching rows)

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
