### PR TITLE
3315 - Fix errors thrown when using Masks on HTMLInputElement number fields

### DIFF
--- a/app/views/components/mask/test-input-type-numeric.html
+++ b/app/views/components/mask/test-input-type-numeric.html
@@ -9,7 +9,7 @@
   <div class="six columns">
     <div class="field">
       <label for="test-input">Numeric Input</label>
-      <input id="test-input" type="number" class="new-mask" data-options='{ "process": "number", "patternOptions": { "allowThousandsSeparator": true, "allowDecimal": true, "allowNegative": true, "integerLimit": 7, "decimalLimit": 2 } }' placeholder="-#,###,###.00"/>
+      <input id="test-input" type="number" class="new-mask" data-options='{ "process": "number", "patternOptions": { "allowThousandsSeparator": false, "allowDecimal": true, "allowNegative": true, "integerLimit": 7, "decimalLimit": 2 } }' placeholder="-#######.00"/>
     </div>
   </div>
 </div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[Locale]` Added the ability to set a 5 digit language (`fr-FR` and `fr-CA` vs `fr`) and added separate strings for `fr-CA` vs `fr-FR`. ([#3245](https://github.com/infor-design/enterprise/issues/3245))
 - `[Locale]` Changed incorrect Chinese locale year formats to the correct format as noted by translators. For example `2019年 12月`. ([#3081](https://github.com/infor-design/enterprise/issues/3081))
 - `[Locale]` Corrected and added the firstDayofWeek setting for every locale. ([#3060](https://github.com/infor-design/enterprise/issues/3060))
+- `[Mask]` Fixed an issue when applying Masks to input fields configured for numbers, where errors would be thrown when the Mask attempted to overwrite the input field value. ([#3315](https://github.com/infor-design/enterprise/issues/3315))
 - `[Modal]` Fixed an issue where the returns focus to button after closing was not working. ([#3166](https://github.com/infor-design/enterprise/issues/3166))
 - `[Multiselect]` Adjusted the placeholder color as it was too dark. ([#3276](https://github.com/infor-design/enterprise/issues/3276))
 - `[Searchfield]` Fixed an issue where multiselect items' checkboxes and text were misaligned in RTL mode. ([#1811](https://github.com/infor-design/enterprise/issues/1811))

--- a/src/components/mask/mask-input.js
+++ b/src/components/mask/mask-input.js
@@ -241,8 +241,8 @@ MaskInput.prototype = {
       return false;
     }
 
-    let posBegin = this.element.selectionStart;
-    let posEnd = this.element.selectionEnd;
+    let posBegin = this.element.selectionStart || 0;
+    let posEnd = this.element.selectionEnd || 0;
 
     // On Android, the first character inserted into a field is automatically
     // selected when it shouldn't be. This snippet fixes that problem.

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -854,8 +854,15 @@ utils.isNumber = function isNumber(value) {
  * @param {HTMLElement} element the element to get selection
  * @param {number} startPos starting position of the text caret
  * @param {number} endPos ending position of the text caret
+ * @returns {void}
  */
 utils.safeSetSelection = function safeSetSelection(element, startPos, endPos) {
+  // If this text field doesn't support text caret selection, return out
+  const compatibleTypes = ['text', 'password', 'search', 'url', 'week', 'month'];
+  if (!(element instanceof HTMLInputElement) || compatibleTypes.indexOf(element.type) === -1) {
+    return;
+  }
+
   if (startPos && endPos === undefined) {
     endPos = startPos;
   }

--- a/test/components/mask/mask.e2e-spec.js
+++ b/test/components/mask/mask.e2e-spec.js
@@ -46,3 +46,24 @@ describe('Mask Percent Format Tests', () => {
     expect(await inputEl.getAttribute('value')).toEqual('100 ٪');
   });
 });
+
+describe('Number Masks', () => {
+  it('should correctly format on `input[type="number"]` fields', async () => {
+    await utils.setPage('/components/mask/test-input-type-numeric');
+    const inputEl = await element(by.id('test-input'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(inputEl), config.waitsFor);
+
+    await inputEl.clear();
+    await inputEl.sendKeys('123.45');
+
+    expect(await inputEl.getAttribute('value')).toEqual('123.45');
+
+    await inputEl.clear();
+    await inputEl.sendKeys('777777777777'); // 12
+
+    expect(await inputEl.getAttribute('value')).toEqual('7777777'); // 7
+
+    await (utils.checkForErrors());
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a bug in the system that renders correctly-masked values into Mask Input fields with a `type="number"` attribute.  The component was previously attempting to use the `setSelectionRange()` API on these elements, but that API doesn't exist on number fields, and was causing Javascript errors to throw and mask values to be incorrect.

This PR removes the use of this API when Masks are configured against number inputs.

**Related github/jira issue (required)**:
Closes #3315

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the app
- Open http://localhost:4000/components/mask/test-input-type-numeric.html
- Try to key in numbers beyond the first three integers, and test using decimals.  All numbers fitting the mask should render properly.
- There should be no console errors.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
