### PR TITLE
2737 - Fix parse date for leap year with locale

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@
 - `[Field Filter]` Fixed an issues where the icons are not vertically centered, and layout issues when opening the dropdown in a smaller height browser. ([#2951](https://github.com/infor-design/enterprise/issues/2951))
 - `[Header]` Fixed an iOS bug where the theme switcher wasn't working after Popupmenu lifecycle changes. ([#2986](https://github.com/infor-design/enterprise/issues/2986))
 - `[Hierarchy]` Fixed the border color on hierarchy cards. ([#423](https://github.com/infor-design/design-system/issues/423))
+- `[Locale]` Fixed an issue where the parseDate method was not working for leap year. ([#2737](https://github.com/infor-design/enterprise/issues/2737))
 - `[Locale]` Fixed an issue where some culture files does not have a name property in the calendar. ([#2880](https://github.com/infor-design/enterprise/issues/2880))
 - `[Locale]` Fixed an issue where cultures with a group of space was not parsing correctly. ([#2959](https://github.com/infor-design/enterprise/issues/2959))
 - `[Lookup]` Fixed missing X button in searchfield on a mobile viewport. ([#2948](https://github.com/infor-design/enterprise/issues/2948))

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -1027,9 +1027,20 @@ const Locale = {  // eslint-disable-line
       }
     }
 
+    const isLeap = y => ((y % 4 === 0) && (y % 100 !== 0)) || (y % 400 === 0);
+    const closestLeap = (y) => {
+      let closestLeapYear = typeof y === 'number' && !isNaN(y) ? y : (new Date()).getFullYear();
+      for (let i2 = 0; i2 < 4; i2++) {
+        if (isLeap(closestLeapYear)) {
+          break;
+        }
+        closestLeapYear--;
+      }
+      return closestLeapYear;
+    };
+
     dateObj.return = undefined;
-    dateObj.leapYear = ((dateObj.year % 4 === 0) &&
-      (dateObj.year % 100 !== 0)) || (dateObj.year % 400 === 0);
+    dateObj.leapYear = isLeap(dateObj.year);
 
     if ((isDateTime && !dateObj.h && !dateObj.mm)) {
       return undefined;
@@ -1044,7 +1055,8 @@ const Locale = {  // eslint-disable-line
         }
       }
       if (dateObj.isUndefindedYear) {
-        dateObj.year = (new Date()).getFullYear();
+        const isFeb29 = parseInt(dateObj.day, 10) === 29 && parseInt(dateObj.month, 10) === 1;
+        dateObj.year = isFeb29 ? closestLeap() : (new Date()).getFullYear();
       } else {
         delete dateObj.year;
       }

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -495,11 +495,24 @@ describe('Locale API', () => {
     expect(Locale.parseDate('10/28/2015 8:10:65', 'M/d/yyyy h:mm:ss').getTime()).toEqual(new Date(2015, 9, 28, 8, 10, 0).getTime());
   });
 
-  it('Should should handle leap years', () => {
+  it('Should handle leap years', () => {
+    const isLeap = y => ((y % 4 === 0) && (y % 100 !== 0)) || (y % 400 === 0);
+    const closestLeap = () => {
+      let closestLeapYear = (new Date()).getFullYear();
+      for (let i2 = 0; i2 < 4; i2++) {
+        if (isLeap(closestLeapYear)) {
+          break;
+        }
+        closestLeapYear--;
+      }
+      return closestLeapYear;
+    };
     Locale.set('en-US');
 
     expect(Locale.parseDate('02/29/2016', 'M/d/yyyy').getTime()).toEqual(new Date(2016, 1, 29).getTime());
     expect(Locale.parseDate('02/30/2016', 'M/d/yyyy')).toEqual(undefined);
+    expect(Locale.parseDate('0229', 'MMdd').getTime()).toEqual(new Date(closestLeap(), 1, 29).getTime());
+    expect(Locale.parseDate('February 29', 'MMMM d').getTime()).toEqual(new Date(closestLeap(), 1, 29).getTime());
   });
 
   it('Should cleanly handle non dates', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed parseDate() was not working for leap year (February 29) with Locale.

**Related github/jira issue (required)**:
Closes #2737

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datepicker/example-anniversary-format.html
- Click on the date picker icon for the Month Day field
- Datepicker will open, select February 29 2016
- Datepicker should close and will display value `February 29`
- Tab out of the field
- It should remain display value `February 29`

Additionally check:
- Open developer tools and run
- Enter > Soho.Locale.parseDate("0229", "MMdd", false);
- Response > Mon Feb 29 2016 00:00:00 GMT-0500 (Eastern Standard Time)
- Enter > Soho.Locale.parseDate("February 29", "MMMM d", false);
- Response > Mon Feb 29 2016 00:00:00 GMT-0500 (Eastern Standard Time)

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
