### PR TITLE
3370 - Fix IE/Edge/Firefox icon alignment on Multiselect Tags [v4.25.x]

### DIFF
--- a/src/components/dropdown/_dropdown-uplift.scss
+++ b/src/components/dropdown/_dropdown-uplift.scss
@@ -210,7 +210,22 @@ div.multiselect {
   }
 }
 
-// Dropdown icon for firefox
+// Fix Tag icon placement on IE/Edge
+html.ie {
+  div.dropdown,
+  div.multiselect {
+    .tag-list {
+      .dismissible-btn,
+      .linkable-btn {
+        .icon {
+          top: -1px;
+        }
+      }
+    }
+  }
+}
+
+// Dropdown icon and Tags for Firefox
 .is-firefox {
   div.dropdown,
   div.multiselect {
@@ -219,6 +234,17 @@ div.multiselect {
 
       &.swatch {
         left: 12px;
+      }
+    }
+
+    .tag-content {
+      line-height: normal;
+    }
+
+    .dismissible-btn,
+    .linkable-btn {
+      .icon {
+        top: -1px;
       }
     }
   }

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -968,6 +968,13 @@ div.dropdown-xs,
     &.has-tags {
       padding: 1px 30px 0 10px;
     }
+
+    .dismissible-btn,
+    .linkable-btn {
+      .icon {
+        top: 2px;
+      }
+    }
   }
 
   // Reset the padding in the rule above for Short Fields

--- a/test/components/popupmenu/popupmenu.func-spec.js
+++ b/test/components/popupmenu/popupmenu.func-spec.js
@@ -58,17 +58,14 @@ describe('Popupmenu Menu Button API', () => {
     expect(popupmenuObj.getPositionFromEvent(eClient)).toEqual({ x: 222, y: 333 });
   });
 
-  it('Should position correctly', (done) => {
+  it('Should position correctly', () => {
     // Indirectly tests Place component
     popupmenuObj.position(ePage);
 
-    setTimeout(() => {
-      const ulElem = document.querySelector('ul#popupmenu-1');
-      const parentElem = ulElem.parentNode;
+    const ulElem = popupmenuObj.menu[0];
+    const parentElem = ulElem.parentNode;
 
-      expect(parentElem.className).toContain('placeable bottom');
-      done();
-    }, 10);
+    expect(parentElem.className).toContain('placeable bottom');
   });
 
   it('Should open', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a bug on text/icon alignments of Tags within the Multiselect component in some browsers.

**Related github/jira issue (required)**:
Closes #3370

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the app
- Open http://localhost:4000/components/multiselect/example-index and http://localhost:4000/components/multiselect/example-index?theme=uplift in Firefox, IE, and Edge on a Windows machine.  Ensure the text/icon alignment looks right.
