### PR TITLE
Locale: parseNumber not parsing correctly when culture file has group of space

### DIFF
--- a/app/views/components/mask/test-number-parsing.html
+++ b/app/views/components/mask/test-number-parsing.html
@@ -1,0 +1,42 @@
+<div class="row">
+  <div class="six columns">
+    <div class="field">
+      <label for="number-field">Number Field</label>
+      <input id="number-field" />
+    </div>
+
+    <div class="field">
+      <label for="parsed-number-field">Parsed Number result</label>
+      <input id="parsed-number-field" />
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').on('initialized', function(locale, args) {
+    const numberInfo = Locale.currentLocale.data.numbers;
+
+    $('#number-field').mask({
+      process       : 'number',
+      patternOptions: {
+        allowDecimal           : true,
+        allowNegative          : false,
+        allowThousandsSeparator: true,
+        decimalLimit           : 2,
+        integerLimit           : 12,
+        symbols                : {
+          decimal  : numberInfo.decimal,
+          negative : numberInfo.minusSign,
+          thousands: numberInfo.group
+        }
+      }
+    })
+    .on('change', () => {
+      var value = $('#number-field').val();
+
+      // transform
+      var nbr = Soho.Locale.parseNumber(value);
+      $('#parsed-number-field').val(nbr);
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[Datagrid]` Fixed an issue where the select all button for multiselect grouping was not working. ([#2895](https://github.com/infor-design/enterprise/issues/2895))
 - `[Dropdown]` Fixed an issue where the dropdown icons are misaligned in IE11 in the Uplift theme. ([#2826](https://github.com/infor-design/enterprise/issues/2912))
 - `[Locale]` Fixed an issue where some culture files does not have a name property in the calendar. ([#2880](https://github.com/infor-design/enterprise/issues/2880))
+- `[Locale]` Fixed an issue where cultures with a group of space was not parsing correctly. ([#2959](https://github.com/infor-design/enterprise/issues/2959))
 - `[Pie]` Fixed an issue where legends in pie chart gets cut off on mobile view. ([#902](https://github.com/infor-design/enterprise/issues/902))
 - `[Popupmenu]` In mobile settings (specifically iOS), input fields will now allow for text input when also being assigned a context menu. ([#2613](https://github.com/infor-design/enterprise/issues/2613))
 - `[Popupmenu]` Fixed an issue where the destroy event was bubbling up to other parent components. ([#2809](https://github.com/infor-design/enterprise/issues/2809))

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -1397,7 +1397,8 @@ const Locale = {  // eslint-disable-line
     const percentSign = numSettings ? numSettings.percentSign : '%';
     const currencySign = localeData.currencySign || '$';
 
-    numString = numString.replace(new RegExp(`\\${group}`, 'g'), '');
+    const exp = (group === ' ') ? new RegExp(/\s/, 'g') : new RegExp(`\\${group}`, 'g');
+    numString = numString.replace(exp, '');
     numString = numString.replace(decimal, '.');
     numString = numString.replace(percentSign, '');
     numString = numString.replace(currencySign, '');

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -751,6 +751,24 @@ describe('Locale API', () => {
     expect(Locale.parseNumber(undefined)).toEqual(NaN);
   });
 
+  it('Should parse with decimal and group properties', () => {
+    // group = space; decimal = comma
+    Locale.set('fr-FR');
+    expect(Locale.parseNumber('1 234 567 890,1234')).toEqual(1234567890.1234);
+
+    // // group = D9AC; decimal = D9AB
+    Locale.set('ar-SA');
+    expect(Locale.parseNumber('1٬234٬567٬890٫1234')).toEqual(1234567890.1234);
+
+    // group = period; decimal = comma
+    Locale.set('es-ES');
+    expect(Locale.parseNumber('1.234.567.890,1234')).toEqual(1234567890.1234);
+
+    // group = comma; decimal = period
+    Locale.set('en-US');
+    expect(Locale.parseNumber('1,234,567,890.1234')).toEqual(1234567890.1234);
+  });
+
   it('Should parse with multiple group separators', () => {
     Locale.set('en-US');
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fixed parseNumber() to properly remove spaces.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #2959 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/mask/test-number-parsing.html?locale=fr-FR
- Enter `1234567,12` into the Number Field and then tab out
- The Number Field should display `1 234 567,12`
- Parsed Number result field should display `1234567.12`
- Change the url to test cultures with other group and decimal values:
- locale=es-ES - Enter `1234567,12` and tab out
- Number Field should display `1.234.567,12`
- Parsed Number result field should display `1234567.12`
- locale=ar-SA - Enter or paste `1234567٫12` and tab out
- Number Field should display `1٬234٬567٫12`
- Parsed Number result field should display `1234567.12`
- no locale or locale=en-US - Enter `1234567.12` and tab out
- Number Field should display `1,234,567.12`
- Parsed Number result field should display `1234567.12`

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
