### PR TITLE
3315 - Prevent masks on number input fields from allowing double decimal points [v4.25.x]

### DIFF
--- a/app/views/components/mask/test-input-type-numeric.html
+++ b/app/views/components/mask/test-input-type-numeric.html
@@ -9,7 +9,7 @@
   <div class="six columns">
     <div class="field">
       <label for="test-input">Numeric Input</label>
-      <input id="test-input" type="number" class="new-mask" data-options='{ "process": "number", "patternOptions": { "allowThousandsSeparator": false, "allowDecimal": true, "allowNegative": true, "integerLimit": 7, "decimalLimit": 2 } }' placeholder="-#######.00"/>
+      <input id="test-input" type="number" class="new-mask" data-options='{ "process": "number", "patternOptions": { "allowThousandsSeparator": false, "allowDecimal": true, "allowNegative": true, "integerLimit": 7, "decimalLimit": 2 } }' placeholder="-#######.00" step="0.01"/>
     </div>
   </div>
 </div>

--- a/app/views/components/mask/test-input-type-numeric.html
+++ b/app/views/components/mask/test-input-type-numeric.html
@@ -9,7 +9,7 @@
   <div class="six columns">
     <div class="field">
       <label for="test-input">Numeric Input</label>
-      <input id="test-input" type="number" class="new-mask" data-options='{ "process": "number", "patternOptions": { "allowThousandsSeparator": false, "allowDecimal": true, "allowNegative": true, "integerLimit": 7, "decimalLimit": 2 } }' placeholder="-#######.00" step="0.01"/>
+      <input id="test-input" type="number" class="new-mask" data-options='{ "process": "number", "patternOptions": { "allowLeadingZeroes": true, "allowThousandsSeparator": false, "allowDecimal": true, "allowNegative": true, "integerLimit": 7, "decimalLimit": 2 } }' placeholder="-#######.00" step="0.01"/>
     </div>
   </div>
 </div>

--- a/test/components/button/button-api.func-spec.js
+++ b/test/components/button/button-api.func-spec.js
@@ -83,9 +83,12 @@ describe('Button API', () => {
     expect(buttonAPI.settings.hideMenuArrow).toEqual(settings.hideMenuArrow);
   });
 
-  it('Should remove menu icon if hideMenuArrow set to true', () => {
+  it('Should remove menu icon if hideMenuArrow set to true', (done) => {
     buttonAPI.updated({ hideMenuArrow: true });
 
-    expect(document.body.querySelector('.icon-dropdown')).toBeFalsy();
+    setTimeout(() => {
+      expect(document.body.querySelector('.icon-dropdown')).toBeFalsy();
+      done();
+    }, 10);
   });
 });

--- a/test/components/popupmenu/popupmenu.func-spec.js
+++ b/test/components/popupmenu/popupmenu.func-spec.js
@@ -58,13 +58,17 @@ describe('Popupmenu Menu Button API', () => {
     expect(popupmenuObj.getPositionFromEvent(eClient)).toEqual({ x: 222, y: 333 });
   });
 
-  it('Should position correctly', () => {
+  it('Should position correctly', (done) => {
     // Indirectly tests Place component
     popupmenuObj.position(ePage);
-    const ulElem = document.querySelector('ul#popupmenu-1');
-    const parentElem = ulElem.parentNode;
 
-    expect(parentElem.classList.toString()).toContain('placeable bottom');
+    setTimeout(() => {
+      const ulElem = document.querySelector('ul#popupmenu-1');
+      const parentElem = ulElem.parentNode;
+
+      expect(parentElem.className).toContain('placeable bottom');
+      done();
+    }, 10);
   });
 
   it('Should open', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR is a Q/A follow up issue for PR #3322, which fixes a couple things:
- The original issue was that the number input field was not allowing the user to enter leading zeroes. This wasn't a bug with the component, but was an issue with the sample not having the `allowLeadingZeroes` setting turned on.  The sample has been updated to allow leading zeroes.
- It was possible to enter double decimal points on `input[type="number"]` fields, due to issues with detection of non-numeric characters specifically on these fields.  The ability to do this has been removed.

**Related github/jira issue (required)**:
Closes #3315 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the demoapp.
- Open http://localhost:4000/components/mask/test-input-type-numeric
- Try to type more than one zero in the field.  It should work correctly.
- Tap out a number and attempt to add decimal points, followed by decimal numbers.  After adding the decimal numbers, try adding a second decimal point.  This should not be allowed. (should fix the problem noted [here](https://github.com/infor-design/enterprise/issues/3315#issuecomment-575065791)

NOTE: I need to raise a followup issue for permanently fixing a problem in Firefox that occurs, where typing too many `0`s at end of a decimal number resets all the decimal places.  For the purposes of generally fixing this case, I haven't done that in this PR.