### PR TITLE
2986 - Fixed Theme Switcher on iOS Environments

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Datepicker]` Fixed an issue where the validation after body re-initialize was not working. ([#2410](https://github.com/infor-design/enterprise/issues/2410))
 - `[Dropdown]` Fixed an issue where the dropdown icons are misaligned in IE11 in the Uplift theme. ([#2826](https://github.com/infor-design/enterprise/issues/2912))
 - `[Field Filter]` Fixed an issues where the icons are not vertically centered, and layout issues when opening the dropdown in a smaller height browser. ([#2951](https://github.com/infor-design/enterprise/issues/2951))
+- `[Header]` Fixed an iOS bug where the theme switcher wasn't working after Popupmenu lifecycle changes. ([#2986](https://github.com/infor-design/enterprise/issues/2986))
 - `[Locale]` Fixed an issue where some culture files does not have a name property in the calendar. ([#2880](https://github.com/infor-design/enterprise/issues/2880))
 - `[Locale]` Fixed an issue where cultures with a group of space was not parsing correctly. ([#2959](https://github.com/infor-design/enterprise/issues/2959))
 - `[Lookup]` Fixed missing X button in searchfield on a mobile viewport. ([#2948](https://github.com/infor-design/enterprise/issues/2948))

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -522,8 +522,10 @@ Header.prototype = {
       const themeNameAttr = link.attr('data-theme-name');
       const themeVariantAttr = link.attr('data-theme-variant');
       if (themeNameAttr || themeVariantAttr) {
-        const name = changer.next().find('.is-checked a[data-theme-name]').attr('data-theme-name');
-        const variant = changer.next().find('.is-checked a[data-theme-variant]').attr('data-theme-variant');
+        const api = changer.data('popupmenu');
+        const menu = api.menu;
+        const name = menu.find('.is-checked a[data-theme-name]').attr('data-theme-name');
+        const variant = menu.find('.is-checked a[data-theme-variant]').attr('data-theme-variant');
         if (name && variant) {
           personalization.setTheme(`${name}-${variant}`);
         }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes an iOS bug in Personalize and the Theme Switcher, where the theme could not be switched.  This due to a bug introduced in this PR #2977 that moved the location of the Popupmenu in the DOM specifically in iOS environments.

**Related github/jira issue (required)**:
Closes #2986

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Open an iOS Simulator, or an iPhone on Browserstack.
- Open any page with a theme switcher present, such as localhost:4000/components/radios/example-index.html
- Click the `...` button in the header to open the theme switcher, and choose any combination.  It should work as expected.

**Included in this Pull Request**:
- [x] A note to the change log.
