### PR TITLE
3040 - Fix header text color in safari [v4.24.x]

### DIFF
--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -344,12 +344,14 @@ label,
 // don't want to use generally because it conflicts.
 .is-safari {
   input {
-    &::-webkit-input-placeholder {
-      -webkit-text-fill-color: $input-placeholder-color;
-    }
-
     &[disabled] {
       -webkit-text-fill-color: $input-disabled-color;
+    }
+  }
+
+  .searchfield {
+    &[disabled] {
+      -webkit-text-fill-color: $theme-color-palette-graphite-70;
     }
   }
 }

--- a/src/themes/theme-soho-contrast.scss
+++ b/src/themes/theme-soho-contrast.scss
@@ -160,7 +160,7 @@ $secondary-border-btn-ripple-color: $theme-color-brand-primary-alt;
 
 // Input Fields
 $input-color: $input-color-initial-font;
-$input-disabled-color: $input-color-disabled-font;
+$input-disabled-color: $theme-color-palette-graphite-80;
 $input-placeholder-color: $input-color-initial-placeholder;
 $input-readonly-color: $input-color-readonly-font;
 

--- a/src/themes/theme-uplift-contrast.scss
+++ b/src/themes/theme-uplift-contrast.scss
@@ -158,7 +158,7 @@ $secondary-border-btn-ripple-color: $theme-color-brand-primary-alt;
 // Input Fields
 $input-color: $input-color-initial-font;
 $input-disabled-color: $input-color-disabled-font;
-$input-placeholder-color: $theme-color-palette-slate-90;
+$input-placeholder-color: $theme-color-palette-graphite-70;
 $input-readonly-color: $input-color-readonly-font;
 
 //States


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixed some missing styles on the safari, placeholders on search.

**Related github/jira issue (required)**:
Fixes #3040 

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/header/example-searchfield-expanded.html
- placeholder should be white at 50%

http://localhost:4000/components/input/example-index.html?theme=uplift&variant=contrast
- disabled input should show its placeholder
- also i lowered the placeholder color as it was the same as text

http://localhost:4000/components/colorpicker/test-states.html?theme=uplift&variant=contrast
- disabled input should show its placeholder

http://localhost:4000/components//fileupload/example-index.html?theme=soho&variant=light
- disabled input should show its placeholder

http://localhost:4000/components/listview/test-search-disabled.html?theme=uplift&variant=contrast
- disabled input should show its placeholder

http://localhost:4000/components/personalize/example-index.html?theme=uplift&variant=contrast&colors=9279a6
- disabled input should show its placeholder

http://localhost:4000/components/spinbox/example-disabled.html
- input should show its placeholder
