### PR TITLE
650 - Fix xss issues in dropdown

### DIFF
--- a/app/src/js/middleware/csp-handler.js
+++ b/app/src/js/middleware/csp-handler.js
@@ -9,6 +9,7 @@ function addNonceToScript(html, nonce) {
   nonced = nonced.replace(/&lt;script/ig, '<scriptno-nonce-lt');
   nonced = nonced.replace(/<script>/ig, `<script nonce="${nonce}">`);
   nonced = nonced.replace(/<script id/ig, `<script nonce="${nonce}" id`);
+  nonced = nonced.replace(/<script src/ig, `<script nonce="${nonce}" src`);
   nonced = nonced.replace(/<scriptno-nonce>/ig, '<script>');
   nonced = nonced.replace(/<scriptno-nonce-lt/ig, '&lt;script');
   return nonced;

--- a/app/src/js/middleware/csp-handler.js
+++ b/app/src/js/middleware/csp-handler.js
@@ -5,7 +5,13 @@ function addNonceToScript(html, nonce) {
   if (!html || !html.length) {
     return '';
   }
-  return html.replace(/<script/ig, `<script nonce="${nonce}"`);
+  let nonced = html.replace(/<script no-nonce>/ig, '<scriptno-nonce>');
+  nonced = nonced.replace(/&lt;script/ig, '<scriptno-nonce-lt');
+  nonced = nonced.replace(/<script>/ig, `<script nonce="${nonce}">`);
+  nonced = nonced.replace(/<script id/ig, `<script nonce="${nonce}" id`);
+  nonced = nonced.replace(/<scriptno-nonce>/ig, '<script>');
+  nonced = nonced.replace(/<scriptno-nonce-lt/ig, '&lt;script');
+  return nonced;
 }
 
 function addNonceToStyle(html, nonce) {

--- a/app/views/components/applicationmenu/example-personalized-role-switcher.html
+++ b/app/views/components/applicationmenu/example-personalized-role-switcher.html
@@ -74,7 +74,7 @@
 
   {{> includes/footer}}
 
-  <script type="text/javascript">
+  <script>
     // May need to do more here.
     $('.application-menu-switcher-panel .accordion').on('selected', function (e, args) {
       $('body').toast({title: 'Role ' + args.innerText + ' Selected',  message: 'In a real application, you could refresh the app menu with new contents for the selected role.'});

--- a/app/views/components/applicationmenu/test-all-chevrons.html
+++ b/app/views/components/applicationmenu/test-all-chevrons.html
@@ -74,7 +74,7 @@
 
   {{> includes/footer}}
 
-  <script type="text/javascript">
+  <script>
     // May need to do more here.
     $('.application-menu-switcher-panel .accordion').on('selected', function (e, args) {
       $('body').toast({title: 'Role ' + args.innerText + ' Selected',  message: 'In a real application, you could refresh the app menu with new contents for the selected role.'});

--- a/app/views/components/applicationmenu/test-hcm-icons.html
+++ b/app/views/components/applicationmenu/test-hcm-icons.html
@@ -74,7 +74,7 @@
 
   {{> includes/footer}}
 
-  <script type="text/javascript">
+  <script>
     // May need to do more here.
     $('.application-menu-switcher-panel .accordion').on('selected', function (e, args) {
       $('body').toast({title: 'Role ' + args.innerText + ' Selected',  message: 'In a real application, you could refresh the app menu with new contents for the selected role.'});

--- a/app/views/components/applicationmenu/test-hcm.html
+++ b/app/views/components/applicationmenu/test-hcm.html
@@ -74,7 +74,7 @@
 
   {{> includes/footer}}
 
-  <script type="text/javascript">
+  <script>
     // May need to do more here.
     $('.application-menu-switcher-panel .accordion').on('selected', function (e, args) {
       $('body').toast({title: 'Role ' + args.innerText + ' Selected',  message: 'In a real application, you could refresh the app menu with new contents for the selected role.'});

--- a/app/views/components/applicationmenu/test-personalized-role-switcher-long-title.html
+++ b/app/views/components/applicationmenu/test-personalized-role-switcher-long-title.html
@@ -74,7 +74,7 @@
 
   {{> includes/footer}}
 
-  <script type="text/javascript">
+  <script>
     // May need to do more here.
     $('.application-menu-switcher-panel .accordion').on('selected', function (e, args) {
       $('body').toast({title: 'Role ' + args.innerText + ' Selected',  message: 'In a real application, you could refresh the app menu with new contents for the selected role.'});

--- a/app/views/components/button/example-disabled-button-tooltip.html
+++ b/app/views/components/button/example-disabled-button-tooltip.html
@@ -104,6 +104,6 @@
 </div>
 
 
-<script type="text/javascript">
+<script>
   $('div[title]').tooltip();
 </script>

--- a/app/views/components/datagrid/example-index.html
+++ b/app/views/components/datagrid/example-index.html
@@ -8,7 +8,7 @@
   </div>
 </div>
 
-<script  id="datagrid-script">
+<script id="datagrid-script">
   $('body').one('initialized', function () {
 
       var columns = [];

--- a/app/views/components/datagrid/test-actions-reload.html
+++ b/app/views/components/datagrid/test-actions-reload.html
@@ -28,7 +28,7 @@
   <li><a href="#">Action Three</a></li>
 </ul>
 
-<script  id="datagrid-script">
+<script id="datagrid-script">
   $('body').one('initialized', function () {
 
     var grid,

--- a/app/views/components/dropdown/test-xss.html
+++ b/app/views/components/dropdown/test-xss.html
@@ -1,10 +1,20 @@
 <div class="row">
   <div class="twelve columns">
-    <label for="states" class="label">State</label>
+    <label for="states" class="label">Xss Test One</label>
     <select id="states" class="dropdown">
       <option value="Hello">Hello</option>
-      <option value="<script>window.alert('dropdown xss')</script>XSS">&lt;script&gt;window.alert('dropdown xss')&lt;/script&gt;XSS</option>
+      <option value="<script no-nonce>window.alert('dropdown xss')</script>XSS">&lt;script&gt;window.alert('dropdown xss')&lt;/script&gt;XSS</option>
       <option value="World">World</option>
+    </select>
+    <label for="states2" class="label">Xss Test Two</label>
+    <select id="states2" class="dropdown">
+      <option value="Hello1">Hello</option>
+      <option value="Hello2">&lt; Hello</option>
+      <option value="Hello3">&gt; Hello</option>
+      <option value="Hello4">< Hello</option>
+      <option value="<script no-nonce>window.alert('dropdown xss')</script>XSS">&lt;script&gt;window.alert('dropdown xss')&lt;/script&gt;XSS</option>
+      <option value="World">World</option>
+      <option value="World2">&lt;World&gt;</option>
     </select>
   </div>
 </div>

--- a/app/views/components/dropdown/test-xss.html
+++ b/app/views/components/dropdown/test-xss.html
@@ -9,9 +9,11 @@
     <label for="states2" class="label">Xss Test Two</label>
     <select id="states2" class="dropdown">
       <option value="Hello1">Hello</option>
-      <option value="Hello2">&lt; Hello</option>
-      <option value="Hello3">&gt; Hello</option>
-      <option value="Hello4">< Hello</option>
+      <option value="Hello2">Hello 0 1 2 & Hello 3 4 5</option>
+      <option value="Hello3">Hello "there"</option>
+      <<option value="Hello5">&lt; Hello</option>
+      <option value="Hello6">&gt; Hello</option>
+      <option value="Hello7">< Hello</option>
       <option value="<script no-nonce>window.alert('dropdown xss')</script>XSS">&lt;script&gt;window.alert('dropdown xss')&lt;/script&gt;XSS</option>
       <option value="World">World</option>
       <option value="World2">&lt;World&gt;</option>

--- a/app/views/components/personalize/example-color-theme-api.html
+++ b/app/views/components/personalize/example-color-theme-api.html
@@ -28,7 +28,7 @@
   </div>
 </div>
 
-<script type="text/javascript">
+<script>
   $('body').on('initialized', function () {
     const PERSONALIZE_API = $('html').data('personalize');
     const $html = $('html');

--- a/app/views/components/toolbar-flex/example-index.html
+++ b/app/views/components/toolbar-flex/example-index.html
@@ -224,7 +224,7 @@
   </div>
 </div>
 
-<script type="text/javascript">
+<script>
   $('.flex-toolbar').on('selected.test', function(e, item, secondArg) {
     var text = $(item.element).text().trim();
     var selectedItem;

--- a/app/views/components/toolbar-flex/example-more-actions-ajax.html
+++ b/app/views/components/toolbar-flex/example-more-actions-ajax.html
@@ -58,7 +58,7 @@
   </div>
 </div>
 
-<script type="text/javascript">
+<script>
   var TOP_LEVEL_POPUPMENU_CONTENT = '' +
     '<li><a href="#">AJAX Option #1</a></li>' +
     '<li><a href="#">AJAX Option #2</a></li>' +

--- a/app/views/components/toolbar-flex/test-empty-buttonset-ajax-more-menu.html
+++ b/app/views/components/toolbar-flex/test-empty-buttonset-ajax-more-menu.html
@@ -26,7 +26,7 @@
   </div>
 </div>
 
-<script type="text/javascript">
+<script>
   var TOP_LEVEL_POPUPMENU_CONTENT = '' +
     '<li><a href="#">AJAX Option #1</a></li>' +
     '<li><a href="#">AJAX Option #2</a></li>' +

--- a/app/views/components/toolbar-flex/test-gauntlet.html
+++ b/app/views/components/toolbar-flex/test-gauntlet.html
@@ -191,7 +191,7 @@
   </div>
 </div>
 
-<script type="text/javascript">
+<script>
   var STATE = {};
 
   $('body').on('initialized', function() {

--- a/app/views/includes/head.html
+++ b/app/views/includes/head.html
@@ -20,7 +20,7 @@
   <script src="{{basepath}}js/promise-polyfill.js"></script>
 
   {{#SohoConfig}}
-  <script type="text/javascript">
+  <script>
     window.SohoConfig = JSON.parse('{{{SohoConfig}}}');
   </script>
   {{/SohoConfig}}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@
 - `[Datepicker]` Fixed an issue where the validation after body re-initialize was not working. ([#2410](https://github.com/infor-design/enterprise/issues/2410))
 - `[Dropdown]` Fixed an issue where the dropdown icons are misaligned in IE11 in the Uplift theme. ([#2826](https://github.com/infor-design/enterprise/issues/2912))
 - `[Dropdown]` Fixed an issue where the placeholder was incorrectly renders when initially set selected item. ([#2870](https://github.com/infor-design/enterprise/issues/2870))
+- `[Dropdown]` Fixed an issue where it was possible to inject xss when clearing the typehead. ([#650](https://github.com/infor-design/enterprise-ng/issues/650))
 - `[Field Filter]` Fixed an issues where the icons are not vertically centered, and layout issues when opening the dropdown in a smaller height browser. ([#2951](https://github.com/infor-design/enterprise/issues/2951))
 - `[Header]` Fixed an iOS bug where the theme switcher wasn't working after Popupmenu lifecycle changes. ([#2986](https://github.com/infor-design/enterprise/issues/2986))
 - `[Header Tabs]` Added a more distinct style to selected header tabs. ([infor-design/design-system#422](https://github.com/infor-design/design-system/issues/422))

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -118,7 +118,7 @@ div.multiselect {
     height: 16px;
     left: 14px;
     position: absolute;
-    top: 11px;
+    top: 9px;
     vertical-align: middle;
     width: 16px;
 

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -883,7 +883,7 @@ Dropdown.prototype = {
     text = text.trim();
     const span = this.pseudoElem.find('span');
     if (span.length > 0) {
-      span[0].innerHTML = `<span class="audible">${this.label.text()} </span>${text}`;
+      span[0].innerHTML = `<span class="audible">${this.label.text()} </span>${xssUtils.escapeHTML(text)}`;
     }
 
     this.setPlaceholder(text);
@@ -1058,6 +1058,7 @@ Dropdown.prototype = {
     list.not(results).add(headers).addClass('hidden');
     list.filter(results).each(function (i) {
       const li = $(this);
+      const a = li.children('a');
       li.attr('tabindex', i === 0 ? '0' : '-1');
 
       if (!selected) {
@@ -1067,14 +1068,15 @@ Dropdown.prototype = {
 
       // Highlight Term
       const exp = self.getSearchRegex(term);
-      const text = li.text().replace(exp, '<span class="dropdown-highlight">$1</span>').trim();
+      const text = xssUtils.escapeHTML(li.text()).replace(exp, '<span class="dropdown-highlight">$1</span>').trim();
       const icon = li.children('a').find('svg').length !== 0 ? new XMLSerializer().serializeToString(li.children('a').find('svg')[0]) : '';
 
       if (icon) {
         hasIcons = true;
       }
-
-      li.children('a').html(icon + text);
+      if (a[0]) {
+        a[0].innerHTML = icon + text;
+      }
     });
 
     headers.each(function () {
@@ -1116,14 +1118,16 @@ Dropdown.prototype = {
       const a = $(this).children('a');
       const li = $(this);
 
-      const text = a.text();
+      const text = xssUtils.escapeHTML(a.text());
       const icon = li.children('a').find('svg').length !== 0 ? new XMLSerializer().serializeToString(li.children('a').find('svg')[0]) : '';
 
       if (icon) {
         hasIcons = true;
       }
 
-      a.html(icon + text);
+      if (a[0]) {
+        a[0].innerHTML = icon + text;
+      }
     });
 
     // Adjust height / top position

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -523,7 +523,7 @@ Dropdown.prototype = {
     const optText = this.getOptionText(opts);
     this.tooltipApi = this.pseudoElem.find('span')
       .tooltip({
-        content: optText,
+        content: xssUtils.escapeHTML(optText),
         parentElement: this.pseudoElem,
         trigger: this.isMobile() ? 'immediate' : 'hover',
       })
@@ -1068,14 +1068,25 @@ Dropdown.prototype = {
 
       // Highlight Term
       const exp = self.getSearchRegex(term);
-      const text = xssUtils.escapeHTML(li.text()).replace(exp, '<span class="dropdown-highlight">$1</span>').trim();
+      // const text = xssUtils.escapeHTML(li.text()).replace(exp, '<span class="dropdown-highlight">$1</span>').trim();
+      let text = li.text();
+      text = xssUtils.escapeHTML(text);
+      text = text.replace(/&lt;/g, '&#16;');
+      text = text.replace(/&gt;/g, '&#17;');
+      text = text.replace(/&amp;/g, '&');
+      text = text.replace(exp, '<span class="dropdown-highlight">$1</span>').trim();
+      text = text.replace(/&#16;/g, '&lt;');
+      text = text.replace(/&#17;/g, '&gt;');
+
       const icon = li.children('a').find('svg').length !== 0 ? new XMLSerializer().serializeToString(li.children('a').find('svg')[0]) : '';
+      const swatch = li.children('a').find('.swatch');
+      const swatchHtml = swatch.length !== 0 ? swatch[0].outerHTML : '';
 
       if (icon) {
         hasIcons = true;
       }
       if (a[0]) {
-        a[0].innerHTML = icon + text;
+        a[0].innerHTML = swatchHtml + icon + text;
       }
     });
 
@@ -1120,13 +1131,15 @@ Dropdown.prototype = {
 
       const text = xssUtils.escapeHTML(a.text());
       const icon = li.children('a').find('svg').length !== 0 ? new XMLSerializer().serializeToString(li.children('a').find('svg')[0]) : '';
+      const swatch = li.children('a').find('.swatch');
+      const swatchHtml = swatch.length !== 0 ? swatch[0].outerHTML : '';
 
       if (icon) {
         hasIcons = true;
       }
 
       if (a[0]) {
-        a[0].innerHTML = icon + text;
+        a[0].innerHTML = swatchHtml + icon + text;
       }
     });
 

--- a/src/components/listfilter/listfilter.js
+++ b/src/components/listfilter/listfilter.js
@@ -157,6 +157,7 @@ ListFilter.prototype = {
     // string result from that callback. Otherwise, perform the standard method
     // of grabbing text content.
     function getSearchableContent(item) {
+      let santitize = true;
       if (typeof self.settings.searchableTextCallback === 'function') {
         return self.settings.searchableTextCallback(item);
       }
@@ -167,12 +168,17 @@ ListFilter.prototype = {
       } else if (item instanceof $) {
         targetContent = $(item).text();
       } else if (item instanceof HTMLElement) {
+        santitize = false; // safe from innerText and we wan encoding.
         targetContent = item.innerText;
       } else { // Object
         targetContent = getObjectPropsAsText(item);
       }
 
-      return xssUtils.sanitizeHTML(targetContent);
+      let ret = targetContent;
+      if (santitize) {
+        ret = xssUtils.sanitizeHTML(targetContent);
+      }
+      return ret;
     }
 
     // Iterates through each list item and attempts to find the provided search term.

--- a/src/utils/xss.js
+++ b/src/utils/xss.js
@@ -137,15 +137,11 @@ xssUtils.escapeHTML = function (value) {
  * @returns {string} the modified value
  */
 xssUtils.unescapeHTML = function (value) {
-  let newValue = value;
   if (typeof value === 'string') {
-    newValue = newValue.replace(/&amp;/g, '&');
-    newValue = newValue.replace(/&lt;/g, '<').replace(/&gt;/g, '>');
-    newValue = newValue.replace(/&quot;/g, '"');
-    newValue = newValue.replace(/&#x27;/g, "'");
-    newValue = newValue.replace(/&#x2F;/g, '/');
+    const doc = new DOMParser().parseFromString(value, 'text/html');
+    return doc.documentElement.textContent;
   }
-  return newValue;
+  return value;
 };
 
 /**

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -555,4 +555,28 @@ describe('Dropdown xss tests', () => {
 
     await utils.checkForErrors();
   });
+
+  it('Should not get confused filtering with encoding', async () => { //eslint-disable-line
+    const dropdownEl = await element(by.css('#states + .dropdown-wrapper div.dropdown'));
+    await dropdownEl.sendKeys('l');
+
+    const searchEl = await element(by.css('.dropdown-search'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(searchEl), config.waitsFor);
+
+    expect(await element(by.id('list-option-1')).getText()).toEqual('<script>window.alert(\'dropdown xss\')</script>XSS');
+    await utils.checkForErrors();
+  });
+
+  it('Should filter on &', async () => { //eslint-disable-line
+    const dropdownEl = await element(by.css('#states2 + .dropdown-wrapper div.dropdown'));
+    await dropdownEl.sendKeys('&');
+
+    const searchEl = await element(by.css('.dropdown-search'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(searchEl), config.waitsFor);
+
+    expect(await element(by.id('list-option-1')).getText()).toEqual('Hello 0 1 2 & Hello 3 4 5');
+    await utils.checkForErrors();
+  });
 });

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -529,8 +529,30 @@ describe('Dropdown xss tests', () => {
     await browser.switchTo().activeElement().sendKeys(protractor.Key.ENTER);
     await browser.switchTo().activeElement().sendKeys(protractor.Key.TAB);
 
-    expect(await element(by.id('states')).getAttribute('value')).toEqual('<script nonce=');
+    expect(await element(by.id('states')).getAttribute('value')).toEqual('<script>window.alert(\'dropdown xss\')</script>XSS');
     await browser.driver.sleep(config.sleep);
+    await utils.checkForErrors();
+  });
+
+  it('Should not inject scripts on reset list', async () => {
+    const dropdownEl = await element(by.css('#states + .dropdown-wrapper div.dropdown'));
+    await dropdownEl.sendKeys('x');
+
+    const searchEl = await element(by.css('.dropdown-search'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(searchEl), config.waitsFor);
+
+    expect(await element(by.id('list-option-1')).getText()).toEqual('<script>window.alert(&#x27;dropdown xss\')</script>XSS');
+    await utils.checkForErrors();
+    await browser.driver.sleep(config.sleep);
+
+    await searchEl.sendKeys(protractor.Key.BACK_SPACE);
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.id('list-option-0')).getText()).toEqual('Hello');
+    expect(await element(by.id('list-option-1')).getText()).toEqual('<script>window.alert(&#x27;dropdown xss\')</script>XSS');
+    expect(await element(by.id('list-option-2')).getText()).toEqual('World');
+
     await utils.checkForErrors();
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The xss was not working when doing a backspace in dropdown. (There were CSP errors).

**Related github/jira issue (required)**:
Fixes infor-design/enterprise-ng#650

**Steps necessary to review your pull request (required)**:

**Test One**
- pull this and restart the demo app
- go to http://localhost:4000/components/dropdown/test-xss.html
- type a and make sure it filters
- make sure you can select the <> formatted items
- backspace to clear
- make sure no console errors (CSP Error will happen if it injects)

**Test Two**
- go to http://localhost:4000/components/dropdown/test-special-chars.html
- make sure you can select all the items especially `<test>`

**Test Three**
- go to http://localhost:4000
- check the console and make sure there are no CSP errors

**Test Four**
- go to http://localhost:4000/components/dropdown/example-icons.html
- type anything to search
- backspace to clear
- ensure this example is working

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

cc @anhallbe 