### PR TITLE
2696 - Fix truncating of leading zeros

### DIFF
--- a/app/views/components/datagrid/test-custom-date-formats.html
+++ b/app/views/components/datagrid/test-custom-date-formats.html
@@ -1,0 +1,59 @@
+
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="contextual-toolbar toolbar is-hidden">
+      <div class="title selection-count">1 Selected</div>
+      <div class="buttonset">
+        <button class="btn" type="button">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-delete"></use>
+          </svg>
+          <span>Remove</span>
+        </button>
+      </div>
+    </div>
+
+    <div id="datagrid">
+
+    </div>
+  </div>
+</div>
+
+<script>
+  var gridApi = null;
+
+  $('body').one('initialized', function () {
+    var grid,
+        data = [],
+        columns = [];
+
+      // Some Sample Data
+      data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  '<svg/onload=alert(1)>', quantity: 1, price: 210.99, status: 'OK', state:'California', orderDate:  new Date(2016, 2, 15, 12, 30, 36, 120), portable: false, description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning'});
+      data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, status: '', state:'Oklahoma', orderDate: new Date(2016, 2, 15, 0, 30, 36, 010), portable: false, description: 'The kit has an air blow gun that can be used for cleaning'});
+      data.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity:  'Inspect and Repair', portable: true, quantity: 1, price: 120.992, status: null, state:'Wisconsin', orderDate: new Date(2014, 6, 3, 001)});
+      data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', portable: true, quantity: 3, price: null, status: 'OK', state:'Michigan', orderDate: new Date(2015, 3, 3), description: 'Compressor comes with with air tool kit'});
+      data.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, status: 'OK', state:'Northern Mariana Island Teritory', orderDate: new Date(2015, 5, 5)});
+      data.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', portable: false, quantity: 41, price: 120.99, status: 'OK', state:'New York', orderDate: new Date(2014, 6, 9)});
+      data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', state:'Idaho', orderDate: new Date(2014, 6, 9)});
+      data.push({ id: 8, productId: 2642207, productName: 'Some Compressor', activity:  'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', state:'Idaho', orderDate: '2015-01-02T06:00:00.120Z'});
+
+      // Define Columns for the Grid.
+      columns.push({ id: 'orderDate', name: 'Date (Normal)', field: 'orderDate', formatter: Formatters.Date,filterType: 'date'});
+      columns.push({ id: 'orderDate1', name: 'Date (Time 24hr)', field: 'orderDate', formatter: Formatters.Date, filterType: 'date', dateFormat: 'M/d/yyyy HH:mm:ss'});
+      columns.push({ id: 'orderDate2', name: 'Date (Time Am/Pm)', field: 'orderDate', formatter: Formatters.Date, filterType: 'date', dateFormat: Locale.calendar().dateFormat.datetime});
+      columns.push({ id: 'orderDate3', name: 'Date (Time Seconds)', field: 'orderDate', formatter: Formatters.Date, filterType: 'date', dateFormat: 'yyyy-MM-ddTHH:mm:ss.SSS'});
+      columns.push({ id: 'orderDate4', name: 'Date (Normal w settings)', field: 'orderDate', formatter: Formatters.Date, dateFormat: Locale.calendar().dateFormat.date});
+      columns.push({ id: 'orderTime', name: 'Order Time', field: 'orderDate', formatter: Formatters.Time, filterType: 'time', timeFormat: Locale.calendar().dateFormat.timestamp});
+
+      // Init and get the api for the grid
+      $('#datagrid').datagrid({
+        columns: columns,
+        dataset: data,
+        editable: false,
+        filterable: false,
+        toolbar: {title: 'Compressors', results: true, actions: true, rowHeight: true}
+      });
+  });
+
+</script>

--- a/app/views/components/datagrid/test-custom-date-formats.html
+++ b/app/views/components/datagrid/test-custom-date-formats.html
@@ -42,7 +42,7 @@
       columns.push({ id: 'orderDate', name: 'Date (Normal)', field: 'orderDate', formatter: Formatters.Date,filterType: 'date'});
       columns.push({ id: 'orderDate1', name: 'Date (Time 24hr)', field: 'orderDate', formatter: Formatters.Date, filterType: 'date', dateFormat: 'M/d/yyyy HH:mm:ss'});
       columns.push({ id: 'orderDate2', name: 'Date (Time Am/Pm)', field: 'orderDate', formatter: Formatters.Date, filterType: 'date', dateFormat: Locale.calendar().dateFormat.datetime});
