### PR TITLE
2878 - Fix islamic calendar with datepicker

### DIFF
--- a/app/views/components/datepicker/test-ar-sa-umalqura-and-en-us-gregorian.html
+++ b/app/views/components/datepicker/test-ar-sa-umalqura-and-en-us-gregorian.html
@@ -1,0 +1,24 @@
+
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="field">
+      <label for="gregorian-date-us" class="label">Date Picker (en-US - gregorian)</label>
+      <input id="gregorian-date-us" data-init="false" class="datepicker" name="gregorian-date-us" type="text"/>
+    </div>
+
+    <div class="field">
+      <label for="islamic-date-us" class="label">Date Picker (ar-SA islamic-umalqura in current locale)</label>
+      <input id="islamic-date-us" data-init="false" class="datepicker" name="islamic-date-us" type="text"/>
+    </div>
+
+  </div>
+</div>
+
+<script>
+  $('body').on('initialized', function () {
+    $('#gregorian-date-us').datepicker({locale: 'en-US', calendarName: 'gregorian'});
+    $('#islamic-date-us').datepicker({locale: 'ar-SA', calendarName: 'islamic-umalqura', dateFormat: 'yyyy/MM/dd'});
+  });
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `[Datagrid]` Fixed an issue where the select all button for multiselect grouping was not working. ([#2895](https://github.com/infor-design/enterprise/issues/2895))
 - `[Datagrid]` Fixed an issue where the select children for tree was not working. ([#2961](https://github.com/infor-design/enterprise/issues/2961))
 - `[Datepicker]` Fixed an issue where the validation after body re-initialize was not working. ([#2410](https://github.com/infor-design/enterprise/issues/2410))
+- `[Datepicker]` Fixed an issue where the islamic-umalqura calendar was not working, when used with user vs settings locale and translate data was not loading from parent locale. ([#2878](https://github.com/infor-design/enterprise/issues/2878))
 - `[Dropdown]` Fixed an issue where the dropdown icons are misaligned in IE11 in the Uplift theme. ([#2826](https://github.com/infor-design/enterprise/issues/2912))
 - `[Dropdown]` Fixed an issue where the placeholder was incorrectly renders when initially set selected item. ([#2870](https://github.com/infor-design/enterprise/issues/2870))
 - `[Field Filter]` Fixed an issues where the icons are not vertically centered, and layout issues when opening the dropdown in a smaller height browser. ([#2951](https://github.com/infor-design/enterprise/issues/2951))

--- a/src/components/datepicker/_datepicker.scss
+++ b/src/components/datepicker/_datepicker.scss
@@ -167,6 +167,18 @@ html[dir='rtl'] {
       }
     }
   }
+
+  .monthview-popup.popover {
+    .hyperlink.today {
+      left: 85px;
+      right: auto;
+
+      &::after {
+        left: auto;
+        right: 8px;
+      }
+    }
+  }
 }
 
 // IE Hack

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -1353,11 +1353,15 @@ DatePicker.prototype = {
         pattern: this.pattern,
         locale: this.locale.name
       });
-      gregorianValue = this.conversions.toGregorian(
-        islamicValue[0],
-        islamicValue[1],
-        islamicValue[2]
-      );
+      if (islamicValue instanceof Date) {
+        gregorianValue = this.conversions.toGregorian(islamicValue);
+      } else if (islamicValue instanceof Array) {
+        gregorianValue = this.conversions.toGregorian(
+          islamicValue[0],
+          islamicValue[1],
+          islamicValue[2]
+        );
+      }
     }
 
     this.currentDate = gregorianValue || new Date();
@@ -1382,6 +1386,7 @@ DatePicker.prototype = {
       this.currentYear = this.currentDateIslamic[0];
       this.currentMonth = this.currentDateIslamic[1];
       this.currentDay = this.currentDateIslamic[2];
+      this.currentIslamicDate = this.currentDateIslamic;
     } else {
       this.currentDate = this.currentDate || new Date();
       this.currentMonth = this.currentDate.getMonth();

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -254,6 +254,13 @@ const Locale = {  // eslint-disable-line
         nativeName: data.nativeName || (langData ? langData.nativeName : ''),
         messages: data.messages || (langData ? langData.messages : {})
       };
+    } else if (!this.languages[lang] && !data.messages) {
+      const match = this.defaultLocales.filter(a => a.lang === lang);
+      const parentLocale = match[0] || [{ default: 'en-US' }];
+      if (parentLocale.default && parentLocale.default !== locale &&
+        !this.cultures[parentLocale.default]) {
+        this.appendLocaleScript(parentLocale.default);
+      }
     }
   },
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed islamic-umalqura calendar was not working, when used with user vs settings locale and translate data was not loading from parent locale with Datepicker.

**Related github/jira issue (required)**:
Closes #2878

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datepicker/test-ar-sa-umalqura-and-en-us-gregorian.html
- Open developer tools
- Open the Date Picker (ar-SA islamic-umalqura in current locale)
- See words should be translate to proper language (for example footer button text)
- Select any date
- Date Picker should close
- Open the same Date Picker again
- See console, should not be any error and Date Picker should open fine

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
