### PR TITLE
3135 - Fix overlapping text when searchfield is clearable

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `[Locale]` Corrected and added the firstDayofWeek setting for every locale. ([#3060](https://github.com/infor-design/enterprise/issues/3060))
 - `[Modal]` Fixed an issue where the returns focus to button after closing was not working. ([#3166](https://github.com/infor-design/enterprise/issues/3166))
 - `[Scrollbar]` Fixed styles for windows chrome to work with all themes. ([#3172](https://github.com/infor-design/enterprise/issues/3172))
+- `[Searchfield]` Fixed an overlapping text in searchfield when close icon button is showed. ([#3135](https://github.com/infor-design/enterprise/issues/3135))
 - `[Tabs]` Fixed an issue where scroll was not working on mobile view for scrollable-flex layout. ([#2931](https://github.com/infor-design/enterprise/issues/2931))
 
 ### v4.25.0 Chores & Maintenance

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -64,6 +64,13 @@
     border-color 300ms $cubic-ease);
   }
 
+  // This rule will only work when searchfield is clearable.
+  &.has-close-icon-button {
+    .searchfield {
+      padding-right: 28px;
+    }
+  }
+
   // This variation is used on white-backgrounds (usually in list-detail, listviews, or builder pattern)
   &.context {
     white-space: nowrap;

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -67,7 +67,10 @@
   // This rule will only work when searchfield is clearable.
   &.has-close-icon-button {
     .searchfield {
+      overflow: hidden;
       padding-right: 28px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
   }
 

--- a/src/components/searchfield/searchfield.js
+++ b/src/components/searchfield/searchfield.js
@@ -425,6 +425,7 @@ SearchField.prototype = {
 
     if (this.settings.clearable) {
       this.element.clearable();
+      this.wrapper.addClass('has-close-icon-button');
       this.xButton = this.wrapper.children('.icon.close');
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes an overlapping text when searchfield is clearable which close icon button is presented.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/3135

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app.
- Navigate to any test pages that has clearable searchfield e.g.,

1. http://localhost:4000/components/searchfield/example-index.html
2. http://localhost:4000/components/searchfield/test-application-server-data-label.html

- Type any as you go through the searchfield.
- Long text should not overlap the close icon button.
- Test also to non-clearable searchfield. It should not affect nor change the spacing of non-clearable searchfield.

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
