### PR TITLE
3350 - Fix focus align in date picker field with datagrid [v4.25.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `[Datagrid]` Fixed a bug where floating point math would cause the grouping sum aggregator to round incorrectly. ([#3233](https://github.com/infor-design/enterprise/issues/3233))
 - `[Datagrid]` Fixed style issues in all theme and theme variants when using the list style including grouped headers and states. ([#3265](https://github.com/infor-design/enterprise/issues/3265))
 - `[Datagrid]` Fixed an issue where converting circular structure to JSON was throwing an error. ([#3309](https://github.com/infor-design/enterprise/issues/3309))
+- `[Datagrid]` Fixed an issue where focus in date picker field was not aligning. ([#3350](https://github.com/infor-design/enterprise/issues/3350))
 - `[Editor]` Fixed an issue where line spacing was inconsistent. ([#3335](https://github.com/infor-design/enterprise/issues/3335))
 - `[Homepage]` Fixed an issue where the DOM order was not working for triple width widgets. ([#3101](https://github.com/infor-design/enterprise/issues/3101))
 - `[Locale]` Fixed an issue where enter all digits was not working for fr-FR. ([#3217](https://github.com/infor-design/enterprise/issues/3217))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -741,8 +741,8 @@ $datagrid-short-row-height: 25px;
           }
 
           .datepicker {
-            margin-top: 12px;
-            padding: 0 15px;
+            margin-top: 3px;
+            padding: 0 5px 0 15px;
           }
 
           input {
@@ -1113,7 +1113,8 @@ $datagrid-short-row-height: 25px;
           }
 
           .datepicker {
-            margin-top: 6px;
+            height: 3rem;
+            margin-top: 0;
             padding: 0 10px;
 
             + .icon {
@@ -2096,9 +2097,9 @@ $datagrid-short-row-height: 25px;
       //Date Picker
       .datepicker {
         border: 0;
-        margin-top: 17px;
+        margin-top: 8px;
         padding: 0 0 0 20px;
-        width: calc(100% - 28px);
+        width: calc(100% - 27px);
 
         ~ .icon {
           left: auto;
@@ -3236,7 +3237,7 @@ td .btn-actions {
         }
 
         .datepicker {
-          margin-top: 13px;
+          margin-top: 4px;
 
           ~ .icon {
             top: calc(50% - 15px);
@@ -3258,14 +3259,6 @@ td .btn-actions {
         .lookup-wrapper {
           .lookup ~ .trigger .icon {
             top: calc(50% - 5px);
-          }
-        }
-
-        .datepicker {
-          margin-top: 8px;
-
-          ~ .icon {
-            top: calc(50% - 14px);
           }
         }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed focus in date picker field was not aligning with Datagrid.

**Related github/jira issue (required)**:
Closes #3350

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/example-placeholder.html
- Click on any cell in column `Order Date`
- See it should be aligned while in edit mode

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
