### PR TITLE
3101 - Fix to keep the widget dom order with homepage

### DIFF
--- a/app/views/components/homepage/example-four-column.html
+++ b/app/views/components/homepage/example-four-column.html
@@ -4,55 +4,55 @@
 
       <div class="widget double-height">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x2 (Dom Order 1)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x2 (Dom Order 1) - A</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 2)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 2) - B</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 3)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 3) - C</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 4)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 4) - D</h2>
         </div>
       </div>
 
       <div class="widget double-width">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 5)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 2x1 (Dom Order 5) - E</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 6)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 6) - F</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 7)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 7) - G</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 8)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 8) - H</h2>
         </div>
       </div>
 
       <div class="widget double-width">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 9)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 2x1 (Dom Order 9) - I</h2>
         </div>
       </div>
     </div>

--- a/app/views/components/homepage/example-scenario-a.html
+++ b/app/views/components/homepage/example-scenario-a.html
@@ -1,22 +1,22 @@
 <div id="maincontent" class="page-container scrollable" role="main">
   <div class="homepage" data-columns="3">
     <div class="content">
-      
+
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 1)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 1) - A</h2>
         </div>
       </div>
 
       <div class="widget double-width">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 2x1 (Dom Order 2)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 2x1 (Dom Order 2) - B</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 3)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 3) - C</h2>
         </div>
       </div>
 

--- a/app/views/components/homepage/example-scenario-b.html
+++ b/app/views/components/homepage/example-scenario-b.html
@@ -4,22 +4,22 @@
 
       <div class="widget double-width double-height">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 2x2 (Dom Order 1)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 2x2 (Dom Order 1) - A</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 2)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 2) - B</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 3)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 3) - C</h2>
         </div>
       </div>
-      
+
     </div>
   </div>
 </div>

--- a/app/views/components/homepage/example-scenario-c.html
+++ b/app/views/components/homepage/example-scenario-c.html
@@ -4,19 +4,19 @@
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 1)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 1) - A</h2>
         </div>
       </div>
 
       <div class="widget double-width double-height">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 2x2 (Dom Order 2)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 2x2 (Dom Order 2) - B</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 3)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 3) - C</h2>
         </div>
       </div>
 

--- a/app/views/components/homepage/example-scenario-d.html
+++ b/app/views/components/homepage/example-scenario-d.html
@@ -4,19 +4,19 @@
 
       <div class="widget triple-width">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 3x1 (Dom Order 1)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 3x1 (Dom Order 1) - A</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 2)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 2) - B</h2>
         </div>
       </div>
 
       <div class="widget double-width">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 2x1 (Dom Order 3)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 2x1 (Dom Order 3) - C</h2>
         </div>
       </div>
 

--- a/app/views/components/homepage/example-scenario-e.html
+++ b/app/views/components/homepage/example-scenario-e.html
@@ -4,25 +4,19 @@
 
       <div class="widget double-height">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 1)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x2 (Dom Order 1) - A</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 2x1 (Dom Order 2)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 2) - B</h2>
         </div>
       </div>
-<!--
-      <div class="widget">
-        <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x2 (Dom Order 3)</h2>
-        </div>
-      </div>
--->
+
       <div class="widget double-width">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x2 (Dom Order 3)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 2x1 (Dom Order 3) - C</h2>
         </div>
       </div>
 

--- a/app/views/components/homepage/example-scenario-f.html
+++ b/app/views/components/homepage/example-scenario-f.html
@@ -4,31 +4,31 @@
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 1)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 1) - A</h2>
         </div>
       </div>
 
       <div class="widget double-height">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x2 (Dom Order 2)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x2 (Dom Order 2) - B</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 3)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 3) - C</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 4)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 4) - D</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 5)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 5) - E</h2>
         </div>
       </div>
 

--- a/app/views/components/homepage/example-scenario-g.html
+++ b/app/views/components/homepage/example-scenario-g.html
@@ -4,25 +4,25 @@
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 1)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 1) - A</h2>
         </div>
       </div>
 
       <div class="widget double-width">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 2x1 (Dom Order 2)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 2x1 (Dom Order 2) - B</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 3)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 3) - C</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 4)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 4) - D</h2>
         </div>
       </div>
 

