### PR TITLE
3183 - Fix text color in safari

### DIFF
--- a/src/core/_reset.scss
+++ b/src/core/_reset.scss
@@ -138,6 +138,6 @@ button {
 // Fix the way some browsers apply webkit text fill by default, so we
 // don't have to keep overriding it everwhere.
 // Skip IE so it doesn't cause errors due to not being supported.
-html:not(.ie) {
+html:not(.ie):not(.is-safari) {
   -webkit-text-fill-color: unset;
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Recent change caused colors to "go dark" in safari. This fixes the issue but it is curious so gave a look @EdwardCoyle 

Also hoping the calendar tests to work on this PR. Testing for that as well.

**Related github/jira issue (required)**:
Fixes #3183 
**Steps necessary to review your pull request (required)**:
- open mac safari
- go to http://localhost:4000/components/datagrid/example-index
- text should look same again like https://4230-enterprise.demo.design.infor.com/components/datagrid/example-index.html
- also test IOS