### PR TITLE
3315 - Prevent masks on number input fields from allowing double decimal points [v4.25.x]

### DIFF
--- a/app/views/components/mask/test-input-type-numeric.html
+++ b/app/views/components/mask/test-input-type-numeric.html
@@ -9,7 +9,7 @@
   <div class="six columns">
     <div class="field">
       <label for="test-input">Numeric Input</label>
-      <input id="test-input" type="number" class="new-mask" data-options='{ "process": "number", "patternOptions": { "allowThousandsSeparator": false, "allowDecimal": true, "allowNegative": true, "integerLimit": 7, "decimalLimit": 2 } }' placeholder="-#######.00"/>
+      <input id="test-input" type="number" class="new-mask" data-options='{ "process": "number", "patternOptions": { "allowThousandsSeparator": false, "allowDecimal": true, "allowNegative": true, "integerLimit": 7, "decimalLimit": 2 } }' placeholder="-#######.00" step="0.01"/>
     </div>
   </div>
 </div>

--- a/app/views/components/mask/test-input-type-numeric.html
+++ b/app/views/components/mask/test-input-type-numeric.html
@@ -9,7 +9,7 @@
   <div class="six columns">
     <div class="field">
       <label for="test-input">Numeric Input</label>
-      <input id="test-input" type="number" class="new-mask" data-options='{ "process": "number", "patternOptions": { "allowThousandsSeparator": false, "allowDecimal": true, "allowNegative": true, "integerLimit": 7, "decimalLimit": 2 } }' placeholder="-#######.00" step="0.01"/>
+      <input id="test-input" type="number" class="new-mask" data-options='{ "process": "number", "patternOptions": { "allowLeadingZeroes": true, "allowThousandsSeparator": false, "allowDecimal": true, "allowNegative": true, "integerLimit": 7, "decimalLimit": 2 } }' placeholder="-#######.00" step="0.01"/>
     </div>
   </div>
 </div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ids-enterprise",
   "slug": "ids-enterprise",
-  "version": "4.25.0-dev",
+  "version": "4.25.0-beta.0",
   "description": "Infor Design System (IDS) Enterprise Components for the web",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR is a Q/A follow up issue for PR #3322, which fixes a couple things:
- The original issue was that the number input field was not allowing the user to enter leading zeroes. This wasn't a bug with the component, but was an issue with the sample not having the `allowLeadingZeroes` setting turned on.  The sample has been updated to allow leading zeroes.
- It was possible to enter double decimal points on `input[type="number"]` fields, due to issues with detection of non-numeric characters specifically on these fields.  The ability to do this has been removed.

**Related github/jira issue (required)**:
Closes #3315 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the demoapp.
- Open http://localhost:4000/components/mask/test-input-type-numeric
- Try to type more than one zero in the field.  It should work correctly.
- Tap out a number and attempt to add decimal points, followed by decimal numbers.  After adding the decimal numbers, try adding a second decimal point.  This should not be allowed. (should fix the problem noted [here](https://github.com/infor-design/enterprise/issues/3315#issuecomment-575065791)

NOTE: I need to raise a followup issue for permanently fixing a problem in Firefox that occurs, where typing too many `0`s at end of a decimal number resets all the decimal places.  For the purposes of generally fixing this case, I haven't done that in this PR.