### PR TITLE
3002 - Fix Safari "change" event not firing

### DIFF
--- a/app/views/components/mask/test-number-parsing.html
+++ b/app/views/components/mask/test-number-parsing.html
@@ -37,6 +37,11 @@
       // transform
       var nbr = Soho.Locale.parseNumber(value);
       $('#parsed-number-field').val(nbr);
+
+      $('body').toast({
+        title: 'Change Event Fired!',
+        message: 'Parsed Number: <b>'+ nbr +'</b>'
+      });
     });
   });
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `[Editor]` Fixed many memory leaks related to view swapping and `destroy()` in the Editor. ([#3112](https://github.com/infor-design/enterprise/issues/3112))
 - `[EmptyMessage]` Added a fix so that click will only fire on the button part of the empty message. ([#3139](https://github.com/infor-design/enterprise/issues/3139))
 - `[Locale]` Fixed a problem in fi-FI where some date formats where incorrect with one digit days. ([#3019](https://github.com/infor-design/enterprise/issues/3019))
+- `[Mask]` Fixed a Safari bug where certain masked values would not trigger a "change" event on the input field. ([#3002](https://github.com/infor-design/enterprise/issues/3002))
 - `[Modal]` Added a new setting `overlayOpacity` that give the user to control the opacity level of the modal/message dialog overlay. ([#2975](https://github.com/infor-design/enterprise/issues/2975))
 - `[Progress]` Added the ability to init the progress and update it to zero, this was previously not working. ([#3020](https://github.com/infor-design/enterprise/issues/3020))
 - `[Toast]` Fixed an issue where the saved position was not working for whole app. ([#3025](https://github.com/infor-design/enterprise/issues/3025))

--- a/src/components/mask/mask-input.js
+++ b/src/components/mask/mask-input.js
@@ -168,6 +168,12 @@ MaskInput.prototype = {
   handleEvents() {
     const self = this;
 
+    // On change event
+    this.changeEventHandler = function () {
+      self.hasTriggeredChangeEvent = true;
+    };
+    this.element.addEventListener('change', this.changeEventHandler);
+
     // Store an initial value on focus
     this.focusEventHandler = function () {
       self.state.initialValue = self.element.value;
@@ -176,6 +182,7 @@ MaskInput.prototype = {
 
     // Handle all masking on the `input` event
     this.inputEventHandler = function () {
+      self.hasTriggeredChangeEvent = false;
       return self.process();
     };
     this.element.addEventListener('input', this.inputEventHandler);
@@ -192,8 +199,9 @@ MaskInput.prototype = {
         // in IE11 or Edge, change event doesn't fire for some unknown reason.
         // Added this for backwards compatility with this OS/Browser combo.
         // See http://jira.infor.com/browse/SOHO-6895
-        if (self._hasChangedValue() && self._isEdgeIE()) {
+        if (self._hasChangedValue() && (self._isEdgeIE() || !self.hasTriggeredChangeEvent)) {
           $(self.element).trigger('change');
+          self.hasTriggeredChangeEvent = true;
         }
       }
 
@@ -591,6 +599,11 @@ MaskInput.prototype = {
     if (this.blurEventHandler) {
       this.element.removeEventListener('blur', this.blurEventHandler);
       delete this.blurEventHandler;
+    }
+
+    if (this.changeEventHandler) {
+      this.element.removeEventListener('change', this.changeEventHandler);
+      delete this.changeEventHandler;
     }
 
     return this;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a bug where Safari would not fire a change event if a Masked Input field was modified, but the value didn't contain a decimal.  This is fixed by simply forcing the event to go off when a change is made, and making an internal record that the event was fired so it doesn't reoccur.

**Related github/jira issue (required)**:
Closes #3002

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run app
- Open http://localhost:4000/components/mask/test-number-parsing.html in Safari
- In the field "Number Field", type "12345" and tab out.  The next field, "Parsed Number Result" should be modified to contain "12345".
- Tab back into the "Number Field",  type "54321.12", and tab out.  The next field, "Parsed Number Result" should be modified to contain "12345".
- In both of the above cases, a Toast will display.  The toast should only appear once.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.