### PR TITLE
1384 - Form: Fix field sizes of spinbox on mobile

### DIFF
--- a/app/views/components/form/test-spinbox-compound-field.html
+++ b/app/views/components/form/test-spinbox-compound-field.html
@@ -8,13 +8,14 @@
       </div>
 
       <div class="field">
-        <label for="test-spinbox-age2">Age2</label>
-        <input id="test-spinbox-age2" name="test-spinbox-age2" type="text" class="spinbox" />
-      </div>
-
-      <div class="field">
-        <label for="test-spinbox-age3">Age3</label>
-        <input id="test-spinbox-age3" name="test-spinbox-age3" type="text" class="spinbox" />
+        <div class="spinbox-field-container">
+          <label for="test-spinbox-age2">Age2</label>
+          <input id="test-spinbox-age2" name="test-spinbox-age2" type="text" class="spinbox" />
+        </div>
+        <div class="spinbox-field-container">
+          <label for="test-spinbox-age3">Age3</label>
+          <input id="test-spinbox-age3" name="test-spinbox-age3" type="text" class="spinbox" />
+        </div>
       </div>
 
       <div class="field">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[Dropdown]` Fixed an issue where the dropdown icons are misaligned in IE11 in the Uplift theme. ([#2826](https://github.com/infor-design/enterprise/issues/2912))
 - `[Dropdown]` Fixed an issue where the placeholder was incorrectly renders when initially set selected item. ([#2870](https://github.com/infor-design/enterprise/issues/2870))
 - `[Field Filter]` Fixed an issues where the icons are not vertically centered, and layout issues when opening the dropdown in a smaller height browser. ([#2951](https://github.com/infor-design/enterprise/issues/2951))
+- `[Form]` Fixed the field sizes of spinbox on mobile. ([#1384](https://github.com/infor-design/enterprise/issues/1384))
 - `[Header]` Fixed an iOS bug where the theme switcher wasn't working after Popupmenu lifecycle changes. ([#2986](https://github.com/infor-design/enterprise/issues/2986))
 - `[Header Tabs]` Added a more distinct style to selected header tabs. ([infor-design/design-system#422](https://github.com/infor-design/design-system/issues/422))
 - `[Hierarchy]` Fixed the border color on hierarchy cards. ([#423](https://github.com/infor-design/design-system/issues/423))

--- a/src/components/spinbox/_spinbox.scss
+++ b/src/components/spinbox/_spinbox.scss
@@ -36,6 +36,18 @@ input::-webkit-inner-spin-button {
     position: relative;
     vertical-align: top;
   }
+
+  .spinbox-field-container {
+    display: inline-block;
+
+    > .spinbox-wrapper {
+      width: 148px;
+
+      @media (min-width: $breakpoint-phone-to-tablet) {
+        width: 232px;
+      }
+    }
+  }
 }
 
 .spinbox-control {

--- a/test/components/form/form.e2e-spec.js
+++ b/test/components/form/form.e2e-spec.js
@@ -6,6 +6,8 @@ requireHelper('rejection');
 
 jasmine.getEnv().addReporter(browserStackErrorReporter);
 
+const spinboxId = 'test-spinbox-age2';
+
 describe('Form Tests', () => {
   if (utils.isChrome() && utils.isCI()) {
     it('Should not visual regress on compound fields', async () => {
@@ -44,4 +46,22 @@ describe('Form Tests', () => {
       expect(await browser.protractorImageComparison.checkElement(containerEl, 'form-checkbox-in-columns')).toEqual(0);
     });
   }
+});
+
+describe('Spinbox test-spinbox-compound-field tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/form/test-spinbox-compound-field');
+    await browser.driver
+      .wait(protractor.ExpectedConditions
+        .presenceOf(element(by.id(spinboxId))), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should align both spinbox on mobile', async () => {
+    expect(await element(by.css('.spinbox-wrapper'))
+      .getCssValue('width')).toEqual('232px');
+  });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This will fix the fied sizes of spinbox on mobile. Added a custom container for spinbox and add width for the spinbox wrapper.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/1384

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Navigate to http://localhost:4000/components/form/test-spinbox-compound-field.html
- Test it on mobile device or use browserstack
- `Age2` and `Age3` spinbox should align in a single column and matches the width of the input fields

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
