### PR TITLE
3133 - Add fix for overlapping button in application menu uplift theme

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### v4.26.0 Fixes
 
+- `[Application Menu]` Fixed overlap button when label is too long, and aligned dropdown icon in application menu uplift theme. ([#3133](https://github.com/infor-design/enterprise/issues/3133))
 - `[Datagrid]` Fixed an issue where focus on reload data was forced to be on active cell. ([#358](https://github.com/infor-design/enterprise-ng/issues/358))
 - `[Pie]` Fixed an issue where initial selection was getting error. ([#3157](https://github.com/infor-design/enterprise/issues/3157))
 - `[Splitter]` Fixed an issue in the destroy function where the expand button was not removed. ([#3371](https://github.com/infor-design/enterprise/issues/3371))

--- a/src/components/applicationmenu/_applicationmenu-uplift.scss
+++ b/src/components/applicationmenu/_applicationmenu-uplift.scss
@@ -60,6 +60,18 @@
     }
   }
 
+  .accordion-static-panel {
+    .btn-menu {
+      span {
+        max-width: 150px;
+      }
+
+      svg {
+        margin-top: -10px;
+      }
+    }
+  }
+
   .btn-icon {
     font-size: normal;
   }

--- a/src/components/applicationmenu/_applicationmenu.scss
+++ b/src/components/applicationmenu/_applicationmenu.scss
@@ -227,7 +227,7 @@ body.is-open-touch {
   }
 
   .accordion-static-panel {
-    background-color: $theme-color-palette-slate-70;
+    background-color: $accordion-static-panel-bg-color;
     border-bottom-color: $theme-color-palette-slate-90 !important;
     margin: 0 auto;
     min-height: 85px;
@@ -243,6 +243,7 @@ body.is-open-touch {
 
     .btn-menu {
       margin-top: -5px;
+      text-align: left;
 
       span {
         color: inherit;

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -497,6 +497,7 @@ $accordion-hover-border-color: $theme-color-palette-graphite-100;
 $accordion-hover-text-color: $theme-color-font-base;
 
 $accordion-panel-border-color: $theme-color-palette-graphite-20;
+$accordion-static-panel-bg-color: $theme-color-palette-slate-70;
 
 $accordion-alternate-bg-color: $theme-color-palette-white;
 $accordion-alternate-border-color: $theme-color-palette-graphite-20;

--- a/src/themes/theme-uplift-contrast.scss
+++ b/src/themes/theme-uplift-contrast.scss
@@ -433,6 +433,7 @@ $accordion-hover-border-color: $theme-color-palette-black;
 $accordion-hover-text-color: $theme-color-palette-graphite-100;
 
 $accordion-panel-border-color: $theme-color-palette-graphite-40;
+$accordion-static-panel-bg-color: $theme-color-palette-slate-90;
 
 $accordion-alternate-bg-color: $theme-color-palette-white;
 $accordion-alternate-border-color: $theme-color-palette-graphite-40;

--- a/src/themes/theme-uplift-dark.scss
+++ b/src/themes/theme-uplift-dark.scss
@@ -405,6 +405,7 @@ $accordion-hover-border-color: $theme-color-palette-white;
 $accordion-hover-text-color: $theme-color-palette-white;
 
 $accordion-panel-border-color: $theme-color-palette-slate-90;
+$accordion-static-panel-bg-color: $theme-color-palette-slate-90;
 
 $accordion-alternate-bg-color: $theme-color-palette-slate-90;
 $accordion-alternate-border-color: $theme-color-palette-slate-100;

--- a/src/themes/theme-uplift-light.scss
+++ b/src/themes/theme-uplift-light.scss
@@ -27,6 +27,7 @@ $accordion-inverse-bg-color: $theme-color-palette-slate-90;
 $accordion-inverse-pane-bg-color: $theme-color-palette-slate-90;
 $accordion-inverse-border-color:  $theme-color-palette-slate-90;
 $accordion-inverse-text-color: $theme-color-palette-white;
+$accordion-static-panel-bg-color: $theme-color-palette-slate-90;
 
 $cardlist-box-shadow-color: rgba(0, 0, 0, 0.1);
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed overlap button when label is too long, and aligned dropdown icon in application menu uplift theme. Adjust the `max-width` a bit of span inside of the button will do the trick. This bug occurs when the application menu contains a lot of menus (which the scrollbar will appear). 

This will also fix the focus state to not also overlap on accordion content container.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/3133

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app.
- Navigate to http://localhost:4000/components/applicationmenu/example-menubutton.html?theme=uplift&variant=contrast&colors=0563C2
- Add more menus or you can open developer tools just to make the scrollbar appears on the application menu.
- Click on `Add Item` button
- Select `Employee Transition Programs`
- Button shouldn't overlap by now. 
- Dropdown icon should also align properly.
- Focus state shouldn't overlap too.

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
