### PR TITLE
3172 - Fix scrollbar styles for windows chrome

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Datagrid]` Fixed a bug where floating point math would cause the grouping sum aggregator to round incorrectly. ([#3233](https://github.com/infor-design/enterprise/issues/3233))
 - `[Homepage]` Fixed an issue where the DOM order was not working for triple width widgets. ([#3101](https://github.com/infor-design/enterprise/issues/3101))
 - `[Locale]` Added the ability to set a 5 digit language (`fr-FR` and `fr-CA` vs `fr`) and added separate strings for `fr-CA` vs `fr-FR`. ([#3245](https://github.com/infor-design/enterprise/issues/3245))
+- `[Scrollbar]` Fixed styles for windows chrome to work with all themes. ([#3172](https://github.com/infor-design/enterprise/issues/3172))
 - `[Tabs]` Fixed an issue where scroll was not working on mobile view for scrollable-flex layout. ([#2931](https://github.com/infor-design/enterprise/issues/2931))
 
 ### v4.25.0 Chores & Maintenance

--- a/src/themes/theme-uplift-contrast.scss
+++ b/src/themes/theme-uplift-contrast.scss
@@ -813,3 +813,25 @@ body::before {
     }
   }
 }
+
+html.is-chrome:not(.is-mac) {
+  ::-webkit-scrollbar-track {
+    background-color: $theme-color-body-base;
+    border-left: 1px solid $theme-color-brand-secondary-lighter;
+  }
+
+  ::-webkit-scrollbar {
+    background-color: transparent;
+    height: 8px;
+    width: 8px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: $theme-color-brand-secondary-base;
+    border-radius: 10px;
+
+    &:hover {
+      background: $theme-color-brand-secondary-alt;
+    }
+  }
+}

--- a/src/themes/theme-uplift-dark.scss
+++ b/src/themes/theme-uplift-dark.scss
@@ -767,3 +767,25 @@ body::before {
 .dropdown-list.multiple li:hover:not(.group-label)::before {
   border: 1px solid $theme-color-palette-slate-40;
 }
+
+html.is-chrome:not(.is-mac) {
+  ::-webkit-scrollbar-track {
+    background-color: $theme-color-body-base;
+    border-left: 1px solid $theme-color-brand-secondary-lighter;
+  }
+
+  ::-webkit-scrollbar {
+    background-color: transparent;
+    height: 8px;
+    width: 8px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: $theme-color-brand-secondary-base;
+    border-radius: 10px;
+
+    &:hover {
+      background: $theme-color-brand-secondary-alt;
+    }
+  }
+}

--- a/test/components/calendar/calendar.e2e-spec.js
+++ b/test/components/calendar/calendar.e2e-spec.js
@@ -79,8 +79,8 @@ describe('Calendar ajax loading tests', () => {
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('.calendar-event-more'))), 4000);
 
-    expect(await element.all(by.css('.calendar-event-more')).count()).toEqual(1);
-    expect(await element.all(by.css('.calendar-event.azure')).count()).toEqual(3);
+    expect(await element.all(by.css('.monthview-table .calendar-event-more')).count()).toEqual(1);
+    expect(await element.all(by.css('.monthview-table .calendar-event.azure')).count()).toEqual(3);
   });
 
   it('Should render ajax loaded dates for sept 2018', async () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed scrollbar styles for windows chrome to work with all themes.

**Related github/jira issue (required)**:
Closes #3172

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Open windows chrome
- Navigate to http://localhost:4000/components/listview/example-index.html
- Change the theme to `Vibrant`
- See scrollbar style on every `Variant` or `Colors` options

also check for JS error (cannot reproduce, it might be fixed by other issue)
http://localhost:4000/
- Open developer tools
- Switch the themes or colors
- See in console should not be any JS error

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
