### PR TITLE
3004 - Fix personalized columns with datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `[Datagrid]` Fixed an issue where the dirty cell indicator was not updating after remove row. ([#2960](https://github.com/infor-design/enterprise/issues/2960))
 - `[Datagrid]` Fixed an issue where the method getModifiedRows was not working, it had duplicate entries for the same row. ([#2908](https://github.com/infor-design/enterprise/issues/2908))
+- `[Datagrid]` Fixed an issue where the personalized columns were not working when toggle columns and drag drop. ([#3004](https://github.com/infor-design/enterprise/issues/3004))
 - `[Datepicker]` Fixed missing background color on disable dates and adjusted the colors in all themes. ([#2910](https://github.com/infor-design/enterprise/issues/2910))
 - `[Datepicker]` Fixed a layout issue on the focus state on colored/legend days. ([#2910](https://github.com/infor-design/enterprise/issues/2910))
 - `[Dropdown]` Fix a bug where a dropdown in a datagrid cell would sometimes not display the correct value when selected. ([#2919](https://github.com/infor-design/enterprise/issues/2919))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5287,7 +5287,7 @@ Datagrid.prototype = {
             searchableTextCallback: item => item.name
           }
         })
-        .on('selected', (selectedEvent, args) => {
+        .on('selected', function (selectedEvent, args) {
           const chk = args.elem.find('.checkbox');
           const id = chk.attr('data-column-id');
           const isChecked = chk.prop('checked');
@@ -5299,12 +5299,23 @@ Datagrid.prototype = {
           }
           self.isColumnsChanged = true;
 
+          // Set listview dataset node state, to be in sync after filtering
+          const lv = { node: {}, api: $(this).data('listview') };
+          if (lv.api) {
+            const idx = self.columnIdxById(id);
+            if (idx !== -1 && lv.api.settings.dataset[idx]) {
+              lv.node = lv.api.settings.dataset[idx];
+            }
+          }
+
           if (!isChecked) {
             self.showColumn(id);
             chk.prop('checked', true);
+            lv.node.hidden = false;
           } else {
             self.hideColumn(id);
             chk.prop('checked', false);
+            lv.node.hidden = true;
           }
         });
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5184,6 +5184,12 @@ Datagrid.prototype = {
     // Shrink or add colgroups
     this.updateColumnGroup();
 
+    // Handle initially hidden column
+    if (this.headerWidths[idx] && this.headerWidths[idx].width < 1) {
+      this.clearHeaderCache();
+      this.syncColGroups();
+    }
+
     // Handle colSpans if present on the column
     if (this.hasColSpans) {
       let colSpan = this.headerContainer.find('th').eq(idx).attr('colspan');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed personalized columns were not working when toggle columns and drag drop with Datagrid.

**Related github/jira issue (required)**:
Closes #3004

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/example-export-from-button.html
- Click on toolbar button `...` then click on `Personalized Columns`
- In personalized modal window uncheck `Quantity` and `Status`
- Click on `Close` to close the modal window
- Drag and Drop the column `Action Item` (could be any column) to where column `Quantity` was located
- Click again on toolbar button `...` then click on `Personalized Columns`
- In personalized modal window  make checked on `Quantity` and `Status`
- Click on `Close` to close the modal window
- Both columns `Quantity` and `Status` should be visible at this point

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
