### PR TITLE
3023 - Fix editable single column with datagrid

### DIFF
--- a/app/views/components/datagrid/test-editable-single-column.html
+++ b/app/views/components/datagrid/test-editable-single-column.html
@@ -1,0 +1,37 @@
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid"></div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    var data = [];
+    var columns = [];
+
+    // Some Sample Data
+    data.push({ productName: 'Compressor' });
+    data.push({ productName: 'Some Compressor' });
+    data.push({ productName: 'Portable Compressor' });
+    data.push({ productName: 'Another Compressor' });
+    data.push({ productName: 'De Wallt Compressor' });
+    data.push({ productName: 'Air Compressors' });
+    data.push({ productName: 'Some Compressor' });
+
+    // Define Columns for the Grid.
+    columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input });
+
+    // Init the grid
+    $('#datagrid').datagrid({
+      columns: columns,
+      dataset: data,
+      editable: true,
+      showNewRowIndicator: false,
+      clickToSelect: false,
+      toolbar: { title: 'Data Grid Header Title', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: true,  collapsibleFilter: true }
+    }).on('cellchange', function (e, args) {
+      console.log('cellchange', args);
+    });
+
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[Datagrid]` Fixed an issue where the method getModifiedRows was not working, it had duplicate entries for the same row. ([#2908](https://github.com/infor-design/enterprise/issues/2908))
 - `[Datagrid]` Fixed an issue where the personalized columns were not working when toggle columns and drag drop. ([#3004](https://github.com/infor-design/enterprise/issues/3004))
 - `[Datagrid]` Fixed an issue where the grouping filter was not working after do sort. ([#3012](https://github.com/infor-design/enterprise/issues/3012))
+- `[Datagrid]` Fixed an issue where the editable single column was not working. ([#3023](https://github.com/infor-design/enterprise/issues/3023))
 - `[Datagrid]` Fixed an issue where when hovering a parent row the same row index in the child row will show the hover state. ([#2227](https://github.com/infor-design/enterprise/issues/2227))
 - `[Datepicker]` Fixed missing background color on disable dates and adjusted the colors in all themes. ([#2910](https://github.com/infor-design/enterprise/issues/2910))
 - `[Datepicker]` Fixed a layout issue on the focus state on colored/legend days. ([#2910](https://github.com/infor-design/enterprise/issues/2910))

--- a/src/components/datagrid/_datagrid-uplift.scss
+++ b/src/components/datagrid/_datagrid-uplift.scss
@@ -47,6 +47,19 @@
     }
   }
 
+  // Medium Row Height
+  &.medium-rowheight {
+    tbody tr {
+      td {
+        &.is-editing {
+          &.has-singlecolumn {
+            min-height: $datagrid-medium-row-height + 10;
+          }
+        }
+      }
+    }
+  }
+
   // Short Row Height
   &.short-rowheight {
     tbody {

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -786,6 +786,10 @@ $datagrid-short-row-height: 25px;
 
         //Editing
         &.is-editing {
+          &.has-singlecolumn {
+            min-height: $datagrid-medium-row-height + 8;
+          }
+
           .colorpicker-container {
             padding: 4px 15px 0;
           }
@@ -1133,6 +1137,10 @@ $datagrid-short-row-height: 25px;
 
         //Editing
         &.is-editing {
+          &.has-singlecolumn {
+            min-height: $datagrid-short-row-height + 8;
+          }
+
           &.is-fileupload {
             .trigger,
             .trigger-close {
@@ -1921,6 +1929,11 @@ $datagrid-short-row-height: 25px;
       background-color: $datagrid-cell-editing-bg-color;
       position: relative;
 
+      &.has-singlecolumn {
+        display: block;
+        min-height: $datagrid-row-height + 7;
+      }
+
       .datagrid-cell-wrapper {
         border: 1px solid $theme-color-brand-primary-base;
         left: 0;
@@ -1966,6 +1979,13 @@ $datagrid-short-row-height: 25px;
 
       .checkbox-label::after {
         left: 9px;
+      }
+
+      &.has-singlecolumn {
+        .checkbox-label::after {
+          left: 7px;
+          top: 20px;
+        }
       }
 
       &.is-fileupload {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -8489,6 +8489,10 @@ Datagrid.prototype = {
     */
     this.element.triggerHandler('beforeentereditmode', [{ row: idx, cell, item: rowData, target: cellNode, value: cellValue, column: col, editor: this.editor }]);
 
+    if (this.visibleColumns().length === 1) {
+      cellParent.addClass('has-singlecolumn');
+    }
+
     this.editor =  new col.editor(idx, cell, cellValue, cellNode, col, event, this, rowData); // eslint-disable-line
     this.editor.row = idx;
     this.editor.cell = cell;
@@ -8627,7 +8631,7 @@ Datagrid.prototype = {
 
     // Format Cell again
     const isInline = cellNode.hasClass('is-editing-inline');
-    cellNode.removeClass('is-editing is-editing-inline');
+    cellNode.removeClass('is-editing is-editing-inline has-singlecolumn');
 
     // Editor.destroy
     this.editor.destroy();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed editable single column was not working with Datagrid.

**Related github/jira issue (required)**:
Closes #3023

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/test-editable-single-column.html
- Grid should render one column only
- Click on any cell to go in edit mode
- Should be able to edit the cell

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
