### PR TITLE
3217 - Fix enter all digits for fr-fr with locale

### DIFF
--- a/app/views/components/mask/test-number-mask-gauntlet.html
+++ b/app/views/components/mask/test-number-mask-gauntlet.html
@@ -240,6 +240,17 @@
         var numberSpan = $(this).prev('label').find('.number');
         var spanText = numberSpan.text();
 
+        // Update quintillion text
+        if (spanText.indexOf('18') > -1) {
+          var quintillion = {
+            '(18, 6)': '100,000,000,000,000,000.000000',
+            'Minus (18, 6)': '-100,000,000,000,000,000.000000',
+            '(18) Digits': '100000000000000000',
+            'Minus (18) Digits': '-100000000000000000',
+          }
+          spanText = quintillion[spanText];
+        }
+
         // Check for thousands separators and decimals inside the label span
         var thousandsRegex = new RegExp(',', 'g');
         var hasThousands = thousandsRegex.test(spanText);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Datagrid]` Fixed a bug where floating point math would cause the grouping sum aggregator to round incorrectly. ([#3233](https://github.com/infor-design/enterprise/issues/3233))
 - `[Datagrid]` Fixed style issues in all theme and theme variants when using the list style including grouped headers and states. ([#3265](https://github.com/infor-design/enterprise/issues/3265))
 - `[Homepage]` Fixed an issue where the DOM order was not working for triple width widgets. ([#3101](https://github.com/infor-design/enterprise/issues/3101))
+- `[Locale]` Fixed an issue where enter all digits was not working for fr-FR. ([#3217](https://github.com/infor-design/enterprise/issues/3217))
 - `[Locale]` Added the ability to set a 5 digit language (`fr-FR` and `fr-CA` vs `fr`) and added separate strings for `fr-CA` vs `fr-FR`. ([#3245](https://github.com/infor-design/enterprise/issues/3245))
 - `[Locale]` Changed incorrect Chinese locale year formats to the correct format as noted by translators. For example `2019年 12月`. ([#3081](https://github.com/infor-design/enterprise/issues/3081))
 - `[Locale]` Corrected and added the firstDayofWeek setting for every locale. ([#3060](https://github.com/infor-design/enterprise/issues/3060))

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -833,6 +833,7 @@ const Locale = {  // eslint-disable-line
 
   /**
   * Find browser default separator for given locale
+  * @private
   * @param {string} locale The locale
   * @param {string} separatorType The separator type be found `group`|`decimal`
   * @returns {string} The browser default separator character

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -815,13 +815,34 @@ const Locale = {  // eslint-disable-line
   * @param {number} number The number to convert
   * @param {string} locale The number to convert
   * @param {object} options The number to convert
+  * @param {string} groupSeparator If provided will replace with browser default character
   * @returns {string} The converted number.
   */
-  toLocaleString(number, locale, options) {
+  toLocaleString(number, locale, options, groupSeparator) {
     if (typeof number !== 'number') {
       return '';
     }
-    return number.toLocaleString(locale || Locale.currentLocale.name, options || undefined);
+    const args = { locale: locale || Locale.currentLocale.name, options: options || undefined };
+    let n = number.toLocaleString(args.locale, args.options);
+    if (!(/undefined|null/.test(typeof groupSeparator))) {
+      const gSeparator = this.getSeparator(args.locale, 'group');
+      n = n.replace(new RegExp(gSeparator, 'g'), groupSeparator.toString());
+    }
+    return n;
+  },
+
+  /**
+  * Find browser default separator for given locale
+  * @param {string} locale The locale
+  * @param {string} separatorType The separator type be found `group`|`decimal`
+  * @returns {string} The browser default separator character
+  */
+  getSeparator(locale, separatorType) {
+    const number = 1000.1;
+    return Intl.NumberFormat(locale)
+      .formatToParts(number)
+      .find(part => part.type === separatorType)
+      .value;
   },
 
   /**

--- a/src/components/mask/masks.js
+++ b/src/components/mask/masks.js
@@ -107,7 +107,7 @@ function addThousandsSeparator(n, thousands, locale, options) {
   if (n === '' || isNaN(n)) {
     return n;
   }
-  return Locale.toLocaleString(Number(n), locale, options);
+  return Locale.toLocaleString(Number(n), locale, options, thousands);
 }
 
 // Gets an array of Regex objects matching the number of digits present in a source string

--- a/test/components/mask/mask.e2e-spec.js
+++ b/test/components/mask/mask.e2e-spec.js
@@ -45,4 +45,37 @@ describe('Mask Percent Format Tests', () => {
 
     expect(await inputEl.getAttribute('value')).toEqual('100 ٪');
   });
+
+  it('Should be type in fr-FR', async () => {
+    await utils.setPage('/components/mask/test-number-mask-gauntlet.html?locale=fr-FR');
+    let inputEl = await element(by.id('number-dec-thousands'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(inputEl), config.waitsFor);
+    await browser.driver.sleep(config.sleepShort);
+
+    await inputEl.clear();
+    await inputEl.sendKeys('1234,');
+
+    expect(await inputEl.getAttribute('value')).toEqual('1 234,');
+
+    inputEl = await element(by.id('longer-number-dec-thousands'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(inputEl), config.waitsFor);
+    await browser.driver.sleep(config.sleepShort);
+
+    await inputEl.clear();
+    await inputEl.sendKeys('1234567,');
+
+    expect(await inputEl.getAttribute('value')).toEqual('1 234 567,');
+
+    inputEl = await element(by.id('way-longer-number-dec-thousands'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(inputEl), config.waitsFor);
+    await browser.driver.sleep(config.sleepShort);
+
+    await inputEl.clear();
+    await inputEl.sendKeys('1234567890,');
+
+    expect(await inputEl.getAttribute('value')).toEqual('1 234 567 890,');
+  });
 });

--- a/test/components/mask/mask.e2e-spec.js
+++ b/test/components/mask/mask.e2e-spec.js
@@ -46,7 +46,7 @@ describe('Mask Percent Format Tests', () => {
     expect(await inputEl.getAttribute('value')).toEqual('100 ٪');
   });
 
-  it('Should be type in fr-FR', async () => {
+  it('Should be able to type in fr-FR', async () => {
     await utils.setPage('/components/mask/test-number-mask-gauntlet.html?locale=fr-FR');
     let inputEl = await element(by.id('number-dec-thousands'));
     await browser.driver

--- a/test/components/mask/masked-input-api.func-spec.js
+++ b/test/components/mask/masked-input-api.func-spec.js
@@ -174,7 +174,7 @@ describe('Mask Input Field Api', () => {
     expect(inputComponent.settings.patternOptions.symbols.decimal).toEqual(',');
     expect(inputComponent.settings.patternOptions.symbols.thousands).toEqual(' ');
     expect(inputComponent.settings.patternOptions.symbols.currency).toEqual('€');
-    expect(['5 333,66 €', '5 333,66 €']).toContain(input.value);
+    expect(['5 333,66 €', '5 333,66 €']).toContain(input.value);
   });
 
   it('Should display reversed prefix/suffix when in RTL mode', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed enter all digits was not working for fr-FR with Locale.

**Related github/jira issue (required)**:
Closes #3217

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/mask/test-number-mask-gauntlet.html?locale=fr-FR
- For the Number: 1 000,00 field, enter `1234,`
- Should let you enter and the value should change to `1 234,`
- For the Millions: 1 000 000,00 field, enter 1234567,
- Should let you enter and the value should change to `1 234 567,`
- For the Billions: 1 000 000 000,00 field, enter 1234567890,
- Should let you enter and the value should change to `1 234 567 890,`
- Also see the Quintillion fields should not be any NaN in the placeholder and labels

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
