### PR TITLE
690 - Fix for datagrid resetColumns when columsn are empty [v4.24.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `[All]` Removed the property `-webkit-text-fill-color` from usage throughout out our codebase, except for one rule that changes it to `unset` if it's present. ([#3041](https://github.com/infor-design/enterprise/issues/3041))
 - `[Application Menu]` Fixed issue in application menu where scrollbar is visible even if it's not needed in uplift theme. ([#3134](https://github.com/infor-design/enterprise/issues/3134))
 - `[Datagrid]` Fixed an issue where the hide pager on one page setting was not working correctly when applying a filter. ([#2676](https://github.com/infor-design/enterprise/issues/2676))
+- `[Datagrid]` Fixed an issue where if the grid is initialized with an empty array then updateColumns is used the resetColumns function failed. ([#690](https://github.com/infor-design/enterprise-ng/issues/690))
 - `[Datagrid]` Fixed an issue where the dirty cell indicator was not updating after remove row. ([#2960](https://github.com/infor-design/enterprise/issues/2960))
 - `[Datagrid]` Fixed an issue where the method getModifiedRows was not working, it had duplicate entries for the same row. ([#2908](https://github.com/infor-design/enterprise/issues/2908))
 - `[Datagrid]` Fixed an issue where the personalized columns were not working when toggle columns and drag drop. ([#3004](https://github.com/infor-design/enterprise/issues/3004))


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

I pushed accidentally the core fix of this issue direct to 4.24.x so the steps are a bit wierd. Just noting but the fix should be safe. Except for the changelog.

If looks good will post a new nightly on dev tomorrow AM and release a NG dev build.

Examine fix changes here already accidentally pushed : https://github.com/infor-design/enterprise/commit/4704df485f1f5f48d4a0dfaa10bcc223a8e849ce 

**Related github/jira issue (required)**:
Fixes infor-design/enterprise-ng#690 (NG)

**Steps necessary to review your pull request (required)**:
- pull this branch
- go to http://localhost:4000/components/datagrid/test-update-columns-empty
- hit update to updateColumns
- resize a column or two
- hit reset to restColumns
- should reset and not be empty
- also try this by apply these changes on a master branch of enterprise-ng
- go to http://localhost:4200/ids-enterprise-ng-demo/datagrid-breadcrumb
- reset the columns
- hit reset columns in the ... menu

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
