### PR TITLE
688 - Fix two errors shown in the NG project [v4.24.x]

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -2929,6 +2929,10 @@ Datagrid.prototype = {
     self.bodyColGroupHtmlRight = '<colgroup>';
     self.triggerDestroyCell(); // Trigger Destroy on previous cells
 
+    if (!self.settings.columns || self.settings.columns.length === 0) {
+      self.settings.columns.push({ id: 'blank', value: '', field: '' });
+    }
+
     for (j = 0; j < self.settings.columns.length; j++) {
       const col = self.settings.columns[j];
       const container = self.getContainer(col.id);
@@ -5033,77 +5037,83 @@ Datagrid.prototype = {
           $('body').off('open.datagrid');
         }
       }]
-    }).on('beforeopen.datagrid', (e, modal) => {
-      self.isColumnsChanged = false;
-      modal.element.find('.searchfield').searchfield({ clearable: true });
-      modal.element.find('.listview')
-        .listview({
-          source: this.settings.columns,
-          template: `
-          <ul>
-          {{#dataset}}
-            {{#name}}
-            <li>
-              <a href="#" target="_self" tabindex="-1">
-                <label class="inline">
-                  <input tabindex="-1" type="checkbox" class="checkbox" {{^hideable}}disabled{{/hideable}} {{^hidden}}checked{{/hidden}} data-column-id="{{id}}"/>
-                  <span class="label-text">{{name}}</span>
-                </label>
-              </a>
-            </li>
-            {{/name}}
-          {{/dataset}}
-          </ul>`,
-          searchable: true,
-          selectOnFocus: false,
-          listFilterSettings: {
-            filterMode: 'contains',
-            searchableTextCallback: item => item.name
-          }
-        })
-        .off('selected.datagrid').on('selected.datagrid', function (selectedEvent, args) {
-          const chk = args.elem.find('.checkbox');
-          const id = chk.attr('data-column-id');
-          const isChecked = chk.prop('checked');
+    }).off('beforeopen.datagrid')
+      .on('beforeopen.datagrid', (e, modal) => {
+        if (!modal) {
+          return;
+        }
 
-          args.elem.removeClass('is-selected hide-selected-color');
-
-          if (chk.is(':disabled')) {
-            return;
-          }
-          self.isColumnsChanged = true;
-
-          // Set listview dataset node state, to be in sync after filtering
-          const lv = { node: {}, api: $(this).data('listview') };
-          if (lv.api) {
-            const idx = self.columnIdxById(id);
-            if (idx !== -1 && lv.api.settings.dataset[idx]) {
-              lv.node = lv.api.settings.dataset[idx];
+        self.isColumnsChanged = false;
+        modal.element.find('.searchfield').searchfield({ clearable: true });
+        modal.element.find('.listview')
+          .listview({
+            source: this.settings.columns,
+            template: `
+            <ul>
+            {{#dataset}}
+              {{#name}}
+              <li>
+                <a href="#" target="_self" tabindex="-1">
+                  <label class="inline">
+                    <input tabindex="-1" type="checkbox" class="checkbox" {{^hideable}}disabled{{/hideable}} {{^hidden}}checked{{/hidden}} data-column-id="{{id}}"/>
+                    <span class="label-text">{{name}}</span>
+                  </label>
+                </a>
+              </li>
+              {{/name}}
+            {{/dataset}}
+            </ul>`,
+            searchable: true,
+            selectOnFocus: false,
+            listFilterSettings: {
+              filterMode: 'contains',
+              searchableTextCallback: item => item.name
             }
-          }
+          })
+          .off('selected.datagrid')
+          .on('selected.datagrid', function (selectedEvent, args) {
+            const chk = args.elem.find('.checkbox');
+            const id = chk.attr('data-column-id');
+            const isChecked = chk.prop('checked');
 
-          if (!isChecked) {
-            self.showColumn(id);
-            chk.prop('checked', true);
-            lv.node.hidden = false;
-          } else {
-            self.hideColumn(id);
-            chk.prop('checked', false);
-            lv.node.hidden = true;
+            args.elem.removeClass('is-selected hide-selected-color');
+
+            if (chk.is(':disabled')) {
+              return;
+            }
+            self.isColumnsChanged = true;
+
+            // Set listview dataset node state, to be in sync after filtering
+            const lv = { node: {}, api: $(this).data('listview') };
+            if (lv.api) {
+              const idx = self.columnIdxById(id);
+              if (idx !== -1 && lv.api.settings.dataset[idx]) {
+                lv.node = lv.api.settings.dataset[idx];
+              }
+            }
+
+            if (!isChecked) {
+              self.showColumn(id);
+              chk.prop('checked', true);
+              lv.node.hidden = false;
+            } else {
+              self.hideColumn(id);
+              chk.prop('checked', false);
+              lv.node.hidden = true;
+            }
+          });
+
+        modal.element.on('close.datagrid', () => {
+          self.isColumnsChanged = false;
+        });
+        modal.element.on('keydown.datagrid', (event) => {
+          // Escape Button Code. Make sure to close the modal correctly.
+          if (event.keyCode === 27) {
+            modal.close();
+            $('body').off('open.datagrid');
           }
         });
-
-      modal.element.on('close.datagrid', () => {
-        self.isColumnsChanged = false;
       });
-      modal.element.on('keydown.datagrid', (event) => {
-        // Escape Button Code. Make sure to close the modal correctly.
-        if (event.keyCode === 27) {
-          modal.close();
-          $('body').off('open.datagrid');
-        }
-      });
-    });
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixed two issues that may cause NG upgrade issues. Two bugs...first is that if the columns are initially empty array then calling updateColumns fails to put columns on. Second is that if a message is opened then opening a personalization dialog after will next time fail as it uses the same beforeopen event

**Related github/jira issue (required)**:
Fixes infor-design/enterprise-ng#688 (NG)

**Steps necessary to review your pull request (required)**:
- pull this branch and build
- apply the changes over to a branch of NG off latest master (copy the node_modules/ids-enterprise or use npm link)
- go to http://localhost:4200/ids-enterprise-ng-demo/datagrid-breadcrumb
- page should show column headers and
- open .. and then personalize columns then just close it
- click the "Delete" button to open a message
- open .. and then personalize columns then just close it
- check console for errors.
- also can reproduce on EP by : 
- edit this page local and change this line to empty `[]` array https://github.com/infor-design/enterprise/blob/master/app/views/components/datagrid/test-update-columns.html#L67
- open the page
- initially the rows will now load with no column info
- press update columns (should work)

