### PR TITLE
1384 - Fix incorrect padding on `xs` Spinbox size [v4.24.x]

### DIFF
--- a/src/components/spinbox/_spinbox.scss
+++ b/src/components/spinbox/_spinbox.scss
@@ -89,6 +89,16 @@ input::-webkit-inner-spin-button {
   }
 }
 
+// Modify the control size on `.spinbox-xs` classes
+.spinbox-xs {
+  .spinbox-control {
+    &.down,
+    &.up {
+      padding: 7px 3px;
+    }
+  }
+}
+
 // Everything inside the spinbox wrapper is vertically-aligned middle.
 .spinbox-wrapper {
   display: inline-block;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes an issue on the `xs` size Spinbox on the Vibrant theme, where an incorrect amount of padding was causing the spinbox to appear to wrap.

**Related github/jira issue (required)**:
Closes #1384

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run app
- Open http://localhost:4000/components/spinbox/example-sizes.html?theme=uplift&variant=light
- Ensure the field labelled "Extra-Small Spinbox" renders all on one line, and appears to be the same width (including buttons) as the corresponding Input field.