### PR TITLE
2908/2958 - Fix get modified rows method with datagrid

### DIFF
--- a/app/views/components/datagrid/test-new-row-dirty-indicators.html
+++ b/app/views/components/datagrid/test-new-row-dirty-indicators.html
@@ -17,8 +17,8 @@
         <button type="button" id="modified-rows" class="btn">
           <span>Get Modified Rows</span>
         </button>
-        <button type="button" id="modified-rows-data-nodes-only" class="btn">
-          <span>Get Modified Rows(DataNodesOnly)</span>
+        <button type="button" id="modified-rows-only-changed-values" class="btn">
+          <span>Get Modified Rows(onlyChangedValues)</span>
         </button>
       </div>
     </div>
@@ -158,11 +158,11 @@
         console.log(modifiedRows);
         // alert('Number Modified Rows: ' + modifiedRows.length);
       });
-      $('#modified-rows-data-nodes-only').on('click', function () {
-        var modifiedRowsDataNodesOnly = gridApi.getModifiedRows(true);
-        console.log('modifiedRowsDataNodesOnly ++++');
-        console.log(modifiedRowsDataNodesOnly);
-        // alert('Number Modified Rows Data Nodes Only: ' + modifiedRowsDataNodesOnly.length);
+      $('#modified-rows-only-changed-values').on('click', function () {
+        var modifiedRowsOnlyChangedValues = gridApi.getModifiedRows(true);
+        console.log('modifiedRowsOnlyChangedValues ++++');
+        console.log(modifiedRowsOnlyChangedValues);
+        // alert('Number Modified Rows Only Changed Values: ' + modifiedRowsOnlyChangedValues.length);
       });
     });
   });

