### PR TITLE
2834 - Fix min-width issues with new CAP samples

### DIFF
--- a/app/views/components/contextualactionpanel/test-close-button-flex-from-settings.html
+++ b/app/views/components/contextualactionpanel/test-close-button-flex-from-settings.html
@@ -3,7 +3,7 @@
     <button id="test-cap" data-init="false" type="button" class="btn-secondary contextual-action-panel-trigger">
       Contextual Action Panel
     </button>
-    <div class="contextual-action-panel" style="min-width: 600px;">
+    <div class="contextual-action-panel">
       <div class="row">
         <div class="six columns">
           <div class="field">
@@ -82,7 +82,16 @@
   </div>
 </div>
 
-<script>
+<style type="text/css" id="test-style">
+  /* Mimic the "phone-to-tablet" breakpoint */
+  @media (min-width: 767px) {
+    .contextual-action-panel {
+      min-width: 600px;
+    }
+  }
+</style>
+
+<script id="test-script">
   $('body').on('initialized', function() {
     $('#test-cap').contextualactionpanel({
       title: 'Company Information',

--- a/app/views/components/contextualactionpanel/test-close-button-flex.html
+++ b/app/views/components/contextualactionpanel/test-close-button-flex.html
@@ -3,7 +3,7 @@
     <button id="test-cap" data-init="false" type="button" class="btn-secondary contextual-action-panel-trigger">
       Contextual Action Panel
     </button>
-    <div class="contextual-action-panel" style="min-width: 600px;">
+    <div class="contextual-action-panel">
       <div class="flex-toolbar">
         <div class="toolbar-section title"><h2>Company Information</h2></div>
         <div class="toolbar-section buttonset">
@@ -121,7 +121,16 @@
   </div>
 </div>
 
-<script>
+<style type="text/css" id="test-style">
+  /* Mimic the "phone-to-tablet" breakpoint */
+  @media (min-width: 767px) {
+    .contextual-action-panel {
+      min-width: 600px;
+    }
+  }
+</style>
+
+<script id="test-script">
   $('body').on('initialized', function() {
     $('#test-cap').contextualactionpanel({
       showCloseButton: true,

--- a/app/views/components/contextualactionpanel/test-close-button-from-settings.html
+++ b/app/views/components/contextualactionpanel/test-close-button-from-settings.html
@@ -82,7 +82,16 @@
   </div>
 </div>
 
-<script>
+<style type="text/css" id="test-style">
+  /* Mimic the "phone-to-tablet" breakpoint */
+  @media (min-width: 767px) {
+    .contextual-action-panel {
+      min-width: 600px;
+    }
+  }
+</style>
+
+<script id="test-script">
   $('body').on('initialized', function() {
     $('#test-cap').contextualactionpanel({
       title: 'Company Information',

--- a/app/views/components/contextualactionpanel/test-close-button.html
+++ b/app/views/components/contextualactionpanel/test-close-button.html
@@ -117,7 +117,16 @@
   </div>
 </div>
 
-<script>
+<style type="text/css" id="test-style">
+  /* Mimic the "phone-to-tablet" breakpoint */
+  @media (min-width: 767px) {
+    .contextual-action-panel {
+      min-width: 600px;
+    }
+  }
+</style>
+
+<script id="test-script">
   $('body').on('initialized', function() {
     $('#test-cap').contextualactionpanel({
       showCloseButton: true


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Some Contextual Action Panel (CAP) samples added as part of #2984 contained a hard-coded minimum width that was causing issues in responsive scenarios.  This PR adjusts those new samples to only display the minimum width when above the "phone-to-tablet" breakpoint.

**Related github/jira issue (required)**:
- Related to #2984
- Closes #2834

**Steps necessary to review your pull request (required)**:
Pull this branch, build, and run the app.  Check the following samples at responsive breakpoints and make sure the CAP fits within the page boundary properly:
- http://localhost:4000/components/contextualactionpanel/test-close-button?theme=uplift
- http://localhost:4000/components/contextualactionpanel/test-close-button-from-settings?theme=uplift
- http://localhost:4000/components/contextualactionpanel/test-close-button-flex?theme=uplift
- http://localhost:4000/components/contextualactionpanel/test-close-button-flex-from-settings?theme=uplift