### PR TITLE
3218 - Add support for tab in and out with popdown [v4.25.x]

### DIFF
--- a/app/views/components/popdown/test-first-last-tab-custom-elements.html
+++ b/app/views/components/popdown/test-first-last-tab-custom-elements.html
@@ -1,0 +1,125 @@
+<style>
+  #popdown-example-trigger span:first-child:after {
+    content: '•';
+    color: #5C5C5C;
+    font-size: 18px;
+    padding-left: 5px;
+    margin-right: 5px;
+    position: relative;
+    top: 2px;
+  }
+
+  #popdown-example-trigger {
+    border: 1px black solid;
+    width: 90px;
+    height: 34px;
+    line-height: 27px;
+  }
+
+  #popdown-example-trigger:focus {
+    border: solid 1px #368ac0;
+    box-shadow: 0 0 4px 3px rgba(54, 138, 192, 0.3);
+    outline: none;
+  }
+
+  #popdown-example-trigger span {
+    position: relative;
+    top: 4px;
+    font-size: 1.4rem;
+  }
+
+  #popdown-example-trigger span:first-child {
+    margin-left: 5px;
+  }
+
+  #popdown-example-trigger span:last-of-type {
+    right: 5px;
+  }
+
+  #popdown-example-contents .field {
+    margin-left: 5px;
+    margin-right: 5px;
+  }
+
+  #popdown-example-contents .field:first-child {
+    margin-top: 5px;
+  }
+</style>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+    <h2>Popdown Example: Tabbing into and out from a popdown (custom function).</h2>
+    <p>
+      1. When compound field opens, the first input in the popdown should be focused.<br/>
+      2. Shift + Tab on first input in the popdown should close the popdown and focus to previous element (Date Field).<br/>
+      3. Tab on last input in the popdown should close the popdown and focus to next element (Another Field).
+    </p>
+    <hr/>
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="field">
+      <label for="date-field-normal" class="label">Date Field</label>
+      <input id="date-field-normal" class="datepicker" name="date-field" type="text"/>
+    </div>
+
+    <div class="field">
+      <label for="popdown-example-trigger">Compound Field, mouse click or tab into</label>
+      <div id="popdown-example-trigger" data-popdown="true" data-init="false" tabindex="0">
+        <span class="data" id="first-name-span">Joe</span>
+        <span class="data" id="last-name-span">Smith</span>
+      </div>
+      <div class="popdown hidden" id="popdown-example-contents">
+        <div class="field">
+          <label for="first-name">First Name</label>
+          <input type="text" id="first-name" name="first-name"/>
+        </div>
+        <div class="field">
+          <label for="last-name">Last Name</label>
+          <input type="text" id="last-name" name="last-name"/>
+        </div>
+      </div>
+    </div>
+    <div class="field">
+      <label for="another-field">Another Field</label>
+      <input type="text" id="another-field" name="another-field" placeholder="This Is Here"/>
+    </div>
+  </div>
+</div>
+
+
+<script>
+  $('body').one('initialized', function () {
+    // An example for custom function to fire on tab or shift-tab for the first/last given element in popdown.
+    function customFirstLastTabAction(args) {
+      // console.log(args);
+      const focusable = $(document).find(':focusable');
+      let index = focusable.index(args.self.trigger);
+      if (args.e.shiftKey) {
+        index = ((index - 1) < 0 ? -1 : (index - 1));
+      } else {
+        index = ((index + 1) >= focusable.length ? -1 : (index + 1));
+      }
+      if (index !== -1) {
+        focusable.eq(index).focus();
+      }
+      args.self.close();
+    }
+
+    // Invoke the popdown
+    $('#popdown-example-trigger').popdown({
+      keepOpen: true,
+      autoFocus: true,
+      toggleOnFocus: true,
+      firstLastTab: {
+        first: '#first-name',
+        last: '#last-name',
+        callback: customFirstLastTabAction
+      }
+    });
+  });
+
+</script>

