### PR TITLE
3159 - Prevent Sparkline Chart from throwing errors during a theme change

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,7 +31,7 @@
 - `[Locale]` Fixed a problem in fi-FI where some date formats where incorrect with one digit days. ([#3019](https://github.com/infor-design/enterprise/issues/3019))
 - `[Modal]` Added a new setting `overlayOpacity` that give the user to control the opacity level of the modal/message dialog overlay. ([#2975](https://github.com/infor-design/enterprise/issues/2975))
 - `[Progress]` Added the ability to init the progress and update it to zero, this was previously not working. ([#3020](https://github.com/infor-design/enterprise/issues/3020))
-- `[Sparkline Chart]` Fixed an issue where an error was thrown while a sparkline chart was present during a theme chnage. ([#3159])(https://github.com/infor-design/enterprise/issues/3159)
+- `[Sparkline Chart]` Fixed an issue where an error was thrown while a sparkline chart was present during a theme chnage. ([#3159](https://github.com/infor-design/enterprise/issues/3159))
 - `[Toast]` Fixed an issue where the saved position was not working for whole app. ([#3025](https://github.com/infor-design/enterprise/issues/3025))
 
 ### v4.24.0 Chores & Maintenance

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `[Locale]` Fixed a problem in fi-FI where some date formats where incorrect with one digit days. ([#3019](https://github.com/infor-design/enterprise/issues/3019))
 - `[Modal]` Added a new setting `overlayOpacity` that give the user to control the opacity level of the modal/message dialog overlay. ([#2975](https://github.com/infor-design/enterprise/issues/2975))
 - `[Progress]` Added the ability to init the progress and update it to zero, this was previously not working. ([#3020](https://github.com/infor-design/enterprise/issues/3020))
+- `[Sparkline Chart]` Fixed an issue where an error was thrown while a sparkline chart was present during a theme chnage. ([#3159])(https://github.com/infor-design/enterprise/issues/3159)
 - `[Toast]` Fixed an issue where the saved position was not working for whole app. ([#3025](https://github.com/infor-design/enterprise/issues/3025))
 
 ### v4.24.0 Chores & Maintenance

--- a/src/components/sparkline/sparkline.js
+++ b/src/components/sparkline/sparkline.js
@@ -315,8 +315,8 @@ Sparkline.prototype = {
    * @private
    */
   handleEvents() {
-    this.element.on(`updated.${COMPONENT_NAME}`, () => {
-      this.updated();
+    this.element.on(`updated.${COMPONENT_NAME}`, (e, settings) => {
+      this.updated(settings);
     });
 
     if (this.settings.redrawOnResize) {
@@ -361,9 +361,9 @@ Sparkline.prototype = {
    * @returns {object} The api for chaining.
    */
   updated(settings) {
-    const type = (settings && settings.type) || this.settings.type;
-    this.settings = settings;
-    this.settings.type = type;
+    if (settings) {
+      this.settings = utils.mergeSettings(this.element[0], settings, this.settings);
+    }
     this.element.empty();
 
     return this


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a small bug in the Sparkline Chart, where changing themes using the personalization API would cause the chart to throw a JS error.  This is due to a bug in how the `updated()` method previously handled transforming incoming settings.

This PR also makes it possible to pass a `settings` object as a second argument if triggering an `updated` event on the Sparkline chart.

**Related github/jira issue (required)**:
Closes #3159

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the app
- Open http://localhost:4000/components/sparkline/example-index.html
- Use the theme changer to switch to "Vibrant" theme.
- Open a dev tools console and make sure no errors were thrown.

**Included in this Pull Request**:
- [x] A note to the change log.
