### PR TITLE
#3213 Datagrid Grouping on multiple columns

### DIFF
--- a/app/views/components/datagrid/example-grouping-multiple.html
+++ b/app/views/components/datagrid/example-grouping-multiple.html
@@ -1,0 +1,77 @@
+
+<div class="row bottom-padding">
+  <div class="twelve columns">
+    <div class="toolbar">
+      <div class="title">
+        Compressors
+        <span class="datagrid-group-count">N</span>
+      </div>
+      <div class="buttonset">
+        <button class="btn-icon" type="button" id="add-btn">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-add"></use>
+          </svg>
+          <span class="audible">Add</span>
+        </button>
+      </div>
+      <div class="more">
+        <button class="btn-actions" type="button">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use xlink:href="#icon-more"></use>
+          </svg>
+          <span class="audible">More Actions</span>
+        </button>
+        <ul class="popupmenu">
+          <li><a data-option="personalize-columns" href="#" data-translate="text">PersonalizeColumns</a></li>
+          <li><a data-option="reset-layout" href="#" data-translate="text">ResetDefault</a></li>
+          <li class="separator single-selectable-section"></li>
+          <li class="heading">Row Height</li>
+          <li class="is-selectable"><a data-option="row-short" href="#" data-translate="text">Short</a></li>
+          <li class="is-selectable"><a data-option="row-medium" href="#" data-translate="text">Medium</a></li>
+          <li class="is-selectable is-checked"><a data-option="row-normal" href="#" data-translate="text">Normal</a></li>
+        </ul>
+      </div>
+    </div>
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+
+<script>
+  $('body').one('initialized', function () {
+
+      var grid,
+        columns = [],
+        data = [];
+
+      //Define Columns for the Grid.
+      // columns.push({ id: 'drilldown', name: '', field: '', resizable: false, formatter: Formatters.Drilldown, click: function(e, args) {
+      //   console.log('Drilldown ', args[0]);
+      // }, align: 'center', sortable: false});
+      columns.push({ id: 'id', name: 'Customer Id', field: 'id'});
+      columns.push({ id: 'type', name: 'Type', field: 'type'});
+      columns.push({ id: 'location', name: 'Location', field: 'location', formatter: Formatters.Hyperlink});
+      columns.push({ id: 'firstname', name: 'First Name', field: 'firstname'});
+      columns.push({ id: 'lastname', name: 'Last Name', field: 'lastname'});
+      columns.push({ id: 'phone', name: 'Phone', field: 'phone'});
+      columns.push({ id: 'purchases', name: 'Purchases', field: 'purchases'});
+
+      //Get some data via ajax
+      var url = '{{basepath}}api/accounts';
+
+      $.getJSON(url, function(res) {
+        $('#datagrid').datagrid({
+          columns: columns,
+          dataset: res,
+          groupable: {
+            fields: ['type', 'firstname'],
+            aggregatedColumns: [{field: 'purchases', aggregator: 'sum'}, {field: 'id', aggregator: 'count'}],
+            expanded: true
+          },
+          toolbar: {title: 'Accounts', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: false}
+        });
+      });
+ });
+
+</script>

--- a/app/views/components/datagrid/example-grouping-multiple.html
+++ b/app/views/components/datagrid/example-grouping-multiple.html
@@ -49,13 +49,13 @@
       // columns.push({ id: 'drilldown', name: '', field: '', resizable: false, formatter: Formatters.Drilldown, click: function(e, args) {
       //   console.log('Drilldown ', args[0]);
       // }, align: 'center', sortable: false});
-      columns.push({ id: 'id', name: 'Customer Id', field: 'id'});
+      columns.push({ id: 'id', name: 'Customer Id', field: 'id', align: 'right'});
       columns.push({ id: 'type', name: 'Type', field: 'type'});
       columns.push({ id: 'location', name: 'Location', field: 'location', formatter: Formatters.Hyperlink});
       columns.push({ id: 'firstname', name: 'First Name', field: 'firstname'});
       columns.push({ id: 'lastname', name: 'Last Name', field: 'lastname'});
       columns.push({ id: 'phone', name: 'Phone', field: 'phone'});
-      columns.push({ id: 'purchases', name: 'Purchases', field: 'purchases'});
+      columns.push({ id: 'purchases', name: 'Purchases', field: 'purchases', align: 'right'});
 
       //Get some data via ajax
       var url = '{{basepath}}api/accounts';

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # What's New with Enterprise
 
+## #3213 Datagrid Grouping on multiple columns
+- `[DataGrid]` Created a new default behavior on column grouping. ([#3213](https://github.com/infor-design/enterprise/issues/3213))
+
 ## v4.24.0
 
 ### v4.24.0 Important Changes

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -2949,6 +2949,13 @@ Datagrid.prototype = {
       return;
     }
 
+    // if there is an expander column in this grid then don't add
+    const expanderColumn = this.columnById('expander');
+    if (!expanderColumn || expanderColumn.length === 0){
+      this.settings.columns.splice(0, 0, {id:'expander'});
+    }
+   
+
     if (!this.originalDataset) {
       this.originalDataset = this.settings.dataset.slice();
     } else {
@@ -3687,9 +3694,9 @@ Datagrid.prototype = {
 
     if (this.settings.groupable && isGroup && !isFooter) {
       const groupRowHtml = Formatters.GroupRow(dataRowIdx, 0, null, null, rowData, this);
-      containerHtml.left = `<tr class="datagrid-rowgroup-header${isHidden ? '' : ' is-expanded'}" role="rowgroup"><td role="gridcell" colspan="${visibleColumnsLeft}">${groupRowHtml.left || '<span>&nbsp;</span>'}</td></tr>`;
-      containerHtml.center = `<tr class="datagrid-rowgroup-header${isHidden ? '' : ' is-expanded'}" role="rowgroup"><td role="gridcell" colspan="${visibleColumnsCenter}">${groupRowHtml.center || '<span>&nbsp;</span>'}</td></tr>`;
-      containerHtml.right = `<tr class="datagrid-rowgroup-header${isHidden ? '' : ' is-expanded'}" role="rowgroup"><td role="gridcell" colspan="${visibleColumnsRight}">${groupRowHtml.right || '<span>&nbsp;</span>'}</td></tr>`;
+      containerHtml.left = '<tr class="datagrid-rowgroup-header' + (isHidden ? '' : ' is-expanded') + '" role="rowgroup">' + (groupRowHtml.left || '<span>&nbsp;</span>') + '</tr>';
+      containerHtml.center = '<tr class="datagrid-rowgroup-header' + (isHidden ? '' : ' is-expanded') + '" role="rowgroup">' + (groupRowHtml.center || '<span>&nbsp;</span>') + '</tr>';
+      containerHtml.right = '<tr class="datagrid-rowgroup-header' + (isHidden ? '' : ' is-expanded') + '" role="rowgroup">' + (groupRowHtml.right || '<span>&nbsp;</span>') + '</tr>';
       return containerHtml;
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Replaced the default grouping functionality with grouping that places the group headers on their own place.
Added a demo file with grouping on multiple columns
![Example grouping](https://user-images.githubusercontent.com/56438371/70266173-46e57000-179c-11ea-8234-e34beb01a8d3.png)


**Related github/jira issue (required)**:
Closes #3213 Datagrid Grouping on multiple columns

**Steps necessary to review your pull request (required)**:
<!--
Include:
Test URL 
http://localhost:4000/components/datagrid/example-grouping-multiple.html
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

**Included in this Pull Request**:
- [X ] An e2e or functional test for the bug or feature.
  A functional test is included
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
