### PR TITLE
3136 - Fix theme change to fire resize after load / Calendar Tests

### DIFF
--- a/app/views/components/calendar/test-specific-month.html
+++ b/app/views/components/calendar/test-specific-month.html
@@ -44,6 +44,7 @@ $('body').one('initialized', function () {
       $('.calendar').calendar({
         month: 9,
         year: 2018,
+        day: 9,
         eventTypes: eventTypes,
         events: events,
         upcomingEventDays: 0,

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -22,6 +22,7 @@ const COMPONENT_NAME_DEFAULTS = {
   language: null,
   month: new Date().getMonth(),
   year: new Date().getFullYear(),
+  day: new Date().getDate(),
   showViewChanger: true,
   onRenderMonth: null,
   template: null,
@@ -57,8 +58,9 @@ const COMPONENT_NAME_DEFAULTS = {
  * @param {array} [settings.events] An array of objects with data for the events.
  * @param {string} [settings.locale] The name of the locale to use for this instance. If not set the current locale will be used.
  * @param {string} [settings.language] The name of the language to use for this instance. If not set the current locale will be used or the passed locale will be used.
- * @param {array} [settings.month] Initial month to show.
  * @param {array} [settings.year] Initial year to show.
+ * @param {array} [settings.month] Initial month to show.
+ * @param {number} [settings.day] The initial selected day to show.
  * @param {array} [settings.upcomingEventDays=14] How many days in advance should we show in the upcoming events pane.
  * @param {boolean} [settings.showViewChanger] If false the dropdown to change views will not be shown.
  * @param {function} [settings.onRenderMonth] Fires when a month is rendered, allowing you to pass back events or event types to show.
@@ -204,6 +206,7 @@ Calendar.prototype = {
       locale: this.settings.locale,
       month: this.settings.month,
       year: this.settings.year,
+      day: this.settings.day,
       eventTooltip: this.eventTooltip,
       iconTooltip: this.iconTooltip,
       showToday: this.settings.showToday,

--- a/src/components/monthview/monthview.js
+++ b/src/components/monthview/monthview.js
@@ -14,6 +14,7 @@ const COMPONENT_NAME_DEFAULTS = {
   language: null,
   month: new Date().getMonth(),
   year: new Date().getFullYear(),
+  day: new Date().getDate(),
   activeDate: null,
   activeDateIslamic: null,
   isPopup: false,
@@ -63,6 +64,7 @@ const COMPONENT_NAME_DEFAULTS = {
  * @param {string} [settings.language] The name of the language to use for this instance. If not set the current locale will be used or the passed locale will be used.
  * @param {number} [settings.month] The month to show.
  * @param {number} [settings.year] The year to show.
+ * @param {number} [settings.day] The initial selected day to show.
  * @param {number} [settings.activeDate] The date to highlight as selected/today.
  * @param {number} [settings.activeDateIslamic] The date to highlight as selected/today (as an array for islamic)
  * @param {number} [settings.isPopup] Is it in a popup (datepicker using it)
@@ -369,7 +371,7 @@ MonthView.prototype = {
       this.currentDate.setMonth(month);
     }
 
-    this.currentDay = this.currentDay || now.getDate();
+    this.currentDay = this.currentDay || this.settings.day;
     if (!this.currentCalendar || !this.currentCalendar.days) {
       this.currentCalendar = Locale.calendar();
     }
@@ -517,7 +519,11 @@ MonthView.prototype = {
     });
 
     if (!foundSelected && !s.range.useRange) {
-      const firstDay = self.dayMap.filter(d => d.key === stringUtils.padDate(year, month, 1));
+      const firstDay = self.dayMap.filter(d => d.key === stringUtils.padDate(
+        year,
+        month,
+        this.settings.day
+      ));
       if (firstDay.length) {
         setSelected(firstDay[0].elem, false);
       }

--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -363,8 +363,6 @@ Personalize.prototype = {
     // record state of theme in settings
     this.settings.theme = incomingTheme;
     theme.setTheme(incomingTheme);
-
-    $('body').trigger('resize');
   },
 
   /**
@@ -418,6 +416,7 @@ Personalize.prototype = {
         this.settings.colors || theme.themeColors().brand.primary.alt.value,
       theme: incomingTheme || 'theme-soho-light'
     });
+    $('body').trigger('resize');
   },
 
   /**

--- a/test/components/calendar/calendar-api.func-spec.js
+++ b/test/components/calendar/calendar-api.func-spec.js
@@ -15,7 +15,8 @@ const settings = {
   eventTypes,
   events,
   month: 10,
-  year: 2018
+  year: 2018,
+  day: 10
 };
 
 describe('Calendar API', () => {

--- a/test/components/calendar/calendar.e2e-spec.js
+++ b/test/components/calendar/calendar.e2e-spec.js
@@ -168,7 +168,7 @@ describe('Calendar specific month tests', () => {
   });
 
   it('Should offer a right click menu', async () => {
-    expect(await element.all(by.css('.calendar-event')).count()).toEqual(16);
+    expect(await element.all(by.css('.calendar-event')).count()).toEqual(17);
 
     const event = await element.all(by.cssContainingText('.monthview-table td', '1')).first();
     await browser.actions().mouseMove(event).perform();
@@ -180,11 +180,11 @@ describe('Calendar specific month tests', () => {
     expect(await element(by.id('calendar-actions-menu')).getAttribute('class')).toContain('is-open');
     await element.all(by.css('#calendar-actions-menu a')).first().click();
 
-    expect(await element.all(by.css('.calendar-event')).count()).toEqual(15);
+    expect(await element.all(by.css('.calendar-event')).count()).toEqual(16);
   });
 
   it('Should add new events on click and cancel', async () => {
-    expect(await element.all(by.css('.calendar-event')).count()).toEqual(16);
+    expect(await element.all(by.css('.calendar-event')).count()).toEqual(17);
 
     const event = await element.all(by.cssContainingText('.monthview-table td', '1')).first();
     await event.click();
@@ -195,11 +195,11 @@ describe('Calendar specific month tests', () => {
     await element(by.id('subject')).sendKeys('New Event Name');
     await element(by.css('.calendar-popup .btn-close')).click();
 
-    expect(await element.all(by.css('.calendar-event')).count()).toEqual(16);
+    expect(await element.all(by.css('.calendar-event')).count()).toEqual(17);
   });
 
   it('Should add new events on click and submit', async () => {
-    expect(await element.all(by.css('.calendar-event')).count()).toEqual(16);
+    expect(await element.all(by.css('.calendar-event')).count()).toEqual(17);
 
     const event = await element.all(by.cssContainingText('.monthview-table td', '1')).first();
     await event.click();
@@ -210,26 +210,23 @@ describe('Calendar specific month tests', () => {
     await element(by.id('subject')).sendKeys('New Event Name');
     await element(by.id('submit')).click();
 
-    expect(await element.all(by.css('.calendar-event')).count()).toEqual(16);
+    expect(await element.all(by.css('.calendar-event')).count()).toEqual(17);
   });
 
   it('Should be able to add with the modal', async () => {
-    const beforeCount = await element.all(by.css('.calendar-monthview .calendar-event')).count();
     await element.all(by.cssContainingText('.monthview-table td', '13')).first().click();
     await browser.actions()
       .doubleClick(await element.all(by.cssContainingText('.monthview-table td', '13')).first())
       .perform();
 
-    expect(beforeCount).toEqual(16);
+    expect(await element.all(by.css('.calendar-event')).count()).toEqual(17);
 
     await browser.driver
       .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('subject'))), config.waitsFor);
     await element(by.id('subject')).sendKeys('Test Event');
     await element(by.id('submit')).click();
 
-    const afterCount = await element.all(by.css('.calendar-event')).count();
-
-    expect(afterCount).toEqual(beforeCount + 1);
+    expect(await element.all(by.css('.calendar-event')).count()).toEqual(19);
   });
 
   it('Should update datepicker date', async () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Attempting to fix #3136, while i don't see the issue. I know that this code was giving me timing issues before. So move the event triggering to AFTER the style sheet is loaded and the old one is removed. Also fixed the calendar tests by fixing a bug, that the week would change every day in the weekview.

**Related github/jira issue (required)**:
Fixes #3136 

**Steps necessary to review your pull request (required)**:
**Resize Bug**
- go to http://localhost:4000/components/tabs/example-index.html?theme=soho&variant=light&colors=2578a9
- select last (or any tab)
- change between subtle and vibrant themes (the tab selection indicator should resize after and look aligned over the tab)

**Calendar Bug**
- go to http://localhost:4000/components/calendar/test-specific-month
- should always be on 9th by setting
- open day and week view (should show the week and that day)
- smoke testhttp://localhost:4000/components/calendar/ http://localhost:4000/components/monthview http://localhost:4000/components/datepicker a bit