### PR TITLE
2888 - Fixed memory leaks and multiple event handlers in Searchfield/Autocomplete

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### v4.23.0 Fixes
 
+- `[Autocomplete]` Fixed memory leaks by preventing re-rendering of an open autocomplete list from attaching new events, adding multiple `aria-polite` elements, etc. ([#2888](https://github.com/infor-design/enterprise/issues/2888))
 - `[Contextual Action Panel]` Fixed an issue where the CAP close but beforeclose event not fired. ([#2826](https://github.com/infor-design/enterprise/issues/2826))
 - `[Hierarchy]` Fixed the border color on hierarchy cards. ([#423](https://github.com/infor-design/design-system/issues/423))
 - `[Datagrid]` Fixed an issue where the tree children expand and collapse was not working. ([#633](https://github.com/infor-design/enterprise-ng/issues/633))

--- a/test/components/autocomplete/autocomplete-events.func-spec.js
+++ b/test/components/autocomplete/autocomplete-events.func-spec.js
@@ -66,7 +66,7 @@ describe('Autocomplete API', () => {
 
     autocompleteAPI.select($(resultItems[0].querySelector('a')), data);
 
-    expect(spySelectedEvent).toHaveBeenTriggered()
+    expect(spySelectedEvent).toHaveBeenTriggered();
     expect(spySelectedEvent.calls.count()).toEqual(1);
     done();
   });

--- a/test/components/autocomplete/autocomplete-events.func-spec.js
+++ b/test/components/autocomplete/autocomplete-events.func-spec.js
@@ -66,7 +66,8 @@ describe('Autocomplete API', () => {
 
     autocompleteAPI.select($(resultItems[0].querySelector('a')), data);
 
-    expect(spySelectedEvent).toHaveBeenTriggered();
+    expect(spySelectedEvent).toHaveBeenTriggered()
+    expect(spySelectedEvent.calls.count()).toEqual(1);
     done();
   });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR addresses a couple issues in the Autocomplete component (and by proxy, the Searchfield):
- The Autocomplete no longer binds events and invokes the popupmenu every time a search term is changed.
- The Autocomplete properly cleans up the `#ac-is-arialive` element, responsible for accessibility/speech announcements whenever the search term is changed, instead of stacking multiple of these elements.

**Related github/jira issue (required)**:
Closes #2888

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run app
- Open http://localhost:4000/components/searchfield/example-index?theme=uplift
- Type "Co" in the searchfield.
- Wait until the results list appears, then type "l".
- Wait again for a re-filtering, then type "o".
- Wait until filtering occurs again, then select "Colorado" from the list.
- Open a dev tools console.  There should be console output stating `"Selected" event was fired`, and it should only have one occurrence instead of multiple.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

----
paging @darinw