### PR TITLE
3266 - Fix restoring columns after rerender [v4.24.x]

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3903,10 +3903,6 @@ Datagrid.prototype = {
     let hasButton = false;
     const self = this;
 
-    if (columnDef.hidden) {
-      return 0;
-    }
-
     if (columnDef.formatter === Formatters.Colorpicker) {
       maxText = '';
     } else if (columnDef.formatter === Formatters.Dropdown && columnDef.options) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixed a bug when restoring columns after a rerender when some are hidden. When this occurs the width becomes zero so the column was not visible.

**Related github/jira issue (required)**:
Fixes #3266 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-custom-toolbar.html
- in the .. menu open personalize columns
- hide the product name and / or activity column
- on the toolbar do a search for .99 (this used to do a rerender and sets the hidden widths to zero)
- in the .. menu open personalize columns
- show the product name and / or activity column
- their restore size should be roughly what it was before when visible.