### PR TITLE
3008 - Fix comma in format with datepicker

### DIFF
--- a/app/views/components/datepicker/example-custom-format.html
+++ b/app/views/components/datepicker/example-custom-format.html
@@ -9,22 +9,27 @@
 
     <div class="field">
       <label for="date-field-1" class="label">Uses Locale</label>
-      <input id="date-field-1" class="datepicker" name="date-field" type="text"/>
+      <input id="date-field-1" class="datepicker" name="date-field-1" type="text"/>
     </div>
 
     <div class="field">
       <label for="date-field-2" class="label">Uses ISO Date</label>
-      <input id="date-field-2" data-options="{'dateFormat': 'yyyy-dd-MM'}" class="datepicker" name="date-field" type="text"/>
+      <input id="date-field-2" data-options="{'dateFormat': 'yyyy-dd-MM'}" class="datepicker" name="date-field-2" type="text"/>
     </div>
 
     <div class="field">
       <label for="date-field-3" class="label">Uses 3 Digit Month</label>
-      <input id="date-field-3" data-options="{'dateFormat': 'd MMM yyyy'}" class="datepicker" name="date-field" type="text"/>
+      <input id="date-field-3" data-options="{'dateFormat': 'd MMM yyyy'}" class="datepicker" name="date-field-3" type="text"/>
     </div>
 
     <div class="field">
       <label for="date-field-4" class="label">Uses Custom Override</label>
-      <input id="date-field-4" data-options="{'dateFormat': 'dd/MM/yyyy'}"class="datepicker" name="date-field" type="text"/>
+      <input id="date-field-4" data-options="{'dateFormat': 'dd/MM/yyyy'}" class="datepicker" name="date-field-4" type="text"/>
+    </div>
+
+    <div class="field">
+      <label for="date-field-5" class="label">Uses Comma (MMM d, yyyy)</label>
+      <input id="date-field-5" data-options="{'dateFormat': 'MMM d, yyyy'}" class="datepicker" name="date-field-5" type="text"/>
     </div>
 
   </div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - `[Datagrid]` Fixed an issue where focus on reload data was forced to be on active cell. ([#358](https://github.com/infor-design/enterprise-ng/issues/358))
 - `[Datagrid]` Fixed hover color should not be similar to alternate rows when hovering in uplift high contrast. ([#3338](https://github.com/infor-design/enterprise/issues/3338))
+- `[Datepicker]` Fixed an issue where setting date format with comma character was not working. ([#3008](https://github.com/infor-design/enterprise/issues/3008))
 - `[Pie]` Fixed an issue where initial selection was getting error. ([#3157](https://github.com/infor-design/enterprise/issues/3157))
 - `[Splitter]` Fixed an issue in the destroy function where the expand button was not removed. ([#3371](https://github.com/infor-design/enterprise/issues/3371))
 - `[Validation]` Fixed an issue where calling removeMessage would not remove a manually added error class. ([#3318](https://github.com/infor-design/enterprise/issues/3318))

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -957,6 +957,10 @@ const Locale = {  // eslint-disable-line
     dateFormat = dateFormat.replace(' de ', ' ');
     dateString = dateString.replace(' de ', ' ');
 
+    // Remove commas
+    dateFormat = dateFormat.replace(',', '');
+    dateString = dateString.replace(',', '');
+
     if (dateFormat === 'Mdyyyy' || dateFormat === 'dMyyyy') {
       dateString = `${dateString.substr(0, dateString.length - 4)}/${dateString.substr(dateString.length - 4, dateString.length)}`;
       dateString = `${dateString.substr(0, dateString.indexOf('/') / 2)}/${dateString.substr(dateString.indexOf('/') / 2)}`;

--- a/src/components/validation/validation.js
+++ b/src/components/validation/validation.js
@@ -114,8 +114,10 @@ function ValidationRules() {
 
         let dateFormat = (value.indexOf(':') > -1) ? Locale.calendar().dateFormat.datetime : Locale.calendar().dateFormat.short;
 
+        let dtApi = null;
         if (field && field.data('datepicker')) {
-          dateFormat = field.data('datepicker').pattern;
+          dtApi = field.data('datepicker');
+          dateFormat = dtApi.pattern;
         }
 
         const isStrict = !(
@@ -125,6 +127,13 @@ function ValidationRules() {
           dateFormat === 'MMMM d' ||
           dateFormat === 'yyyy'
         );
+        if (dtApi) {
+          dateFormat = {
+            locale: dtApi.locale.name,
+            pattern: dateFormat,
+            calendarName: dtApi.currentCalendar.name
+          };
+        }
         const parsedDate = Locale.parseDate(value, dateFormat, isStrict);
         return !(((parsedDate === undefined) && value !== ''));
       },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed setting date format with comma character was not working with Datepicker.

**Related github/jira issue (required)**:
Closes #3008

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datepicker/example-custom-format.html
- Open last Datepicker `Uses Commas (MMM d, yyyy)`
- Choose any date
- Click somewhere else to blur from field
- Should remain date in field fine

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
