### PR TITLE
633 - Fix tree children expand and collapse with datepicker

### DIFF
--- a/app/views/components/datagrid/test-tree-children-expand-collapse.html
+++ b/app/views/components/datagrid/test-tree-children-expand-collapse.html
@@ -1,0 +1,322 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+
+    // Some Sample Data
+    var data = [{
+      id: 1,
+      escalated: 2,
+      depth: 1,
+      expanded: false,
+      taskName: 'Follow up action with HMM Global',
+      desc: '',
+      comments: null,
+      time: '',
+      children: [{
+        id: 2,
+        escalated: 1,
+        depth: 2,
+        taskName: 'Quotes due to expire',
+        desc: 'Update pending quotes and send out again to customers.',
+        comments: 3,
+        time: '7:10 AM'
+      },
+      {
+        id: 3,
+        escalated: 0,
+        depth: 2,
+        taskName: 'Follow up action with Universal Shipping Logistics Customers',
+        desc: 'Contact sales representative with the updated purchase order.',
+        comments: 2,
+        time: '9:10 AM'
+      },
+      {
+        id: 4,
+        escalated: 0,
+        depth: 2,
+        taskName: 'Sales Person',
+        desc: 'Sales Person.',
+        comments: 2,
+        time: '14:10 PM'
+      },
+      {
+        id: 5,
+        escalated: 0,
+        depth: 2,
+        taskName: 'Address sales order line number',
+        desc: 'Address sales order line number.',
+        comments: 2,
+        time: '14:10 PM'
+      },
+      {
+        id: 6,
+        escalated: 0,
+        depth: 2,
+        taskName: 'Contact sales order',
+        desc: 'Contact sales order.',
+        comments: 2,
+        time: '14:10 PM'
+      },
+      {
+        id: 7,
+        escalated: 0,
+        depth: 2,
+        taskName: 'Contact name',
+        desc: 'Contact sales order.',
+        comments: 2,
+        time: '14:10 PM'
+      }]
+    },
+    {
+      id: 8,
+      escalated: 2,
+      depth: 1,
+      expanded: false,
+      taskName: 'Follow up action with HMM Global',
+      desc: '',
+      comments: null,
+      time: '',
+      children: [{
+        id: 9,
+        escalated: 1,
+        depth: 2,
+        taskName: 'Quotes due to expire',
+        desc: 'Update pending quotes and send out again to customers.',
+        comments: 3,
+        time: '7:10 AM'
+      },
+      {
+        id: 10,
+        escalated: 0,
+        depth: 2,
+        taskName: 'Follow up action with Universal Shipping Logistics Customers',
+        desc: 'Contact sales representative with the updated purchase order.',
+        comments: 2,
+        time: '9:10 AM'
+      },
+      {
+        id: 11,
+        escalated: 0,
+        depth: 2,
+        taskName: 'Sales Person',
+        desc: 'Sales Person.',
+        comments: 2,
+        time: '14:10 PM'
+      },
+      {
+        id: 12,
+        escalated: 0,
+        depth: 2,
+        taskName: 'Address sales order line number',
+        desc: 'Address sales order line number.',
+        comments: 2,
+        time: '14:10 PM'
+      },
+      {
+        id: 13,
+        escalated: 0,
+        depth: 2,
+        taskName: 'Contact sales order',
+        desc: 'Contact sales order.',
+        comments: 2,
+        time: '14:10 PM'
+      },
+      {
+        id: 14,
+        escalated: 0,
+        depth: 2,
+        taskName: 'Contact name',
+        desc: 'Contact sales order.',
+        comments: 2,
+        time: '14:10 PM',
+        children: [{
+          id: 15,
+          escalated: 1,
+          depth: 3,
+          taskName: 'Quotes due to expire',
+          desc: 'Update pending quotes and send out again to customers.',
+          comments: 3,
+          time: '7:10 AM'
+        },
+        {
+          id: 16,
+          escalated: 0,
+          depth: 3,
+          taskName: 'Follow up action with Universal Shipping Logistics Customers',
+          desc: 'Contact sales representative with the updated purchase order.',
+          comments: 2,
+          time: '9:10 AM'
+        },
+        {
+          id: 17,
+          escalated: 0,
+          depth: 3,
+          taskName: 'Sales Person',
+          desc: 'Sales Person.',
+          comments: 2,
+          time: '14:10 PM'
+        },
+        {
+          id: 18,
+          escalated: 0,
+          depth: 3,
+          taskName: 'Address sales order line number',
+          desc: 'Address sales order line number.',
+          comments: 2,
+          time: '14:10 PM'
+        },
+        {
+          id: 19,
+          escalated: 0,
+          depth: 3,
+          taskName: 'Contact sales order',
+          desc: 'Contact sales order.',
+          comments: 2,
+          time: '14:10 PM',
+          children: [{
+            id: 20,
+            escalated: 1,
+            depth: 4,
+            taskName: 'Quotes due to expire',
+            desc: 'Update pending quotes and send out again to customers.',
+            comments: 3,
+            time: '7:10 AM'
+          },
+          {
+            id: 21,
+            escalated: 0,
+            depth: 4,
+            taskName: 'Follow up action with Universal Shipping Logistics Customers',
+            desc: 'Contact sales representative with the updated purchase order.',
+            comments: 2,
+            time: '9:10 AM'
+          },
+          {
+            id: 22,
+            escalated: 0,
+            depth: 4,
+            taskName: 'Sales Person',
+            desc: 'Sales Person.',
+            comments: 2,
+            time: '14:10 PM'
+          },
+          {
+            id: 23,
+            escalated: 0,
+            depth: 4,
+            taskName: 'Address sales order line number',
+            desc: 'Address sales order line number.',
+            comments: 2,
+            time: '14:10 PM'
+          },
+          {
+            id: 24,
+            escalated: 0,
+            depth: 4,
+            taskName: 'Contact sales order',
+            desc: 'Contact sales order.',
+            comments: 2,
+            time: '14:10 PM'
+          },
+          {
+            id: 25,
+            escalated: 0,
+            depth: 4,
+            taskName: 'Contact name',
+            desc: 'Contact sales order.',
+            comments: 2,
+            time: '14:10 PM'
+          }]
+        },
+        {
+          id: 26,
+          escalated: 0,
+          depth: 3,
+          taskName: 'Contact name',
+          desc: 'Contact sales order.',
+          comments: 2,
+          time: '14:10 PM',
+          children: [{
+            id: 27,
+            escalated: 1,
+            depth: 4,
+            taskName: 'Quotes due to expire',
+            desc: 'Update pending quotes and send out again to customers.',
+            comments: 3,
+            time: '7:10 AM'
+          },
+          {
+            id: 28,
+            escalated: 0,
+            depth: 4,
+            taskName: 'Follow up action with Universal Shipping Logistics Customers',
+            desc: 'Contact sales representative with the updated purchase order.',
+            comments: 2,
+            time: '9:10 AM'
+          },
+          {
+            id: 29,
+            escalated: 0,
+            depth: 4,
+            taskName: 'Sales Person',
+            desc: 'Sales Person.',
+            comments: 2,
+            time: '14:10 PM'
+          },
+          {
+            id: 30,
+            escalated: 0,
+            depth: 4,
+            taskName: 'Address sales order line number',
+            desc: 'Address sales order line number.',
+            comments: 2,
+            time: '14:10 PM'
+          },
+          {
+            id: 31,
+            escalated: 0,
+            depth: 4,
+            taskName: 'Contact sales order',
+            desc: 'Contact sales order.',
+            comments: 2,
+            time: '14:10 PM'
+          },
+          {
+            id: 32,
+            escalated: 0,
+            depth: 4,
+            taskName: 'Contact name',
+            desc: 'Contact sales order.',
+            comments: 2,
+            time: '14:10 PM'
+          }]
+        }]
+      }]
+    }];
+
+    // Define Columns for the Grid
+    var columns = [];
+    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, width: 50, formatter: Formatters.SelectionCheckbox, align: 'center'});
+    columns.push({ id: 'id', name: 'Id', field: 'id', formatter: Formatters.Hyperlink});
+    columns.push({ id: 'taskName', name: 'Task', field: 'taskName', expanded: 'expanded', formatter: Formatters.Tree});
+    columns.push({ id: 'desc', name: 'Description', field: 'desc'});
+    columns.push({ id: 'time', name: 'Time', field: 'time'});
+
+    // initialize the Grid
+    $('#datagrid').datagrid({
+      columns: columns,
+      dataset: data,
+      selectable: 'multiple',
+      treeGrid: true,
+      toolbar: { title: 'Tasks (Hierarchical)', results: true, personalize: true }
+    });
+
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - `[Contextual Action Panel]` Fixed an issue where the CAP close but beforeclose event not fired. ([#2826](https://github.com/infor-design/enterprise/issues/2826))
 - `[Hierarchy]` Fixed the border color on hierarchy cards. ([#423](https://github.com/infor-design/design-system/issues/423))
+- `[Datagrid]` Fixed an issue where the tree children expand and collapse was not working. ([#633](https://github.com/infor-design/enterprise-ng/issues/633))
 - `[Datagrid]` Fixed an issue where the pager was not updating with updated method. ([#2759](https://github.com/infor-design/enterprise/issues/2759))
 - `[Datagrid]` Fixed an issue where string include zeroes not working with text filter. ([#2854](https://github.com/infor-design/enterprise/issues/2854))
 - `[Datagrid]` Fixed an issue where the select all button for multiselect grouping was not working. ([#2895](https://github.com/infor-design/enterprise/issues/2895))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9905,7 +9905,7 @@ Datagrid.prototype = {
       self.setExpandedInDataset(parentRowIdx, !isExpanded);
 
       const setChildren = function (elem, lev, expanded) {
-        const nodes = elem.nextUntil(`[aria-level="${level}"]`);
+        const nodes = elem.nextUntil(`[aria-level="${lev}"]`);
 
         if (expanded) {
           nodes.each(function () {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the tree children expand and collapse was not working with Datagrid.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#633

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/test-tree-children-expand-collapse.html
- Expand row with id `8`
- Expand row with id `14`
- Expand row with id `19`
- Now Collapse row with id `8`
- Then again expand row with id `8`
- See the row `14` and `19` should be expanded
- And make sure the row `26` should not be expanded at this point

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
