### PR TITLE
2870 - Fix placeholder for initially selected with dropdown

### DIFF
--- a/app/views/components/dropdown/test-placeholder-initial-selected.html
+++ b/app/views/components/dropdown/test-placeholder-initial-selected.html
@@ -1,0 +1,61 @@
+<div class="row">
+  <div class="twelve columns">
+    <div class="field">
+      <label for="states" class="label">States</label>
+      <select id="states" name="states" class="dropdown" placeholder="Select a State">
+        <option value="blank">&nbsp;</option>
+        <option value="AL">Alabama</option>
+        <option value="AK">Alaska</option>
+        <option value="AZ">Arizona</option>
+        <option value="AR">Arkansas</option>
+        <option value="CA">California</option>
+        <option value="CO">Colorado</option>
+        <option value="CT">Connecticut</option>
+        <option value="DE" selected>Delaware</option>
+        <option value="DC">District Of Columbia</option>
+        <option value="FL">Florida</option>
+        <option value="GA">Georgia</option>
+        <option value="HI">Hawaii</option>
+        <option value="ID">Idaho</option>
+        <option value="IL">Illinois</option>
+        <option value="IN">Indiana</option>
+        <option value="IA">Iowa</option>
+        <option value="KS">Kansas</option>
+        <option value="KY">Kentucky</option>
+        <option value="LA">Louisiana</option>
+        <option value="ME">Maine</option>
+        <option value="MD">Maryland</option>
+        <option value="MA">Massachusetts</option>
+        <option value="MI">Michigan</option>
+        <option value="MN">Minnesota</option>
+        <option value="MS">Mississippi</option>
+        <option value="MO">Missouri</option>
+        <option value="MT">Montana</option>
+        <option value="NE">Nebraska</option>
+        <option value="NV">Nevada</option>
+        <option value="NH">New Hampshire</option>
+        <option value="NJ">New Jersey</option>
+        <option value="NM">New Mexico</option>
+        <option value="NY">New York</option>
+        <option value="NC">North Carolina</option>
+        <option value="ND">North Dakota</option>
+        <option value="OH">Ohio</option>
+        <option value="OK">Oklahoma</option>
+        <option value="OR">Oregon</option>
+        <option value="PA">Pennsylvania</option>
+        <option value="RI">Rhode Island</option>
+        <option value="SC">South Carolina</option>
+        <option value="SD">South Dakota</option>
+        <option value="TN">Tennessee</option>
+        <option value="TX">Texas</option>
+        <option value="UT">Utah</option>
+        <option value="VT">Vermont</option>
+        <option value="VA">Virginia</option>
+        <option value="WA">Washington</option>
+        <option value="WV">West Virginia</option>
+        <option value="WI">Wisconsin</option>
+        <option value="WY">Wyoming</option>
+      </select>
+    </div>
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `[Datagrid]` Fixed an issue where the select all button for multiselect grouping was not working. ([#2895](https://github.com/infor-design/enterprise/issues/2895))
 - `[Datepicker]` Fixed an issue where the validation after body re-initialize was not working. ([#2410](https://github.com/infor-design/enterprise/issues/2410))
 - `[Dropdown]` Fixed an issue where the dropdown icons are misaligned in IE11 in the Uplift theme. ([#2826](https://github.com/infor-design/enterprise/issues/2912))
+- `[Dropdown]` Fixed an issue where the placeholder was incorrectly renders when initially set selected item. ([#2870](https://github.com/infor-design/enterprise/issues/2870))
 - `[Field Filter]` Fixed an issues where the icons are not vertically centered, and layout issues when opening the dropdown in a smaller height browser. ([#2951](https://github.com/infor-design/enterprise/issues/2951))
 - `[Locale]` Fixed an issue where some culture files does not have a name property in the calendar. ([#2880](https://github.com/infor-design/enterprise/issues/2880))
 - `[Locale]` Fixed an issue where cultures with a group of space was not parsing correctly. ([#2959](https://github.com/infor-design/enterprise/issues/2959))

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -104,7 +104,7 @@ div.multiselect {
     text-overflow: ellipsis;
     vertical-align: top;
 
-    &[data-selected-text='']::before {
+    &[data-placeholder-text]::before {
       color: $input-placeholder-color;
       content: attr(data-placeholder-text);
       -webkit-text-fill-color: $input-placeholder-color;

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -871,6 +871,7 @@ Dropdown.prototype = {
       DOM.html(span, `<span class="audible">${this.label.text()} </span>`, '<div><p><span><ul><li><a><abbr><b><i><kbd><small><strong><sub><svg><use><br>');
       span = $(`#${this.element.attr('id')}`).next().find('span').first();
       DOM.html(span, `<span class="audible">${this.label.text()} </span>`, '<div><p><span><ul><li><a><abbr><b><i><kbd><small><strong><sub><svg><use><br>');
+      this.setPlaceholder(text);
       return;
     }
 
@@ -885,10 +886,7 @@ Dropdown.prototype = {
       span[0].innerHTML = `<span class="audible">${this.label.text()} </span>${text}`;
     }
 
-    // If there is a placeholder set the selected text
-    if (this.element.attr('placeholder')) {
-      this.pseudoElem.find('span').not('.audible').attr('data-selected-text', text);
-    }
+    this.setPlaceholder(text);
 
     // Set the "previousActiveDescendant" to the first of the items
     this.previousActiveDescendant = opts.first().val();
@@ -925,11 +923,22 @@ Dropdown.prototype = {
       this.pseudoElem.hide().prev('label').hide();
       this.pseudoElem.next('svg').hide();
     }
+  },
 
-    // set placeholder text on pseudoElem span element
-    if (this.element.attr('placeholder')) {
-      this.pseudoElem.find('span').not('.audible').attr('data-placeholder-text', this.element.attr('placeholder'));
-      this.pseudoElem.find('span').not('.audible').attr('data-selected-text', '');
+  /**
+   * Set placeholder text, if value empty
+   * @private
+   * @param  {string} text The selected text value.
+   * @returns {void}
+   */
+  setPlaceholder(text) {
+    this.placeholder = this.placeholder || { text: this.element.attr('placeholder') };
+    if (this.placeholder.text) {
+      const isEmpty = (typeof text !== 'string' || (typeof text === 'string' && text === ''));
+      this.placeholder.elem = this.placeholder.elem || this.pseudoElem.find('span:not(.audible)');
+      this.placeholder.elem.attr('data-placeholder-text', isEmpty ? this.placeholder.text : '');
+    } else {
+      delete this.placeholder;
     }
   },
 
@@ -1707,9 +1716,6 @@ Dropdown.prototype = {
         .text()
         .trim();
       this.searchInput.val(fieldValue);
-      if (this.element.attr('placeholder')) {
-        this.pseudoElem.find('span').not('.audible').attr('data-selected-text', '');
-      }
     }
 
     const noScroll = this.settings.multiple;
@@ -2940,6 +2946,9 @@ Dropdown.prototype = {
   destroy() {
     if (this.selectedValues) {
       delete this.selectedValues;
+    }
+    if (this.placeholder) {
+      delete this.placeholder;
     }
 
     $.removeData(this.element[0], COMPONENT_NAME);

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -462,7 +462,31 @@ describe('Dropdown placeholder tests', () => {
   });
 
   it('Show a placeholder', async () => {
-    expect(await element.all(by.css('[data-placeholder-text]')).first().isDisplayed()).toBeTruthy();
+    const selector = 'div.dropdown [data-placeholder-text]';
+    const placeholderEl = await element(by.css(selector));
+
+    expect(await element.all(by.css(selector)).count()).toEqual(1);
+    expect(await placeholderEl.isDisplayed()).toBeTruthy();
+    expect(await placeholderEl.getAttribute('data-placeholder-text')).toEqual('Select a State');
+  });
+});
+
+describe('Dropdown placeholder with initially selected tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/dropdown/test-placeholder-initial-selected');
+
+    const dropdownEl = await element(by.css('div.dropdown'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dropdownEl), config.waitsFor);
+  });
+
+  it('Should not show a placeholder', async () => {
+    const selector = 'div.dropdown [data-placeholder-text]';
+    const placeholderEl = await element(by.css(selector));
+
+    expect(await element.all(by.css(selector)).count()).toEqual(1);
+    expect(await placeholderEl.isDisplayed()).toBeTruthy();
+    expect(await placeholderEl.getAttribute('data-placeholder-text')).toEqual('');
   });
 });
 

--- a/test/components/multiselect/multiselect.e2e-spec.js
+++ b/test/components/multiselect/multiselect.e2e-spec.js
@@ -325,9 +325,18 @@ describe('Multiselect typeahead-reloading tests', () => {
 describe('Multiselect placeholder tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/multiselect/example-placeholder');
+
+    const multiselectEl = await element(by.css('select.multiselect + .dropdown-wrapper div.dropdown'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(multiselectEl), config.waitsFor);
   });
 
   it('Show a placeholder', async () => {
-    expect(await element.all(by.css('[data-placeholder-text]')).first().isDisplayed()).toBeTruthy();
+    const selector = 'select.multiselect + .dropdown-wrapper div.dropdown [data-placeholder-text]';
+    const placeholderEl = await element(by.css(selector));
+
+    expect(await element.all(by.css(selector)).count()).toEqual(1);
+    expect(await placeholderEl.isDisplayed()).toBeTruthy();
+    expect(await placeholderEl.getAttribute('data-placeholder-text')).toEqual('Select a State');
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed placeholder was incorrectly renders when initially set selected item with Dropdown.

**Related github/jira issue (required)**:
Closes #2870

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/dropdown/test-placeholder-initial-selected.html
- See dropdown text should be `Delaware`
- Open dropdown list and select first item (blank item)
- See placeholder text should show

Check below links should work fine too
http://localhost:4000/components/dropdown/example-placeholder.html
http://localhost:4000/components/multiselect/example-placeholder.html

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
