### PR TITLE
3371 - Fix destroy and uplift for expand button on the splitter

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### v4.26.0 Fixes
 
 - `[Pie]` Fixed an issue where initial selection was getting error. ([#3157](https://github.com/infor-design/enterprise/issues/3157))
+- `[Splitter]` Fixed an issue in the destroy function where the expand button was not removed. ([#3371](https://github.com/infor-design/enterprise/issues/3371))
 
 ### v4.26.0 Chores & Maintenance
 

--- a/scripts/data/expected-files.json
+++ b/scripts/data/expected-files.json
@@ -262,6 +262,7 @@
 	"/dist/sass/src/components/slider/_slider.scss",
 	"/dist/sass/src/components/spinbox/_spinbox-uplift.scss",
 	"/dist/sass/src/components/spinbox/_spinbox.scss",
+	"/dist/sass/src/components/splitter/_splitter-uplift.scss",
 	"/dist/sass/src/components/splitter/_splitter.scss",
 	"/dist/sass/src/components/stepchart/_stepchart.scss",
 	"/dist/sass/src/components/swaplist/_swaplist-uplift.scss",

--- a/src/components/splitter/_splitter-uplift.scss
+++ b/src/components/splitter/_splitter-uplift.scss
@@ -1,0 +1,15 @@
+// Splitter
+//========================================================
+.splitter .splitter-btn {
+  margin-left: -1px;
+  margin-top: -6px;
+
+  &.rotate {
+    left: -4px;
+  }
+
+  .icon {
+    height: 12px;
+    width: 12px;
+  }
+}

--- a/src/components/splitter/_splitter.scss
+++ b/src/components/splitter/_splitter.scss
@@ -57,23 +57,29 @@
     &::after {
       color: $splitter-active-grip-bg-color;
     }
+
+    .splitter-btn .icon {
+      color: $splitter-active-grip-bg-color;
+    }
   }
 
   .splitter-btn {
     height: 30px;
-    left: -2px;
+    left: -4px;
+    margin-top: -2px;
     position: absolute;
     transform: none;
     width: 30px;
     z-index: 101;
 
     .icon {
+      color: $splitter-grip-bg-color;
       height: 16px;
       width: 16px;
     }
 
     &.rotate {
-      left: -7px;
+      left: -6px;
       margin-top: -5px;
       transform: rotate(180deg);
     }

--- a/src/components/splitter/splitter.js
+++ b/src/components/splitter/splitter.js
@@ -95,12 +95,12 @@ Splitter.prototype = {
 
       if (s.collapseButton) {
         let savedOffset = 0;
-        const splitterButton = $('<button type="button" class="splitter-btn" id="splitter-collapse-btn"><svg class="icon" focusable="false" aria-hidden="true" role="presentation"><use xlink:href="#icon-double-chevron"></use></svg></button>');
-        splitterButton.appendTo(splitter);
+        this.splitterCollapseButton = $('<button type="button" class="splitter-btn" id="splitter-collapse-btn"><svg class="icon" focusable="false" aria-hidden="true" role="presentation"><use xlink:href="#icon-double-chevron"></use></svg></button>');
+        this.splitterCollapseButton.appendTo(splitter);
         if (splitter[0].offsetLeft > 10) {
-          $('#splitter-collapse-btn').addClass('rotate');
+          this.splitterCollapseButton.addClass('rotate');
         }
-        $('#splitter-collapse-btn').click(function () {
+        this.splitterCollapseButton.click(function () {
           if (savedOffset <= 0) {
             if (splitter[0].offsetLeft <= 10) {
               self.splitTo(defaultOffset, parentHeight);
@@ -154,7 +154,7 @@ Splitter.prototype = {
     this.splitTo(w, parentHeight);
 
     if (w <= 10) {
-      $('#splitter-collapse-btn').removeClass('rotate');
+      this.splitterCollapseButton.removeClass('rotate');
     }
 
     // Add the Splitter Events
@@ -333,7 +333,7 @@ Splitter.prototype = {
       this.settings = utils.mergeSettings(this.element, settings, SPLITTER_DEFAULTS);
     }
     return this
-      .unbind()
+      .destroy()
       .init();
   },
 
@@ -343,6 +343,9 @@ Splitter.prototype = {
   */
   destroy() {
     this.unbind();
+    if (this.splitterCollapseButton) {
+      this.splitterCollapseButton.remove();
+    }
     $.removeData(this.element[0], COMPONENT_NAME);
   },
 

--- a/src/core/_controls-uplift.scss
+++ b/src/core/_controls-uplift.scss
@@ -90,6 +90,7 @@
 @import '../components/spinbox/spinbox';
 @import '../components/spinbox/spinbox-uplift';
 @import '../components/splitter/splitter';
+@import '../components/splitter/splitter-uplift';
 @import '../components/swaplist/swaplist';
 @import '../components/swaplist/swaplist-uplift';
 @import '../components/tabs/tabs';


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The splitter destroy event did not remove the expand/collapse button. Also adjust the icon for uplift.

**Related github/jira issue (required)**:
Fixes #3371 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/splitter/test-collapse-button.html?theme=uplift&variant=light
- in the console type:
```
$('#splitter').data('splitter').destroy()
$('#splitter').splitter({'collapseButton': true})
```
- the top expand button should still work.

**Included in this Pull Request**:
- [x] A note to the change log.
