### PR TITLE
3060 - Fix firstDayofWeek for all locales

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[Homepage]` Fixed an issue where the DOM order was not working for triple width widgets. ([#3101](https://github.com/infor-design/enterprise/issues/3101))
 - `[Locale]` Added the ability to set a 5 digit language (`fr-FR` and `fr-CA` vs `fr`) and added separate strings for `fr-CA` vs `fr-FR`. ([#3245](https://github.com/infor-design/enterprise/issues/3245))
 - `[Locale]` Changed incorrect Chinese locale year formats to the correct format as noted by translators. For example `2019年 12月`. ([#3081](https://github.com/infor-design/enterprise/issues/3081))
+- `[Locale]` Corrected and added the firstDayofWeek setting for every locale. ([#3060](https://github.com/infor-design/enterprise/issues/3060))
 - `[Tabs]` Fixed an issue where scroll was not working on mobile view for scrollable-flex layout. ([#2931](https://github.com/infor-design/enterprise/issues/2931))
 
 ### v4.25.0 Chores & Maintenance

--- a/src/components/locale/cultures/af-ZA.js
+++ b/src/components/locale/cultures/af-ZA.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('af-ZA', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['vm.', 'nm.']
+    dayPeriods: ['vm.', 'nm.'],
+    firstDayofWeek: 0 // Starts on Sunday
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'S',

--- a/src/components/locale/cultures/ar-EG.js
+++ b/src/components/locale/cultures/ar-EG.js
@@ -42,7 +42,8 @@ Soho.Locale.addCulture('ar-EG', {
       // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
       timeFormat: 'h:mm a',
       // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-      dayPeriods: ['ص', 'م']
+      dayPeriods: ['ص', 'م'],
+      firstDayofWeek: 6 // Starts on Sat
     },
     {
       name: 'islamic-umalqura',

--- a/src/components/locale/cultures/ar-SA.js
+++ b/src/components/locale/cultures/ar-SA.js
@@ -37,7 +37,7 @@ Soho.Locale.addCulture('ar-SA', {
       },
       timeFormat: 'h:mm a',
       dayPeriods: ['ص', 'م'],
-      firstDayofWeek: 6, // Starts on Sat
+      firstDayofWeek: 0, // Starts on Sun
       conversions: {
         yearInfo: [
           [746, -2198707200000],
@@ -277,7 +277,8 @@ Soho.Locale.addCulture('ar-SA', {
       // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
       timeFormat: 'h:mm a',
       // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-      dayPeriods: ['ص', 'م']
+      dayPeriods: ['ص', 'م'],
+      firstDayofWeek: 0 // Starts on Sun
     }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '﷼',

--- a/src/components/locale/cultures/bg-BG.js
+++ b/src/components/locale/cultures/bg-BG.js
@@ -40,7 +40,8 @@ Soho.Locale.addCulture('bg-BG', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'H:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['пр.об', 'сл.об']
+    dayPeriods: ['пр.об', 'сл.об'],
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'лв',

--- a/src/components/locale/cultures/cs-CZ.js
+++ b/src/components/locale/cultures/cs-CZ.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('cs-CZ', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'H:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['AM', 'PM']
+    dayPeriods: ['AM', 'PM'],
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'Kč',

--- a/src/components/locale/cultures/da-DK.js
+++ b/src/components/locale/cultures/da-DK.js
@@ -40,7 +40,8 @@ Soho.Locale.addCulture('da-DK', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH.mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['', '']
+    dayPeriods: ['', ''],
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'kr',

--- a/src/components/locale/cultures/de-DE.js
+++ b/src/components/locale/cultures/de-DE.js
@@ -40,7 +40,8 @@ Soho.Locale.addCulture('de-DE', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/abbreviated
-    dayPeriods: ['vorm.', 'nachm.'] // Not used 24h
+    dayPeriods: ['vorm.', 'nachm.'], // Not used 24h
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '€',

--- a/src/components/locale/cultures/el-GR.js
+++ b/src/components/locale/cultures/el-GR.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('el-GR', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'h:mm a',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['π.μ.', 'μ.μ.']
+    dayPeriods: ['π.μ.', 'μ.μ.'],
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '€',

--- a/src/components/locale/cultures/en-AU.js
+++ b/src/components/locale/cultures/en-AU.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('en-AU', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'h:mm a',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['AM', 'PM']
+    dayPeriods: ['AM', 'PM'],
+    firstDayofWeek: 0 // Starts on Sun
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '$',

--- a/src/components/locale/cultures/en-GB.js
+++ b/src/components/locale/cultures/en-GB.js
@@ -40,7 +40,7 @@ Soho.Locale.addCulture('en-GB', {
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
     dayPeriods: ['am', 'pm'],
-    firstDayofWeek: 1, // Starts on Monday
+    firstDayofWeek: 1 // Starts on Monday
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '£',

--- a/src/components/locale/cultures/en-IN.js
+++ b/src/components/locale/cultures/en-IN.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('en-IN', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'h:mm a',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['am', 'pm']
+    dayPeriods: ['am', 'pm'],
+    firstDayofWeek: 0 // Starts on Sun
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '₹',

--- a/src/components/locale/cultures/en-NZ.js
+++ b/src/components/locale/cultures/en-NZ.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('en-NZ', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'h:mm a',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['am', 'pm']
+    dayPeriods: ['am', 'pm'],
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '$',

--- a/src/components/locale/cultures/en-US.js
+++ b/src/components/locale/cultures/en-US.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('en-US', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'h:mm a',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['AM', 'PM']
+    dayPeriods: ['AM', 'PM'],
+    firstDayofWeek: 0 // Starts on Sunday
   }],
 
   // numbers/currencyFormats-numberSystem-latn/standard

--- a/src/components/locale/cultures/en-ZA.js
+++ b/src/components/locale/cultures/en-ZA.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('en-ZA', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['AM', 'PM']
+    dayPeriods: ['AM', 'PM'],
+    firstDayofWeek: 0 // Starts on Sun
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'S',

--- a/src/components/locale/cultures/es-419.js
+++ b/src/components/locale/cultures/es-419.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('es-419', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['a.m.', 'p.m.']
+    dayPeriods: ['a.m.', 'p.m.'],
+    firstDayofWeek: 0 // Starts on Sun
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '$',

--- a/src/components/locale/cultures/es-AR.js
+++ b/src/components/locale/cultures/es-AR.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('es-AR', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['a.m.', 'p.m.']
+    dayPeriods: ['a.m.', 'p.m.'],
+    firstDayofWeek: 0 // Starts on Sun
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '$',

--- a/src/components/locale/cultures/es-ES.js
+++ b/src/components/locale/cultures/es-ES.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('es-ES', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'H:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/abbreviated
-    dayPeriods: ['a.m.', 'p.m.']
+    dayPeriods: ['a.m.', 'p.m.'],
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '€',

--- a/src/components/locale/cultures/es-MX.js
+++ b/src/components/locale/cultures/es-MX.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('es-MX', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'H:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['a.m.', 'p.m.']
+    dayPeriods: ['a.m.', 'p.m.'],
+    firstDayofWeek: 0 // Starts on Sun
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '$',

--- a/src/components/locale/cultures/es-US.js
+++ b/src/components/locale/cultures/es-US.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('es-US', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'h:mm a',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['AM', 'PM']
+    dayPeriods: ['AM', 'PM'],
+    firstDayofWeek: 0 // Starts on Sun
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '$',

--- a/src/components/locale/cultures/et-EE.js
+++ b/src/components/locale/cultures/et-EE.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('et-EE', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['e.k.', 'p.k.']
+    dayPeriods: ['e.k.', 'p.k.'],
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'kr',

--- a/src/components/locale/cultures/fi-FI.js
+++ b/src/components/locale/cultures/fi-FI.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('fi-FI', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'H.mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['ap.', 'ip.']
+    dayPeriods: ['ap.', 'ip.'],
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '€',

--- a/src/components/locale/cultures/fr-CA.js
+++ b/src/components/locale/cultures/fr-CA.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('fr-CA', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['AM', 'PM']
+    dayPeriods: ['AM', 'PM'],
+    firstDayofWeek: 0 // Starts on Sun
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '$',

--- a/src/components/locale/cultures/fr-FR.js
+++ b/src/components/locale/cultures/fr-FR.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('fr-FR', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['AM', 'PM']
+    dayPeriods: ['AM', 'PM'],
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '€',

--- a/src/components/locale/cultures/he-IL.js
+++ b/src/components/locale/cultures/he-IL.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('he-IL', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'H:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['לפנה״צ', 'אחה״צ']
+    dayPeriods: ['לפנה״צ', 'אחה״צ'],
+    firstDayofWeek: 0 // Starts on Sun
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '₪',

--- a/src/components/locale/cultures/hi-IN.js
+++ b/src/components/locale/cultures/hi-IN.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('hi-IN', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'h:mm a',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['पूर्व', 'अपर']
+    dayPeriods: ['पूर्व', 'अपर'],
+    firstDayofWeek: 0 // Starts on Sun
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '₹',

--- a/src/components/locale/cultures/hr-HR.js
+++ b/src/components/locale/cultures/hr-HR.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('hr-HR', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['AM', 'PM']
+    dayPeriods: ['AM', 'PM'],
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'kn',

--- a/src/components/locale/cultures/hu-HU.js
+++ b/src/components/locale/cultures/hu-HU.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('hu-HU', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'H:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['de.', 'du.']
+    dayPeriods: ['de.', 'du.'],
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'Ft',

--- a/src/components/locale/cultures/id-ID.js
+++ b/src/components/locale/cultures/id-ID.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('id-ID', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH.mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['AM', 'PM']
+    dayPeriods: ['AM', 'PM'],
+    firstDayofWeek: 0 // Starts on Sun
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'Rp',

--- a/src/components/locale/cultures/it-IT.js
+++ b/src/components/locale/cultures/it-IT.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('it-IT', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['AM', 'PM']
+    dayPeriods: ['AM', 'PM'],
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '€',

--- a/src/components/locale/cultures/ja-JP.js
+++ b/src/components/locale/cultures/ja-JP.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('ja-JP', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'H:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['午前', '午後']
+    dayPeriods: ['午前', '午後'],
+    firstDayofWeek: 0 // Starts on Sun
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '¥',

--- a/src/components/locale/cultures/ko-KR.js
+++ b/src/components/locale/cultures/ko-KR.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('ko-KR', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'a h:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['오전', '오후']
+    dayPeriods: ['오전', '오후'],
+    firstDayofWeek: 0 // Starts on Sun
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '₩',

--- a/src/components/locale/cultures/la-IT.js
+++ b/src/components/locale/cultures/la-IT.js
@@ -37,7 +37,8 @@ Soho.Locale.addCulture('la-IT', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['AM', 'PM']
+    dayPeriods: ['AM', 'PM'],
+    firstDayofWeek: 1 // Starts on Monday
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '€',

--- a/src/components/locale/cultures/lt-LT.js
+++ b/src/components/locale/cultures/lt-LT.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('lt-LT', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['pr.p.', 'pop.']
+    dayPeriods: ['pr.p.', 'pop.'],
+    firstDayofWeek: 1 // Starts on Monday
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'Lt',

--- a/src/components/locale/cultures/lv-LV.js
+++ b/src/components/locale/cultures/lv-LV.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('lv-LV', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['priekšpusdienā', 'pēcpusdienā']
+    dayPeriods: ['priekšpusdienā', 'pēcpusdienā'],
+    firstDayofWeek: 1 // Starts on Monday
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'Ls',

--- a/src/components/locale/cultures/ms-bn.js
+++ b/src/components/locale/cultures/ms-bn.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('ms-bn', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'h:mm a',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['PG', 'PTG']
+    dayPeriods: ['PG', 'PTG'],
+    firstDayofWeek: 1 // Starts on Monday
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '$',

--- a/src/components/locale/cultures/ms-my.js
+++ b/src/components/locale/cultures/ms-my.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('ms-MY', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'h:mm a',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['PG', 'PTG']
+    dayPeriods: ['PG', 'PTG'],
+    firstDayofWeek: 1 // Starts on Monday
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'RM',

--- a/src/components/locale/cultures/nb-NO.js
+++ b/src/components/locale/cultures/nb-NO.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('nb-NO', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['AM', 'PM']
+    dayPeriods: ['AM', 'PM'],
+    firstDayofWeek: 1 // Starts on Monday
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'kr',

--- a/src/components/locale/cultures/nl-NL.js
+++ b/src/components/locale/cultures/nl-NL.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('nl-NL', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['AM', 'PM']
+    dayPeriods: ['AM', 'PM'],
+    firstDayofWeek: 1 // Starts on Monday
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '€',

--- a/src/components/locale/cultures/no-NO.js
+++ b/src/components/locale/cultures/no-NO.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('no-NO', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['AM', 'PM']
+    dayPeriods: ['AM', 'PM'],
+    firstDayofWeek: 1 // Starts on Monday
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'kr',

--- a/src/components/locale/cultures/pl-PL.js
+++ b/src/components/locale/cultures/pl-PL.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('pl-PL', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['AM', 'PM']
+    dayPeriods: ['AM', 'PM'],
+    firstDayofWeek: 1 // Starts on Monday
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'zł',

--- a/src/components/locale/cultures/pt-BR.js
+++ b/src/components/locale/cultures/pt-BR.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('pt-BR', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['AM', 'PM']
+    dayPeriods: ['AM', 'PM'],
+    firstDayofWeek: 0 // Starts on Sun
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'R$',

--- a/src/components/locale/cultures/pt-PT.js
+++ b/src/components/locale/cultures/pt-PT.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('pt-PT', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['da manhã', 'da tarde']
+    dayPeriods: ['da manhã', 'da tarde'],
+    firstDayofWeek: 0 // Starts on Sun
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '€',

--- a/src/components/locale/cultures/ro-RO.js
+++ b/src/components/locale/cultures/ro-RO.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('ro-RO', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['a.m.', 'p.m.']
+    dayPeriods: ['a.m.', 'p.m.'],
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'LEI',

--- a/src/components/locale/cultures/ru-RU.js
+++ b/src/components/locale/cultures/ru-RU.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('ru-RU', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['AM', 'PM']
+    dayPeriods: ['AM', 'PM'],
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'руб',

--- a/src/components/locale/cultures/sk-SK.js
+++ b/src/components/locale/cultures/sk-SK.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('sk-SK', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'H:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['AM', 'PM']
+    dayPeriods: ['AM', 'PM'],
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'Sk',

--- a/src/components/locale/cultures/sl-SI.js
+++ b/src/components/locale/cultures/sl-SI.js
@@ -2,8 +2,8 @@
 Soho.Locale.addCulture('sl-SI', {
   // layout/language
   language: 'sl',
-  englishName: 'Slovenian (Slovenia)!!!',
-  nativeName: 'slovenski (Slovenija)!!!',
+  englishName: 'Slovenian (Slovenia)',
+  nativeName: 'slovenski (Slovenija)',
   // layout/orientation/@characters
   direction: 'left-to-right',
   // ca-gregorian
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('sl-SI', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['dop.', 'pop.']
+    dayPeriods: ['dop.', 'pop.'],
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'Sk',

--- a/src/components/locale/cultures/sv-SE.js
+++ b/src/components/locale/cultures/sv-SE.js
@@ -40,7 +40,7 @@ Soho.Locale.addCulture('sv-SE', {
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
     dayPeriods: ['fm', 'em'],
-    firstDayofWeek: 1, // Starts on Monday
+    firstDayofWeek: 1 // Starts on Monday
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'kr',

--- a/src/components/locale/cultures/th-TH.js
+++ b/src/components/locale/cultures/th-TH.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('th-TH', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['ก่อนเที่ยง', 'หลังเที่ยง']
+    dayPeriods: ['ก่อนเที่ยง', 'หลังเที่ยง'],
+    firstDayofWeek: 0 // Starts on Sun
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'kr',

--- a/src/components/locale/cultures/tr-TR.js
+++ b/src/components/locale/cultures/tr-TR.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('tr-TR', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['ÖÖ', 'ÖS']
+    dayPeriods: ['ÖÖ', 'ÖS'],
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '₤',

--- a/src/components/locale/cultures/uk-UA.js
+++ b/src/components/locale/cultures/uk-UA.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('uk-UA', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['дп', 'пп']
+    dayPeriods: ['дп', 'пп'],
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '₴',

--- a/src/components/locale/cultures/vi-VN.js
+++ b/src/components/locale/cultures/vi-VN.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('vi-VN', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['SA', 'CH']
+    dayPeriods: ['SA', 'CH'],
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '₫',

--- a/src/components/locale/cultures/zh-CN.js
+++ b/src/components/locale/cultures/zh-CN.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('zh-CN', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'ah:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['上午', '下午']
+    dayPeriods: ['上午', '下午'],
+    firstDayofWeek: 0 // Starts on Sun
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '¥',

--- a/src/components/locale/cultures/zh-Hans.js
+++ b/src/components/locale/cultures/zh-Hans.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('zh-Hans', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'ah:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['上午', '下午']
+    dayPeriods: ['上午', '下午'],
+    firstDayofWeek: 0 // Starts on Sun
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: '¥',

--- a/src/components/locale/cultures/zh-Hant.js
+++ b/src/components/locale/cultures/zh-Hant.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('zh-Hant', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'ah:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['上午', '下午']
+    dayPeriods: ['上午', '下午'],
+    firstDayofWeek: 0 // Starts on Sun
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'NT$',

--- a/src/components/locale/cultures/zh-TW.js
+++ b/src/components/locale/cultures/zh-TW.js
@@ -39,7 +39,8 @@ Soho.Locale.addCulture('zh-TW', {
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
     timeFormat: 'ah:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
-    dayPeriods: ['上午', '下午']
+    dayPeriods: ['上午', '下午'],
+    firstDayofWeek: 0 // Starts on Sun
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'NT$',

--- a/test/components/calendar/calendar-api.func-spec.js
+++ b/test/components/calendar/calendar-api.func-spec.js
@@ -111,8 +111,8 @@ describe('Calendar API', () => {
     calendarObj = new Calendar(calendarEl, newSettings);
 
     expect(document.getElementById('monthview-datepicker-field').textContent).toEqual('marts 2019');
-    expect(document.body.querySelector('thead tr th:first-child').textContent.trim()).toEqual('søn');
-    expect(document.body.querySelector('thead tr th:last-child').textContent.trim()).toEqual('lør');
+    expect(document.body.querySelector('thead tr th:first-child').textContent.trim()).toEqual('man');
+    expect(document.body.querySelector('thead tr th:last-child').textContent.trim()).toEqual('søn');
   });
 
   it('Should render upcoming dates', () => {
@@ -281,8 +281,8 @@ describe('Calendar API', () => {
     calendarObj.updated(updatedSettings);
 
     expect(document.getElementById('monthview-datepicker-field').textContent).toEqual('juni 2019');
-    expect(document.body.querySelector('thead tr th:first-child').textContent.trim()).toEqual('søn');
-    expect(document.body.querySelector('thead tr th:last-child').textContent.trim()).toEqual('lør');
+    expect(document.body.querySelector('thead tr th:first-child').textContent.trim()).toEqual('man');
+    expect(document.body.querySelector('thead tr th:last-child').textContent.trim()).toEqual('søn');
     expect(document.querySelectorAll('.calendar-event').length).toEqual(3);
     expect(Locale.currentLocale.name).toEqual('en-US');
   });

--- a/test/components/monthview/monthview-api.func-spec.js
+++ b/test/components/monthview/monthview-api.func-spec.js
@@ -82,9 +82,9 @@ describe('Monthview API', () => {
     monthviewAPI.showMonth(7, 1440);
 
     expect(document.getElementById('monthview-datepicker-field').textContent).toEqual('ربيع الأول 1440');
-    expect(document.body.querySelector('thead tr th:first-child').textContent.trim()).toEqual('السبت');
-    expect(document.body.querySelector('tbody tr:first-child td:first-child').textContent.trim()).toEqual('25');
-    expect(document.body.querySelector('tbody tr:first-child td:last-child').textContent.trim()).toEqual('1');
+    expect(document.body.querySelector('thead tr th:first-child').textContent.trim()).toEqual('الأحد');
+    expect(document.body.querySelector('tbody tr:first-child td:first-child').textContent.trim()).toEqual('26');
+    expect(document.body.querySelector('tbody tr:first-child td:last-child').textContent.trim()).toEqual('2');
   });
 
   it('Should render based on locale setting', () => {
@@ -96,8 +96,8 @@ describe('Monthview API', () => {
     });
 
     expect(document.getElementById('monthview-datepicker-field').textContent).toEqual('maj 2019');
-    expect(document.body.querySelector('thead tr th:first-child').textContent.trim()).toEqual('søn');
-    expect(document.body.querySelector('thead tr th:last-child').textContent.trim()).toEqual('lør');
+    expect(document.body.querySelector('thead tr th:first-child').textContent.trim()).toEqual('man');
+    expect(document.body.querySelector('thead tr th:last-child').textContent.trim()).toEqual('søn');
   });
 
   it('Should render disabled days', () => {

--- a/test/components/monthview/monthview.e2e-spec.js
+++ b/test/components/monthview/monthview.e2e-spec.js
@@ -269,8 +269,8 @@ describe('MonthView specific locale tests', () => {
   it('Should render a specific locale', async () => {
     expect(await element(by.id('monthview-datepicker-field')).getText()).toEqual('maj 2019');
     expect(await element(by.css('.hyperlink.today')).getText()).toEqual('I dag');
-    expect(await element(by.css('.monthview-table tr th:nth-child(1)')).getText()).toEqual('søn');
-    expect(await element(by.css('.monthview-table tr th:nth-child(7)')).getText()).toEqual('lør');
+    expect(await element(by.css('.monthview-table tr th:nth-child(1)')).getText()).toEqual('man');
+    expect(await element(by.css('.monthview-table tr th:nth-child(7)')).getText()).toEqual('søn');
   });
 });
 
@@ -290,7 +290,7 @@ describe('MonthView specific language tests', () => {
 
     expect(await element(by.id('monthview-datepicker-field')).getText()).toEqual('oktober 2019');
     expect(await element(by.css('.hyperlink.today')).getText()).toEqual('Heute');
-    expect(await element(by.css('.monthview-table tr th:nth-child(1)')).getText()).toEqual('søn');
-    expect(await element(by.css('.monthview-table tr th:nth-child(7)')).getText()).toEqual('lør');
+    expect(await element(by.css('.monthview-table tr th:nth-child(1)')).getText()).toEqual('man');
+    expect(await element(by.css('.monthview-table tr th:nth-child(7)')).getText()).toEqual('søn');
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The option firstDayofWeek in locale was not set for all locales or wrong in some cases. This fixes that.

**Related github/jira issue (required)**:
Fixes #3060 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datepicker/example-index.html?locale=sv-SE (this starts monday in the calendar)
- go to http://localhost:4000/components/datepicker/example-index.html (this starts sunday in the calendar)
- if you want to test the first date is correct one way is to compare it to mac settings (system prefs/date time / open lang and region and change region
![Screen Shot 2019-12-20 at 11 05 08 AM](https://user-images.githubusercontent.com/814283/71267472-9db08500-2318-11ea-8df6-c362b1fccbca.png)

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
