### PR TITLE
3165- Fix a bug parsing numbers

### DIFF
--- a/app/views/components/datagrid/test-custom-number-formats.html
+++ b/app/views/components/datagrid/test-custom-number-formats.html
@@ -19,6 +19,7 @@
       columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', formatter: Formatters.Decimal, numberFormat: {style: 'percent'}});
       columns.push({ id: 'quantity', name: 'Integer', field: 'quantity', formatter: Formatters.Integer});
       columns.push({ id: 'quantity', name: 'Decimal', field: 'quantity', formatter: Formatters.Decimal});
+      columns.push({ id: 'quantity', name: 'Decimal (NL)', field: 'quantityStr', formatter: Formatters.Decimal});
 
       //Init and get the api for the grid
       grid = $('#datagrid').datagrid({
@@ -34,7 +35,15 @@
           var clone = JSON.parse(JSON.stringify(data.data));;
           clone[0].quantity = 145000;
           clone[1].quantity = 283423;
-          data.data.splice(0, 0, clone[0], clone[1]);
+          clone[0].quantityStr = '100' + Locale.currentLocale.data.numbers.decimal + '00';
+          clone[1].quantityStr = '836' + Locale.currentLocale.data.numbers.decimal + '45';
+          clone[2].quantityStr = '1200' + Locale.currentLocale.data.numbers.decimal + '12';
+          clone[3].quantityStr = '1' + Locale.currentLocale.data.numbers.group + '200' + Locale.currentLocale.data.numbers.decimal + '12';
+          clone[4].quantityStr = '10' + Locale.currentLocale.data.numbers.decimal + '99';
+          clone[5].quantityStr = '130300' + Locale.currentLocale.data.numbers.decimal + '00';
+          clone[6].quantityStr = '130' + Locale.currentLocale.data.numbers.group + '300' + Locale.currentLocale.data.numbers.decimal + '00';
+
+          data.data.splice(0, 0, clone[0], clone[1], clone[2], clone[3], clone[4], clone[5], clone[6]);
         }
         grid.loadData(data.data);
       });

--- a/app/views/components/dropdown/test-on-modal.html
+++ b/app/views/components/dropdown/test-on-modal.html
@@ -484,7 +484,7 @@
             <label for="context-type" class="required">Type</label>
             <select class="dropdown" id="context-type" name="type" aria-required="true" data-validate="required">
               <option value="">-- Select Type ---</option>
