### PR TITLE
3055 - Fix alignment of placeholder text in App Menu Searchfields in Vibrant theme [v4.25.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,7 @@
 - `[Multiselect]` Adjusted the placeholder color as it was too dark. ([#3276](https://github.com/infor-design/enterprise/issues/3276))
 - `[Popupmenu]` Switched the `attachToBody` setting to be true by default. ([#3331](https://github.com/infor-design/enterprise/issues/3331))
 - `[Searchfield]` Fixed an issue where multiselect items' checkboxes and text were misaligned in RTL mode. ([#1811](https://github.com/infor-design/enterprise/issues/1811))
+- `[Searchfield]` Fixed placeholder text alignment issues on Vibrant theme in Firefox. ([#3055](https://github.com/infor-design/enterprise/issues/3055))
 - `[Scrollbar]` Fixed styles for windows chrome to work with all themes. ([#3172](https://github.com/infor-design/enterprise/issues/3172))
 - `[Searchfield]` Fixed an overlapping text in searchfield when close icon button is showed. ([#3135](https://github.com/infor-design/enterprise/issues/3135))
 - `[Tabs]` Fixed an issue where scroll was not working on mobile view for scrollable-flex layout. ([#2931](https://github.com/infor-design/enterprise/issues/2931))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `[Accordion]` Fixed inconsistency style of focus element after clicking on a certain accordion header. ([#3082](https://github.com/infor-design/enterprise/issues/3082))
 - `[Accordion]` Fixed an issue that when all panes are expanded then they could no longer be closed. ([#701](https://github.com/infor-design/enterprise-ng/issues/3217))
 - `[Application Menu]` Fixed minor usability issues when attempting to filter on application menus, display of hidden filtered children, and filtering reset when a Searchfield is blurred. ([#3285](https://github.com/infor-design/enterprise/issues/3285))
+- `[Application Menu]` Fixed incorrect font-size/padding around list item headers' bullet points. ([#3364](https://github.com/infor-design/enterprise/issues/3364))
 - `[Autocomplete]` Fixed an issue where selected event was not firing when its parent is partly overflowing. ([#3072](https://github.com/infor-design/enterprise/issues/3072))
 - `[Calendar]` Fixed an issue setting the legend checked elements to false in the api. ([#3170](https://github.com/infor-design/enterprise/issues/3170))
 - `[Datagrid]` Fixed an issue where the data after commit edit was not in sync for tree. ([#659](https://github.com/infor-design/enterprise-ng/issues/659))

--- a/src/components/accordion/_accordion-uplift.scss
+++ b/src/components/accordion/_accordion-uplift.scss
@@ -61,27 +61,5 @@ html {
     .btn {
       top: -1px;
     }
-
-    /*
-    &.filtered.has-filtered-children {
-      &:not(:hover),
-      &:not(.is-selected) {
-        > a {
-          color: inherit;
-        }
-
-        > .icon {
-          color: inherit;
-        }
-
-        > .btn > .icon {
-          &::before,
-          &::after {
-            background-color: inherit;
-          }
-        }
-      }
-    }
-    */
   }
 }

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -838,6 +838,19 @@
   padding: 15px 0 15px 20px;
 }
 
+// Slight adjustment to padding/placement of icons on JP styles.
+// JP fonts have different character spacing/padding requirements.
+// See Github: infor-design/enterprise#3364
+html[lang='ja-JP'] {
+  .accordion-pane {
+    .accordion-header.list-item {
+      &::before {
+        font-size: 0.8rem;
+      }
+    }
+  }
+}
+
 // RTL Styles
 html[dir='rtl'] {
   .accordion {

--- a/src/components/applicationmenu/_applicationmenu-uplift.scss
+++ b/src/components/applicationmenu/_applicationmenu-uplift.scss
@@ -375,7 +375,9 @@
 
         &.list-item {
           &::before {
-            font-size: 1rem;
+            color: inherit;
+            font-size: 0.8rem;
+            padding-right: 12px;
           }
         }
 
@@ -477,10 +479,20 @@ html[dir='rtl'] {
 
     .accordion.panel.inverse {
       .accordion-pane {
-        .accordion-header:not(.has-chevron) {
-          .icon.chevron {
-            left: auto;
-            right: -5px;
+        .accordion-header {
+          &:not(.has-chevron) {
+            .icon.chevron {
+              left: auto;
+              right: -5px;
+            }
+          }
+
+          &.list-item {
+            &::before {
+              font-size: 1.2rem;
+              padding-left: 8px;
+              padding-right: 28px;
+            }
           }
         }
       }

--- a/src/components/applicationmenu/_applicationmenu-uplift.scss
+++ b/src/components/applicationmenu/_applicationmenu-uplift.scss
@@ -27,7 +27,6 @@
 
       &::-moz-placeholder {
         color: $uplift-appmenu-searchfield-placeholder-color;
-        line-height: normal;
         opacity: 1;
       }
 

--- a/src/components/applicationmenu/_applicationmenu-uplift.scss
+++ b/src/components/applicationmenu/_applicationmenu-uplift.scss
@@ -39,6 +39,10 @@
     > .icon {
       top: 13px;
     }
+
+    &:first-child {
+      margin-top: 10px;
+    }
   }
 
   .application-menu-header,

--- a/src/themes/theme-uplift-contrast.scss
+++ b/src/themes/theme-uplift-contrast.scss
@@ -771,7 +771,7 @@ $uplift-acc-subheader-text-color: $theme-color-palette-slate-50;
 
 $uplift-acc-expanded-bg-color: $theme-color-palette-slate-100;
 
-$uplift-appmenu-searchfield-placeholder-color: $theme-color-palette-slate-50;
+$uplift-appmenu-searchfield-placeholder-color: $theme-color-palette-slate-30;
 
 $uplift-appmenu-main-bg-color: $theme-color-palette-black;
 $uplift-appmenu-header-bg-color: $theme-color-palette-black;

--- a/src/themes/theme-uplift-dark.scss
+++ b/src/themes/theme-uplift-dark.scss
@@ -737,7 +737,7 @@ $uplift-acc-subheader-text-color: $theme-color-palette-slate-50;
 
 $uplift-acc-expanded-bg-color: $theme-color-palette-slate-100;
 
-$uplift-appmenu-searchfield-placeholder-color: $theme-color-palette-slate-60;
+$uplift-appmenu-searchfield-placeholder-color: $theme-color-palette-slate-50;
 
 $uplift-appmenu-main-bg-color: $theme-color-palette-black;
 $uplift-appmenu-header-bg-color: $theme-color-palette-black;

--- a/src/themes/theme-uplift-light.scss
+++ b/src/themes/theme-uplift-light.scss
@@ -66,7 +66,7 @@ $uplift-acc-subheader-text-color: $theme-color-palette-slate-50;
 
 $uplift-acc-expanded-bg-color: $theme-color-palette-black;
 
-$uplift-appmenu-searchfield-placeholder-color: $theme-color-palette-slate-70;
+$uplift-appmenu-searchfield-placeholder-color: $theme-color-palette-slate-60;
 
 $uplift-appmenu-main-bg-color: $theme-color-palette-slate-100;
 $uplift-appmenu-header-bg-color: $theme-color-palette-slate-100;

--- a/test/components/button/button-api.func-spec.js
+++ b/test/components/button/button-api.func-spec.js
@@ -83,12 +83,10 @@ describe('Button API', () => {
     expect(buttonAPI.settings.hideMenuArrow).toEqual(settings.hideMenuArrow);
   });
 
-  it('Should remove menu icon if hideMenuArrow set to true', (done) => {
+  it('Should remove menu icon if hideMenuArrow set to true', () => {
+    const elem = buttonAPI.element[0];
     buttonAPI.updated({ hideMenuArrow: true });
 
-    setTimeout(() => {
-      expect(document.body.querySelector('.icon-dropdown')).toBeFalsy();
-      done();
-    }, 10);
+    expect(elem.querySelector('.icon-dropdown')).toBeFalsy();
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes misaligned placeholder text in Application Menu Searchfields on the Vibrant theme.

**Related github/jira issue (required)**:
Closes #3055
Closes #3364 

**Steps necessary to review your pull request (required)**:
Pull this branch, build, run the app.  Then:

_Test placeholder text alignment:_
- Open http://localhost:4000/components/applicationmenu/example-filterable?theme=uplift&variant=light in Firefox
- Look at the empty searchfield and ensure its placeholder text is aligned vertically in the center of the input field.

_Test JP bullet point alignment:_
- Open http://localhost:4000/components/applicationmenu/test-six-levels.html?locale=ja-JP
- Expand the "Level 1" app menu header
- Observe that all the Level 1 pane's accordion headers should be properly aligned and visible.
- Also open the Vibrant theme and check the same thing: http://localhost:4000/components/applicationmenu/test-six-levels.html?locale=ja-JP&theme=uplift

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
