### PR TITLE
3160 - Fix lookup layout issues and padding [v4.25.x]

### DIFF
--- a/app/views/components/datagrid/test-editable-lookup.html
+++ b/app/views/components/datagrid/test-editable-lookup.html
@@ -109,7 +109,7 @@
         columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input});
         columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, validate: 'required customRule', editorOptions: lookupOptions });
         columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, align: 'right', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###.000'});
-        columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date5});
+        columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date});
 
         //Init and get the api for the grid
         grid = $('#datagrid').datagrid({

--- a/app/views/components/datagrid/test-editable-lookup.html
+++ b/app/views/components/datagrid/test-editable-lookup.html
@@ -107,7 +107,7 @@
 
         //Define Columns for the Grid.
         columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input});
-        columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, validate: 'required customRule', editorOptions: lookupOptions });
+        columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editor: Editors.Lookup, maxLength: 7, validate: 'required customRule', editorOptions: lookupOptions });
         columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, align: 'right', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###.000'});
         columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date});
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,20 @@
 # What's New with Enterprise
 
+## v4.26.0
+
+### v4.26.0 Deprecation
+
+### v4.26.0 Features
+
+- `[Datagrid]` Added fixes for editing lookup fields, fixed the styling of the lookup editor and improved padding, also fixed the sort indicator color. ([#3160](https://github.com/infor-design/enterprise/issues/3160))
+- `[Icons]` Added new icons `icon-play, icon-stop, icon-record, icon-pause` for video players. ([#397](https://github.com/infor-design/design-system/issues/397))
+
+### v4.26.0 Fixes
+
+- `[Pie]` Fixed an issue where initial selection was getting error. ([#3157](https://github.com/infor-design/enterprise/issues/3157))
+
+### v4.26.0 Chores & Maintenance
+
 ## v4.25.0
 
 ### v4.25.0 Deprecation

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,20 +1,5 @@
 # What's New with Enterprise
 
-## v4.26.0
-
-### v4.26.0 Deprecation
-
-### v4.26.0 Features
-
-- `[Icons]` Added new icons `icon-play, icon-stop, icon-record, icon-pause` for video players. ([#397](https://github.com/infor-design/design-system/issues/397))
-
-### v4.26.0 Fixes
-
-- `[Datagrid]` Added fixes for editing lookup fields, fixed the styling of the lookup editor and improved padding, also fixed the sort indicator color. ([#3160](https://github.com/infor-design/enterprise/issues/3160))
-- `[Pie]` Fixed an issue where initial selection was getting error. ([#3157](https://github.com/infor-design/enterprise/issues/3157))
-
-### v4.26.0 Chores & Maintenance
-
 ## v4.25.0
 
 ### v4.25.0 Deprecation
@@ -45,6 +30,7 @@
 - `[Datagrid]` Fixed style issues in all theme and theme variants when using the list style including grouped headers and states. ([#3265](https://github.com/infor-design/enterprise/issues/3265))
 - `[Datagrid]` Fixed an issue where converting circular structure to JSON was throwing an error. ([#3309](https://github.com/infor-design/enterprise/issues/3309))
 - `[Datagrid]` Fixed an issue where focus in date picker field was not aligning. ([#3350](https://github.com/infor-design/enterprise/issues/3350))
+- `[Datagrid]` Added fixes for editing lookup fields, fixed the styling of the lookup editor and improved padding, also fixed the sort indicator color. ([#3160](https://github.com/infor-design/enterprise/issues/3160))
 - `[Editor]` Fixed an issue where line spacing was inconsistent. ([#3335](https://github.com/infor-design/enterprise/issues/3335))
 - `[General]` Added detection for wkWebView which is paired with safari. This caused issues with all black text as this browser had previously been unknown. ([#3336](https://github.com/infor-design/enterprise/issues/3336))
 - `[Homepage]` Fixed an issue where the DOM order was not working for triple width widgets. ([#3101](https://github.com/infor-design/enterprise/issues/3101))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,11 +6,11 @@
 
 ### v4.26.0 Features
 
-- `[Datagrid]` Added fixes for editing lookup fields, fixed the styling of the lookup editor and improved padding, also fixed the sort indicator color. ([#3160](https://github.com/infor-design/enterprise/issues/3160))
 - `[Icons]` Added new icons `icon-play, icon-stop, icon-record, icon-pause` for video players. ([#397](https://github.com/infor-design/design-system/issues/397))
 
 ### v4.26.0 Fixes
 
+- `[Datagrid]` Added fixes for editing lookup fields, fixed the styling of the lookup editor and improved padding, also fixed the sort indicator color. ([#3160](https://github.com/infor-design/enterprise/issues/3160))
 - `[Pie]` Fixed an issue where initial selection was getting error. ([#3157](https://github.com/infor-design/enterprise/issues/3157))
 
 ### v4.26.0 Chores & Maintenance

--- a/src/components/datagrid/_datagrid-uplift.scss
+++ b/src/components/datagrid/_datagrid-uplift.scss
@@ -51,10 +51,18 @@
 
 // Main Grid
 .datagrid {
-  td {
-    // Adjust Row Links
-    .hyperlink {
-      margin-top: -2px;
+  > tbody > tr .datagrid-cell-wrapper {
+    padding: 3px 19px 0;
+  }
+
+  td.is-editing {
+    .lookup-wrapper {
+      padding-top: 5px;
+
+      .trigger {
+        margin-left: -36px;
+        margin-top: 0;
+      }
     }
   }
 
@@ -68,6 +76,11 @@
           }
         }
       }
+    }
+
+    .is-editing .lookup-wrapper .trigger {
+      margin-left: -10px !important;
+      margin-top: -3px !important;
     }
   }
 
@@ -84,6 +97,14 @@
           // Adjust Row Buttons
           .row-btn {
             min-height: 25px;
+          }
+
+          // Adjust editors
+          &.is-editing {
+            .lookup-wrapper .trigger {
+              margin-left: -34px;
+              margin-top: -6px;
+            }
           }
         }
       }

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1006,6 +1006,7 @@ $datagrid-short-row-height: 25px;
 
         .hyperlink {
           line-height: 1.4rem;
+          vertical-align: middle;
         }
 
         .row-btn {

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -746,10 +746,11 @@ $datagrid-short-row-height: 25px;
           }
 
           input {
-            padding: 7px 0;
             vertical-align: top;
 
             &.lookup {
+              height: inherit;
+              padding: 7px 15px 7px 0;
               width: calc(100% - 13px);
 
               ~ .trigger .icon {
@@ -883,8 +884,8 @@ $datagrid-short-row-height: 25px;
       padding-top: 2px !important;
 
       .trigger {
-        margin-left: -10px !important;
-        margin-top: -5px !important;
+        margin-left: -8px !important;
+        margin-top: -4px !important;
       }
 
       .align-text-right {
@@ -902,7 +903,11 @@ $datagrid-short-row-height: 25px;
     .datagrid-trigger-cell {
       .icon {
         left: -6px;
-        top: 3px;
+        top: 4px;
+
+        &.icon-calendar {
+          top: 2px;
+        }
       }
 
       .colorpicker-container {
@@ -1001,7 +1006,6 @@ $datagrid-short-row-height: 25px;
 
         .hyperlink {
           line-height: 1.4rem;
-          vertical-align: middle;
         }
 
         .row-btn {
@@ -1050,14 +1054,13 @@ $datagrid-short-row-height: 25px;
 
           .icon {
             height: 16px;
-            margin-bottom: -1px;
             top: 3px;
 
             &.icon-calendar,
             &.icon-fileupload {
               height: 15px;
               left: -5px;
-              top: 1px;
+              top: 2px;
             }
 
             &.icon-clock {
@@ -1134,8 +1137,7 @@ $datagrid-short-row-height: 25px;
           }
 
           input {
-            padding: 3px 0 0;
-            vertical-align: top;
+            height: 26px;
           }
 
           .dropdown {
@@ -1144,10 +1146,11 @@ $datagrid-short-row-height: 25px;
 
           .lookup-wrapper {
             padding-left: 10px;
+            padding-top: 2px;
 
             .trigger {
-              margin-left: -34px;
-              top: -6px;
+              margin-left: -32px;
+              margin-top: -7px;
             }
           }
 
@@ -1926,8 +1929,8 @@ $datagrid-short-row-height: 25px;
 
       .lookup-wrapper {
         margin-bottom: 0;
-        padding-left: 19px;
-        padding-top: 4px;
+        padding-left: 18px;
+        padding-top: 8px;
         vertical-align: top;
         width: 100%;
 
@@ -1942,8 +1945,8 @@ $datagrid-short-row-height: 25px;
         }
 
         .trigger {
-          margin-left: -37px;
-          margin-top: 1px;
+          margin-left: -34px;
+          margin-top: -3px;
         }
       }
 
@@ -1979,6 +1982,9 @@ $datagrid-short-row-height: 25px;
         width: 100%;
 
         &.lookup {
+          margin-left: -1px;
+          padding-right: 33px;
+
           &.align-text-right {
             width: 100%;
           }
@@ -2989,7 +2995,7 @@ td .btn-actions {
     visibility: hidden;
 
     &.icon-search-list {
-      left: -2px;
+      left: -1px;
       top: 4px;
     }
   }

--- a/src/components/searchfield/_searchfield-uplift.scss
+++ b/src/components/searchfield/_searchfield-uplift.scss
@@ -13,7 +13,7 @@
 
     &.close {
       right: 8px;
-      top: 13px;
+      top: 11px;
     }
   }
 
@@ -37,17 +37,7 @@
       padding-top: 10px;
     }
 
-    .icon:not(.close) {
-      top: 12px;
-    }
-
     .icon.close {
-      top: 12px;
-    }
-  }
-
-  &.is-open {
-    .icon {
       top: 12px;
     }
   }

--- a/src/themes/theme-uplift-light.scss
+++ b/src/themes/theme-uplift-light.scss
@@ -40,6 +40,7 @@ $datagrid-list-group-header-bg-color: $theme-color-palette-graphite-20;
 $datagrid-list-group-header-border-color: $theme-color-palette-graphite-10;
 $datagrid-list-header-active-color: $theme-color-palette-graphite-20;
 $datagrid-list-sort-icon-color: $theme-color-palette-slate-40;
+$datagrid-sort-icon-color: $theme-color-palette-slate-50;
 $listview-border-color: $theme-color-palette-slate-20;
 $panel-border-color: $theme-color-palette-graphite-30;
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Went to fix the padding on this issue so that the editor will not overlap and noticed some issues which i fixed.
- search field icon was out of alignment in uplift
- the datagrid sort color was invisible in uplift (light)

May require test (Visual test) adjustments?

**Related github/jira issue (required)**:
Fixes #3160 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-editable-lookup.html
- test this page in all themes and variants for the following:
- expand the search toolbar and type - icons should be align OK
- edit the lookup field (product id) and this should align -> also test this in all three row heights 
- in uplift light hover the datagrid columns and the arrows should now be visible

Note: Datepicker was a separate issue (last column)  https://github.com/infor-design/enterprise/issues/3350 so didnt touch this too much

**Included in this Pull Request**:
- [x] A note to the change log.