-              <option value="1">Context 01</option>
+              <option value="1">longer test option that shows a tooltip Context 01</option>
               <option value="2">Context 02</option>
               <option value="3">Context 03</option>
               <option value="4">Context 04</option>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,7 @@
 - `[EmptyMessage]` Added a fix so that click will only fire on the button part of the empty message. ([#3139](https://github.com/infor-design/enterprise/issues/3139))
 - `[Locale]` Fixed a problem in fi-FI where some date formats where incorrect with one digit days. ([#3019](https://github.com/infor-design/enterprise/issues/3019))
 - `[Locale]` Fixed an issue when formatting with `SSS` in the format string, the leading zeros were incorrectly removed from the millisecond output. ([#2696](https://github.com/infor-design/enterprise/issues/2696))
+- `[Locale/Datagrid]` Fixed an issue in the datagrid/locale that meant if a string is provided in the current locale for a number it wont parse correctly if the decimal format is a `,` (such as nl-NL). ([#3165](https://github.com/infor-design/enterprise/issues/3165))
 - `[Mask]` Fixed a Safari bug where certain masked values would not trigger a "change" event on the input field. ([#3002](https://github.com/infor-design/enterprise/issues/3002))
 - `[Modal]` Added a new setting `overlayOpacity` that give the user to control the opacity level of the modal/message dialog overlay. ([#2975](https://github.com/infor-design/enterprise/issues/2975))
 - `[Progress]` Added the ability to init the progress and update it to zero, this was previously not working. ([#3020](https://github.com/infor-design/enterprise/issues/3020))

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -1343,9 +1343,6 @@ const Locale = {  // eslint-disable-line
     }
 
     if (typeof number === 'string') {
-      if (decimal !== '.') {
-        number = number.replace(decimal, '.');
-      }
       number = Locale.parseNumber(number);
     }
 

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -1871,6 +1871,24 @@ describe('Datagrid custom number format tests', () => {
     expect(await element(by.css('#datagrid tbody tr:nth-child(1) td:nth-child(5)')).getText()).toEqual('14,500,000 %');
     expect(await element(by.css('#datagrid tbody tr:nth-child(1) td:nth-child(6)')).getText()).toEqual('145,000');
     expect(await element(by.css('#datagrid tbody tr:nth-child(1) td:nth-child(7)')).getText()).toEqual('145,000.00');
+    expect(await element(by.css('#datagrid tbody tr:nth-child(1) td:nth-child(8)')).getText()).toEqual('100.00');
+    expect(await element(by.css('#datagrid tbody tr:nth-child(2) td:nth-child(8)')).getText()).toEqual('836.45');
+  });
+
+  it('Should format numbers correctly as strings (nl-NL)', async () => {
+    await utils.setPage('/components/datagrid/test-custom-number-formats?layout=nofrills&locale=nl-NL');
+
+    const datagridEl = await element(by.css('#datagrid tbody tr:nth-child(1)'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+
+    expect(await element(by.css('#datagrid tbody tr:nth-child(1) td:nth-child(8)')).getText()).toEqual('100,00');
+    expect(await element(by.css('#datagrid tbody tr:nth-child(2) td:nth-child(8)')).getText()).toEqual('836,45');
+    expect(await element(by.css('#datagrid tbody tr:nth-child(3) td:nth-child(8)')).getText()).toEqual('1.200,12');
+    expect(await element(by.css('#datagrid tbody tr:nth-child(4) td:nth-child(8)')).getText()).toEqual('1.200,12');
+    expect(await element(by.css('#datagrid tbody tr:nth-child(5) td:nth-child(8)')).getText()).toEqual('10,99');
+    expect(await element(by.css('#datagrid tbody tr:nth-child(6) td:nth-child(8)')).getText()).toEqual('130.300,00');
+    expect(await element(by.css('#datagrid tbody tr:nth-child(7) td:nth-child(8)')).getText()).toEqual('130.300,00');
   });
 });
 

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -943,6 +943,16 @@ describe('Locale API', () => {
     expect(Locale.parseNumber('12.345,12 €')).toEqual(12345.12);
   });
 
+  it('Should format numbers in current locale', () => {
+    Locale.set('nl-NL');
+
+    expect(Locale.parseNumber('100,00')).toEqual(100);
+    expect(Locale.parseNumber('836,45')).toEqual(836.45);
+    expect(Locale.parseNumber('1200,12')).toEqual(1200.12);
+    expect(Locale.parseNumber('10,99')).toEqual(10.99);
+    expect(Locale.parseNumber('130300,00')).toEqual(130300.00);
+  });
+
   it('Should return NaN for bad numbers', () => {
     Locale.set('en-US');
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Datagrid had a bug that meant if a string is provided in the current locale for a number it wont parse correctly if the decimal format is a `,` (such as nl-NL). This fixes the issue and adds some tests

**Related github/jira issue (required)**:
Fixes #3165 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-custom-number-formats?locale=nl-NL
- the last column values should be the same as in the test file `100,00`, `836,45`, `1.200,12`, `1.200,12`, `10,99`, ` 130.300,00`, `130.300,00` ect..
- go to http://localhost:4000/components/datagrid/test-custom-number-formats
- numbers should be the same but in current locale still `100.00`, `836.45`, `1,200.12`, `1,200.12`, `10.99`, ` 130,300.00`, `130,300.00` ect..
- this is also covered by tests

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
