### PR TITLE
650 - Fix encoding in dropdown search

### DIFF
--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -6,6 +6,7 @@ import { Environment as env } from '../../utils/environment';
 import { Locale } from '../locale/locale';
 import { ListFilter } from '../listfilter/listfilter';
 import { xssUtils } from '../../utils/xss';
+import { stringUtils } from '../../utils/string';
 
 // jQuery Components
 import '../icons/icons.jquery';
@@ -1079,10 +1080,14 @@ Dropdown.prototype = {
       text = xssUtils.escapeHTML(text);
       text = text.replace(/&lt;/g, '&#16;');
       text = text.replace(/&gt;/g, '&#17;');
+      text = text.replace(/&apos;/g, '&#18;');
+      text = text.replace(/&quot;/g, '&#19;');
       text = text.replace(/&amp;/g, '&');
       text = text.replace(exp, '<span class="dropdown-highlight">$1</span>').trim();
       text = text.replace(/&#16;/g, '&lt;');
       text = text.replace(/&#17;/g, '&gt;');
+      text = text.replace(/&#18;/g, '&apos;');
+      text = text.replace(/&#19;/g, '&quot;');
 
       const icon = li.children('a').find('svg').length !== 0 ? new XMLSerializer().serializeToString(li.children('a').find('svg')[0]) : '';
       const swatch = li.children('a').find('.swatch');
@@ -1575,7 +1580,7 @@ Dropdown.prototype = {
     let regex;
 
     try {
-      regex = new RegExp(`(${term})`, 'i');
+      regex = new RegExp(`(${stringUtils.escapeRegExp(term)})`, 'i');
     } catch (e) {
       // create a "matches all" regex if we can't create a regex from the search term
       regex = /[\s\S]*/i;

--- a/src/utils/xss.js
+++ b/src/utils/xss.js
@@ -121,7 +121,7 @@ xssUtils.escapeHTML = function (value) {
       '<': '&lt;',
       '>': '&gt;',
       '"': '&quot;',
-      "'": '&#x27;'
+      "'": '&apos;'
     };
     const reg = /[&<>"']/ig;
     return newValue.replace(reg, match => (map[match]));

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -542,7 +542,7 @@ describe('Dropdown xss tests', () => {
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(searchEl), config.waitsFor);
 
-    expect(await element(by.id('list-option-1')).getText()).toEqual('<script>window.alert(&#x27;dropdown xss\')</script>XSS');
+    expect(await element(by.id('list-option-1')).getText()).toEqual('<script>window.alert(\'dropdown xss\')</script>XSS');
     await utils.checkForErrors();
     await browser.driver.sleep(config.sleep);
 
@@ -550,7 +550,7 @@ describe('Dropdown xss tests', () => {
     await browser.driver.sleep(config.sleep);
 
     expect(await element(by.id('list-option-0')).getText()).toEqual('Hello');
-    expect(await element(by.id('list-option-1')).getText()).toEqual('<script>window.alert(&#x27;dropdown xss\')</script>XSS');
+    expect(await element(by.id('list-option-1')).getText()).toEqual('<script>window.alert(\'dropdown xss\')</script>XSS');
     expect(await element(by.id('list-option-2')).getText()).toEqual('World');
 
     await utils.checkForErrors();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

650 was failed QA because some strings cannot be searched correctly due to missing encoding re-correction. This fixes that problem. Addressing this comment https://github.com/infor-design/enterprise-ng/issues/650#issuecomment-550225737 on this PR

Note: I noticed searching for ( and ) was an issue in all older versions (for what thats worth)

**Related github/jira issue (required)**:
Fixes #650 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/dropdown/test-xss.html
- type ( or ) and it should work (in the first dropdown)
- type x and it should work (in the first dropdown)
- type t in the (second dropdown) and it should work
