### PR TITLE
659 - Fix data after commit edit for tree with datagrid

### DIFF
--- a/app/views/components/datagrid/test-tree-editable-children.html
+++ b/app/views/components/datagrid/test-tree-editable-children.html
@@ -9,11 +9,11 @@
   $('body').one('initialized', function () {
     var auditData = [
       {
-        id: 1, escalated: 2, depth: 1, expanded: false, entity: 'All', view: false, create: false, change: false,
+        id: 1, escalated: 2, depth: 1, expanded: true, entity: 'All', view: false, create: false, change: false,
         delete: false, activate: false, deactivate: false, export: false, import: false, purge: false, approve: false,
         children: [
           {
-            id: 2, escalated: 0, depth: 2, entity: 'Process', view: false, create: false, change: false,
+            id: 2, escalated: 0, depth: 2, entity: 'Process', view: false, create: false, change: false, expanded: true,
             delete: false, activate: false, deactivate: false, export: false, import: false, purge: false, approve: false,
             children: [
               {
@@ -31,7 +31,7 @@
           },
           {
             id: 5, escalated: 0, depth: 2, entity: 'Connect',
-            view: false, create: false, change: false,
+            view: false, create: false, change: false, expanded: true,
             delete: false, activate: false, deactivate: false, export: false, import: false,
             purge: false, approve: false, children: [
               {
@@ -49,7 +49,7 @@
           },
 
           {
-            id: 8, escalated: 0, depth: 2, entity: 'Scripting', view: false, create: false, change: false,
+            id: 8, escalated: 0, depth: 2, entity: 'Scripting', view: false, create: false, change: false, expanded: true,
             delete: false, activate: false, deactivate: false, export: false, import: false, purge: false, approve: false,
             children: [
               {
@@ -71,17 +71,17 @@
 
     // Define Columns for the Grid.
     var columns = [
-      { id: 'name', name: 'Entity', field: 'entity', expanded: 'expanded', formatter: Formatters.Tree, filterType: 'text' },
-      { id: 'view', name: 'View', field: 'view', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95 },
-      { id: 'create', name: 'Create', field: 'create', formatter: Formatters.SelectionCheckbox, editor: Editors.Checkbox, width: 95 },
-      { id: 'change', name: 'Change', field: 'change', formatter: Formatters.SelectionCheckbox, editor: Editors.Checkbox, width: 95 },
-      { id: 'delete', name: 'Delete', field: 'delete', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95 },
-      { id: 'activate', name: 'Activate', field: 'activate', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95 },
-      { id: 'deactivate', name: 'Deactivate', field: 'deactivate', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95 },
-      { id: 'export', name: 'Export', field: 'export', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95 },
-      { id: 'import', name: 'Import', field: 'import', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95 },
-      { id: 'purge', name: 'Purge', field: 'purge', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95 },
-      { id: 'approve', name: 'Approve', field: 'approve', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95 }
+      { id: 'name', name: 'Entity', field: 'entity', expanded: 'expanded', formatter: Formatters.Tree, filterType: 'text', sortable: false },
+      { id: 'view', name: 'View', field: 'view', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95, align: 'center', sortable: false },
+      { id: 'create', name: 'Create', field: 'create', formatter: Formatters.SelectionCheckbox, editor: Editors.Checkbox, width: 95, align: 'center', sortable: false },
+      { id: 'change', name: 'Change', field: 'change', formatter: Formatters.SelectionCheckbox, editor: Editors.Checkbox, width: 95, align: 'center', sortable: false },
+      { id: 'delete', name: 'Delete', field: 'delete', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95, align: 'center', sortable: false },
+      { id: 'activate', name: 'Activate', field: 'activate', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95, align: 'center', sortable: false },
+      { id: 'deactivate', name: 'Deactivate', field: 'deactivate', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95, align: 'center', sortable: false },
+      { id: 'export', name: 'Export', field: 'export', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95, align: 'center', sortable: false },
+      { id: 'import', name: 'Import', field: 'import', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95, align: 'center', sortable: false },
+      { id: 'purge', name: 'Purge', field: 'purge', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95, align: 'center', sortable: false },
+      { id: 'approve', name: 'Approve', field: 'approve', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95, align: 'center', sortable: false }
     ];
 
     // Init the grid
@@ -91,9 +91,7 @@
       treeGrid: true,
       editable: true,
       showDirty: true,
-      paging: true,
-      pagesize: 2,
-      toolbar: {title: 'Tasks (Hierarchical)', results: true, personalize: true}
+      toolbar: { title: 'Tasks (Hierarchical)', results: true, personalize: true }
     }).on('cellchange', function (e, args) {
       console.log('cellchange:', { arguments: args, data: auditData });
     });

--- a/app/views/components/datagrid/test-tree-editable-children.html
+++ b/app/views/components/datagrid/test-tree-editable-children.html
@@ -71,17 +71,17 @@
 
     // Define Columns for the Grid.
     var columns = [
-      { id: 'name', name: 'Entity', field: 'entity', expanded: 'expanded', formatter: Soho.Formatters.Tree, filterType: 'text' },
-      { id: 'view', name: 'View', field: 'view', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox, width: 95 },
-      { id: 'create', name: 'Create', field: 'create', formatter: Soho.Formatters.SelectionCheckbox, editor: Soho.Editors.Checkbox, width: 95 },
-      { id: 'change', name: 'Change', field: 'change', formatter: Soho.Formatters.SelectionCheckbox, editor: Soho.Editors.Checkbox, width: 95 },
-      { id: 'delete', name: 'Delete', field: 'delete', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox, width: 95 },
-      { id: 'activate', name: 'Activate', field: 'activate', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox, width: 95 },
-      { id: 'deactivate', name: 'Deactivate', field: 'deactivate', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox, width: 95 },
-      { id: 'export', name: 'Export', field: 'export', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox, width: 95 },
-      { id: 'import', name: 'Import', field: 'import', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox, width: 95 },
-      { id: 'purge', name: 'Purge', field: 'purge', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox, width: 95 },
-      { id: 'approve', name: 'Approve', field: 'approve', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox, width: 95 }
+      { id: 'name', name: 'Entity', field: 'entity', expanded: 'expanded', formatter: Formatters.Tree, filterType: 'text' },
+      { id: 'view', name: 'View', field: 'view', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95 },
+      { id: 'create', name: 'Create', field: 'create', formatter: Formatters.SelectionCheckbox, editor: Editors.Checkbox, width: 95 },
+      { id: 'change', name: 'Change', field: 'change', formatter: Formatters.SelectionCheckbox, editor: Editors.Checkbox, width: 95 },
+      { id: 'delete', name: 'Delete', field: 'delete', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95 },
+      { id: 'activate', name: 'Activate', field: 'activate', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95 },
+      { id: 'deactivate', name: 'Deactivate', field: 'deactivate', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95 },
+      { id: 'export', name: 'Export', field: 'export', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95 },
+      { id: 'import', name: 'Import', field: 'import', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95 },
+      { id: 'purge', name: 'Purge', field: 'purge', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95 },
+      { id: 'approve', name: 'Approve', field: 'approve', formatter: Formatters.Checkbox, editor: Editors.Checkbox, width: 95 }
     ];
 
     // Init the grid

--- a/app/views/components/datagrid/test-tree-editable-children.html
+++ b/app/views/components/datagrid/test-tree-editable-children.html
@@ -1,0 +1,102 @@
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    var auditData = [
+      {
+        id: 1, escalated: 2, depth: 1, expanded: false, entity: 'All', view: false, create: false, change: false,
+        delete: false, activate: false, deactivate: false, export: false, import: false, purge: false, approve: false,
+        children: [
+          {
+            id: 2, escalated: 0, depth: 2, entity: 'Process', view: false, create: false, change: false,
+            delete: false, activate: false, deactivate: false, export: false, import: false, purge: false, approve: false,
+            children: [
+              {
+                id: 3, escalated: 0, depth: 3, entity: 'Workflows',
+                view: false, create: false, change: false,
+                delete: false, activate: false, deactivate: false, export: false, import: false,
+                purge: false, approve: false
+              },
+              {
+                id: 4, escalated: 0, depth: 3, entity: 'Monitors',
+                view: false, create: false, change: false,
+                delete: false, activate: false, deactivate: false, export: false, import: false,
+                purge: false, approve: false
+              }]
+          },
+          {
+            id: 5, escalated: 0, depth: 2, entity: 'Connect',
+            view: false, create: false, change: false,
+            delete: false, activate: false, deactivate: false, export: false, import: false,
+            purge: false, approve: false, children: [
+              {
+                id: 6, escalated: 0, depth: 3, entity: 'Document Flows',
+                view: false, create: false, change: false,
+                delete: false, activate: false, deactivate: false, export: false, import: false,
+                purge: false, approve: false
+              },
+              {
+                id: 7, escalated: 0, depth: 3, entity: 'Connection points',
+                view: false, create: false, change: false,
+                delete: false, activate: false, deactivate: false, export: false, import: false,
+                purge: false, approve: false
+              }]
+          },
+
+          {
+            id: 8, escalated: 0, depth: 2, entity: 'Scripting', view: false, create: false, change: false,
+            delete: false, activate: false, deactivate: false, export: false, import: false, purge: false, approve: false,
+            children: [
+              {
+                id: 9, escalated: 0, depth: 3, entity: 'Scripting submenu1',
+                view: false, create: false, change: false,
+                delete: false, activate: false, deactivate: false, export: false, import: false,
+                purge: false, approve: false
+              },
+              {
+                id: 10, escalated: 0, depth: 3, entity: 'Scripting submenu2',
+                view: false, create: false, change: false,
+                delete: false, activate: false, deactivate: false, export: false, import: false,
+                purge: false, approve: false
+              }]
+          },
+        ]
+      }
+    ];
+
+    // Define Columns for the Grid.
+    var columns = [
+      { id: 'name', name: 'Entity', field: 'entity', expanded: 'expanded', formatter: Soho.Formatters.Tree, filterType: 'text' },
+      { id: 'view', name: 'View', field: 'view', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox, width: 95 },
+      { id: 'create', name: 'Create', field: 'create', formatter: Soho.Formatters.SelectionCheckbox, editor: Soho.Editors.Checkbox, width: 95 },
+      { id: 'change', name: 'Change', field: 'change', formatter: Soho.Formatters.SelectionCheckbox, editor: Soho.Editors.Checkbox, width: 95 },
+      { id: 'delete', name: 'Delete', field: 'delete', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox, width: 95 },
+      { id: 'activate', name: 'Activate', field: 'activate', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox, width: 95 },
+      { id: 'deactivate', name: 'Deactivate', field: 'deactivate', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox, width: 95 },
+      { id: 'export', name: 'Export', field: 'export', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox, width: 95 },
+      { id: 'import', name: 'Import', field: 'import', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox, width: 95 },
+      { id: 'purge', name: 'Purge', field: 'purge', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox, width: 95 },
+      { id: 'approve', name: 'Approve', field: 'approve', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox, width: 95 }
+    ];
+
+    // Init the grid
+    $('#datagrid').datagrid({
+      columns: columns,
+      dataset: auditData,
+      treeGrid: true,
+      editable: true,
+      showDirty: true,
+      paging: true,
+      pagesize: 2,
+      toolbar: {title: 'Tasks (Hierarchical)', results: true, personalize: true}
+    }).on('cellchange', function (e, args) {
+      console.log('cellchange:', { arguments: args, data: auditData });
+    });
+
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[About]` Added further indication for Microsoft Edge Chrome next to the underlying chrome version. ([#3073](https://github.com/infor-design/enterprise/issues/3073))
 - `[About]` Fixed a bug where the browser language was shown as the locale name, we now show browser language and IDs language and locale separate. ([#2913](https://github.com/infor-design/enterprise/issues/2913))
 - `[About]` Fixed a bug where the OS version was duplicated. ([#1650](https://github.com/infor-design/enterprise/issues/1650))
+- `[Datagrid]` Fixed an issue where the data after commit edit was not in sync for tree. ([#659](https://github.com/infor-design/enterprise-ng/issues/659))
 - `[Datagrid]` Fixed an issue where time picker filter trigger icon and text was overlapping. ([#3062](https://github.com/infor-design/enterprise/issues/3062))
 - `[Datagrid]` Fixed a bug where floating point math would cause the grouping sum aggregator to round incorrectly. ([#3233](https://github.com/infor-design/enterprise/issues/3233))
 - `[Homepage]` Fixed an issue where the DOM order was not working for triple width widgets. ([#3101](https://github.com/infor-design/enterprise/issues/3101))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -8192,9 +8192,10 @@ Datagrid.prototype = {
     }
 
     const thisRow = this.actualRowNode(row);
-    const idx = this.settings.treeGrid ? this.actualPagingRowIndex(this.actualRowIndex(thisRow)) :
+    const idx = this.settings.treeGrid ?
+      this.actualPagingRowIndex(this.actualRowIndex(thisRow)) :
       this.dataRowIndex(thisRow);
-    const rowData = this.rowData(this.dataRowIndex(thisRow));
+    const rowData = this.rowData(idx);
 
     const isEditor = $('.is-editor', cellParent).length > 0;
     const isPlaceholder = $('.is-placeholder', cellNode).length > 0;
@@ -9065,7 +9066,10 @@ Datagrid.prototype = {
     const formatter = (col.formatter ? col.formatter : this.defaultFormatter);
     const isEditor = $('.editor', cellNode).length > 0;
     const isTreeGrid = this.settings.treeGrid;
-    let dataRowIndex = this.dataRowIndex(rowNodes);
+    let dataRowIndex = isTreeGrid ?
+      this.actualPagingRowIndex(this.actualRowIndex(rowNodes)) :
+      this.dataRowIndex(rowNodes);
+
     if (dataRowIndex === null || dataRowIndex === undefined || isNaN(dataRowIndex)) {
       dataRowIndex = row;
     }

--- a/test/components/calendar/calendar.e2e-spec.js
+++ b/test/components/calendar/calendar.e2e-spec.js
@@ -79,8 +79,8 @@ describe('Calendar ajax loading tests', () => {
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('.calendar-event-more'))), 4000);
 
-    expect(await element.all(by.css('.calendar-event-more')).count()).toEqual(1);
-    expect(await element.all(by.css('.calendar-event.azure')).count()).toEqual(3);
+    expect(await element.all(by.css('.monthview-table .calendar-event-more')).count()).toEqual(1);
+    expect(await element.all(by.css('.monthview-table .calendar-event.azure')).count()).toEqual(3);
   });
 
   it('Should render ajax loaded dates for sept 2018', async () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed data after commit edit was not in sync for tree with Datagrid.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#659

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/test-tree-editable-children.html
- Open developer tools
- Click on checkbox in column `view` to make checked for `Workflows` 3rd row
- See console for `arguments: rowData > view` should be updated(true/false)
- And also `data: [0] > children[0] > children[0] > children[0] > children[0] > view` should be updated(true/false)


**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
