### PR TITLE
2931 - Fix scroll on mobile view with tabs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # What's New with Enterprise
 
+## v4.25.0
+
+### v4.25.0 Deprecation
+
+### v4.25.0 Features
+
+### v4.25.0 Fixes
+
+- `[Tabs]` Fixed an issue where scroll was not working on mobile view for scrollable-flex layout. ([#2931](https://github.com/infor-design/enterprise/issues/2931))
+
+### v4.25.0 Chores & Maintenance
+
 ## v4.24.0
 
 ### v4.24.0 Important Changes

--- a/src/components/compositeform/_compositeform.scss
+++ b/src/components/compositeform/_compositeform.scss
@@ -77,7 +77,11 @@
   // Responsive Mode (more columns)
   //=================================================
   &.is-in-responsive-mode {
+    overflow: auto;
+
     > .scrollable-flex-content {
+      flex-shrink: 0;
+
       > .tab-container {
         height: 40px;
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed scroll was not working on mobile view for scrollable-flex layout with tabs.

**Related github/jira issue (required)**:
Closes #2931

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/tabs/example-composite-form-on-side.html
- Open developer tools
- Click on mobile icon in dev tool window to switch mobile viewport inspector 
- Use any phone device and flip the device to landscape mode
- See the content on page should be scrollable

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
