### PR TITLE
3018 - Correct ZH month translations

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Datagrid]` Fixed a bug where floating point math would cause the grouping sum aggregator to round incorrectly. ([#3233](https://github.com/infor-design/enterprise/issues/3233))
 - `[Homepage]` Fixed an issue where the DOM order was not working for triple width widgets. ([#3101](https://github.com/infor-design/enterprise/issues/3101))
 - `[Locale]` Added the ability to set a 5 digit language (`fr-FR` and `fr-CA` vs `fr`) and added separate strings for `fr-CA` vs `fr-FR`. ([#3245](https://github.com/infor-design/enterprise/issues/3245))
+- `[Locale]` Changed incorrect Chinese locale year formats to the correct format as noted by translators. For example `"2019年 12月`. ([#3081](https://github.com/infor-design/enterprise/issues/3081))
 - `[Tabs]` Fixed an issue where scroll was not working on mobile view for scrollable-flex layout. ([#2931](https://github.com/infor-design/enterprise/issues/2931))
 
 ### v4.25.0 Chores & Maintenance

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@
 - `[Datagrid]` Fixed a bug where floating point math would cause the grouping sum aggregator to round incorrectly. ([#3233](https://github.com/infor-design/enterprise/issues/3233))
 - `[Homepage]` Fixed an issue where the DOM order was not working for triple width widgets. ([#3101](https://github.com/infor-design/enterprise/issues/3101))
 - `[Locale]` Added the ability to set a 5 digit language (`fr-FR` and `fr-CA` vs `fr`) and added separate strings for `fr-CA` vs `fr-FR`. ([#3245](https://github.com/infor-design/enterprise/issues/3245))
-- `[Locale]` Changed incorrect Chinese locale year formats to the correct format as noted by translators. For example `"2019年 12月`. ([#3081](https://github.com/infor-design/enterprise/issues/3081))
+- `[Locale]` Changed incorrect Chinese locale year formats to the correct format as noted by translators. For example `2019年 12月`. ([#3081](https://github.com/infor-design/enterprise/issues/3081))
 - `[Tabs]` Fixed an issue where scroll was not working on mobile view for scrollable-flex layout. ([#2931](https://github.com/infor-design/enterprise/issues/2931))
 
 ### v4.25.0 Chores & Maintenance

--- a/src/components/locale/cultures/zh-CN.js
+++ b/src/components/locale/cultures/zh-CN.js
@@ -18,7 +18,7 @@ Soho.Locale.addCulture('zh-CN', {
       long: 'yyyy年M月d日',
       full: 'yyyy年M月d日EEEE',
       month: 'M月d日',
-      year: 'yyyy年M',
+      year: 'yyyy年 M月',
       timestamp: 'HH:mm:ss',
       hour: 'HH:mm',
       datetime: 'yyyy/M/d ah:mm',
@@ -33,8 +33,8 @@ Soho.Locale.addCulture('zh-CN', {
     },
     // ca-gregorian/main/dates/calendars/gregorian/months/format/wide
     months: {
-      wide: ['一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月'],
-      abbreviated: ['一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月']
+      wide: ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'],
+      abbreviated: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']
     },
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'ah:mm',

--- a/src/components/locale/cultures/zh-Hans.js
+++ b/src/components/locale/cultures/zh-Hans.js
@@ -18,7 +18,7 @@ Soho.Locale.addCulture('zh-Hans', {
       long: 'yyyy年M月d日',
       full: 'yyyy年M月d日EEEE',
       month: 'M月d日',
-      year: 'yyyy年M',
+      year: 'yyyy年 M月',
       timestamp: 'HH:mm:ss',
       hour: 'HH:mm',
       datetime: 'yyyy/M/d ah:mm',
@@ -33,8 +33,8 @@ Soho.Locale.addCulture('zh-Hans', {
     },
     // ca-gregorian/main/dates/calendars/gregorian/months/format/wide
     months: {
-      wide: ['一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月'],
-      abbreviated: ['一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月']
+      wide: ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'],
+      abbreviated: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']
     },
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'ah:mm',

--- a/src/components/locale/cultures/zh-Hant.js
+++ b/src/components/locale/cultures/zh-Hant.js
@@ -18,7 +18,7 @@ Soho.Locale.addCulture('zh-Hant', {
       long: 'yyyy年M月d日',
       full: 'yyyy年M月d日 EEEE',
       month: 'M月d日',
-      year: 'yyyy年M',
+      year: 'yyyy年 M月',
       timestamp: 'ah:mm:ss',
       hour: 'ah:mm',
       datetime: 'M/d/yyyy ah:mm',
@@ -33,8 +33,8 @@ Soho.Locale.addCulture('zh-Hant', {
     },
     // ca-gregorian/main/dates/calendars/gregorian/months/format/wide
     months: {
-      wide: ['一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月'],
-      abbreviated: ['一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月']
+      wide: ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'],
+      abbreviated: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']
     },
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'ah:mm',

--- a/src/components/locale/cultures/zh-TW.js
+++ b/src/components/locale/cultures/zh-TW.js
@@ -18,7 +18,7 @@ Soho.Locale.addCulture('zh-TW', {
       long: 'yyyy年M月d日',
       full: 'yyyy年M月d日 EEEE',
       month: 'M月d日',
-      year: 'yyyy年M',
+      year: 'yyyy年 M月',
       timestamp: 'ah:mm:ss',
       hour: 'ah:mm',
       datetime: 'M/d/yyyy ah:mm',
@@ -33,8 +33,8 @@ Soho.Locale.addCulture('zh-TW', {
     },
     // ca-gregorian/main/dates/calendars/gregorian/months/format/wide
     months: {
-      wide: ['一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月'],
-      abbreviated: ['一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月']
+      wide: ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'],
+      abbreviated: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']
     },
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'ah:mm',

--- a/test/components/calendar/calendar.e2e-spec.js
+++ b/test/components/calendar/calendar.e2e-spec.js
@@ -79,8 +79,8 @@ describe('Calendar ajax loading tests', () => {
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('.calendar-event-more'))), 4000);
 
-    expect(await element.all(by.css('.calendar-event-more')).count()).toEqual(1);
-    expect(await element.all(by.css('.calendar-event.azure')).count()).toEqual(3);
+    expect(await element.all(by.css('.monthview-table .calendar-event-more')).count()).toEqual(1);
+    expect(await element.all(by.css('.monthview-table .calendar-event.azure')).count()).toEqual(3);
   });
 
   it('Should render ajax loaded dates for sept 2018', async () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Translators told us all ZH locales are wrong in the datepicker/monthview. This corrects them.

**Related github/jira issue (required)**:
Fixes #3081 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datepicker/example-index.html?locale=zh-CN
- open calendar
- should be of format `2019年 12月` fx `<yearno>年 <monthno>月`
- effects all zh* locales

**Included in this Pull Request**:
- [x] A note to the change log.
