### PR TITLE
3012 - Fix group filter after sort with datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Datagrid]` Fixed an issue where the dirty cell indicator was not updating after remove row. ([#2960](https://github.com/infor-design/enterprise/issues/2960))
 - `[Datagrid]` Fixed an issue where the method getModifiedRows was not working, it had duplicate entries for the same row. ([#2908](https://github.com/infor-design/enterprise/issues/2908))
 - `[Datagrid]` Fixed an issue where the personalized columns were not working when toggle columns and drag drop. ([#3004](https://github.com/infor-design/enterprise/issues/3004))
+- `[Datagrid]` Fixed an issue where the grouping filter was not working after do sort. ([#3012](https://github.com/infor-design/enterprise/issues/3012))
 - `[Datepicker]` Fixed missing background color on disable dates and adjusted the colors in all themes. ([#2910](https://github.com/infor-design/enterprise/issues/2910))
 - `[Datepicker]` Fixed a layout issue on the focus state on colored/legend days. ([#2910](https://github.com/infor-design/enterprise/issues/2910))
 - `[Dropdown]` Fix a bug where a dropdown in a datagrid cell would sometimes not display the correct value when selected. ([#2919](https://github.com/infor-design/enterprise/issues/2919))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3111,6 +3111,20 @@ Datagrid.prototype = {
 
       // Handle Grouping
       if (this.settings.groupable) {
+        // Filter and sorted
+        if (s.dataset[i].values) {
+          const thisLength = s.dataset[i].values.length;
+          let thisFilterCount = 0;
+          for (let k = 0; k < thisLength; k++) {
+            if (s.dataset[i].values[k].isFiltered) {
+              thisFilterCount++;
+            }
+          }
+          if (thisFilterCount === thisLength) {
+            continue; //eslint-disable-line
+          }
+        }
+
         // First push group row
         if (!this.settings.groupable.suppressGroupRow) {
           // Show the grouping row

--- a/test/components/datagrid/datagrid-filtering.func-spec.js
+++ b/test/components/datagrid/datagrid-filtering.func-spec.js
@@ -5,8 +5,10 @@ import { Editors } from '../../../src/components/datagrid/datagrid.editors';
 const datagridHTML = require('../../../app/views/components/datagrid/example-index.html');
 const svg = require('../../../src/components/icons/svg.html');
 const originalData = require('../../../app/data/datagrid-sample-data');
+const originalGroupingData = require('../../../app/data/accounts');
 
 let data = [];
+let groupingData = [];
 require('../../../src/components/locale/cultures/en-US.js');
 
 let datagridEl;
@@ -27,6 +29,16 @@ columns.push({ id: 'percent', align: 'right', name: 'Actual %', field: 'percent'
 columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', reorderable: true, formatter: Formatters.Date, dateFormat: 'M/d/yyyy' });
 columns.push({ id: 'phone', name: 'Phone', field: 'phone', reorderable: true, filterType: 'Text', formatter: Formatters.Text });
 columns.push({ id: 'inStock', name: 'In Stock', field: 'inStock', reorderable: false, filterType: 'Checkbox', formatter: Formatters.Checkbox });
+
+// Define Grouping Columns for the Grid.
+const groupingColumns = [];
+groupingColumns.push({ id: 'id', name: 'Customer Id', field: 'id', filterType: 'text' });
+groupingColumns.push({ id: 'type', name: 'Type', field: 'type', filterType: 'text' });
+groupingColumns.push({ id: 'location', name: 'Location', field: 'location', formatter: Formatters.Hyperlink, filterType: 'text' });
+groupingColumns.push({ id: 'firstname', name: 'First Name', field: 'firstname', filterType: 'text' });
+groupingColumns.push({ id: 'lastname', name: 'Last Name', field: 'lastname', filterType: 'text' });
+groupingColumns.push({ id: 'phone', name: 'Phone', field: 'phone', filterType: 'text' });
+groupingColumns.push({ id: 'purchases', name: 'Purchases', field: 'purchases', filterType: 'text' });
 
 describe('Datagrid Filter API', () => {
   const Locale = window.Soho.Locale;
@@ -215,5 +227,32 @@ describe('Datagrid Filter API', () => {
     expect(document.body.querySelectorAll('tbody tr').length).toEqual(7);
     expect(document.querySelectorAll('.is-dirty-cell').length).toEqual(0);
     expect(cell1.classList.contains('is-dirty-cell')).toBeFalsy();
+  });
+
+  it('Should be able to filter and sort with grouping', () => {
+    datagridObj.destroy();
+    groupingData = JSON.parse(JSON.stringify(originalGroupingData));
+    datagridObj = new Datagrid(datagridEl, {
+      columns: groupingColumns,
+      dataset: groupingData,
+      filterable: true,
+      groupable: { fields: ['type'], expanded: true, aggregator: 'sum' },
+      toolbar: { title: 'Accounts', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: false }
+    });
+
+    expect(document.body.querySelectorAll('tbody tr[role="row"]').length).toEqual(16);
+    expect(document.body.querySelectorAll('tbody tr[role="rowgroup"]').length).toEqual(7);
+
+    let filter = [];
+    filter = [{ columnId: 'location', operator: 'contains', value: 'USA' }];
+    datagridObj.applyFilter(filter);
+
+    expect(document.body.querySelectorAll('tbody tr[role="row"]').length).toEqual(7);
+    expect(document.body.querySelectorAll('tbody tr[role="rowgroup"]').length).toEqual(5);
+
+    datagridObj.setSortColumn('location', true);
+
+    expect(document.body.querySelectorAll('tbody tr[role="row"]').length).toEqual(7);
+    expect(document.body.querySelectorAll('tbody tr[role="rowgroup"]').length).toEqual(5);
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed grouping filter was not working after do sort with Datagrid.

**Related github/jira issue (required)**:
Closes #3012

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/example-grouping-filter.html
- Use column `Location` to filter `USA`
- Should filter accordingly
- Click any column header to sort the list (ascending/descending)
- Should keep filter and sorted result

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
