### PR TITLE
3226 - Fix the calendar layout with datepicker [v4.24.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,7 +39,7 @@
 - `[Datagrid]` Fixed an issue that resizing the last column would create a gap. ([#1671](https://github.com/infor-design/enterprise/issues/1671))
 - `[Datepicker]` Fixed missing background color on disable dates and adjusted the colors in all themes. ([#2910](https://github.com/infor-design/enterprise/issues/2910))
 - `[Datepicker]` Fixed a layout issue on the focus state on colored/legend days. ([#2910](https://github.com/infor-design/enterprise/issues/2910))
-- `[Datepicker]` Fixed an issue where the calendar layout was not working on ie11. ([#2931](https://github.com/infor-design/enterprise/issues/3226))
+- `[Datepicker]` Fixed an issue where the calendar layout was not working on ie11. ([#3226](https://github.com/infor-design/enterprise/issues/3226))
 - `[Dropdown]` Fix a bug where a dropdown in a datagrid cell would sometimes not display the correct value when selected. ([#2919](https://github.com/infor-design/enterprise/issues/2919))
 - `[Dropdown]` Fix a layout issue in RTL on the badges example. ([#3150](https://github.com/infor-design/enterprise/issues/3150))
 - `[Editor]` Corrected CSP errors and broken images in the Editor Preview when inserting the default image. ([#2937](https://github.com/infor-design/enterprise/issues/2937))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,7 @@
 - `[Datagrid]` Fixed an issue that resizing the last column would create a gap. ([#1671](https://github.com/infor-design/enterprise/issues/1671))
 - `[Datepicker]` Fixed missing background color on disable dates and adjusted the colors in all themes. ([#2910](https://github.com/infor-design/enterprise/issues/2910))
 - `[Datepicker]` Fixed a layout issue on the focus state on colored/legend days. ([#2910](https://github.com/infor-design/enterprise/issues/2910))
+- `[Datepicker]` Fixed an issue where the calendar layout was not working on ie11. ([#2931](https://github.com/infor-design/enterprise/issues/3226))
 - `[Dropdown]` Fix a bug where a dropdown in a datagrid cell would sometimes not display the correct value when selected. ([#2919](https://github.com/infor-design/enterprise/issues/2919))
 - `[Dropdown]` Fix a layout issue in RTL on the badges example. ([#3150](https://github.com/infor-design/enterprise/issues/3150))
 - `[Editor]` Corrected CSP errors and broken images in the Editor Preview when inserting the default image. ([#2937](https://github.com/infor-design/enterprise/issues/2937))

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -484,8 +484,15 @@ Tooltip.prototype = {
       content = $(content);
       contentArea.html(content);
       contentArea.find('.hidden').removeClass('hidden');
+    } else if (useHtml) {
+      const clone = content[0].cloneNode(true);
+      const id = clone.id;
+      if (id) {
+        clone.id = `${id}-${this.uniqueId}`;
+      }
+      contentArea.html(clone.outerHTML);
     } else {
-      contentArea.html(useHtml ? content[0].outerHTML : content);
+      contentArea.html(content);
     }
 
     const popoverWidth = contentArea.width();

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -478,21 +478,14 @@ Tooltip.prototype = {
 
     this.tooltip[0].setAttribute('class', classes);
 
-    const useHtml = env.browser.name === 'ie' && env.browser.isIE11() && content instanceof $ && content.length;
+    const useHtml = env.browser.name === 'ie' && env.browser.isIE11() && content instanceof $ && content.length && this.settings.trigger === 'hover';
 
     if (typeof content === 'string') {
       content = $(content);
       contentArea.html(content);
       contentArea.find('.hidden').removeClass('hidden');
-    } else if (useHtml) {
-      const clone = content[0].cloneNode(true);
-      const id = clone.id;
-      if (id) {
-        clone.id = `${id}-${this.uniqueId}`;
-      }
-      contentArea.html(clone.outerHTML);
     } else {
-      contentArea.html(content);
+      contentArea.html(useHtml ? content[0].outerHTML : content);
     }
 
     const popoverWidth = contentArea.width();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the calendar layout was not working on ie11 with Datepicker.

**Related github/jira issue (required)**:
Closes #3226

**Steps necessary to review your pull request (required)**:
Open IE11

http://localhost:4000/components/datepicker/example-index.html
- Open the calendar
- Make sure it renders
- The functionality of the calendar should work fine

also check this
http://localhost:4000/components/popover/example-attached-to-textbox.html
- Mouse over the icon inside the text box
- Popover should show up
- Switch between themes then verify the popover again
- Should show popover content

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
