### PR TITLE
change `CODEOWNERS` file to work off of Github Teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Each line is a file pattern followed by one or more owners.
 
 # Default owners for the repo:
-* @tmcconechy @EdwardCoyle @deep7102 @davidcarlsonberg @ericangeles @jmacaluso711
+* @infor-design/eng-ids


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR removes individual names of developers from the Github `CODEOWNERS` file and instead makes the [IDS Engineering Team](https://github.com/orgs/infor-design/teams/eng-ids/members) a dynamic list of code owners for this repo.