### PR TITLE
2363 - Fix empty message with datagrid [v4.24.x]

### DIFF
--- a/src/components/emptymessage/_emptymessage.scss
+++ b/src/components/emptymessage/_emptymessage.scss
@@ -66,3 +66,13 @@
     width: inherit;
   }
 }
+
+// IE11
+.ie11 {
+  .datagrid-container {
+    .empty-message-container {
+      left: 0;
+      top: 0;
+    }
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed empty message was not showing for ie11 with Datagrid.

**Related github/jira issue (required)**:
Closes #2363

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Open ie11
- Navigate to http://localhost:4000/components/datagrid/example-filter.html
- Type something to filter in any column which does not match
- Empty message should show

Scrolling header on safari fixed with other PR #3238