### PR TITLE
3233 - Fix aggregator sum errors

### DIFF
--- a/app/data/accounts-sm.json
+++ b/app/data/accounts-sm.json
@@ -7,7 +7,7 @@
 		"firstname": "Jonathon",
 		"lastname": "Hardy",
 		"phone": "(312) 555-7854",
-		"purchases": 2000,
+		"purchases": 56.48,
 		"percentage": 25
 	},
 	{
@@ -18,7 +18,7 @@
 		"firstname": "Coyle",
 		"lastname": "Rita",
 		"phone": "+49 (897) 104-6155",
-		"purchases": 2000,
+		"purchases": 16,
 		"percentage": 25
 	},
 	{
@@ -29,7 +29,7 @@
 		"firstname": "Mike",
 		"lastname": "Warneke",
 		"phone": "(503) 555-1358",
-		"purchases": 2000,
+		"purchases": 0,
 		"percentage": 25
 	},
 	{
@@ -40,7 +40,7 @@
 		"firstname": "Marc",
 		"lastname": "Bianco",
 		"phone": "(924) 555-8609",
-		"purchases": 2000,
+		"purchases": 0,
 		"percentage": 25
 	}
 ]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### v4.25.0 Fixes
 
+- `[Datagrid]` Fixed a bug where floating point math would cause the grouping sum aggregator to round incorrectly. ([#3233](https://github.com/infor-design/enterprise/issues/3233))
 - `[Tabs]` Fixed an issue where scroll was not working on mobile view for scrollable-flex layout. ([#2931](https://github.com/infor-design/enterprise/issues/2931))
 
 ### v4.25.0 Chores & Maintenance

--- a/src/components/datagrid/datagrid.groupby.js
+++ b/src/components/datagrid/datagrid.groupby.js
@@ -1,4 +1,5 @@
 import { utils } from '../../utils/utils';
+import { numberUtils } from '../../utils/number';
 
 /**
 * An api for grouping data by a given field (s)
@@ -153,7 +154,11 @@ aggregators.aggregate = function (items, columns) {
         } else {
           value = node[field];
         }
-        return sum + Number(value);
+
+        value = Number(value);
+        const valuePlaces = numberUtils.decimalPlaces(value);
+        const sumPlaces = numberUtils.decimalPlaces(sum);
+        return Number((sum + value).toFixed(Math.max(valuePlaces, sumPlaces)));
       };
 
       const total = items.reduce(self[columns[i].aggregator], 0);

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -1316,6 +1316,25 @@ describe('Datagrid single select tests', () => {
   });
 });
 
+describe('Datagrid summary row tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/example-summary-row');
+
+    const datagridEl = await element(by.css('#datagrid tbody tr:nth-child(1)'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should add up rows', async () => {
+    expect(await element(by.css('#datagrid .datagrid-wrapper tbody tr:nth-child(5) td:nth-child(4)')).getText()).toEqual('72.48');
+    expect(await element(by.css('#datagrid .datagrid-wrapper tbody tr:nth-child(5) td:nth-child(5)')).getText()).toEqual('100 %');
+  });
+});
+
 describe('Datagrid Client Side Filter and Sort Tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-disable-client-filter-and-sort');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The floating point math in JS was causing aggregator display values to add up wrong. This is a fix.

**Related github/jira issue (required)**:
Fixes #3233 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-summary-row.html
- ensure the last two columns add up correctly
- http://localhost:4000/components/datagrid/example-grouping-totals also adds up correctly

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