--- a/app/views/components/popdown/test-first-last-tab-custom.html
+++ b/app/views/components/popdown/test-first-last-tab-custom.html
@@ -1,0 +1,121 @@
+<style>
+  #popdown-example-trigger span:first-child:after {
+    content: '•';
+    color: #5C5C5C;
+    font-size: 18px;
+    padding-left: 5px;
+    margin-right: 5px;
+    position: relative;
+    top: 2px;
+  }
+
+  #popdown-example-trigger {
+    border: 1px black solid;
+    width: 90px;
+    height: 34px;
+    line-height: 27px;
+  }
+
+  #popdown-example-trigger:focus {
+    border: solid 1px #368ac0;
+    box-shadow: 0 0 4px 3px rgba(54, 138, 192, 0.3);
+    outline: none;
+  }
+
+  #popdown-example-trigger span {
+    position: relative;
+    top: 4px;
+    font-size: 1.4rem;
+  }
+
+  #popdown-example-trigger span:first-child {
+    margin-left: 5px;
+  }
+
+  #popdown-example-trigger span:last-of-type {
+    right: 5px;
+  }
+
+  #popdown-example-contents .field {
+    margin-left: 5px;
+    margin-right: 5px;
+  }
+
+  #popdown-example-contents .field:first-child {
+    margin-top: 5px;
+  }
+</style>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+    <h2>Popdown Example: Tabbing into and out from a popdown (custom function).</h2>
+    <p>
+      1. When compound field opens, the first input in the popdown should be focused.<br/>
+      2. Shift + Tab on first input in the popdown should close the popdown and focus to previous element (Date Field).<br/>
+      3. Tab on last input in the popdown should close the popdown and focus to next element (Another Field).
+    </p>
+    <hr/>
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="field">
+      <label for="date-field-normal" class="label">Date Field</label>
+      <input id="date-field-normal" class="datepicker" name="date-field" type="text"/>
+    </div>
+
+    <div class="field">
+      <label for="popdown-example-trigger">Compound Field, mouse click or tab into</label>
+      <div id="popdown-example-trigger" data-popdown="true" data-init="false" tabindex="0">
+        <span class="data" id="first-name-span">Joe</span>
+        <span class="data" id="last-name-span">Smith</span>
+      </div>
+      <div class="popdown hidden" id="popdown-example-contents">
+        <div class="field">
+          <label for="first-name">First Name</label>
+          <input type="text" id="first-name" name="first-name"/>
+        </div>
+        <div class="field">
+          <label for="last-name">Last Name</label>
+          <input type="text" id="last-name" name="last-name"/>
+        </div>
+      </div>
+    </div>
+    <div class="field">
+      <label for="another-field">Another Field</label>
+      <input type="text" id="another-field" name="another-field" placeholder="This Is Here"/>
+    </div>
+  </div>
+</div>
+
+
+<script>
+  $('body').one('initialized', function () {
+    // An example for custom function to fire on tab or shift-tab for the first/last input/select/textarea in popdown.
+    function customFirstLastTabAction(args) {
+      // console.log(args);
+      const focusable = $(document).find(':focusable');
+      let index = focusable.index(args.self.trigger);
+      if (args.e.shiftKey) {
+        index = ((index - 1) < 0 ? -1 : (index - 1));
+      } else {
+        index = ((index + 1) >= focusable.length ? -1 : (index + 1));
+      }
+      if (index !== -1) {
+        focusable.eq(index).focus();
+      }
+      args.self.close();
+    }
+
+    // Invoke the popdown
+    $('#popdown-example-trigger').popdown({
+      keepOpen: true,
+      autoFocus: true,
+      toggleOnFocus: true,
+      firstLastTab: customFirstLastTabAction
+    });
+  });
+
+</script>

