### PR TITLE
3166 - Fix trigger return focus with Modal

### DIFF
--- a/app/views/components/modal/test-trigger-button-return-focus.html
+++ b/app/views/components/modal/test-trigger-button-return-focus.html
@@ -34,7 +34,11 @@ var modals = {
     'add-context': {
       'title': 'Add Context',
       'id': 'my-id',
-      'content': $('#modal-add-context')
+      'content': $('#modal-add-context'),
+			'noRefocus': false,
+			'triggerButton': '#add-context' // selector
+			// 'triggerButton': document.getElementById('add-context') // DOM
+			// 'triggerButton': $('#add-context') // jQuery
     }
   },
 

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -613,7 +613,7 @@ Modal.prototype = {
 
     if (this.settings.triggerButton) {
       this.oldActive = this.useJqEl(this.settings.triggerButton);
-    } else if (!this.trigger || this.trigger.length === 0) {
+    } else if (!this.trigger || this.trigger.length === 0 || this.trigger.is('body')) {
       this.oldActive = $(':focus'); // Save and restore focus for A11Y
     }
 
@@ -1079,7 +1079,6 @@ Modal.prototype = {
       }
       if (this.oldActive && $(this.oldActive).is('a:visible, button:visible, input:visible, textarea:visible')) {
         this.oldActive.focus();
-        this.oldActive = null;
       } else if (this.trigger.parents('.toolbar, .formatter-toolbar').length < 1) {
         this.trigger.focus();
       }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed returns focus to trigger button after closing with Modal.

**Related github/jira issue (required)**:
Closes #3166

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/modal/example-index.html
- Click on button Show Modal to open modal
- Click on button Cancel to close the modal
- See the trigger button `Show Modal` should be focused