### PR TITLE
2925 - Fix filtered header styles on Uplift App Menu [v4.24.x]

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -659,9 +659,12 @@
 .accordion-pane {
   @include transition(padding 300ms cubic-bezier(0.17, 0.04, 0.03, 0.94));
 
-  height: 0;
   overflow: hidden;
   padding: 0;
+
+  &:not(.is-expanded) {
+    height: 0;
+  }
 
   // Visible accordion panes force a border to show up on the next accordion header for visual separation
   &.is-expanded {

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -1242,15 +1242,12 @@ Accordion.prototype = {
     const self = this;
 
     if (doReset) {
-      const collapsePromise = this.collapseAll();
-      this.headers.removeClass('filtered has-filtered-children hide-focus');
-      this.panes.removeClass('all-children-filtered');
+      this.headers.removeClass('filtered has-filtered-children hide-focus is-expanded');
+      this.panes.removeClass('all-children-filtered is-expanded').removeAttr('style');
 
-      $.when(collapsePromise).then(() => {
-        this.currentlyFiltered = $();
-        this.build(undefined, true);
-        this.filter(headers);
-      });
+      this.currentlyFiltered = $();
+      this.build(undefined, true);
+      this.filter(headers);
       return;
     }
 

--- a/src/components/applicationmenu/_applicationmenu-uplift.scss
+++ b/src/components/applicationmenu/_applicationmenu-uplift.scss
@@ -253,6 +253,7 @@
         &.is-selected {
           background-color: $uplift-acc-expanded-bg-color;
           border-bottom-color: transparent;
+          border-top-color: transparent;
 
           &::before {
             background-color: $uplift-appmenu-selected-bg-color;
@@ -379,12 +380,6 @@
         + .accordion-header:not(.is-focused):not(.is-selected),
         + .accordion-content {
           border-top-color: transparent;
-        }
-
-        + .accordion-header {
-          &.is-focused {
-            border-top-color: $uplift-appmenu-selected-border-color;
-          }
         }
       }
     }

--- a/src/components/applicationmenu/_applicationmenu-uplift.scss
+++ b/src/components/applicationmenu/_applicationmenu-uplift.scss
@@ -211,7 +211,7 @@
         background-color: $uplift-acc-expanded-bg-color;
         border-radius: 0;
         margin: 10px -10px 0;
-        padding: 10px 10px 0;
+        padding: 10px;
         position: relative;
 
         &:not(.is-focused),
@@ -233,7 +233,7 @@
             border-radius: $uplift-acc-border-radius;
             content: ' ';
             display: block;
-            height: calc(100% - 12px);
+            height: calc(100% - 22px);
             position: absolute;
             width: calc(100% - 20px);
           }
@@ -269,7 +269,7 @@
           }
         }
 
-        + .accordion-pane {
+        + .accordion-pane:not(.all-children-filtered) {
           background-color: $uplift-acc-expanded-bg-color;
           margin: 0 -10px;
           padding: 0 10px 10px;
@@ -291,6 +291,12 @@
 
       + .accordion-header {
         margin-top: 4px;
+      }
+
+      &.filtered {
+        + .accordion-pane {
+          display: none;
+        }
       }
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a few issues on the filtered styles of an Uplift application menu:
- Extraneous space underneath of a matching top-level filter result, which was caused by a list of children with all children filtered away, is now properly hidden.
- Sizing changes to top-level, expandable headers have been implemented to help strange padding issues.
- A small adjustment to the way `expand()` works now prevents accordion headers with no panes/content from completing the `expand()` process, which was altering the style and incorrectly triggering events.

**Related github/jira issue (required)**:
Closes #2925 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the app.
- Open http://localhost:4000/components/applicationmenu/test-hcm.html?theme=uplift&variant=light
- Filter the app menu on "Profile".  the accordion header labelled "Profile" should be the only result, and it should not have any "expanded" styles around it.
- Clear the filter.  Rerun the filter by typing "The Next".
- The expandable header "The Next Level One Menu Item..." should be the only result.  It should appear "expanded", have no children, and not have any extra space beneath it.
- Clear the filter, ensure nothing looks strange.