### PR TITLE
3105-  Fix dropdown/multiselect test sample to not have duplicate IDs

### DIFF
--- a/app/views/components/dropdown/test-configured-as-multiselect.html
+++ b/app/views/components/dropdown/test-configured-as-multiselect.html
@@ -49,8 +49,8 @@
   <div class="six columns">
     <h2 class="fielset-title">Legacy MoveSelectedToTop</h2>
 
-    <label for="config-like-multi">Bytes:</label>
-    <select id="config-like-multi" multiple class="dropdown" data-options='{ "closeOnSelect": false, "empty": true, "multiple": true }' data-move-selected="true">
+    <label for="legacy-settings">Bytes:</label>
+    <select id="legacy-settings" multiple class="dropdown" data-options='{ "closeOnSelect": false, "empty": true, "multiple": true }' data-move-selected="true">
       <option selected>0</option>
       <option>1</option>
       <option>2</option>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a demoapp sample that had duplicate ID attributes on multiple Dropdown examples, causing some of the Dropdowns to appear not to retain state.  

**Related github/jira issue (required)**:
Closes #3105

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the app.
- Using IE11, open http://localhost:4000/components/dropdown/test-configured-as-multiselect.html?locale=he-IL
- Open the dropdown labeled "Legacy MoveSelectedToTop"
- Select some values, and close the dropdown.  The pseudo-element should appear to set the values properly.
- Reopen the menu.  The items that were previously selected should still be checked off.