### PR TITLE
358 - Fix focus on reload data with datagrid

### DIFF
--- a/app/views/components/datagrid/test-reload-focus.html
+++ b/app/views/components/datagrid/test-reload-focus.html
@@ -1,0 +1,67 @@
+<div class="row">
+  <div class="twelve columns">
+    <h2>Data Grid - Focus on reload data.</h2>
+    <p>
+      Related Ticket: <a class="hyperlink" href="https://github.com/infor-design/enterprise-ng/issues/358" target="_blank">enterprise-ng #358</a><br/>
+      1) Click on any cell in grid to get focused<br/>
+      2) Click on Input Textbox and start typing<br/>
+      3) Every keystroke, grid should reload data with one less row<br/>
+      4) And focus should remain on Input Textbox
+    </p>
+  </div>
+</div>
+<div class="row">
+  <div class="twelve columns">
+    <div class="field">
+      <label for="txt-test">Input Textbox</label>
+      <input type="text" id="txt-test" name="txt-test" />
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script id="datagrid-script">
+  $('body').one('initialized', function () {
+
+    var grid,
+      data = [],
+      columns = [];
+
+    // Define Columns for the Grid.
+    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
+    columns.push({ id: 'productId', hideable: false, name: 'Id', field: 'productId', reorderable: true, formatter: Formatters.Text, width: 100 });
+    columns.push({ id: 'productName', name: 'Product Name', field: 'productName', reorderable: true, formatter: Formatters.Hyperlink, width: 200, minWidth: 150 });
+    columns.push({ id: 'activity', name: 'Activity', field: 'activity', reorderable: true });
+    columns.push({ id: 'hidden', hidden: true, name: 'Hidden', field: 'hidden' });
+    columns.push({ id: 'price', align: 'right', name: 'Actual Price', field: 'price', reorderable: true, formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'currency', currencySign: '$' }});
+    columns.push({ id: 'percent', align: 'right', name: 'Actual %', field: 'percent', reorderable: true, formatter: Formatters.Decimal, numberFormat: { minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'percent' }});
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', reorderable: true, formatter: Formatters.Date, dateFormat: 'M/d/yyyy' });
+    columns.push({ id: 'phone', name: 'Phone', field: 'phone', reorderable: true, formatter: Formatters.Text });
+
+    // Load Data
+    var url = '{{basepath}}api/datagrid-sample-data';
+    $.getJSON(url, function(res) {
+      data = res;
+
+      // Invoke Grid
+      grid = $('#datagrid').datagrid({
+        columns: columns,
+        dataset: data,
+        selectable: 'multiple',
+        toolbar: { title: 'Compressors', results: true, actions: true, rowHeight: true, personalize: true }
+      }).data('datagrid');
+    });
+
+    // Input Textbox
+    $('#txt-test').on('keyup', function () {
+      data = data.slice(0, data.length - 1);
+      grid.loadData(data);
+    });
+
+ });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### v4.26.0 Fixes
 
+- `[Datagrid]` Fixed an issue where focus on reload data was forced to be on active cell. ([#358](https://github.com/infor-design/enterprise-ng/issues/358))
 - `[Pie]` Fixed an issue where initial selection was getting error. ([#3157](https://github.com/infor-design/enterprise/issues/3157))
 
 ### v4.26.0 Chores & Maintenance

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -433,7 +433,7 @@ Datagrid.prototype = {
     self.container = self.element.closest('.datagrid-container');
     self.renderRows();
     self.renderHeader();
-    
+
     if (this.stretchColumnDiff < 0) {
       const currentCol = this.bodyColGroup.find('col').eq(self.getStretchColumnIdx())[0];
       currentCol.style.width = `${this.stretchColumnWidth}px`;
@@ -3328,7 +3328,9 @@ Datagrid.prototype = {
     self.setAlternateRowShading();
     self.createDraggableRows();
 
-    if (self.activeCell.isFocused) {
+    const focusedEl = document.activeElement;
+    if (self.activeCell.isFocused &&
+        (!focusedEl || (focusedEl && focusedEl.tagName.toLowerCase() === 'body'))) {
       self.setActiveCell(self.activeCell.row, self.activeCell.cell);
     }
 
@@ -3357,7 +3359,7 @@ Datagrid.prototype = {
       const currentCol = this.bodyColGroup.find('col').eq(self.getStretchColumnIdx())[0];
       currentCol.style.width = `${this.stretchColumnWidth}px`;
     }
-    
+
     /**
     * Fires after the entire grid is rendered.
     * @event afterrender
@@ -4195,7 +4197,7 @@ Datagrid.prototype = {
       }
     }
   },
-  
+
   /**
    * Return the index of the stretch column
    * @private
@@ -4214,7 +4216,7 @@ Datagrid.prototype = {
         }
       });
     }
-    
+
     return stretchColumnIdx;
   },
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed focus on reload data was forced to be on active cell with Datagrid.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#358

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/test-reload-focus.html
- Click on any cell in grid to get focused
- Click on `Input Textbox` and start typing
- Every keystroke, grid should reload data with one less row
- And focus should remain on `Input Textbox`

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
