### PR TITLE
2951 - Fix UI issues in field filter

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Contextual Action Panel]` Fixed an issue where the CAP close but beforeclose event not fired. ([#2826](https://github.com/infor-design/enterprise/issues/2826))
 - `[Datagrid]` Fixed an issue where the pager was not updating with updated method. ([#2759](https://github.com/infor-design/enterprise/issues/2759))
 - `[Dropdown]` Fixed an issue where the dropdown icons are misaligned in IE11 in the Uplift theme. ([#2826](https://github.com/infor-design/enterprise/issues/2912))
+- `[Field Filter]` Fixed an issues where the icons are not vertically centered, and layout issues when opening the dropdown in a smaller height browser. ([#2951](https://github.com/infor-design/enterprise/issues/2951))
 - `[Locale]` Fixed an issue where some culture files does not have a name property in the calendar. ([#2880](https://github.com/infor-design/enterprise/issues/2880))
 - `[Pie]` Fixed an issue where legends in pie chart gets cut off on mobile view. ([#902](https://github.com/infor-design/enterprise/issues/902))
 - `[Popupmenu]` In mobile settings (specifically iOS), input fields will now allow for text input when also being assigned a context menu. ([#2613](https://github.com/infor-design/enterprise/issues/2613))

--- a/src/components/dropdown/_dropdown-uplift.scss
+++ b/src/components/dropdown/_dropdown-uplift.scss
@@ -55,6 +55,16 @@ div.multiselect {
       }
     }
   }
+
+  &.ffdropdown {
+    &.is-ontop {
+      > .trigger {
+        .icon {
+          top: 10px;
+        }
+      }
+    }
+  }
 }
 
 // Adjust Short Field Dropdowns

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -118,7 +118,7 @@ div.multiselect {
     height: 16px;
     left: 14px;
     position: absolute;
-    top: 9px;
+    top: 11px;
     vertical-align: middle;
     width: 16px;
 
@@ -221,6 +221,10 @@ div.multiselect {
   width: auto;
   z-index: 4501;
 
+  @media screen and (max-height: 270px) {
+    background-color: inherit;
+  }
+
   &.text-align-reverse {
     text-align: right;
   }
@@ -240,6 +244,14 @@ div.multiselect {
 
   &.is-ontop {
     box-shadow: $dropdown-box-shadow-top;
+  }
+
+  &.ffdropdown {
+    > .trigger {
+      .icon {
+        left: 0;
+      }
+    }
   }
 
   ul {

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -252,6 +252,14 @@ div.multiselect {
         left: 0;
       }
     }
+
+    &.is-ontop {
+      > .trigger {
+        .icon {
+          top: 9px;
+        }
+      }
+    }
   }
 
   ul {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes UI issues in field filter component. I also noticed some movement of the icons when you open the field filter dropdown.
- Filter icons are not vertically aligned/centered
- Field filter dropdown shows the content info when it is open on a `270px` below height of browser

Additional issue noticed:
- Icon is moving when clicking/opening the ff dropdown

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/2951

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app

**1.)**
- Navigate to http://localhost:4000/components/field-filter/example-index.html
- Filter icons should now align to each other

**2.)**
- Resize the browser height up to `270px` below
- Open the field filter dropdown
- It should open up to top
- Background content info should not be seen when it is open

**3.)**
- Click any of the field filter dropdown
- Caret icon should not move when toggling/clicking the dropdown

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