--- a/app/views/components/popdown/test-first-last-tab.html
+++ b/app/views/components/popdown/test-first-last-tab.html
@@ -1,0 +1,91 @@
+<style>
+  #popdown-example-trigger span:first-child:after {
+    content: '•';
+    color: #5C5C5C;
+    font-size: 18px;
+    padding-left: 5px;
+    margin-right: 5px;
+    position: relative;
+    top: 2px;
+  }
+
+  #popdown-example-trigger {
+    border: 1px black solid;
+    width: 90px;
+    height: 34px;
+    line-height: 27px;
+  }
+
+  #popdown-example-trigger:focus {
+    border: solid 1px #368ac0;
+    box-shadow: 0 0 4px 3px rgba(54, 138, 192, 0.3);
+    outline: none;
+  }
+
+  #popdown-example-trigger span {
+    position: relative;
+    top: 4px;
+    font-size: 1.4rem;
+  }
+
+  #popdown-example-trigger span:first-child {
+    margin-left: 5px;
+  }
+
+  #popdown-example-trigger span:last-of-type {
+    right: 5px;
+  }
+
+  #popdown-example-contents .field {
+    margin-left: 5px;
+    margin-right: 5px;
+  }
+
+  #popdown-example-contents .field:first-child {
+    margin-top: 5px;
+  }
+</style>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+    <h2>Popdown Example: Tabbing into and out from a popdown.</h2>
+    <p>
+      1. When compound field opens, the first input in the popdown should be focused.<br/>
+      2. Shift + Tab on first input in the popdown should close the popdown and focus to previous element (Date Field).<br/>
+      3. Tab on last input in the popdown should close the popdown and focus to next element (Another Field).
+    </p>
+    <hr/>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+
+    <div class="field">
+      <label for="date-field-normal" class="label">Date Field</label>
+      <input id="date-field-normal" class="datepicker" name="date-field" type="text"/>
+    </div>
+
+    <div class="field">
+      <label for="popdown-example-trigger">Compound Field, mouse click or tab into</label>
+      <div id="popdown-example-trigger" data-popdown="true" data-options='{ "keepOpen": true, "autoFocus": true, "toggleOnFocus": true, "firstLastTab": true }' tabindex="0">
+        <span class="data" id="first-name-span">Joe</span>
+        <span class="data" id="last-name-span">Smith</span>
+      </div>
+      <div class="popdown hidden" id="popdown-example-contents">
+        <div class="field">
+          <label for="first-name">First Name</label>
+          <input type="text" id="first-name" name="first-name"/>
+        </div>
+        <div class="field">
+          <label for="last-name">Last Name</label>
+          <input type="text" id="last-name" name="last-name"/>
+        </div>
+      </div>
+    </div>
+    <div class="field">
+      <label for="another-field">Another Field</label>
+      <input type="text" id="another-field" name="another-field" placeholder="This Is Here"/>
+    </div>
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Fields]` Added a form level class to toggle all fields in the form to a more compact (shorter) mode called `form-layout-compact`. Added and fixed existing components so that there is now the option to have more compact forms by using shorter fields. ([#3249](https://github.com/infor-design/enterprise/issues/3249))
 - `[Tag]` Added a new style for linkable tags that will work for default, info, good, error, alert, and neutral styles. ([#3113](https://github.com/infor-design/enterprise/issues/3113))
 - `[Multiselect]` Added Tag Display as a new style for interacting with selected results in Multiselect components. ([#3114](https://github.com/infor-design/enterprise/issues/3114))
+- `[Popdown]` Added support for tabbing into and exit out of it. ([#3218](https://github.com/infor-design/enterprise/issues/3218))
 - `[Colors]` Updated design system tokens to new colors for uplift and did a pass on all three theme variants. This impacts and improves many internal colors in components and charts. ([#3007](https://github.com/infor-design/enterprise/issues/3007))
 
 ### v4.25.0 Fixes

--- a/test/components/popdown/popdown.e2e-spec.js
+++ b/test/components/popdown/popdown.e2e-spec.js
@@ -69,7 +69,7 @@ describe('Popdown first last tab Tests', () => {
   // 1. On open first input should be focused.
   // 2. On first input (Shift + Tab) should close and focus to previous.
   // 3. On last input Tab should close and focus to next.
-  it('Should keep the Popdown ', async () => {
+  it('Should let close the popdown and if available focus to prev/next', async () => {
     const focusedId = () => browser.driver.switchTo().activeElement().getAttribute('id');
     // Tab on date field
     await element(by.css('#date-field-normal')).sendKeys(protractor.Key.TAB);

--- a/test/components/popdown/popdown.e2e-spec.js
+++ b/test/components/popdown/popdown.e2e-spec.js
@@ -56,3 +56,69 @@ describe('Popdown (with Dropdown) Tests', () => {
     expect(await element(by.css('.popdown')).isDisplayed()).toBeTruthy();
   });
 });
+
+describe('Popdown first last tab Tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/popdown/test-first-last-tab?layout=nofrills');
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  // 1. On open first input should be focused.
+  // 2. On first input (Shift + Tab) should close and focus to previous.
+  // 3. On last input Tab should close and focus to next.
+  it('Should keep the Popdown ', async () => {
+    const focusedId = () => browser.driver.switchTo().activeElement().getAttribute('id');
+    // Tab on date field
+    await element(by.css('#date-field-normal')).sendKeys(protractor.Key.TAB);
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('.popdown'))), config.waitsFor);
+
+    // Popdown should open and first input should be focused.
+    expect(await element(by.css('.popdown')).isDisplayed()).toBeTruthy();
+    expect(await element(by.css('#first-name')).isDisplayed()).toBeTruthy();
+    expect(await element(by.css('#last-name')).isDisplayed()).toBeTruthy();
+    expect(focusedId()).toEqual('first-name');
+
+    // Tab on first input
+    await element(by.css('#first-name')).sendKeys(protractor.Key.TAB);
+    await browser.driver.sleep(config.sleep);
+
+    // Last input should be focused in popdown.
+    expect(focusedId()).toEqual('last-name');
+
+    // Tab on last input in popdown
+    await element(by.css('#last-name')).sendKeys(protractor.Key.TAB);
+    await browser.driver.sleep(config.sleep);
+
+    // Popdown should close and next input (another-field) should be focused.
+    expect(await element(by.css('.popdown')).isDisplayed()).toBeFalsy();
+    expect(await element(by.css('#first-name')).isDisplayed()).toBeFalsy();
+    expect(await element(by.css('#last-name')).isDisplayed()).toBeFalsy();
+    expect(focusedId()).toEqual('another-field');
+
+    // Shift + Tab on this next to popdown input (another-field)
+    await element(by.css('#another-field'))
+      .sendKeys(protractor.Key.chord(protractor.Key.SHIFT, protractor.Key.TAB));
+    await browser.driver.sleep(config.sleep);
+
+    // Popdown should open again and first input should be focused.
+    expect(await element(by.css('.popdown')).isDisplayed()).toBeTruthy();
+    expect(await element(by.css('#first-name')).isDisplayed()).toBeTruthy();
+    expect(await element(by.css('#last-name')).isDisplayed()).toBeTruthy();
+    expect(focusedId()).toEqual('first-name');
+
+    // Shift + Tab on first input in popdown
+    await element(by.css('#first-name'))
+      .sendKeys(protractor.Key.chord(protractor.Key.SHIFT, protractor.Key.TAB));
+    await browser.driver.sleep(config.sleep);
+
+    // Popdown should close and previous input (date field) should be focused.
+    expect(await element(by.css('.popdown')).isDisplayed()).toBeFalsy();
+    expect(await element(by.css('#first-name')).isDisplayed()).toBeFalsy();
+    expect(await element(by.css('#last-name')).isDisplayed()).toBeFalsy();
+    expect(focusedId()).toEqual('date-field-normal');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added support for tabbing into and exit out of the Popdown.

**Related github/jira issue (required)**:
Closes #3218

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/popdown/test-first-last-tab.html
http://localhost:4000/components/popdown/test-first-last-tab-custom.html
http://localhost:4000/components/popdown/test-first-last-tab-custom-elements.html
- Pull this branch and build/run the demo app
- Open above links
- Click or tab into the first Date field
- Press tab (the popdown opens, and the first field should be focused)
- Press tab (the second field in the popdown should be focused)
- Press tab (the popdown should dismiss, and the next field on the base form (Another Field) should be focused)
- And you can go backward by using the `shift + tab`

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
