### PR TITLE
3253 - Change conversion logic for one example [v4.24.x]

### DIFF
--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -149,8 +149,6 @@ Editor.prototype = {
 
     // Convert legacy header settings into Fontpicker settings
     if (this.settings.firstHeader || this.settings.secondHeader) {
-      let removeFirstHeader = false;
-      let removeSecondHeader = false;
       if (!Array.isArray(this.settings.fontpickerSettings.styles)) {
         this.settings.fontpickerSettings.styles = [];
       }
@@ -161,22 +159,35 @@ Editor.prototype = {
         warnAboutDeprecation('`fontpickerSettings.styles` setting', '`firstHeader` setting', 'Editor Component');
         this.settings.fontpickerSettings.styles.push(new FontPickerStyle('legacyHeader1', 'Header 1', this.settings.firstHeader));
         delete this.settings.firstHeader;
-        removeFirstHeader = true;
       }
       if (this.settings.secondHeader) {
         warnAboutDeprecation('`fontpickerSettings.styles` setting', '`secondHeader` setting', 'Editor Component');
         this.settings.fontpickerSettings.styles.push(new FontPickerStyle('legacyHeader2', 'Header 2', this.settings.secondHeader));
         delete this.settings.secondHeader;
-        removeSecondHeader = true;
       }
+    }
 
-      // Remove the old button definitions from the `settings.buttons` array
-      this.settings.buttons.editor = this.settings.buttons.editor.filter((btn) => {
-        if ((btn === 'header1' && removeFirstHeader) || (btn === 'header2' && removeSecondHeader)) {
-          return false;
-        }
-        return true;
-      });
+    if (s.buttons && s.buttons.editor) {
+      let foundOldSettings = false;
+      const styles = [new FontPickerStyle('default', 'Default', 'p')];
+
+      const headers = s.buttons.editor.filter(el => el.substr(0, 6) === 'header');
+
+      for (let i = 0; i < headers.length; i++) {
+        const hLevel = headers[i].substr(6, 1);
+        foundOldSettings = true;
+        styles.push(new FontPickerStyle(`header${hLevel}`, `Header ${hLevel}`, `h${hLevel}`));
+      }
+      if (foundOldSettings) {
+        s.buttons.editor = s.buttons.editor.filter(el => el.substr(0, 6) !== 'header');
+        s.fontpickerSettings = { styles };
+      }
+      if (s.buttons.editor[0] === 'seperator') {
+        s.buttons.editor.splice(0, 1);
+      }
+      if (foundOldSettings) {
+        s.buttons.editor = ['fontPicker'].concat(s.buttons.editor);
+      }
     }
 
     if (!s.anchor.defaultTarget) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Changed the conversion logic to cover the cases on http://localhost:4000/components/editor/example-customize-buttons.html

**Related github/jira issue (required)**:
Fixes #3253 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/editor/example-customize-buttons.html
- the h1 and h2 buttons should be replaced with a font picker
- any other example that convert old settings need to be checked?
- test pages on http://localhost:4000/components/editor/