### PR TITLE
3113/3114 - Q/A improvements for the Tags Component / Fix NG Issues [v4.25.x]

### DIFF
--- a/src/components/badges/_badges.scss
+++ b/src/components/badges/_badges.scss
@@ -510,7 +510,7 @@ html[class*='theme-uplift-'] {
       .dismissible-btn,
       .linkable-btn {
         .icon {
-          top: -1px;
+          top: -3px;
         }
       }
     }

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -695,6 +695,10 @@ input.dropdown.error:focus {
 
   .dropdown {
     height: $input-size-regular-height;
+
+    &.has-tags {
+      height: auto;
+    }
   }
 
   div.dropdown,
@@ -972,6 +976,10 @@ div.dropdown-xs,
       + .icon {
         right: 4px !important;
         top: -2px !important;
+      }
+
+      &.has-tags {
+        height: auto !important;
       }
     }
   }

--- a/src/components/tag/tag.js
+++ b/src/components/tag/tag.js
@@ -122,6 +122,13 @@ Tag.prototype = {
   render() {
     const elemClasses = this.element.classList;
     const currentState = this.settings.style;
+
+    // Update "style" class on the top-level element
+    elemClasses.forEach((cssClass) => {
+      if (tagStyles.indexOf(cssClass) > -1) {
+        elemClasses.remove(cssClass);
+      }
+    });
     if (this.element.className.indexOf(currentState) === -1 && currentState !== 'default') {
       elemClasses.add(currentState);
     }

--- a/src/components/tag/tag.js
+++ b/src/components/tag/tag.js
@@ -121,10 +121,11 @@ Tag.prototype = {
    */
   render() {
     const elemClasses = this.element.classList;
+    const elemClassArr = utils.getArrayFromList(this.element.classList);
     const currentState = this.settings.style;
 
     // Update "style" class on the top-level element
-    elemClasses.forEach((cssClass) => {
+    elemClassArr.forEach((cssClass) => {
       if (tagStyles.indexOf(cssClass) > -1) {
         elemClasses.remove(cssClass);
       }

--- a/test/components/tag/tag.func-spec.js
+++ b/test/components/tag/tag.func-spec.js
@@ -66,4 +66,28 @@ describe('Tag API (as span)', () => {
     expect(tagAPI.element.querySelector('.tag-content').tagName).toEqual('A');
     expect(tagAPI.element.querySelector('a').getAttribute('href')).toEqual(null);
   });
+
+  it('can change its "style" when updating', () => {
+    tagEl.insertAdjacentHTML('afterbegin', '<a class="tag-content">This is a Tag!</a>');
+    tagAPI = new Tag(tagEl, {
+      style: 'info'
+    });
+
+    expect(tagAPI.element.classList.contains('info')).toBeTruthy();
+
+    tagAPI.updated({
+      style: 'error'
+    });
+
+    expect(tagAPI.element.classList.contains('info')).toBeFalsy();
+    expect(tagAPI.element.classList.contains('error')).toBeTruthy();
+
+    // 'default' doesn't render a CSS class
+    tagAPI.updated({
+      style: 'default'
+    });
+
+    expect(tagAPI.element.classList.contains('error')).toBeFalsy();
+    expect(tagAPI.element.classList.contains('default')).toBeFalsy();
+  });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a couple issues:
- Incorrect icon placement on IE11 when using the Linkable tag (#3113).
- There was an issue when using Tags in NG (issue number TBD) where the extra CSS class for changing state/color wouldn't match the new component setting.  This PR fixes the Tag to add/remove the correct classes to match the setting.  This is needed to facilitate fixes on the NG side, coming in another PR.

**Related github/jira issue (required)**:
Closes #3113 

**Steps necessary to review your pull request (required)**:
Pull this branch, build, run the app.  Then:

_Test IE for correct icon placement:_
- Open http://localhost:4000/components/tag/example-linkable.html?theme=uplift&variant=light in IE11
- Ensure the icons correctly align in the middle of the tag, matching the text.

Visual states being programmatically changed are [covered by this test](https://github.com/infor-design/enterprise/compare/4.25.x...3114-tags-qa#diff-72a36fa810fe15fae1aa39482b8684e2R69-R92)

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.