### PR TITLE
2676 - Fix hide pager on one page with datagrid

### DIFF
--- a/app/views/components/datagrid/test-hide-pager-if-one-page-filter.html
+++ b/app/views/components/datagrid/test-hide-pager-if-one-page-filter.html
@@ -1,0 +1,77 @@
+﻿<div class="page-container scrollable" id="maincontent" role="main">
+  <div class="row">
+    <div class="twelve columns">
+      <div id="datagrid"></div>
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    var data = [];
+    var columns = [];
+
+    // Define Some Sample Data
+    data.push({ id: 1, productId: 2142201, productName: 'Compressor', inStock: true, activity: 'Assemble Paint', binLoc: '0101001001', phone: 1112223333, quantity: 1, price: 210.99, status: 'a', orderDate: new Date(2014, 12, 8), action: 'Action' });
+    data.push({ id: 2, productId: 2241202, productName: '1 Different Compressor', inStock: true, activity: 'Inspect and Repair', binLoc: '0101001002', phone: 1234567890, quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold' });
+    data.push({ id: 3, productId: 2342203, productName: 'Compressor', inStock: true, activity: 'Inspect and Repair', binLoc: '0000001001', phone: null, quantity: 1, price: 120.99, status: 'i', orderDate: new Date(2014, 6, 3), action: 'Action' });
+    data.push({ id: 4, productId: 2445204, productName: '1 Another Compressor', inStock: false, activity: 'Assemble Paint', binLoc: '1111111001', phone: null, quantity: 3, price: 210.99, status: 'a', orderDate: new Date(2015, 3, 3), action: 'Action' });
+    data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', inStock: true, activity: 'Inspect and Repair', binLoc: '2222222001', phone: 2221230000, quantity: 4, price: 210.99, status: 'i', orderDate: new Date(2015, 5, 5), action: 'On Hold' });
+    data.push({ id: 6, productId: 2642206, productName: 'Air Compressors', inStock: false, activity: 'Inspect and Repair', binLoc: '2222222002', phone: null, quantity: 41, price: 120.99, status: 'i', orderDate: new Date(2014, 6, 9), action: 'On Hold' });
+    data.push({ id: 7, productId: 2642207, productName: 'Some Compressor', inStock: true, activity: 'inspect and Repair', binLoc: '3333333333', phone: 5557779999, quantity: 41, price: 123.99, status: 'a', orderDate: new Date(2014, 6, 9), action: 'On Hold' });
+    data.push({ id: 8, productId: 2642208, productName: null, activity:  null, binLoc: '', phone: null, quantity: null, price: null, status: 'a', orderDate: null, action: 'Blank Row' });
+    data.push({ id: 9, productId: 2642209, productName: 'Some Compressor 2', inStock: true, activity: 'inspect and Repair', binLoc: '', phone: null, quantity: 0, price: 150.99, status: 'i', orderDate: new Date(2014, 6, 9), action: 'On Hold' });
+    data.push({ id: 10, productId: 2642210, productName: 'Some Compressor 3', inStock: true, activity: 'inspect and Repair', binLoc: '0303003003', phone: null, quantity: 1, price: null, status: 'i', orderDate: new Date(2014, 6, 9), action: 'On Hold' });
+    data.push({ id: 11, productId: 2642211, productName: 'Some Compressor 4', inStock: true, activity: 'inspect and Repair', binLoc: '4444444444', phone: 5551234567, quantity: 0, price: null, status: 'a', orderDate: new Date(2014, 6, 9), action: 'On Hold' });
+
+    var activities = [
+      { id: 'Assemble Paint', value:'Assemble Paint', label: 'Assemble Paint' },
+      { id: 'Inspect and Repair', value:'Inspect and Repair', label: 'Inspect and Repair' }
+    ];
+
+    // Define Columns for the Grid.
+    columns.push({ id: 'selectionCheckbox', name: '', width: 50, formatter: Formatters.SelectionCheckbox, align: 'center', resizable: false, sortable: false });
+    columns.push({ id: '1', name: 'Product Id', field: 'productId', formatter: Formatters.Readonly, filterType: 'text' });
+    columns.push({ id: '2', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink, filterType: 'text' });
+    columns.push({ id: '3', name: 'Activity', field: 'activity', filterType: 'contents', options: activities });
+    columns.push({ id: '4', name: 'Bin Location', field: 'binLoc', filterType: 'text', formatter: function (row, cell, value) {
+      if (value && value.length >= 10) {
+        return value.substr(0, 2) + '/' + value.substr(2, 2) + '/' + value.substr(4, 3) + '/' + value.slice(7);
+      } else {
+        return '';
+      }
+    }});
+    columns.push({ id: '5', name: 'Phone #', field: 'phone', filterType: 'text', formatter: function (row, cell, value) {
+      var str = value ? value.toString() : '';
+      if (str.length >= 10) {
+        return str.substr(0, 3) + '.' + str.substr(3, 3) + '.' + str.slice(6);
+      } else {
+        return '';
+      }
+    }});
+    columns.push({ id: '6', name: 'Accuml. Quantity', field: 'quantity', align: 'right', filterType: 'integer' });
+    columns.push({ id: '7', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'MM/dd/yyyy', filterType: 'date' });
+    columns.push({ id: '8', name: 'In Stock', field: 'inStock', width: 125, formatter: Formatters.Checkbox, align: 'center', filterType: 'checkbox' });
+    columns.push({ id: '9', name: 'Active Status', field: 'status', formatter: Formatters.Checkbox, align: 'center', filterType: 'checkbox', isChecked: function (value) {
+      return value && value.toLowerCase() === 'a';
+    }});
+    columns.push({ id: '10', name: 'Price', field: 'price', formatter: Formatters.Decimal, filterType: 'decimal', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '####.000' });
+
+    // Init the grid
+    $('#datagrid').datagrid({
+      columns: columns,
+      dataset: data,
+      filterable: true,
+      hidePagerOnOnePage: true,
+      selectable: 'multiple',
+      columnReorder: true,
+      saveColumns: false,
+      showFilterTotal: true,
+      paging: true,
+      pagesize: 5,
+      pagesizes: [5, 10, 25],
+      toolbar: { title: 'Filterable Datagrid w/ Paging', filterRow: true, results: true, dateFilter: false, keywordFilter: true, actions: true, views: false, rowHeight: true, collapsibleFilter: true }
+    });
+
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### v4.24.0 Fixes
 
+- `[Datagrid]` Fixed an issue where the hide pager on one page and filter was not working correctly. ([#2676](https://github.com/infor-design/enterprise/issues/2676))
 - `[Datagrid]` Fixed an issue where the dirty cell indicator was not updating after remove row. ([#2960](https://github.com/infor-design/enterprise/issues/2960))
 - `[Datagrid]` Fixed an issue where the method getModifiedRows was not working, it had duplicate entries for the same row. ([#2908](https://github.com/infor-design/enterprise/issues/2908))
 - `[Datagrid]` Fixed an issue where the personalized columns were not working when toggle columns and drag drop. ([#3004](https://github.com/infor-design/enterprise/issues/3004))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### v4.24.0 Fixes
 
-- `[Datagrid]` Fixed an issue where the hide pager on one page and filter was not working correctly. ([#2676](https://github.com/infor-design/enterprise/issues/2676))
+- `[Datagrid]` Fixed an issue where the hide pager on one page setting was not working correctly when applying a filter. ([#2676](https://github.com/infor-design/enterprise/issues/2676))
 - `[Datagrid]` Fixed an issue where the dirty cell indicator was not updating after remove row. ([#2960](https://github.com/infor-design/enterprise/issues/2960))
 - `[Datagrid]` Fixed an issue where the method getModifiedRows was not working, it had duplicate entries for the same row. ([#2908](https://github.com/infor-design/enterprise/issues/2908))
 - `[Datagrid]` Fixed an issue where the personalized columns were not working when toggle columns and drag drop. ([#3004](https://github.com/infor-design/enterprise/issues/3004))

--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -1166,8 +1166,11 @@ Pager.prototype = {
       }
     }
 
-    if (this.hidePagerBar(pagingInfo)) {
-      this.pagerBar[0].classList.add('hidden');
+    const classList = this.pagerBar[0] ? this.pagerBar[0].classList : null;
+    if (this.hidePagerBar(pagingInfo) && classList) {
+      classList.add('hidden');
+    } else if (this.settings.hideOnOnePage && classList && classList.contains('hidden')) {
+      classList.remove('hidden');
     }
 
     this.initTabIndexes();

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -3267,3 +3267,44 @@ describe('Datagrid tree select multiple tests', () => {
     expect(await element.all(await by.css('tr.is-selected')).count()).toEqual(3);
   });
 });
+
+describe('Datagrid hide pager on one page tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/test-hide-pager-if-one-page-filter');
+
+    const datagridEl = await element(by.css('#datagrid .datagrid-body tbody tr:nth-child(4)'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should hide pager on one page and filter', async () => {
+    const selector = {
+      rows: '#datagrid .datagrid-body tbody tr[role="row"]',
+      filter: '#datagrid .datagrid-header thead th[data-column-id="3"] .datagrid-filter-wrapper select',
+      filterSel: '#datagrid .datagrid-header thead th[data-column-id="3"] div.dropdown',
+      filterOpt: '.dropdown-list .dropdown-option #list-option-0'
+    };
+    const pagerBar = await element(by.css('.pager-toolbar'));
+
+    expect(await pagerBar.getAttribute('class')).not.toContain('hidden');
+    expect(await element.all(by.css(selector.rows)).count()).toEqual(5);
+
+    const filterSel = await element(by.css(selector.filterSel));
+    await filterSel.click();
+    const filterOpt = await element(by.css(selector.filterOpt));
+    await filterOpt.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await pagerBar.getAttribute('class')).toContain('hidden');
+    expect(await element.all(by.css(selector.rows)).count()).toEqual(2);
+    await filterOpt.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await pagerBar.getAttribute('class')).not.toContain('hidden');
+    expect(await element.all(by.css(selector.rows)).count()).toEqual(5);
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed hide pager on one page and filter was not working correctly with Datagrid.

**Related github/jira issue (required)**:
Closes #2676

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/test-hide-pager-if-one-page-filter.html
- See pager nav below the grid, should be showing
- Use column `Activity` to filter `Assemble Paint`
- Should filter accordingly (two results only)
- See pager nav below the grid, should not be showing now
- Clear the filter, should show all the rows
- See pager nav below the grid, should be showing again

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
