### PR TITLE
1818 - Fix resize columns with datagrid [v4.24.x]

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3175,7 +3175,7 @@ Datagrid.prototype = {
       }
 
       self.bodyColGroup = $(self.bodyColGroupHtml);
-      self.tableBody.before(self.bodyColGroup);
+      (self.headerRow || self.tableBody).before(self.bodyColGroup);
 
       if (self.hasRightPane) {
         self.bodyColGroupRight = $(self.bodyColGroupHtmlRight);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed resize columns were not working on safari with Datagrid.

**Related github/jira issue (required)**:
Closes #1818

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/test-column-sizing.html
- Click any column header to make sort
- After sort then resize any column by dragging
- It should work fine
