### PR TITLE
3166 - Fix return focus for safari with modal

### DIFF
--- a/app/views/components/modal/example-index.html
+++ b/app/views/components/modal/example-index.html
@@ -61,6 +61,7 @@ var modals = {
   };
 
   $('#add-context').on('click', function () {
+		$(this).focus();
     setModal(modals[this.id]);
   });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed return focus was not working for safari with Modal.

**Related github/jira issue (required)**:
Closes #3166

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Use safari
- Navigate to http://localhost:4000/components/modal/example-index.html
- Click on button Show Modal to open modal
- Click on button Cancel to close the modal
- See the trigger button Show Modal should be focused

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
