### PR TITLE
3350 - Fix date picker focus align for vibrant theme with datagrid [v4.25.x]

### DIFF
--- a/src/components/datagrid/_datagrid-uplift.scss
+++ b/src/components/datagrid/_datagrid-uplift.scss
@@ -32,13 +32,6 @@
   }
 }
 
-// Adjust icon for firefox
-.is-firefox {
-  .datagrid-header .datagrid-filter-wrapper .timepicker + .icon {
-    top: -2px;
-  }
-}
-
 // Adjust header text
 .datagrid-header-text {
   font-size: $theme-size-font-xs !important;
@@ -56,6 +49,12 @@
     .hyperlink {
       margin-top: -2px;
     }
+
+    &.is-editing {
+      .datepicker {
+        margin-top: 6px;
+      }
+    }
   }
 
   // Medium Row Height
@@ -65,6 +64,10 @@
         &.is-editing {
           &.has-singlecolumn {
             min-height: $datagrid-medium-row-height + 10;
+          }
+
+          .datepicker {
+            margin-top: 0;
           }
         }
       }
@@ -95,4 +98,42 @@
 .is-gridlist.has-draggable-columns th .handle {
   font-size: 23px;
   top: -3px;
+}
+
+// Firefox
+.is-firefox {
+  // Adjust icon for firefox
+  .datagrid-header .datagrid-filter-wrapper .timepicker + .icon {
+    top: -2px;
+  }
+
+  // Main Grid for firefox
+  .datagrid {
+    td {
+      &.is-editing {
+        .datepicker {
+          ~ .icon {
+            top: calc(50% - 17px);
+          }
+        }
+      }
+    }
+
+    // Medium Row Height for firefox
+    &.medium-rowheight {
+      tbody tr {
+        td {
+          &.is-editing {
+            .datepicker {
+              margin-top: 0;
+
+              ~ .icon {
+                top: calc(50% - 17px);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/components/datagrid/_datagrid-uplift.scss
+++ b/src/components/datagrid/_datagrid-uplift.scss
@@ -53,6 +53,10 @@
     &.is-editing {
       .datepicker {
         margin-top: 6px;
+
+        ~ .icon {
+          top: calc(50% - 18px);
+        }
       }
     }
   }
@@ -68,6 +72,10 @@
 
           .datepicker {
             margin-top: 0;
+
+            ~ .icon {
+              top: calc(50% - 17px);
+            }
           }
         }
       }
@@ -79,6 +87,14 @@
     tbody {
       tr {
         td {
+          &.is-editing {
+            .datepicker {
+              ~ .icon {
+                top: calc(50% - 18px);
+              }
+            }
+          }
+
           // Adjust Tags
           span {
             line-height: 22px;

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -743,6 +743,10 @@ $datagrid-short-row-height: 25px;
           .datepicker {
             margin-top: 3px;
             padding: 0 5px 0 15px;
+
+            ~ .icon {
+              top: calc(50% - 16px);
+            }
           }
 
           input {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed focus in date picker field for vibrant theme was not aligning with Datagrid.

**Related github/jira issue (required)**:
Closes #3350

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/example-placeholder.html?theme=uplift
- Click on any cell in column `Order Date`
- See it should be aligned while in edit mode
- Focus cell style `blue border, shadow` should not cut off

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