--- a/app/views/components/homepage/example-scenario-h.html
+++ b/app/views/components/homepage/example-scenario-h.html
@@ -4,19 +4,19 @@
 
       <div class="widget double-width">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 2x1 (Dom Order 1)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 2x1 (Dom Order 1) - A</h2>
         </div>
       </div>
 
       <div class="widget double-height">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x2 (Dom Order 2)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x2 (Dom Order 2) - B</h2>
         </div>
       </div>
 
-      <div class="widget  double-width">
+      <div class="widget double-width">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 2x1 (Dom Order 3)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 2x1 (Dom Order 3) - C</h2>
         </div>
       </div>
 

--- a/app/views/components/homepage/example-scenario-i.html
+++ b/app/views/components/homepage/example-scenario-i.html
@@ -4,31 +4,31 @@
 
       <div class="widget triple-width">
         <div class="widget-header">
-          <h2 class="widget-title">Widget One</h2>
+          <h2 class="widget-title">Widget 3x1 (Dom Order 1) - A</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 class="widget-title">Widget Two</h2>
+          <h2 class="widget-title">Widget 1x1 (Dom Order 2) - B</h2>
         </div>
       </div>
 
       <div class="widget double-width">
         <div class="widget-header">
-          <h2 class="widget-title">Widget Three</h2>
+          <h2 class="widget-title">Widget 2x1 (Dom Order 3) - C</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 class="widget-title">Widget Four</h2>
+          <h2 class="widget-title">Widget 1x1 (Dom Order 4) - D</h2>
         </div>
       </div>
 
       <div class="widget double-width">
         <div class="widget-header">
-          <h2 class="widget-title">Widget Five</h2>
+          <h2 class="widget-title">Widget 2x1 (Dom Order 5) - E</h2>
         </div>
       </div>
 

--- a/app/views/components/homepage/example-scenario-j.html
+++ b/app/views/components/homepage/example-scenario-j.html
@@ -4,43 +4,43 @@
 
       <div class="widget double-height">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x2 (Dom Order 1)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x2 (Dom Order 1) - A</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 2)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 2) - B</h2>
         </div>
       </div>
 
       <div class="widget double-width">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 2x1 (Dom Order 3)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 2x1 (Dom Order 3) - C</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 4)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 4) - D</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 5)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 5) - E</h2>
         </div>
       </div>
 
       <div class="widget double-height">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x2 (Dom Order 6)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x2 (Dom Order 6) - F</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 7)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 7) - G</h2>
         </div>
       </div>
 

--- a/app/views/components/homepage/example-scenario-k.html
+++ b/app/views/components/homepage/example-scenario-k.html
@@ -4,25 +4,19 @@
 
       <div class="widget double-height">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x2 (Dom Order 1)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x2 (Dom Order 1) - A</h2>
         </div>
       </div>
 
       <div class="widget">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 2)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 2) - B</h2>
         </div>
       </div>
-<!--
-      <div class="widget">
-        <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 3)</h2>
-        </div>
-      </div>
--->
+
       <div class="widget double-width">
         <div class="widget-header">
-          <h2 tabindex="0" class="widget-title">Widget 1x1 (Dom Order 3)</h2>
+          <h2 tabindex="0" class="widget-title">Widget 2x1 (Dom Order 3) - C</h2>
         </div>
       </div>
 

--- a/app/views/components/homepage/example-scenario-n.html
+++ b/app/views/components/homepage/example-scenario-n.html
@@ -4,7 +4,7 @@
 
       <div class="widget double-width">
         <div class="widget-header">
-          <h2 class="widget-title">Chart Title (Dom Order 1, 2x1, col:4)</h2>
+          <h2 class="widget-title">Widget 2x1 (Dom Order 1) - A</h2>
           <button class="btn-actions" type="button">
             <span class="audible">Actions</span>
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
@@ -20,7 +20,7 @@
 
       <div class="widget double-width">
         <div class="widget-header">
-          <h2 class="widget-title">Alerts (Dom Order 2, 2x1, col:4)</h2>
+          <h2 class="widget-title">Widget 2x1 (Dom Order 2) - B</h2>
           <button class="btn-actions" type="button">
             <span class="audible">Actions</span>
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/homepage/example-scenario-o.html
+++ b/app/views/components/homepage/example-scenario-o.html
@@ -4,35 +4,35 @@
 
       <div class="widget">
         <div class="widget-header">
-          <h2 class="widget-title">Dom Order 1, 1x1, #Small Widget</h2>
+          <h2 class="widget-title">Widget 1x1 (Dom Order 1) - A</h2>
 				</div>
        	<div class="widget-content page-container"></div>
 			</div>
 
 				<div class="widget double-width">
  				<div class="widget-header">
