### PR TITLE
Fix bugs with persistence of query params controlling personalization

### DIFF
--- a/app/views/includes/head.html
+++ b/app/views/includes/head.html
@@ -59,20 +59,101 @@
     {{/colors}}
 
     // If Initialize isnt called need to defer this
-    var handleUrl = function(a) {
-      const parts = a.theme.split('-');
-      var pageUrl = '?theme=' + parts[1] + '&variant=' + parts[2] + '&colors=' + a.colors.replace('#', '');
-      window.history.pushState('', '', pageUrl);
+    var handleUrl = function(a, eventType) {
+      if (!a) {
+        return;
+      }
+
+      // Reset event type if it doesn't match up
+      var eventTypes = ['theme', 'color'];
+      if (eventType && eventTypes.indexOf(eventType) === -1) {
+        eventType === undefined;
+      }
+
+      // Setup theme if applicable
+      var queryParams = [];
+      var hasTheme = false;
+      var themeStringParts = [];
+      if ((eventType && eventType !== 'color')) {
+        hasTheme = typeof a.theme === 'string';
+        themeStringParts = a.theme.split('-');
+        queryParams.push('theme=' + themeStringParts[1]);
+        queryParams.push('variant=' + themeStringParts[2]);
+      }
+
+      // Setup color if applicable
+      var hasColor = false;
+      if (eventType && eventType !== 'theme') {
+        if (typeof a.colors === 'string') {
+          hasColor = true;
+          queryParams.push('colors=' + a.colors.replace('#', ''));
+        } else if (a.colors && typeof a.colors.header === 'string') {
+          hasColor = true;
+          queryParams.push('colors=' + a.colors.header.replace('#', ''));
+        }
+      }
+
+      function stringifyParams(theseParams) {
+        var str = '';
+        theseParams.forEach(function (param) {
+          var and = '';
+          if (queryParams[0] !== param) {
+            and = '&';
+          }
+          str += and + param;
+        });
+        return str;
+      }
+
+      // Used for filtering out existing theme-related parameters from a
+      // @param {string} queryString the URL string
+      // @returns {array} of existing Parameters in string form.
+      // Example: [`locale=ar-EG`, `useFlexToolbar=true`]
+      function existingThemeParamFilter(queryString) {
+        var existingParams = window.location.search
+          .replace('?', '')
+          .split('&');
+        existingParams = existingParams.filter(function (param) {
+          if (!param || param.length < 1) {
+            return false;
+          }
+          if (hasTheme && param.indexOf('theme=') > -1) {
+            return false;
+          }
+          if (hasTheme && param.indexOf('variant=') > -1) {
+            return false;
+          }
+          if (hasColor && param.indexOf('colors=') > -1) {
+            return false;
+          }
+          return true;
+        });
+        return existingParams;
+      }
+
+      if (queryParams.length) {
+        // Persist existing additional params.
+        // Also, overwrite existing color/theme/variant values if they've been added above.
+        queryParams = queryParams.concat(existingThemeParamFilter(window.location.search));
+
+        // Update URL in the browser window
+        var pageUrl = '?' + stringifyParams(queryParams);
+        window.history.pushState('', '', pageUrl);
+      }
     };
 
     $('html')
-      .personalize({colors: colors, theme: longThemeName, blockUI: blockUI})
+      .personalize({
+        colors: colors,
+        theme: longThemeName,
+        blockUI: blockUI
+      })
       .on('colorschanged', function (e, a) {
-        handleUrl(a);
+        handleUrl(a, 'color');
       })
       .on('themechanged', function (e, a) {
         const parts = a.theme.split('-');
-        handleUrl(a);
+        handleUrl(a, 'theme');
 
         if (parts[1] !== shortThemeName) {
           shortThemeName = parts[1];

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,7 @@
 
 ### v4.24.0 Chores & Maintenance
 
+- `[Demoapp]` Allow the query params that affect theming/personalization (theme/variant/colors) to be appended/adjusted on the browser's URL without affecting other query parameters, or adding unnecessary paramters that weren't changed.
 - `[Toolbar Searchfield]` Increased the amount of text shown when the Searchfield is not expanded, and appears similar to a button.  Also modified some styles in all themes to make alignment of the text better between the Searchfield and buttons when the Searchfield is not expanded. ([#2944](https://github.com/infor-design/enterprise/issues/2944))
 
 ## v4.23.0

--- a/src/components/theme/theme.js
+++ b/src/components/theme/theme.js
@@ -66,7 +66,7 @@ const theme = {
    * Get the colors used in the current theme that are reccomended for personalization
    * @returns {object} An object full of the colors with id, name abd hex value
    */
-  personalizationColors: function themeColors() {
+  personalizationColors: function personalizationColors() {
     const palette = this.themeColors().palette;
     const brand = this.themeColors().brand;
     const personalize = {};


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes some issues with some demoapp-specific code that handles using query parameters to persist changes in theme/personalization across page refreshes:
- Previously, using the switcher to set theme or variant on a url like http://master-enterprise.demo.design.infor.com/components/applicationmenu/test-hcm.html would also set the color.  When the page would refresh after the settings change, it would unexpectedly adjust personalized areas to the persisted color.
- Previously, due to the implementation of the persistence, adding another query param for controlling demoapp settings to a URL that already contained theming settings (fx: `?&theme=uplift&locale=ar-EG`) would cause the additional params to disappear.  When refreshing the page, the page would unexpectedly load without the additional changes persent.

**Related github/jira issue (required)**:
n/a

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run app
- Open a page with personalization areas, such as http://localhost:4000/components/applicationmenu/test-hcm.html
- Use the theme switcher to change the theme to "Vibrant".  The URL should change, only adding "theme" and "variant" params (not colors).
- Simply refresh the page. "theme" and "dark" should persist with no changes to the URL.
- Reload http://localhost:4000/components/applicationmenu/test-hcm.html with no query params.
- Use the theme switcher to change the color scheme to Amber.  The URL should change, only adding "colors" (not theme or variant).
- Simply refresh the page. "colors" should persist with no changes to the URL.
- Without refreshing, use the theme switcher to change the variant to "Dark". The URL should change, and all three params "theme", "variant", and "colors" should persist.
- Reload the page with an additional setting via query parameter, such as a Locale change: http://localhost:4000/components/applicationmenu/test-hcm.html?locale=ar-EG
- Use the theme switcher to change the color scheme to Amber.  The URL should change, retaining the `locale=ar-EG` and adding the "colors" param properly.
- Refresh the page.  The "locale" and "colors" params should be persisted.

*NOTES:*
- Sometimes the order of the params shifts around.  Since we don't have a real persistence layer, there's not much we can do about this.
- These changes don't persist settings across pages.  This only persists changes across reloads of the current page.

**Included in this Pull Request**:
- [x] A note to the change log.