--- a/app/views/components/datagrid/test-new-row-dirty-indicators.html
+++ b/app/views/components/datagrid/test-new-row-dirty-indicators.html
@@ -1,0 +1,170 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <div role="toolbar" class="toolbar" data-options="{maxVisibleButtons: 4}">
+
+      <div class="title">
+        Example illustrates a bug in that getModifiedRows was not accurate
+       </div>
+
+      <div class="buttonset">
+        <button type="button" id="add-row-top" class="btn">
+          <span>Add Row</span>
+        </button>
+        <button type="button" id="dirty-rows" class="btn">
+          <span>Get Dirty Rows</span>
+        </button>
+        <button type="button" id="modified-rows" class="btn">
+          <span>Get Modified Rows</span>
+        </button>
+        <button type="button" id="modified-rows-data-nodes-only" class="btn">
+          <span>Get Modified Rows(DataNodesOnly)</span>
+        </button>
+      </div>
+    </div>
+
+    <div id="datagrid">
+
+    </div>
+  </div>
+</div>
+
+<script>
+  var gridApi = null;
+
+  $('body').one('initialized', function () {
+
+    Locale.set('en-US').done(function () {
+        var grid,
+          data = [],
+          columns = [],
+          maskOptions,
+
+          //lookup data
+          lookupOptions,
+          lookupData = [],
+          lookupColumns = [];
+
+          // Some Sample Data for Lookup
+          lookupData.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+          lookupData.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+          lookupData.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+          lookupData.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+          lookupData.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+          lookupData.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+          lookupData.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+
+          //Define Columns for the Lookup Grid.
+          lookupColumns.push({ id: 'productId', name: 'Product Id', field: 'productId', width: 140});
+          lookupColumns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', width: 250, formatter: Formatters.Hyperlink});
+          lookupColumns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', width: 125});
+          lookupColumns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', width: 125});
+          lookupColumns.push({ id: 'price', name: 'Price', field: 'price', width: 125, formatter: Formatters.Decimal});
+          lookupColumns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+
+          lookupOptions = {
+            // field: 'productId',
+            field: function (row, field, grid) {
+              return row.productId;
+            },
+            match: function (value, row, field, grid) {
+              return (row.productId) === value;
+            },
+            options: {
+              columns: lookupColumns,
+              dataset: lookupData,
+              selectable: 'single', //multiselect or single
+              toolbar: {title: 'Products', results: true, dateFilter: false ,keywordFilter: false, advancedFilter: true, actions: true, views: true , rowHeight: true}
+            }
+          };
+
+        maskOptions = {
+          patternOptions: {
+            allowDecimal: false,
+            allowNegative: false,
+            allowThousandsSeparator: false,
+            decimalLimit: 0,
+            integerLimit: 7,
+            symbols: {
+              decimal: '.',
+              negative: '-',
+              thousands: ','
+            }
+          },
+          process: "number"
+        };
+
+        // Some Sample Data
+        data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  '<svg/onload=alert(1)>', quantity: 1, price: 210.99, status: 'OK', orderDate:  new Date(2016, 2, 15, 12, 30, 36), portable: false, action: 'ac', description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning'});
+        data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, status: '', orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false, action: 'oh', description: 'The kit has an air blow gun that can be used for cleaning'});
+        data.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity:  'Inspect and Repair', portable: true, quantity: 1, price: 120.992, status: null, orderDate: new Date(2014, 6, 3), action: 'ac'});
+        data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', portable: true, quantity: 3, price: null, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'ac', description: 'Compressor comes with with air tool kit'});
+        data.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'oh'});
+        data.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', portable: false, quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'oh'});
+        data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'oh'});
+
+        //Define Columns for the Grid.
+        columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
+        columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, editorOptions: lookupOptions, maskOptions: maskOptions });
+        columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Ellipsis, editor: Editors.Input });
+        columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, align: 'right', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###.000'});
+        columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date5});
+
+        //Init and get the api for the grid
+        grid = $('#datagrid').datagrid({
+          columns: columns,
+          dataset: data,
+          editable: true,
+          toolbar: { keywordFilter: true, results: true },
+          showDirty: true,
+          clickToSelect: false,
+          actionableMode: true,
+          cellNavigation: true,
+          enableTooltips: true,
+          paging: true,
+          pagesize: 10,
+          selectable: 'multiple',
+          rowHeight: 'short'
+        }).on('cellchange', function (e, args) {
+          console.log('cell changed');
+          // console.log('cellchange - number dirty rows: ' + gridApi.dirtyRows().length);
+        }).on('addrow', function (e, args) {
+          console.log('row added');
+          // console.log(e, args);
+        }).on('rowremove', function (e, args) {
+          console.log('row removed');
+          // console.log(e, args);
+        }).on('exiteditmode', function (e, args) {
+          console.log('exited edit mode');
+          // console.log(e, args);
+        });
+
+        gridApi = $('#datagrid').data('datagrid');
+
+        $('#add-row-top').on('click', function () {
+          gridApi.addRow({ productName: '' }, 0);
+        });
+
+        $('#dirty-rows').on('click', function () {
+          var dirtyRows = gridApi.dirtyRows();
+          console.log('dirtyRows ***');
+          console.log(dirtyRows);
+          // alert('Number Dirty Rows: ' + dirtyRows.length);
+        });
+
+      $('#modified-rows').on('click', function () {
+        var modifiedRows = gridApi.getModifiedRows();
+        console.log('modifiedRows ++++');
+        console.log(modifiedRows);
+        // alert('Number Modified Rows: ' + modifiedRows.length);
+      });
+      $('#modified-rows-data-nodes-only').on('click', function () {
+        var modifiedRowsDataNodesOnly = gridApi.getModifiedRows(true);
+        console.log('modifiedRowsDataNodesOnly ++++');
+        console.log(modifiedRowsDataNodesOnly);
+        // alert('Number Modified Rows Data Nodes Only: ' + modifiedRowsDataNodesOnly.length);
+      });
+    });
+  });
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v4.24.0 Features
 
