### PR TITLE
2959-fix-locale-breaking-tests

### DIFF
--- a/app/views/components/mask/test-number-parsing.html
+++ b/app/views/components/mask/test-number-parsing.html
@@ -31,7 +31,7 @@
         }
       }
     })
-    .on('change', () => {
+    .on('change', function() {
       var value = $('#number-field').val();
 
       // transform

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -1402,7 +1402,7 @@ const Locale = {  // eslint-disable-line
     const percentSign = numSettings ? numSettings.percentSign : '%';
     const currencySign = localeData.currencySign || '$';
 
-    const exp = (group === ' ') ? new RegExp(/\s/, 'g') : new RegExp(`\\${group}`, 'g');
+    const exp = (group === ' ') ? new RegExp(/\s/g) : new RegExp(`\\${group}`, 'g');
     numString = numString.replace(exp, '');
     numString = numString.replace(decimal, '.');
     numString = numString.replace(percentSign, '');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fix Locale.parseNumber() for broken tests.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #2959 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
Pull this branch and build/run the demo app
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/mask/test-number-parsing.html?locale=fr-FR
- Enter `1234567,12` into the Number Field and then tab out
- The Number Field should display `1 234 567,12`
- Parsed Number result field should display `1234567.12`
- Change the url to test cultures with other group and decimal values:
- locale=es-ES - Enter `1234567,12` and tab out
  - Number Field should display `1.234.567,12`
  - Parsed Number result field should display `1234567.12`
- locale=ar-SA
  - Chrome requires the ar-SA decimal value `٫` to be used, so paste `1234567٫12` and tab out
  - All other browsers, enter `1234567.12` and tab out
  - If unable to enter the period, try pasting `1234567٫12`
    - Number Field should display `1٬234٬567٫12`
    - Parsed Number result field should display `1234567.12`
- no locale or locale=en-US - Enter `1234567.12` and tab out
  - Number Field should display `1,234,567.12`
  - Parsed Number result field should display `1234567.12`

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
