### PR TITLE
3139 - Fixed problems with empty message click

### DIFF
--- a/app/views/components/emptymessage/test-button-click.html
+++ b/app/views/components/emptymessage/test-button-click.html
@@ -1,0 +1,40 @@
+<div class="row">
+  <div class="four columns">
+    <div class="card is-empty">
+      <div class="card-header">
+        <h2 class="widget-title">Projects</h2>
+        <button class="btn-actions" type="button">
+          <span class="audible">Actions</span>
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-more"></use>
+          </svg>
+        </button>
+        <ul class="popupmenu actions top">
+          <li><a href="#">Action One</a></li>
+          <li><a href="#">Action Two</a></li>
+        </ul>
+      </div>
+      <div class="card-content">
+        <div id="empty-message">
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').on('initialized', function () {
+    $('#empty-message').emptymessage({
+      title: 'No Data Available',
+      icon: 'icon-empty-no-data',
+      info: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do siusmod temp.',
+      button: {
+        id: 'test',
+        text: 'Retry',
+        click: () => {
+          $('body').toast({title: 'Button Clicked', message: 'The button click event works.'});
+        }
+      }
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Datagrid]` Fixed an issue where the method getModifiedRows was not working, it had duplicate entries for the same row. ([#2908](https://github.com/infor-design/enterprise/issues/2908))
 - `[Datepicker]` Fixed missing background color on disable dates and adjusted the colors in all themes. ([#2910](https://github.com/infor-design/enterprise/issues/2910))
 - `[Datepicker]` Fixed a layout issue on the focus state on colored/legend days. ([#2910](https://github.com/infor-design/enterprise/issues/2910))
+- `[EmptyMessage]` Added a fix so that click will only fire on the button part of the empty message. ([#3139](https://github.com/infor-design/enterprise/issues/3139))
 - `[Modal]` Added a new setting `overlayOpacity` that give the user to control the opacity level of the modal/message dialog overlay. ([#2975](https://github.com/infor-design/enterprise/issues/2975))
 - `[Progress]` Added the ability to init the progress and update it to zero, this was previously not working. ([#3020](https://github.com/infor-design/enterprise/issues/3020))
 - `[Toast]` Fixed an issue where the saved position was not working for whole app. ([#3025](https://github.com/infor-design/enterprise/issues/3025))

--- a/src/components/emptymessage/emptymessage.js
+++ b/src/components/emptymessage/emptymessage.js
@@ -78,7 +78,7 @@ EmptyMessage.prototype = {
         '</div>').appendTo(this.element);
 
       if (opts.button.click) {
-        this.element.on('click', opts.button.click);
+        this.element.on('click', 'button', opts.button.click);
       }
     }
 
@@ -104,6 +104,7 @@ EmptyMessage.prototype = {
   destroy() {
     $.removeData(this.element[0], COMPONENT_NAME);
     this.element.empty();
+    this.element.removeClass('empty-message');
   }
 };
 

--- a/test/components/emptymessage/emptymessage-api.func-spec.js
+++ b/test/components/emptymessage/emptymessage-api.func-spec.js
@@ -1,0 +1,107 @@
+import { EmptyMessage } from '../../../src/components/emptymessage/emptymessage';
+import { cleanup } from '../../helpers/func-utils';
+
+const svg = require('../../../src/components/icons/theme-soho-svg.html');
+const svgEmpty = require('../../../src/components/emptymessage/theme-soho-svg-empty.html');
+
+const emptymessageHTML = `<div class="row">
+  <div class="four columns">
+    <div class="card is-empty">
+      <div class="card-header">
+        <h2 class="widget-title">Projects</h2>
+        <button class="btn-actions" type="button">
+          <span class="audible">Actions</span>
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-more"></use>
+          </svg>
+        </button>
+        <ul class="popupmenu actions top">
+          <li><a href="#">Action One</a></li>
+          <li><a href="#">Action Two</a></li>
+        </ul>
+      </div>
+      <div class="card-content">
+        <div id="empty-message">
+        </div>
+      </div>
+    </div>
+  </div>
+</div>`;
+
+let emptymessageEl;
+let emptymessageObj;
+
+const settings = {
+  title: 'No Data Available',
+  icon: 'icon-empty-no-data',
+  info: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do siusmod temp.',
+  button: {
+    id: 'test',
+    text: 'Retry'
+  }
+};
+
+describe('EmptyMessage API', () => { //eslint-disable-line
+  beforeEach(() => {
+    emptymessageEl = null;
+    emptymessageObj = null;
+    document.body.insertAdjacentHTML('afterbegin', svg);
+    document.body.insertAdjacentHTML('afterbegin', svgEmpty);
+    document.body.insertAdjacentHTML('afterbegin', emptymessageHTML);
+    emptymessageEl = document.body.querySelector('#empty-message');
+
+    emptymessageObj = new EmptyMessage(emptymessageEl, settings);
+  });
+
+  afterEach(() => {
+    emptymessageObj.destroy();
+    cleanup([
+      '.row',
+      '.svg-icons'
+    ]);
+  });
+
+  it('Should render emptymessage', () => {
+    expect(emptymessageObj).toEqual(jasmine.any(Object));
+
+    expect(emptymessageEl.classList.contains('empty-message')).toBeTruthy();
+    expect(document.body.querySelector('.empty-icon')).toBeTruthy();
+    expect(document.body.querySelector('.empty-title')).toBeTruthy();
+    expect(document.body.querySelector('.empty-info')).toBeTruthy();
+    expect(document.body.querySelector('.empty-actions')).toBeTruthy();
+  });
+
+  it('Should be able to destroy', () => {
+    emptymessageObj.destroy();
+
+    expect(emptymessageEl.classList.contains('empty-message')).toEqual(false);
+    expect(document.body.querySelector('.empty-icon')).toBeFalsy();
+    expect(document.body.querySelector('.empty-title')).toBeFalsy();
+    expect(document.body.querySelector('.empty-info')).toBeFalsy();
+    expect(document.body.querySelector('.empty-actions')).toBeFalsy();
+    expect($(emptymessageEl).data('.emptymessage')).toBeFalsy();
+  });
+
+  it('Should fire the click event from settings', (done) => {
+    emptymessageObj.destroy();
+    emptymessageObj = new EmptyMessage(emptymessageEl, {
+      title: 'No Data Available',
+      icon: 'icon-empty-no-data',
+      info: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do siusmod temp.',
+      button: {
+        id: 'test',
+        text: 'Retry',
+        click: (e) => {
+          expect(e).toBeTruthy();
+          done();
+        }
+      }
+    });
+
+    const buttonSelector = '.empty-message button';
+    const spyEvent = spyOnEvent($(buttonSelector), 'click');
+    document.body.querySelector(buttonSelector).click();
+
+    expect(spyEvent).toHaveBeenTriggered();
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The empty message button click setting fired no matter where you clicked. This is incorrect, so i fixed it.

**Related github/jira issue (required)**:
Fixed #3139 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/emptymessage/test-button-click.html
- click the button and notice a toast
- click anywhere else in the widget and notice no toasts.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
