### PR TITLE
3285 - Fix App Menu usability issues

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[About]` Fixed a bug where the OS version was duplicated. ([#1650](https://github.com/infor-design/enterprise/issues/1650))
 - `[Accordion]` Fixed inconsistency style of focus element after clicking on a certain accordion header. ([#3082](https://github.com/infor-design/enterprise/issues/3082))
 - `[Accordion]` Fixed an issue that when all panes are expanded then they could no longer be closed. ([#701](https://github.com/infor-design/enterprise-ng/issues/3217))
+- `[Application Menu]` Fixed minor usability issues when attempting to filter on application menus, display of hidden filtered children, and filtering reset when a Searchfield is blurred. ([#3285](https://github.com/infor-design/enterprise/issues/3285))
 - `[Autocomplete]` Fixed an issue where selected event was not firing when its parent is partly overflowing. ([#3072](https://github.com/infor-design/enterprise/issues/3072))
 - `[Calendar]` Fixed an issue setting the legend checked elements to false in the api. ([#3170](https://github.com/infor-design/enterprise/issues/3170))
 - `[Datagrid]` Fixed an issue where the data after commit edit was not in sync for tree. ([#659](https://github.com/infor-design/enterprise-ng/issues/659))

--- a/src/components/accordion/_accordion-uplift.scss
+++ b/src/components/accordion/_accordion-uplift.scss
@@ -20,6 +20,15 @@
       }
     }
   }
+
+  &.is-expanded {
+    + .accordion-header {
+      &.is-focused:not(.hide-focus),
+      &.is-selected {
+        border-top-color: $accordion-focused-border-color;
+      }
+    }
+  }
 }
 
 // Reset positioning for Uplift expander buttons
@@ -52,5 +61,27 @@ html {
     .btn {
       top: -1px;
     }
+
+    /*
+    &.filtered.has-filtered-children {
+      &:not(:hover),
+      &:not(.is-selected) {
+        > a {
+          color: inherit;
+        }
+
+        > .icon {
+          color: inherit;
+        }
+
+        > .btn > .icon {
+          &::before,
+          &::after {
+            background-color: inherit;
+          }
+        }
+      }
+    }
+    */
   }
 }

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -198,23 +198,21 @@
         }
       }
 
-      &.has-filtered-children,
-      &.has-filtered-children.is-focused,
-      &.has-filtered-children.is-selected {
-        background-color: $accordion-header-filtered-children-background-color;
+      &.filtered.has-filtered-children {
+        &:not(:hover):not(.is-selected) {
+          > a {
+            color: $accordion-filtered-text-color;
+          }
 
-        > a {
-          color: $accordion-filtered-text-color !important;
-        }
+          > .icon {
+            color: $accordion-filtered-text-color;
+          }
 
-        > .icon {
-          color: $accordion-filtered-text-color !important;
-        }
-
-        > .btn > .icon {
-          &::before,
-          &::after {
-            background-color: $accordion-filtered-text-color !important;
+          > .btn > .icon {
+            &::before,
+            &::after {
+              background-color: $accordion-filtered-text-color;
+            }
           }
         }
       }
@@ -437,12 +435,6 @@
               color: $accordion-selected-text-color;
             }
           }
-
-          &.has-filtered-children,
-          &.has-filtered-children.is-focused,
-          &.has-filtered-children.is-selected {
-            background-color: transparent;
-          }
         }
 
         .accordion-content {
@@ -572,7 +564,7 @@
 
   // Selected color scheme
   &.is-focused:not(.hide-focus) {
-    border-color: $accordion-focused-border-color !important;
+    border-color: $accordion-focused-border-color;
     box-shadow: $focus-box-shadow;
   }
 

--- a/src/components/applicationmenu/_applicationmenu-uplift.scss
+++ b/src/components/applicationmenu/_applicationmenu-uplift.scss
@@ -133,6 +133,7 @@
       @include transition(border-color 300ms $cubic-ease, padding 300ms $cubic-ease, margin 300ms $cubic-ease);
 
       border-bottom-color: transparent;
+      border-radius: $uplift-acc-border-radius;
       color: $uplift-acc-header-text-color;
       height: auto;
 
@@ -184,8 +185,6 @@
 
     // Top level rules
     > .accordion-header {
-      border-radius: $uplift-acc-border-radius;
-
       > a {
         padding-bottom: 7px;
         padding-top: 9px;
@@ -272,9 +271,6 @@
 
         + .accordion-pane:not(.all-children-filtered) {
           background-color: $uplift-acc-expanded-bg-color;
-          margin: 0 -10px;
-          padding: 0 10px 10px;
-          position: relative;
 
           .accordion-header {
             border-radius: $uplift-acc-border-radius;
@@ -294,16 +290,32 @@
         margin-top: 4px;
       }
 
+      .accordion-pane {
+        background-color: transparent;
+      }
+
       &.filtered {
         + .accordion-pane {
-          display: none;
+          background-color: $uplift-acc-expanded-bg-color;
         }
+      }
+    }
+
+    > .accordion-pane {
+      padding: 0;
+      position: relative;
+
+      &.is-expanded {
+        margin: 0 -10px;
+        padding: 0 10px 10px;
       }
     }
 
     // Visible accordion panes force a border to show up on the next
     // accordion header for visual separation
     .accordion-pane {
+      background-color: transparent;
+
       .accordion-header {
         border-bottom-color: transparent;
         color: $uplift-acc-subheader-text-color;

--- a/src/components/applicationmenu/applicationmenu.js
+++ b/src/components/applicationmenu/applicationmenu.js
@@ -45,6 +45,16 @@ function ApplicationMenu(element, settings) {
 ApplicationMenu.prototype = {
 
   /**
+   * @returns {SearchField|undefined} an IDS SearchField API, if one exists.
+   */
+  get searchfieldAPI() {
+    if (!this.searchfield || !this.searchfield.length) {
+      return undefined;
+    }
+    return this.searchfield.data('searchfield');
+  },
+
+  /**
    * Initialize the plugin.
    * @private
    * @returns {void}
@@ -137,11 +147,17 @@ ApplicationMenu.prototype = {
           return item;
         },
         clearResultsCallback() {
-          self.accordionAPI.unfilter();
+          if (self.searchfieldAPI && !self.searchfieldAPI.isFocused) {
+            self.accordionAPI.unfilter();
+          }
         },
         displayResultsCallback(results, done) {
           return self.filterResultsCallback(results, done);
         }
+      });
+
+      this.searchfield.on(`cleared.${COMPONENT_NAME}`, () => {
+        self.accordionAPI.unfilter();
       });
     }
 
@@ -714,7 +730,10 @@ ApplicationMenu.prototype = {
     }
 
     if (this.searchfield && this.searchfield.length) {
-      this.searchfield.off('input.applicationmenu');
+      this.searchfield.off([
+        'input.applicationmenu',
+        `cleared.${COMPONENT_NAME}`
+      ].join(' '));
       const sfAPI = this.searchfield.data('searchfield');
       if (sfAPI) {
         sfAPI.destroy();

--- a/src/themes/theme-uplift-light.scss
+++ b/src/themes/theme-uplift-light.scss
@@ -73,7 +73,7 @@ $uplift-appmenu-footer-bg-color: $theme-color-palette-slate-100;
 
 $uplift-appmenu-hover-bg-color: $theme-color-palette-slate-90;
 $uplift-appmenu-selected-bg-color: $theme-color-palette-slate-80;
-$uplift-appmenu-selected-border-color: $theme-color-palette-slate-80;
+$uplift-appmenu-selected-border-color: $theme-color-brand-primary-alt;
 
 // Core Uplift Controls
 @import '../core/controls-uplift';


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a couple problems related to filtering on the Application Menu:
- When filtering, children of items that had been filtered out would sometimes be hidden by an accordion pane with `display: none;`.  This has been resolved, and items that match the search term, but may be children of items that DON'T match the search term, are all properly displayed.  The non-matching parents have a slightly different text color.
- When using the Searchfield with keyboard navigation, using the Tab key to go from the searchfield to the X button would previously cause the filter to reset.  This has been resolved, and the filter now only disappears if the X button is clicked.

**Related github/jira issue (required)**:
Closes #3285

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the app
- Open http://localhost:4000/components/applicationmenu/test-hcm.html?theme=uplift&variant=light
- Filter on accordion subheaders by typing "3rd Level" in the searchfield.
- Observe that all items containing "3rd Level" should be visible.  Their parents should also be expanded, but displayed in a less-visible text color.
- Focus the searchfield and press the tab key.  The filter on the app menu items should not disappear.
- Press enter while focusing the X button, or click the X button.  The filter should reset and all items in the previously-expanded menus should be visible.

**Included in this Pull Request**:
- [x] A note to the change log.