### PR TITLE
3175 - Fix placement of some modal components in IE11 [v4.24.x]

### DIFF
--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -492,6 +492,25 @@ body.modal-engaged {
   }
 }
 
+// IE-specific adjustments
+html.ie {
+  .modal {
+    &.full-width {
+      margin: 0;
+    }
+  }
+}
+
+// iOS specific adjustments
+html.ios {
+  .has-modal-open {
+    [aria-hidden='true'],
+    [aria-hidden='true'] * {
+      overflow: hidden;
+    }
+  }
+}
+
 // RTL Styles
 html[dir='rtl'] {
   .modal-buttonset {
@@ -538,15 +557,6 @@ html[dir='rtl'] {
     .btn-close {
       left: 10px;
       right: auto;
-    }
-  }
-}
-
-.ios {
-  .has-modal-open {
-    [aria-hidden='true'],
-    [aria-hidden='true'] * {
-      overflow: hidden;
     }
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes some Modal examples' incorrect placement on the page when viewed in IE11

**Related github/jira issue (required)**:
Closes #3175 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the app
- Open http://localhost:4000/components/datagrid/example-export-from-button.html?theme=uplift&variant=light in IE11
- Use the `...` "More Actions" button on the toolbar to pick "Personalize Columns"
- When the modal opens, it should correctly be centered in the page (was previously aligned in the bottom)
