### PR TITLE
2830 - Fix column headers font color in uplift high contrast

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[Contextual Action Panel]` Fixed an issue where the CAP close but beforeclose event not fired. ([#2826](https://github.com/infor-design/enterprise/issues/2826))
 - `[Context Menu]` Fixed a placement bug that would cut the size of the menu to an unusable size in small viewport displays. ([#2899](https://github.com/infor-design/enterprise/issues/2899))
 - `[Contextual Action Panel]` Fixed placement of `(X)` close button on both standard and Flex toolbars when using the `showCloseBtn` setting. ([#2834](https://github.com/infor-design/enterprise/issues/2834))
+- `[Datagrid]` Fixed column headers font color in uplift high contrast. ([#2830](https://github.com/infor-design/enterprise/issues/2830))
 - `[Datagrid]` Fixed an issue where the tree children expand and collapse was not working. ([#633](https://github.com/infor-design/enterprise-ng/issues/633))
 - `[Datagrid]` Fixed an issue where the pager was not updating with updated method. ([#2759](https://github.com/infor-design/enterprise/issues/2759))
 - `[Datagrid]` Fixed an issue where the browser contextmenu was not showing by default. ([#2842](https://github.com/infor-design/enterprise/issues/2842))

--- a/src/themes/theme-uplift-contrast.scss
+++ b/src/themes/theme-uplift-contrast.scss
@@ -527,7 +527,7 @@ $datagrid-list-header-bg-color: $theme-color-brand-secondary-alt;
 $datagrid-list-header-focus-border-color: $theme-color-brand-primary-base;
 $datagrid-list-header-box-shadow: 0 0 4px 1px rgba(80, 83, 90, 0.4);
 $datagrid-list-header-border-color: transparent;
-$datagrid-list-header-color: $theme-color-palette-graphite-100;
+$datagrid-list-header-color: $theme-color-palette-graphite-10;
 $datagrid-list-header-hover-color: $theme-color-brand-secondary-alt;
 $datagrid-list-row-hover-color: transparent;
 $datagrid-list-sort-icon-color: $theme-color-brand-secondary-alt;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fix font color of column headers in datagrid in cards.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/2830

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Navigate to http://localhost:4000/components/cards/test-datagrid.html?theme=uplift&variant=contrast
- Column headers should be visible

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