-- `[Datagrid]` Added support to get data nodes as return array for get modified rows method. ([#2958](https://github.com/infor-design/enterprise/issues/2958))
+- `[Datagrid]` Added support to get only changed values as return array for get modified rows method. ([#2958](https://github.com/infor-design/enterprise/issues/2958))
 
 ### v4.24.0 Fixes
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 ### v4.24.0 Features
 
+- `[Datagrid]` Added support to get data nodes as return array for get modified rows method. ([#2958](https://github.com/infor-design/enterprise/issues/2958))
+
 ### v4.24.0 Fixes
 
+- `[Datagrid]` Fixed an issue where the method getModifiedRows was not working, it had duplicate entries for the same row. ([#2908](https://github.com/infor-design/enterprise/issues/2908))
 - `[Progress]` Added the ability to init the progress and update it to zero, this was previously not working. ([#3020](https://github.com/infor-design/enterprise/issues/3020))
 - `[Toast]` Fixed an issue where the saved position was not working for whole app. ([#3025](https://github.com/infor-design/enterprise/issues/3025))
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9102,10 +9102,10 @@ Datagrid.prototype = {
   /**
   * Return an array containing all of the currently modified rows, the type of modification
   * and the cells that are dirty and the data.
-  * @param  {boolean} isDataNodesOnly If true will return an array of data nodes only
+  * @param  {boolean} onlyChangedValues If true will return an array of only changed values
   * @returns {array} An array showing the dirty row info.
   */
-  getModifiedRows(isDataNodesOnly) {
+  getModifiedRows(onlyChangedValues) {
     const s = this.settings;
     const dataset = s.treeGrid ? s.treeDepth : s.dataset;
     const modified = [];
@@ -9116,8 +9116,8 @@ Datagrid.prototype = {
       // First add the dirty rows
       if (this.isRowDirty(i)) {
         data.type = 'dirty';
-        // No need to run trhu columns loop, if need data nodes only to returns
-        for (let j = 0; (!isDataNodesOnly && (j < this.dirtyArray[i].length)); j++) {
+        // No need to run trhu columns loop, if need only changed values to returns
+        for (let j = 0; (!onlyChangedValues && (j < this.dirtyArray[i].length)); j++) {
           const cellData = this.dirtyArray[i][j];
           if (typeof cellData !== 'undefined' && cellData.isDirty) {
             data.cells.push({ row: i, col: j, cellData });
@@ -9131,7 +9131,7 @@ Datagrid.prototype = {
       }
       // Add to modified
       if (typeof data.type !== 'undefined') {
-        modified.push(isDataNodesOnly ? node : data);
+        modified.push(onlyChangedValues ? node : data);
       }
     }
     return modified;

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9102,41 +9102,36 @@ Datagrid.prototype = {
   /**
   * Return an array containing all of the currently modified rows, the type of modification
   * and the cells that are dirty and the data.
+  * @param  {boolean} isDataNodesOnly If true will return an array of data nodes only
   * @returns {array} An array showing the dirty row info.
   */
-  getModifiedRows() {
+  getModifiedRows(isDataNodesOnly) {
     const s = this.settings;
     const dataset = s.treeGrid ? s.treeDepth : s.dataset;
     const modified = [];
 
-    // First add the dirty rows
-    if (this.dirtyArray && this.dirtyArray.length) {
-      for (let i = 0; i < this.dirtyArray.length; i++) {
-        if (this.dirtyArray[i] === undefined) {
-          continue;
-        }
-
-        const data = {
-          data: s.treeGrid ? dataset[i].node : dataset[i],
-          row: i,
-          type: 'dirty',
-          cells: []
-        };
-
-        for (let j = 0; j < this.dirtyArray[i].length; j++) {
-          if (this.dirtyArray[i][j] !== undefined) {
-            data.cells.push(this.dirtyArray[i][j]);
+    for (let i = 0; i < dataset.length; i++) {
+      const node = s.treeGrid ? dataset[i].node : dataset[i];
+      const data = { row: i, data: node, cells: [] };
+      // First add the dirty rows
+      if (this.isRowDirty(i)) {
+        data.type = 'dirty';
+        // No need to run trhu columns loop, if need data nodes only to returns
+        for (let j = 0; (!isDataNodesOnly && (j < this.dirtyArray[i].length)); j++) {
+          const cellData = this.dirtyArray[i][j];
+          if (typeof cellData !== 'undefined' && cellData.isDirty) {
+            data.cells.push({ row: i, col: j, cellData });
           }
         }
-        modified.push(data);
       }
-    }
-
-    // Now add error and in progress rows
-    for (let i = 0; i < dataset.length; i++) {
-      const el = dataset[i];
-      if (el.rowStatus !== undefined && (el.rowStatus.icon === 'error' || el.rowStatus.icon === 'in-progress')) {
-        modified.push({ data: el, row: i, type: el.rowStatus.icon, cells: [] });
+      // Now add error and in progress rows
+      if (typeof node.rowStatus !== 'undefined' &&
+        (node.rowStatus.icon === 'error' || node.rowStatus.icon === 'in-progress')) {
+        data.type = data.type === 'dirty' ? ['dirty', node.rowStatus.icon] : node.rowStatus.icon;
+      }
+      // Add to modified
+      if (typeof data.type !== 'undefined') {
+        modified.push(isDataNodesOnly ? node : data);
       }
     }
     return modified;
@@ -9429,6 +9424,29 @@ Datagrid.prototype = {
   },
 
   /**
+   * Function to check if given row has true value for isDirty in any cell in it
+   * @private
+   * @param {number} rowIndex The row index
+   * @returns {boolean} true if isDirty
+   */
+  isRowDirty(rowIndex) {
+    let isDirty = false;
+    if (typeof rowIndex === 'number' && this.dirtyArray && this.dirtyArray.length) {
+      const row = this.dirtyArray[rowIndex];
+      if (typeof row !== 'undefined') {
+        for (let i = 0, l = row.length; i < l; i++) {
+          const col = row[i];
+          if (typeof col !== 'undefined' && col.isDirty) {
+            isDirty = true;
+            break;
+          }
+        }
+      }
+    }
+    return isDirty;
+  },
+
+  /**
    * Function to check if given cell has true value for isDirty
    * @private
    * @param {number} row The row index
@@ -9502,7 +9520,7 @@ Datagrid.prototype = {
       this.addToDirtyArray(row, cell, data);
     }
 
-    if (row < 0 || cell < 0) {
+    if (row < 0 || cell < 0 || !cellNode.length) {
       return;
     }
 
@@ -9587,13 +9605,12 @@ Datagrid.prototype = {
     if (row instanceof jQuery) {
       row = row.attr('aria-rowindex') - 1;
     }
-    const leftNodes = this.tableBodyLeft ? this.tableBodyLeft.find(`tr[aria-rowindex="${row + 1}"]`) : $();
-    const centerNodes = this.tableBody.find(`tr[aria-rowindex="${row + 1}"]`);
-    const rightNodes = this.tableBodyRight ? this.tableBodyRight.find(`tr[aria-rowindex="${row + 1}"]`) : $();
+    const getRow = el => (el ? el.find(`tr[aria-rowindex="${row + 1}"]`) : $());
+    const leftNodes = getRow(this.tableBodyLeft);
+    const centerNodes = getRow(this.tableBody);
+    const rightNodes = getRow(this.tableBodyRight);
 
-    return $(centerNodes)
-      .add(leftNodes)
-      .add(rightNodes);
+    return $(centerNodes).add(leftNodes).add(rightNodes);
   },
 
   /**

--- a/test/components/datagrid/datagrid-editing.func-spec.js
+++ b/test/components/datagrid/datagrid-editing.func-spec.js
@@ -78,17 +78,42 @@ describe('Datagrid Editing API', () => {
 
     const modifiedRows = datagridObj.getModifiedRows();
 
-    expect(modifiedRows.length).toEqual(5);
+    expect(modifiedRows.length).toEqual(4);
     expect(modifiedRows[0].type).toEqual('dirty');
     expect(modifiedRows[0].cells.length).toEqual(1);
-    expect(modifiedRows[0].cells[0].isDirty).toEqual(true);
-    expect(modifiedRows[0].cells[0].column.id).toEqual('portable');
-    expect(modifiedRows[0].cells[0].originalVal).toEqual(false);
-    expect(modifiedRows[0].cells[0].value).toEqual(true);
+    expect(modifiedRows[0].cells[0].cellData.isDirty).toEqual(true);
+    expect(modifiedRows[0].cells[0].cellData.column.id).toEqual('portable');
+    expect(modifiedRows[0].cells[0].cellData.originalVal).toEqual(false);
+    expect(modifiedRows[0].cells[0].cellData.value).toEqual(true);
+    expect(modifiedRows[0].cells[0].row).toEqual(0);
+    expect(modifiedRows[0].cells[0].col).toEqual(5);
 
     expect(modifiedRows[1].type).toEqual('dirty');
-    expect(modifiedRows[2].type).toEqual('dirty');
-    expect(modifiedRows[3].type).toEqual('in-progress');
-    expect(modifiedRows[4].type).toEqual('error');
+    expect(modifiedRows[2].type).toEqual(['dirty', 'in-progress']);
+    expect(modifiedRows[3].type).toEqual('error');
+  });
+
+  it('Should be able to get all modified rows data nodes only', () => {
+    // Make a 3 cells dirty
+    datagridObj.addToDirtyArray(0, 5, { originalVal: false, isDirty: false });
+    datagridObj.updateCellNode(0, 5, true, false);
+    datagridObj.addToDirtyArray(1, 5, { originalVal: false, isDirty: false });
+    datagridObj.updateCellNode(1, 5, true, false);
+    datagridObj.addToDirtyArray(2, 5, { originalVal: false, isDirty: false });
+    datagridObj.updateCellNode(2, 5, true, false);
+
+    expect(document.body.querySelectorAll('.is-dirty-cell').length).toEqual(3);
+    // Add an error row and an in progress row
+    datagridObj.rowStatus(2, 'in-progress', 'Row Is In Progress');
+    datagridObj.rowStatus(3, 'error', 'Row has an error');
+
+    const modifiedRows = datagridObj.getModifiedRows(true);
+
+    expect(modifiedRows.length).toEqual(4);
+    expect(modifiedRows[0].portable).toEqual(true);
+    expect(modifiedRows[1].portable).toEqual(true);
+    expect(modifiedRows[2].portable).toEqual(true);
+    expect(modifiedRows[2].rowStatus.icon).toEqual('in-progress');
+    expect(modifiedRows[3].rowStatus.icon).toEqual('error');
   });
 });

--- a/test/components/datagrid/datagrid-editing.func-spec.js
+++ b/test/components/datagrid/datagrid-editing.func-spec.js
@@ -93,7 +93,7 @@ describe('Datagrid Editing API', () => {
     expect(modifiedRows[3].type).toEqual('error');
   });
 
-  it('Should be able to get all modified rows data nodes only', () => {
+  it('Should be able to get all modified rows only changed values', () => {
     // Make a 3 cells dirty
     datagridObj.addToDirtyArray(0, 5, { originalVal: false, isDirty: false });
     datagridObj.updateCellNode(0, 5, true, false);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed getModifiedRows() method was not working with Datagrid. It had duplicate entries for the same row.
Added support to get Only Changed Values as return array for get modified rows method.

**Related github/jira issue (required)**:
Closes #2908
Closes #2958

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app

issue# 2908
- Navigate to http://localhost:4000/components/datagrid/test-dirty-change-cell-externally.html
- Open developer tools
- Click on button `Change Cell` on top of grid
- See in console, should return only one entry in results array

issue# 2958
- Navigate to http://localhost:4000/components/datagrid/test-new-row-dirty-indicators.html
- Open developer tools
- Click on `Add Row` toolbar button
- Tab across all the cells in new row without making any cell changes
- Click on `Get Modified Rows` toolbar button
- See in console, should return empty array
- Edit any cells and 
- Click on `Get Modified Rows` toolbar button
- See in console, should return the modified entry in results array(with data + other info type, row, col etc.)
- Click on `Get Modified Rows(onlyChangedValues)` toolbar button
- See in console, should return the modified entry in results array(with Only Changed Values)

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
