### PR TITLE
3318 - Remove error class in removeMessage

### DIFF
--- a/app/views/components/validation/test-just-error-class.html
+++ b/app/views/components/validation/test-just-error-class.html
@@ -1,0 +1,21 @@
+<form>
+
+  <div class="row top-padding">
+    <div class="twelve columns">
+       <div class="field">
+        <label for="test-input">Just the Error class</label>
+        <input type="text" class="error" id="test-input" name="test-input" />
+        <br />
+        <br />
+        <button type="button" id="clear" class="btn-secondary">Clear Error</button>
+      </div>
+    </div>
+  </div>
+
+</form>
+
+<script>
+  $('#clear').on('click', function (e, args) {
+     $("#test-input").removeMessage();
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### v4.26.0 Fixes
 
 - `[Pie]` Fixed an issue where initial selection was getting error. ([#3157](https://github.com/infor-design/enterprise/issues/3157))
+- `[Validation]` Fixed an issue where calling removeMessage would not remove a manually added error class. ([#3318](https://github.com/infor-design/enterprise/issues/3318))
 
 ### v4.26.0 Chores & Maintenance
 

--- a/src/components/validation/validation.jquery.js
+++ b/src/components/validation/validation.jquery.js
@@ -175,7 +175,9 @@ $.fn.removeMessage = function (settings) {
     const field = $(this);
     const dataAttr = `${settings.type}message`;
     const errors = $.fn.getField(field).data(dataAttr);
-    field.removeClass('error');
+    if (field.hasClass('error') && settings.type === 'error') {
+      field.removeClass('error');
+    }
 
     if (!errors) {
       return;

--- a/src/components/validation/validation.jquery.js
+++ b/src/components/validation/validation.jquery.js
@@ -175,6 +175,8 @@ $.fn.removeMessage = function (settings) {
     const field = $(this);
     const dataAttr = `${settings.type}message`;
     const errors = $.fn.getField(field).data(dataAttr);
+    field.removeClass('error');
+
     if (!errors) {
       return;
     }

--- a/test/components/validation/validation.e2e-spec.js
+++ b/test/components/validation/validation.e2e-spec.js
@@ -600,6 +600,21 @@ describe('Validation narrow field', () => {
   });
 });
 
+describe('Validation just error class tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/validation/test-just-error-class');
+  });
+
+  it('Should be able to remove a manually added error class', async () => {
+    const field = await element(by.id('test-input'));
+
+    expect(await field.getAttribute('class')).toContain('error');
+    await await element(by.id('clear')).click();
+
+    expect(await field.getAttribute('class')).not.toContain('error');
+  });
+});
+
 describe('Validation message types', () => {
   const exprAlerts = /(error|alert|success|info|icon)/;
   const color = {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

If a field just had a error class on it then the removeMessage function would fail to remove it. This used to work in older versions before adding different message types.

**Related github/jira issue (required)**:
Fixes #3318 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/validation/test-just-error-class.html
- click the button
- class / red border should be removed

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