- 					<h2 class="widget-title">Dom Order 2, 2x1, #Medium Widget</h2>
+ 					<h2 class="widget-title">Widget 2x1 (Dom Order 2) - B</h2>
 		    </div>
    			<div class="widget-content page-container"></div>
 			</div>
 
  			<div class="widget triple-width">
 					<div class="widget-header">
- 					<h2 class="widget-title">Dom Order 3, 3x1, #Widget 1</h2>
+ 					<h2 class="widget-title">Widget 3x1 (Dom Order 3) - C</h2>
 					</div>
  				<div class="widget-content page-container"></div>
 			</div>
 
  			<div class="widget triple-width">
         <div class="widget-header">
-          <h2 class="widget-title">Dom Order 4, 3x1, #Widget 2</h2>
+          <h2 class="widget-title">Widget 3x1 (Dom Order 4) - D</h2>
         </div>
         <div class="widget-content page-container"></div>
 			</div>
 
       <div class="widget triple-width">
         <div class="widget-header">
-          <h2 class="widget-title">Dom Order 5, 3x1, #Widget 3</h2>
+          <h2 class="widget-title">Widget 3x1 (Dom Order 5) - E</h2>
         </div>
         <div class="widget-content page-container"></div>
 			</div>

--- a/app/views/components/homepage/example-scenario-p.html
+++ b/app/views/components/homepage/example-scenario-p.html
@@ -1,0 +1,42 @@
+<div class="page-container scrollable">
+  <div class="homepage" data-columns="3" id="maincontent" role="main">
+    <div class="content">
+
+      <div class="widget">
+        <div class="widget-header">
+          <h2 class="widget-title">Widget 1x1 (Dom Order 1) - A</h2>
+        </div>
+        <div class="widget-content page-container"></div>
+      </div>
+
+      <div class="widget">
+        <div class="widget-header">
+          <h2 class="widget-title">Widget 1x1 (Dom Order 2) - B</h2>
+        </div>
+        <div class="widget-content page-container"></div>
+      </div>
+
+      <div class="widget triple-width">
+        <div class="widget-header">
+          <h2 class="widget-title">Widget 3x1 (Dom Order 3) - C</h2>
+        </div>
+        <div class="widget-content page-container"></div>
+      </div>
+
+      <div class="widget triple-width">
+        <div class="widget-header">
+          <h2 class="widget-title">Widget 3x1 (Dom Order 4) - D</h2>
+        </div>
+        <div class="widget-content page-container"></div>
+      </div>
+
+      <div class="widget triple-width">
+        <div class="widget-header">
+          <h2 class="widget-title">Widget 3x1 (Dom Order 5) - E</h2>
+        </div>
+        <div class="widget-content page-container"></div>
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### v4.25.0 Fixes
 
 - `[Datagrid]` Fixed a bug where floating point math would cause the grouping sum aggregator to round incorrectly. ([#3233](https://github.com/infor-design/enterprise/issues/3233))
+- `[Homepage]` Fixed an issue where the DOM order was not working for triple width widgets. ([#3101](https://github.com/infor-design/enterprise/issues/3101))
 - `[Tabs]` Fixed an issue where scroll was not working on mobile view for scrollable-flex layout. ([#2931](https://github.com/infor-design/enterprise/issues/2931))
 
 ### v4.25.0 Chores & Maintenance

--- a/src/components/homepage/homepage.js
+++ b/src/components/homepage/homepage.js
@@ -273,7 +273,8 @@ Homepage.prototype = {
     // Max sized columns brings to top
     if (this.settings.columns > 1) {
       for (let i = 0, j = 0, w = 0, l = this.blocks.length; i < l; i++) {
-        if (this.blocks[i].w >= this.settings.columns && i && w) {
+        if (this.blocks[i].w >= this.settings.columns && i &&
+          w && (w <= (this.settings.columns / 2))) {
           this.arrayIndexMove(this.blocks, i, j);
         }
         w += this.blocks[i].w;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the DOM order was not working for triple width widgets with Homepage.

**Related github/jira issue (required)**:
Closes #3101

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/homepage/example-scenario-p.html
- While browser width more then `740px`
- See the order of widget should be as
- 1st row `(A) single-width` and `(B) single-width`
- 2nd row `(C) tripple-width`
- 3rd row `(D) tripple-width`
- 4th row `(E) tripple-width`

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
