### PR TITLE
2968 - Fix Textarea size shift on IE11/Edge

### DIFF
--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -1,7 +1,8 @@
 //  Form Layouts
 //================================================== //
 
-.page-container {
+.page-container,
+.container {
   .form-responsive {
     input,
     textarea {
@@ -69,7 +70,8 @@
 }
 
 @media (max-width: $breakpoint-phone-to-tablet + 1) {
-  .page-container {
+  .page-container,
+  .container {
     .form-responsive {
       .field .checkbox-label,
       .field .checkbox > label {

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -69,11 +69,13 @@
 }
 
 @media (max-width: $breakpoint-phone-to-tablet + 1) {
-  .form-responsive {
-    .field .checkbox-label,
-    .field .checkbox > label {
-      margin-bottom: 13px;
-      margin-top: -1px;
+  .page-container {
+    .form-responsive {
+      .field .checkbox-label,
+      .field .checkbox > label {
+        margin-bottom: 13px;
+        margin-top: -1px;
+      }
     }
   }
 

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -1,68 +1,70 @@
 //  Form Layouts
 //================================================== //
 
-.form-responsive {
-  input,
-  textarea {
-    width: 100% !important;
-  }
-
-  .colorpicker-container {
-    position: relative;
-    width: 100% !important;
-
-    .colorpicker {
-      width: auto !important;
+.page-container {
+  .form-responsive {
+    input,
+    textarea {
+      width: 100%;
     }
 
-    .trigger {
-      position: absolute;
-      right: 0;
+    .colorpicker-container {
+      position: relative;
+      width: 100%;
+
+      .colorpicker {
+        width: auto;
+      }
+
+      .trigger {
+        position: absolute;
+        right: 0;
+      }
     }
-  }
 
-  .dropdown-wrapper {
-    width: 100%;
+    .dropdown-wrapper {
+      width: 100%;
 
-    div.dropdown,
-    div.multiselect {
-      width: inherit;
+      div.dropdown,
+      div.multiselect {
+        width: inherit;
+      }
     }
-  }
 
-  .field .checkbox-label,
-  .field .checkbox > label {
-    margin-top: 30px;
-  }
-
-  .checkbox-group-label + .compound-field {
     .field .checkbox-label,
     .field .checkbox > label {
-      margin-top: 0;
+      margin-top: 30px;
     }
 
-    .field.field-checkbox {
+    .checkbox-group-label + .compound-field {
+      .field .checkbox-label,
+      .field .checkbox > label {
+        margin-top: 0;
+      }
+
+      .field.field-checkbox {
+        margin-bottom: 0;
+      }
+    }
+
+    .field-checkbox {
+      text-align: left;
+    }
+
+    .lookup-wrapper {
+      width: 100%;
+    }
+
+    .label,
+    label {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .row.no-bottom-margin {
       margin-bottom: 0;
     }
-  }
-
-  .field-checkbox {
-    text-align: left;
-  }
-
-  .lookup-wrapper {
-    width: 100%;
-  }
-
-  .label,
-  label {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .row.no-bottom-margin {
-    margin-bottom: 0;
   }
 }
 
@@ -77,6 +79,36 @@
 
   .form-responsive .checkbox-group-label + .compound-field .field .checkbox-label {
     margin-bottom: 0;
+  }
+}
+
+// Setup specific widths for modals/CAPs with a responsive form
+.modal {
+  &.display-fullsize {
+    .form-responsive {
+      input,
+      textarea {
+        max-width: none;
+        width: 100%;
+      }
+
+      .colorpicker-container {
+        width: 100%;
+
+        .colorpicker {
+          width: auto;
+        }
+      }
+
+      .dropdown-wrapper {
+        width: 100%;
+
+        div.dropdown,
+        div.multiselect {
+          width: inherit;
+        }
+      }
+    }
   }
 }
 

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -61,8 +61,7 @@
     }
 
     textarea {
-      min-width: 300px;
-      width: auto;
+      max-width: 300px;
 
       &[data-error-type='tooltip'] ~ .icon-error,
       &[data-error-type='tooltip'] ~ .icon-success {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR makes some CSS style changes to the Textarea/Inputs on responsive forms contained inside of a Modal or Contextual Action Panel.  These changes fix a bug in IE11/Edge that was causing the size of textareas to shift if they had a large amount of text pasted into them.

**Related github/jira issue (required)**:
Closes #2968

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run app
- Open IE11 or Edge
- Navigate to http://localhost:4000/components/contextualactionpanel/example-index.html
- Open the Contextual Action Panel.
- In the textarea, paste this large blob of text:  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
- Examine the textarea to make sure it didn't grow.
- Defocus the textarea without closing the CAP (fx, click the checkbox).  It should not cause any size shifting in the textarea.

Some changes were made to the responsive form to facilitate these CSS style changes.  Make sure the following pages are all styled correctly:
- http://localhost:4000/components/form/example-inputs.html
- http://localhost:4000/components/form/example-inputs-simple.html
- http://localhost:4000/components/contextualactionpanel/test-fullsize-responsive.html
- http://localhost:4000/components/modal/example-fullsize-responsive.html
- http://localhost:4000/components/personalize/example-form