### PR TITLE
3094 - Fix Calendar Errors adding with the Modal [v4.23.x]

### DIFF
--- a/src/components/calendar/calendar-shared.js
+++ b/src/components/calendar/calendar-shared.js
@@ -180,9 +180,9 @@ calendarShared.cleanEventData = function cleanEventData(
   }
 
   if (event.id === undefined && addPlaceholder) {
-    const lastId = this.settings.events.length === 0
+    const lastId = events.length === 0
       ? 0
-      : parseInt(this.settings.events[this.settings.events.length - 1].id, 10);
+      : parseInt(events[events.length - 1].id, 10);
     event.id = (lastId + 1).toString();
   }
 

--- a/test/components/calendar/calendar.e2e-spec.js
+++ b/test/components/calendar/calendar.e2e-spec.js
@@ -5,7 +5,7 @@ requireHelper('rejection');
 
 jasmine.getEnv().addReporter(browserStackErrorReporter);
 
-fdescribe('Calendar index tests', () => {  //eslint-disable-line
+describe('Calendar index tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/calendar/example-index?layout=nofrills');
     const dateField = await element(by.css('.calendar-monthview #monthview-datepicker-field'));

--- a/test/components/calendar/calendar.e2e-spec.js
+++ b/test/components/calendar/calendar.e2e-spec.js
@@ -75,9 +75,21 @@ describe('Calendar index tests', () => {
     await element(by.id('subject')).sendKeys('Test Event');
     await element(by.id('submit')).click();
 
-    const afterCount = await element.all(by.css('.calendar-event')).count();
+    let afterCount = await element.all(by.css('.calendar-event')).count();
 
     expect(afterCount).toEqual(beforeCount + 1);
+
+    await browser.actions().mouseMove(await element(by.cssContainingText('.calendar-event', 'Test Event'))).perform();
+    await browser.actions().click(protractor.Button.RIGHT).perform();
+
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('calendar-actions-menu'))), config.waitsFor);
+
+    await element.all(by.css('.popupmenu-wrapper li a')).first().click();
+
+    afterCount = await element.all(by.css('.calendar-event')).count();
+
+    expect(afterCount).toEqual(beforeCount);
   });
 });
 
