### PR TITLE
3025 - Fix another case for saved position with toast

### DIFF
--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -73,9 +73,9 @@ Toast.prototype = {
     let isPausePlay = false;
     let percentage = 100;
 
-    this.uniqueId = this.generateUniqueId('usersettings-position');
+    this.uniqueId = s.uniqueid ? this.generateUniqueId('usersettings-position') : '';
 
-    let container = $(`#toast-container-${this.uniqueId}`);
+    let container = $(`#toast-container${this.uniqueId}`);
     const toast = $(`
       <div class="toast">
         <span class="toast-title">${xssUtils.stripHTML(s.title)}</span>
@@ -90,7 +90,7 @@ Toast.prototype = {
     const progress = $('<div class="toast-progress"></div>');
 
     if (!container.length) {
-      container = $(`<div id="toast-container-${this.uniqueId}" class="toast-container" aria-relevant="additions" aria-live="polite"></div>`).appendTo('body');
+      container = $(`<div id="toast-container${this.uniqueId}" class="toast-container" aria-relevant="additions" aria-live="polite"></div>`).appendTo('body');
     }
 
     container
@@ -266,7 +266,7 @@ Toast.prototype = {
     const doc = $(document);
     doc
       .off('mouseup.toast').on('mouseup.toast', (e) => {
-        if ($(`#toast-container-${this.uniqueId} .toast`).length === 1) {
+        if ($(`#toast-container${this.uniqueId} .toast`).length === 1) {
           const dragApi = container.data('drag');
           if (dragApi && typeof dragApi.getElementsFromPoint === 'function') {
             const args = { dragApi, x: e.pageX, y: e.pageY };
@@ -277,7 +277,7 @@ Toast.prototype = {
         }
       })
       .off('touchend.toast').on('touchend.toast', (e) => {
-        if ($(`#toast-container-${this.uniqueId} .toast`).length === 1) {
+        if ($(`#toast-container${this.uniqueId} .toast`).length === 1) {
           const dragApi = container.data('drag');
           if (dragApi && typeof dragApi.getElementsFromPoint === 'function') {
             const orig = e.originalEvent;
@@ -402,7 +402,7 @@ Toast.prototype = {
   remove(toast) {
     const removeCallback = () => {
       toast.remove();
-      const canDestroy = !$(`#toast-container-${this.uniqueId} .toast`).length;
+      const canDestroy = !$(`#toast-container${this.uniqueId} .toast`).length;
       if (canDestroy) {
         this.destroy();
       }
@@ -443,7 +443,7 @@ Toast.prototype = {
    * @returns {void}
    */
   destroy() {
-    const container = $(`#toast-container-${this.uniqueId}`);
+    const container = $(`#toast-container${this.uniqueId}`);
     if (container[0]) {
       const toasts = [].slice.call(container[0].querySelectorAll('.toast'));
       toasts.forEach((toast) => {

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -67,12 +67,15 @@ Toast.prototype = {
    */
   show() {
     const self = this;
-    const s = self.settings;
+    const s = this.settings;
     const maxHideTime = parseFloat(math.convertDelayToFPS(s.timeout));
     const message = s.allowLink ? xssUtils.stripTags(s.message, '<a><br><p>') : xssUtils.stripHTML(s.message);
     let isPausePlay = false;
     let percentage = 100;
-    let container = $('#toast-container');
+
+    this.uniqueId = this.generateUniqueId('usersettings-position');
+
+    let container = $(`#toast-container-${this.uniqueId}`);
     const toast = $(`
       <div class="toast">
         <span class="toast-title">${xssUtils.stripHTML(s.title)}</span>
@@ -87,7 +90,7 @@ Toast.prototype = {
     const progress = $('<div class="toast-progress"></div>');
 
     if (!container.length) {
-      container = $('<div id="toast-container" class="toast-container" aria-relevant="additions" aria-live="polite"></div>').appendTo('body');
+      container = $(`<div id="toast-container-${this.uniqueId}" class="toast-container" aria-relevant="additions" aria-live="polite"></div>`).appendTo('body');
     }
 
     container
@@ -263,7 +266,7 @@ Toast.prototype = {
     const doc = $(document);
     doc
       .off('mouseup.toast').on('mouseup.toast', (e) => {
-        if ($('#toast-container .toast').length === 1) {
+        if ($(`#toast-container-${this.uniqueId} .toast`).length === 1) {
           const dragApi = container.data('drag');
           if (dragApi && typeof dragApi.getElementsFromPoint === 'function') {
             const args = { dragApi, x: e.pageX, y: e.pageY };
@@ -274,7 +277,7 @@ Toast.prototype = {
         }
       })
       .off('touchend.toast').on('touchend.toast', (e) => {
-        if ($('#toast-container .toast').length === 1) {
+        if ($(`#toast-container-${this.uniqueId} .toast`).length === 1) {
           const dragApi = container.data('drag');
           if (dragApi && typeof dragApi.getElementsFromPoint === 'function') {
             const orig = e.originalEvent;
@@ -304,7 +307,7 @@ Toast.prototype = {
     }
 
     // Save position to local storage
-    localStorage[this.uniqueId('usersettings-position')] = JSON.stringify(pos);
+    localStorage[this.uniqueId] = JSON.stringify(pos);
 
     /**
     * Fires after settings are changed in some way
@@ -328,7 +331,7 @@ Toast.prototype = {
       return null;
     }
 
-    const lsPosition = localStorage[this.uniqueId('usersettings-position')];
+    const lsPosition = localStorage[this.uniqueId];
     return lsPosition ? JSON.parse(lsPosition) : null;
   },
 
@@ -355,7 +358,7 @@ Toast.prototype = {
   * @param {object} suffix Add this string to make the id more unique
   * @returns {string} The unique id.
   */
-  uniqueId(suffix) {
+  generateUniqueId(suffix) {
     suffix = (suffix === undefined || suffix === null) ? '' : suffix;
     const uniqueid = `toast-${this.settings.uniqueid || ''}-${suffix}`;
     return uniqueid.replace(/--/g, '-').replace(/-$/g, '');
@@ -399,7 +402,7 @@ Toast.prototype = {
   remove(toast) {
     const removeCallback = () => {
       toast.remove();
-      const canDestroy = !$('#toast-container .toast').length;
+      const canDestroy = !$(`#toast-container-${this.uniqueId} .toast`).length;
       if (canDestroy) {
         this.destroy();
       }
@@ -440,7 +443,7 @@ Toast.prototype = {
    * @returns {void}
    */
   destroy() {
-    const container = $('#toast-container');
+    const container = $(`#toast-container-${this.uniqueId}`);
     if (container[0]) {
       const toasts = [].slice.call(container[0].querySelectorAll('.toast'));
       toasts.forEach((toast) => {
@@ -450,6 +453,7 @@ Toast.prototype = {
     }
     $(document).off('keydown.toast keyup.toast mouseup.toast touchend.toast');
     container.remove();
+    delete this.uniqueId;
     $.removeData(this.element[0], COMPONENT_NAME);
   }
 };


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed an issue with Toast where open the 2nd toast before 1st not being completed yet, both toast were appearing on the same position.

**Related github/jira issue (required)**:
Closes #3025

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/toast/example-draggable.html
- Click on each button to show the toast message
- Drag and drop to different positions each
- Close and open page again, then open each toast message (try to open the 2nd toast before 1st get completed)
- See each message should remain the saved position

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