-      columns.push({ id: 'orderDate3', name: 'Date (Time Seconds)', field: 'orderDate', formatter: Formatters.Date, filterType: 'date', dateFormat: 'yyyy-MM-ddTHH:mm:ss.SSS'});
+      columns.push({ id: 'orderDate3', name: 'Date (Time Millis)', field: 'orderDate', formatter: Formatters.Date, filterType: 'date', dateFormat: 'yyyy-MM-ddTHH:mm:ss.SSS'});
       columns.push({ id: 'orderDate4', name: 'Date (Normal w settings)', field: 'orderDate', formatter: Formatters.Date, dateFormat: Locale.calendar().dateFormat.date});
       columns.push({ id: 'orderTime', name: 'Order Time', field: 'orderDate', formatter: Formatters.Time, filterType: 'time', timeFormat: Locale.calendar().dateFormat.timestamp});
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,7 +29,7 @@
 - `[Editor]` Fixed many memory leaks related to view swapping and `destroy()` in the Editor. ([#3112](https://github.com/infor-design/enterprise/issues/3112))
 - `[EmptyMessage]` Added a fix so that click will only fire on the button part of the empty message. ([#3139](https://github.com/infor-design/enterprise/issues/3139))
 - `[Locale]` Fixed a problem in fi-FI where some date formats where incorrect with one digit days. ([#3019](https://github.com/infor-design/enterprise/issues/3019))
-- `[Locale]` Fixed an where formating milliseconds with SSS would truncate the leading zeros incorrectly. ([#2696](https://github.com/infor-design/enterprise/issues/2696))
+- `[Locale]` Fixed an issue when formatting with `SSS` in the format string, the leading zeros were incorrectly removed from the millisecond output. ([#2696](https://github.com/infor-design/enterprise/issues/2696))
 - `[Modal]` Added a new setting `overlayOpacity` that give the user to control the opacity level of the modal/message dialog overlay. ([#2975](https://github.com/infor-design/enterprise/issues/2975))
 - `[Progress]` Added the ability to init the progress and update it to zero, this was previously not working. ([#3020](https://github.com/infor-design/enterprise/issues/3020))
 - `[Toast]` Fixed an issue where the saved position was not working for whole app. ([#3025](https://github.com/infor-design/enterprise/issues/3025))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `[Editor]` Fixed many memory leaks related to view swapping and `destroy()` in the Editor. ([#3112](https://github.com/infor-design/enterprise/issues/3112))
 - `[EmptyMessage]` Added a fix so that click will only fire on the button part of the empty message. ([#3139](https://github.com/infor-design/enterprise/issues/3139))
 - `[Locale]` Fixed a problem in fi-FI where some date formats where incorrect with one digit days. ([#3019](https://github.com/infor-design/enterprise/issues/3019))
+- `[Locale]` Fixed an where formating milliseconds with SSS would truncate the leading zeros incorrectly. ([#2696](https://github.com/infor-design/enterprise/issues/2696))
 - `[Modal]` Added a new setting `overlayOpacity` that give the user to control the opacity level of the modal/message dialog overlay. ([#2975](https://github.com/infor-design/enterprise/issues/2975))
 - `[Progress]` Added the ability to init the progress and update it to zero, this was previously not working. ([#3020](https://github.com/infor-design/enterprise/issues/3020))
 - `[Toast]` Fixed an issue where the saved position was not working for whole app. ([#3025](https://github.com/infor-design/enterprise/issues/3025))

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -583,7 +583,7 @@ const Locale = {  // eslint-disable-line
     ret = ret.replace('H', hours);
     ret = ret.replace('mm', this.pad(mins, 2));
     ret = ret.replace('ss', this.pad(seconds, 2));
-    ret = ret.replace('SSS', this.pad(millis, 0));
+    ret = ret.replace('SSS', this.pad(millis, 3));
 
     // months
     ret = ret.replace('MMMM', cal ? cal.months.wide[month] : null); // full

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -1334,7 +1334,7 @@ describe('Datagrid Client Side Filter and Sort Tests', () => {
   });
 });
 
-describe('Datagrid Checkbox Disabled Editor', () => {
+describe('Datagrid checkbox disabled editor tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-editable-checkboxes?layout=nofrills');
 
@@ -1848,6 +1848,54 @@ describe('Datagrid Custom Tooltip tests', () => {
 
     expect(await tooltip.getAttribute('class')).not.toContain('is-hidden');
     expect(await tooltip.getText()).toEqual('Row: 0 Cell: 3 Value: Error');
+  });
+});
+
+describe('Datagrid custom number format tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/test-custom-number-formats?layout=nofrills');
+
+    const datagridEl = await element(by.css('#datagrid tbody tr:nth-child(1)'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should format numbers correctly', async () => {
+    expect(await element(by.css('#datagrid tbody tr:nth-child(1) td:nth-child(2)')).getText()).toEqual('145000');
+    expect(await element(by.css('#datagrid tbody tr:nth-child(1) td:nth-child(3)')).getText()).toEqual('210.990');
+    expect(await element(by.css('#datagrid tbody tr:nth-child(1) td:nth-child(4)')).getText()).toEqual('$210.99');
+    expect(await element(by.css('#datagrid tbody tr:nth-child(1) td:nth-child(5)')).getText()).toEqual('14,500,000 %');
+    expect(await element(by.css('#datagrid tbody tr:nth-child(1) td:nth-child(6)')).getText()).toEqual('145,000');
+    expect(await element(by.css('#datagrid tbody tr:nth-child(1) td:nth-child(7)')).getText()).toEqual('145,000.00');
+  });
+});
+
+describe('Datagrid custom date format tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/test-custom-date-formats?layout=nofrills');
+
+    const datagridEl = await element(by.css('#datagrid tbody tr:nth-child(1)'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should format dates correctly', async () => {
+    expect(await element(by.css('#datagrid tbody tr:nth-child(1) td:nth-child(1)')).getText()).toEqual('3/15/2016');
+    expect(await element(by.css('#datagrid tbody tr:nth-child(1) td:nth-child(2)')).getText()).toEqual('3/15/2016 12:30:36');
+    expect(await element(by.css('#datagrid tbody tr:nth-child(1) td:nth-child(3)')).getText()).toEqual('3/15/2016 12:30 PM');
+    expect(await element(by.css('#datagrid tbody tr:nth-child(1) td:nth-child(4)')).getText()).toEqual('2016-03-15T12:30:36.120');
+    expect(await element(by.css('#datagrid tbody tr:nth-child(2) td:nth-child(4)')).getText()).toEqual('2016-03-15T00:30:36.008');
+    expect(await element(by.css('#datagrid tbody tr:nth-child(3) td:nth-child(4)')).getText()).toEqual('2014-07-03T01:00:00.000');
+    expect(await element(by.css('#datagrid tbody tr:nth-child(1) td:nth-child(5)')).getText()).toEqual('3/15/2016');
+    expect(await element(by.css('#datagrid tbody tr:nth-child(1) td:nth-child(6)')).getText()).toEqual('12:30:36 PM');
   });
 });
 

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -484,6 +484,17 @@ describe('Locale API', () => {
     expect(Locale.formatDate(date, opts)).toEqual('01.02.2017 17:27');
   });
 
+  it('Should format milliseconds', () => {
+    Locale.set('en-US');
+
+    expect(Locale.formatDate(new Date('2015-01-01T06:00:00.123Z'), { pattern: 'yyyy-MM-ddTHH:mm:ss.SSS' })).toEqual('2015-01-01T01:00:00.123');
+    expect(Locale.formatDate(new Date('2015-01-02T06:00:00.120Z'), { pattern: 'yyyy-MM-ddTHH:mm:ss.SSS' })).toEqual('2015-01-02T01:00:00.120');
+    expect(Locale.formatDate(new Date('2015-01-03T06:00:00.012Z'), { pattern: 'yyyy-MM-ddTHH:mm:ss.SSS' })).toEqual('2015-01-03T01:00:00.012');
+    expect(Locale.formatDate(new Date('2015-01-04T06:00:00.100Z'), { pattern: 'yyyy-MM-ddTHH:mm:ss.SSS' })).toEqual('2015-01-04T01:00:00.100');
+    expect(Locale.formatDate(new Date('2015-01-05T06:00:00.010Z'), { pattern: 'yyyy-MM-ddTHH:mm:ss.SSS' })).toEqual('2015-01-05T01:00:00.010');
+    expect(Locale.formatDate(new Date('2015-01-06T06:00:00.001Z'), { pattern: 'yyyy-MM-ddTHH:mm:ss.SSS' })).toEqual('2015-01-06T01:00:00.001');
+  });
+
   // monthYear and yearMonth
   it('Should format a year and month locale', () => {
     Locale.set('en-US');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When using a format of `yyyy-MM-ddTHH:mm:ss.SSS` the date formatter would drop leading zeros. This addresses the issue, also added some more tests

**Related github/jira issue (required)**:
Fixes #2696 

**Steps necessary to review your pull request (required)**:
- covered by unit tests but added one visual test page
- check out http://localhost:4000/components/datagrid/test-custom-date-formats.html and it shows a bunch of formats (Date (Time Millis)) being the fixed one. The main thing to note is all dates should have a .NNN (a dot and three digits at the end in that column)

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