@@ -185,7 +197,7 @@ describe('Calendar specific month tests', () => {
   });
 
   it('should offer a right click menu', async () => {
-    expect(await element.all(by.css('.calendar-event')).count()).toEqual(16);
+    expect(await element.all(by.css('.calendar-event')).count()).toEqual(17);
 
     const event = await element.all(by.cssContainingText('.monthview-table td', '1')).first();
     await browser.actions().mouseMove(event).perform();
@@ -197,11 +209,11 @@ describe('Calendar specific month tests', () => {
     expect(await element(by.id('calendar-actions-menu')).getAttribute('class')).toContain('is-open');
     await element.all(by.css('#calendar-actions-menu a')).first().click();
 
-    expect(await element.all(by.css('.calendar-event')).count()).toEqual(15);
+    expect(await element.all(by.css('.calendar-event')).count()).toEqual(16);
   });
 
-  it('should add new events on click and cancel', async () => {
-    expect(await element.all(by.css('.calendar-event')).count()).toEqual(16);
+  it('Should add new events on click and cancel', async () => {
+    expect(await element.all(by.css('.calendar-event')).count()).toEqual(17);
 
     const event = await element.all(by.cssContainingText('.monthview-table td', '1')).first();
     await event.click();
@@ -212,11 +224,11 @@ describe('Calendar specific month tests', () => {
     await element(by.id('subject')).sendKeys('New Event Name');
     await element(by.css('.calendar-popup .btn-close')).click();
 
-    expect(await element.all(by.css('.calendar-event')).count()).toEqual(16);
+    expect(await element.all(by.css('.calendar-event')).count()).toEqual(17);
   });
 
-  it('should add new events on click and submit', async () => {
-    expect(await element.all(by.css('.calendar-event')).count()).toEqual(16);
+  it('Should add new events on click and submit', async () => {
+    expect(await element.all(by.css('.calendar-event')).count()).toEqual(17);
 
     const event = await element.all(by.cssContainingText('.monthview-table td', '1')).first();
     await event.click();
@@ -227,11 +239,11 @@ describe('Calendar specific month tests', () => {
     await element(by.id('subject')).sendKeys('New Event Name');
     await element(by.id('submit')).click();
 
-    expect(await element.all(by.css('.calendar-event')).count()).toEqual(16);
+    expect(await element.all(by.css('.calendar-event')).count()).toEqual(17);
   });
 });
 
-describe('Calendar only calendar', () => {  //eslint-disable-line
+describe('Calendar only calendar', () => {
   beforeEach(async () => {
     await utils.setPage('/components/calendar/example-only-calendar');
     const dateField = await element(by.css('.calendar-monthview #monthview-datepicker-field'));
@@ -335,7 +347,7 @@ describe('Calendar only monthview and legend', () => {
   }
 });
 
-describe('Calendar WeekView settings tests', () => {  //eslint-disable-line
+describe('Calendar WeekView settings tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/calendar/test-weekview-settings?layout=nofrills');
 
@@ -344,12 +356,12 @@ describe('Calendar WeekView settings tests', () => {  //eslint-disable-line
       .wait(protractor.ExpectedConditions.visibilityOf(dateField), config.waitsFor);
   });
 
-  it('Should render without error', async () => {  //eslint-disable-line
+  it('Should render without error', async () => {
     expect(await element.all(by.css('.calendar-event')).count()).toEqual(14);
     await utils.checkForErrors();
   });
 
-  it('Should switch to week', async () => {  //eslint-disable-line
+  it('Should switch to week', async () => {
     expect(await element(by.css('.week-view ')).isDisplayed()).toBe(false);
     const dropdownEl = await element.all(by.css('#calendar-view-changer + .dropdown-wrapper div.dropdown')).first();
     await dropdownEl.sendKeys(protractor.Key.ARROW_DOWN);
@@ -366,7 +378,7 @@ describe('Calendar WeekView settings tests', () => {  //eslint-disable-line
   });
 });
 
-describe('Calendar Switch to Day view', () => {  //eslint-disable-line
+describe('Calendar Switch to Day view', () => {
   beforeEach(async () => {
     await utils.setPage('/components/calendar/test-specific-month?layout=nofrills');
     const dateField = await element(by.css('.calendar-monthview #monthview-datepicker-field'));
@@ -375,13 +387,13 @@ describe('Calendar Switch to Day view', () => {  //eslint-disable-line
   });
 
   it('Should render without error', async () => {
-    expect(await element.all(by.css('.calendar-event')).count()).toEqual(16);
+    expect(await element.all(by.css('.calendar-event')).count()).toEqual(17);
     await utils.checkForErrors();
   });
 
   if (!utils.isCI()) {
     it('Should switch to day', async () => {
-      await browser.driver.sleep(config.sleep);
+      await browser.driver.sleep(config.sleepLonger);
 
       expect(await element(by.css('.week-view')).isDisplayed()).toBe(false);
       await element.all(by.cssContainingText('.monthview-table td', '12')).first().click();
@@ -391,7 +403,7 @@ describe('Calendar Switch to Day view', () => {  //eslint-disable-line
 
       const searchEl = await element(by.css('.dropdown-search'));
       await browser.driver
-        .wait(protractor.ExpectedConditions.presenceOf(searchEl), config.waitsFor);
+        .wait(protractor.ExpectedConditions.visibilityOf(searchEl), config.waitsFor);
 
       await browser.switchTo().activeElement().sendKeys(protractor.Key.ARROW_DOWN);
       await browser.switchTo().activeElement().sendKeys(protractor.Key.ARROW_DOWN);
@@ -399,7 +411,7 @@ describe('Calendar Switch to Day view', () => {  //eslint-disable-line
 
       await browser.driver
         .wait(protractor.ExpectedConditions.visibilityOf(await element.all(by.css('.week-view-table .calendar-event')).last()), config.waitsFor);
-      await browser.driver.sleep(config.sleep);
+      await browser.driver.sleep(config.sleepLonger);
 
       expect(await element(by.css('.week-view-table .calendar-event')).isDisplayed()).toBe(true);
       expect(await element.all(by.css('.week-view-table .calendar-event')).count()).toEqual(1);

--- a/test/components/calendar/calendar.e2e-spec.js
+++ b/test/components/calendar/calendar.e2e-spec.js
@@ -5,12 +5,12 @@ requireHelper('rejection');
 
 jasmine.getEnv().addReporter(browserStackErrorReporter);
 
-describe('Calendar index tests', () => {
+fdescribe('Calendar index tests', () => {  //eslint-disable-line
   beforeEach(async () => {
     await utils.setPage('/components/calendar/example-index?layout=nofrills');
     const dateField = await element(by.css('.calendar-monthview #monthview-datepicker-field'));
     await browser.driver
-      .wait(protractor.ExpectedConditions.presenceOf(dateField), config.waitsFor);
+      .wait(protractor.ExpectedConditions.visibilityOf(dateField), config.waitsFor);
   });
 
   it('Should render without error', async () => {
@@ -65,9 +65,7 @@ describe('Calendar index tests', () => {
 
   it('Should be able to add with the modal', async () => {
     const beforeCount = await element.all(by.css('.calendar-event')).count();
-    await browser.actions()
-      .doubleClick(await element.all(by.cssContainingText('.monthview-table td', '13')).first())
-      .perform();
+    await element.all(by.cssContainingText('.monthview-table td', '13')).first().click();
     await browser.actions()
       .doubleClick(await element.all(by.cssContainingText('.monthview-table td', '13')).first())
       .perform();

--- a/test/components/calendar/calendar.e2e-spec.js
+++ b/test/components/calendar/calendar.e2e-spec.js
@@ -62,6 +62,25 @@ describe('Calendar index tests', () => {
 
     expect(await prevButton.getText()).toEqual('Previous Month');
   });
+
+  it('Should be able to add with the modal', async () => {
+    const beforeCount = await element.all(by.css('.calendar-event')).count();
+    await browser.actions()
+      .doubleClick(await element.all(by.cssContainingText('.monthview-table td', '13')).first())
+      .perform();
+    await browser.actions()
+      .doubleClick(await element.all(by.cssContainingText('.monthview-table td', '13')).first())
+      .perform();
+
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('subject'))), config.waitsFor);
+    await element(by.id('subject')).sendKeys('Test Event');
+    await element(by.id('submit')).click();
+
+    const afterCount = await element.all(by.css('.calendar-event')).count();
+
+    expect(afterCount).toEqual(beforeCount + 1);
+  });
 });
 
 describe('Calendar ajax loading tests', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
When adding the events with a modal, there was an error in a moved/refactored function. This corrects this issue

**Related github/jira issue (required)**:
Fixes #3094 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/calendar/example-index.html
- double click a date
- enter some text on the subject
- press apply
- should add the date and not have any errors in the console

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.