### PR TITLE
3400 - Vibrant theme App Menu colors Q/A [v4.25.x]

### DIFF
--- a/app/views/components/applicationmenu/test-all-plusminus.html
+++ b/app/views/components/applicationmenu/test-all-plusminus.html
@@ -1,0 +1,85 @@
+{{> includes/head}}
+
+<body class="no-scroll">
+  <a href="#maincontent" class="skip-link" data-translate="text">SkipToMain</a>
+  {{> includes/svg-inline-refs}}
+  {{> includes/applicationmenu-all-plusminus}}
+
+  <div class="page-container scrollable">
+
+      <header class="header is-personalizable has-tabs">
+        <div class="toolbar">
+          <div class="title">
+            <button class="btn-icon application-menu-trigger" type="button">
+              <span class="audible">Show navigation</span>
+              <span class="icon app-header">
+                <span class="one"></span>
+                <span class="two"></span>
+                <span class="three"></span>
+              </span>
+            </button>
+
+            <h1><span data-translate="text">UserProfile</span></h1>
+          </div>
+
+          <div class="buttonset">
+            <button class="btn" type="button">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use xlink:href="#icon-edit"></use>
+              </svg>
+              <span>Update Details</span>
+            </button>
+          </div>
+
+          {{> includes/header-actionbutton}}
+        </div>
+
+        <div class="tab-container" data-options='{ "containerElement": "#maincontent" }'>
+          <ul class="tab-list">
+            <li class="tab"><a href="#header-dos">Dates of Service</a></li>
+            <li class="tab"><a href="#header-pi">Personal Information</a></li>
+            <li class="tab"><a href="#header-mp">My Password</a></li>
+          </ul>
+        </div>
+
+      </header>
+
+    <div id="maincontent" class="page-container scrollable" role="main">
+      <div id="header-dos" class="tab-panel">
+        <div class="row top-padding">
+          <div class="twelve columns">
+            <p>Man bun portland venmo, reprehenderit cillum exercitation culpa adaptogen pitchfork unicorn. Jianbing mlkshk cloud bread id. Qui forage twee meditation hammock commodo heirloom gochujang shaman tattooed. Ethical commodo woke, ea est in artisan farm-to-table asymmetrical four loko ut master cleanse thundercats. Gochujang reprehenderit schlitz cred squid tote bag tempor literally consequat exercitation.
+            </p>
+          </div>
+        </div>
+      </div>
+      <div id="header-pi" class="tab-panel">
+        <div class="row top-padding">
+          <div class="twelve columns">
+            <p>Aute est literally, salvia fam esse dolor. Banh mi scenester velit franzen trust fund esse dolore truffaut XOXO, shabby chic nisi nostrud typewriter cliche. Cray fanny pack blue bottle dreamcatcher, pariatur iPhone cronut vaporware offal franzen. Ennui selvage man bun cronut kombucha aesthetic gastropub.</p>
+          </div>
+        </div>
+      </div>
+      <div id="header-mp" class="tab-panel">
+        <div class="row top-padding">
+          <div class="twelve columns">
+            <p>
+              Kale chips meditation freegan commodo jean shorts, kickstarter vegan. Enim taxidermy austin, forage marfa cillum gluten-free freegan activated charcoal salvia pariatur vape magna. Woke mlkshk bespoke, vaporware roof party squid kitsch green juice labore. Tacos tempor blog, poutine normcore try-hard dolore tattooed celiac deep v ipsum aute tofu pop-up.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {{> includes/footer}}
+
+  <script>
+    // May need to do more here.
+    $('.application-menu-switcher-panel .accordion').on('selected', function (e, args) {
+      $('body').toast({title: 'Role ' + args.innerText + ' Selected',  message: 'In a real application, you could refresh the app menu with new contents for the selected role.'});
+       $('.application-menu').data('applicationmenu').closeSwitcherPanel();
+    });
+  </script>
+</body>
+</html>

--- a/app/views/includes/applicationmenu-all-plusminus.html
+++ b/app/views/includes/applicationmenu-all-plusminus.html
@@ -1,0 +1,216 @@
+<nav id="application-menu" class="application-menu is-open is-personalizable" data-options='{ "filterable": true, "dismissOnClickMobile": true }'>
+
+  <div class="flex-wrapper">
+    <div class="application-menu-header expandable-area-header">
+      <img src="/images/11.jpg" class="icon avatar" alt="Photo of Richard Fairbanks"/>
+      <button type="button" class="btn application-menu-switcher-trigger expandable-area-trigger" id="trigger-btn">
+        <span>Employee</span>
+        <svg class="icon icon-closed" focusable="false" aria-hidden="true" role="presentation">
+          <use xlink:href="#icon-caret-down"></use>
+        </svg>
+        <svg class="icon icon-opened" focusable="false" aria-hidden="true" role="presentation">
+          <use xlink:href="#icon-caret-up"></use>
+        </svg>
+      </button>
+      <div class="expandable-area">
+        <div class="expandable-pane application-menu-switcher-panel">
+          <div class="content">
+            <div class="accordion panel inverse">
+              <div class="accordion-header">
+                <a href="#"><span>Manager</span></a>
+              </div>
+              <div class="accordion-header is-selected">
+                <a href="#"><span>Recruiter</span></a>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>Admin</span></a>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>Example Role Thats Really Really Long So Long that it flows into an ellipsis just really long, maybe too long?</span></a>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>Example Role</span></a>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>Example Role</span></a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <span class="name-xl">Richard <br /> Fairbanks</span>
+      <div class="application-menu-toolbar">
+        <div class="flex-toolbar">
+          <div class="toolbar-section buttonset center-text">
+            <button class="btn-icon" title="Download My Profile">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use xlink:href="#icon-download"></use>
+              </svg>
+              <span class="audible">Download</span>
+            </button>
+            <button class="btn-icon" title="Print My Profile">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use xlink:href="#icon-print"></use>
+              </svg>
+              <span class="audible">Print</span>
+            </button>
+            <button class="btn-icon" title="Show Purchasing Info">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use xlink:href="#icon-purchasing"></use>
+              </svg>
+              <span class="audible">Purchasing</span>
+            </button>
+            <button class="btn-icon" title="Show Notification Info">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use xlink:href="#icon-notification"></use>
+              </svg>
+              <span class="audible">Notification</span>
+            </button>
+            <button class="btn-icon" title="Show Inventory Info">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use xlink:href="#icon-inventory"></use>
+              </svg>
+              <span class="audible">Inventory</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="application-menu-content">
+    <div class="searchfield-wrapper">
+      <label class="audible" for="application-menu-searchfield">Search</label>
+      <input id="application-menu-searchfield" class="searchfield" data-options='{ "clearable": true }' placeholder="Look up menu items"/>
+    </div>
+
+    <div class="accordion panel inverse" data-options="{'allowOnePane': false, 'expanderDisplay': 'plusminus'}" >
+      <div class="accordion-header">
+        <a href="#"><span>Home</span></a>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Profile</span></a>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Pay</span></a>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Benefits</span></a>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Time Off</span></a>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Growth</span></a>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Engagements</span></a>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Resources</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="accordion-header">
+          <a href="#"><span>2nd Level Menu Item</span></a>
+        </div>
+        <div class="accordion-pane">
+          <div class="accordion-header">
+            <a href="#"><span>3rd Level Menu Item</span></a>
+          </div>
+          <div class="accordion-pane">
+            <div class="accordion-header">
+              <a href="#"><span>4th Level Menu Item</span></a>
+            </div>
+            <div class="accordion-pane">
+              <div class="accordion-header">
+                <a href="#"><span>5th Level Menu Item</span></a>
+              </div>
+              <div class="accordion-pane">
+                <div class="accordion-header is-expanded">
+                  <a href="#"><span>6th Level Menu Item</span></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="accordion-header">
+          <a href="#"><span>2nd Level Menu Item</span></a>
+        </div>
+        <div class="accordion-pane">
+          <div class="accordion-header">
+            <a href="#"><span>3rd Level Menu Item</span></a>
+          </div>
+          <div class="accordion-pane">
+            <div class="accordion-header">
+              <a href="#"><span>4th Level Menu Item</span></a>
+            </div>
+            <div class="accordion-pane">
+              <div class="accordion-header">
+                <a href="#"><span>5th Level Menu Item</span></a>
+              </div>
+              <div class="accordion-pane">
+                <div class="accordion-header is-expanded">
+                  <a href="#"><span>6th Level Menu Item</span></a>
+                </div>
+              </div>
+              <div class="accordion-header">
+                <a href="#"><span>5th Level Menu Item</span></a>
+              </div>
+            </div>
+            <div class="accordion-header">
+              <a href="#"><span>4th Level Menu Item</span></a>
+            </div>
+          </div>
+          <div class="accordion-header">
+            <a href="#"><span>3rd Level Menu Item</span></a>
+          </div>
+        </div>
+        <div class="accordion-header">
+          <a href="#"><span>2nd Level Menu Item</span></a>
+        </div>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>The Next Level One Menu Item</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="accordion-header">
+          <a href="#"><span>2nd Level Menu item</span></a>
+        </div>
+      </div>
+      <div class="accordion-header">
+        <a href="#"><span>Proxy</span></a>
+      </div>
+    </div>
+  </div>
+
+  <div class="application-menu-footer">
+    <div class="application-menu-toolbar">
+      <div class="flex-toolbar">
+        <div class="toolbar-section buttonset">
+          <button class="btn" type="button" title="Show Settings">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use xlink:href="#icon-settings"></use>
+            </svg>
+            <span>Settings</span>
+          </button>
+          <button class="btn-icon" type="button" title="Proxy as user">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use xlink:href="#icon-employee-directory"></use>
+            </svg>
+          </button>
+          <button class="btn-icon" type="button" title="About this App">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use xlink:href="#icon-info-linear"></use>
+            </svg>
+          </button>
+          <button class="btn-icon" type="button" title="Log Out">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use xlink:href="#icon-logout"></use>
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</nav>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[Accordion]` Fixed an issue that when all panes are expanded then they could no longer be closed. ([#701](https://github.com/infor-design/enterprise-ng/issues/3217))
 - `[Application Menu]` Fixed minor usability issues when attempting to filter on application menus, display of hidden filtered children, and filtering reset when a Searchfield is blurred. ([#3285](https://github.com/infor-design/enterprise/issues/3285))
 - `[Application Menu]` Fixed incorrect font-size/padding around list item headers' bullet points. ([#3364](https://github.com/infor-design/enterprise/issues/3364))
+- `[Application Menu]` Tweaked some font colors on the Vibrant theme. ([#3400](https://github.com/infor-design/enterprise/issues/3400))
 - `[Autocomplete]` Fixed an issue where selected event was not firing when its parent is partly overflowing. ([#3072](https://github.com/infor-design/enterprise/issues/3072))
 - `[Calendar]` Fixed an issue setting the legend checked elements to false in the api. ([#3170](https://github.com/infor-design/enterprise/issues/3170))
 - `[Datagrid]` Fixed an issue where the data after commit edit was not in sync for tree. ([#659](https://github.com/infor-design/enterprise-ng/issues/659))

--- a/src/themes/theme-uplift-contrast.scss
+++ b/src/themes/theme-uplift-contrast.scss
@@ -764,10 +764,10 @@ $calendar-disabled-color: $theme-color-palette-graphite-100;
 
 // Uplift-only Variables
 $uplift-acc-border-radius: 6px;
-$uplift-acc-header-text-color: $theme-color-palette-slate-40;
+$uplift-acc-header-text-color: $theme-color-palette-slate-10;
 $uplift-acc-header-selected-text-color: $theme-color-palette-white;
 
-$uplift-acc-subheader-text-color: $theme-color-palette-slate-50;
+$uplift-acc-subheader-text-color: $theme-color-palette-slate-10;
 
 $uplift-acc-expanded-bg-color: $theme-color-palette-slate-100;
 

--- a/src/themes/theme-uplift-dark.scss
+++ b/src/themes/theme-uplift-dark.scss
@@ -730,10 +730,10 @@ $calendar-disabled-color: $theme-color-palette-slate-40;
 
 // Uplift-only Variables
 $uplift-acc-border-radius: 6px;
-$uplift-acc-header-text-color: $theme-color-palette-slate-40;
+$uplift-acc-header-text-color: $theme-color-palette-slate-20;
 $uplift-acc-header-selected-text-color: $theme-color-palette-white;
 
-$uplift-acc-subheader-text-color: $theme-color-palette-slate-50;
+$uplift-acc-subheader-text-color: $theme-color-palette-slate-20;
 
 $uplift-acc-expanded-bg-color: $theme-color-palette-slate-100;
 

--- a/src/themes/theme-uplift-light.scss
+++ b/src/themes/theme-uplift-light.scss
@@ -60,10 +60,10 @@ $calendar-disabled-color: $theme-color-brand-secondary-contrast;
 
 // Uplift-only Variables
 $uplift-acc-border-radius: 6px;
-$uplift-acc-header-text-color: $theme-color-palette-slate-40;
+$uplift-acc-header-text-color: $theme-color-palette-slate-20;
 $uplift-acc-header-selected-text-color: $theme-color-palette-white;
 
-$uplift-acc-subheader-text-color: $theme-color-palette-slate-50;
+$uplift-acc-subheader-text-color: $theme-color-palette-slate-20;
 
 $uplift-acc-expanded-bg-color: $theme-color-palette-black;
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR improves the color contrast between font and background colors in the Application Menu in the Vibrant theme.  Previous changes from #3298 and #3356 modified token colors, which inadvertently lowered the amount of contrast between font and background colors on all variants of the Vibrant theme.

**Related github/jira issue (required)**:
Closes #3400

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the app
- Open http://localhost:4000/components/applicationmenu/example-personalized-roles.html?theme=uplift&variant=light
- Also open http://4240-enterprise.demo.design.infor.com/components/applicationmenu/example-personalized-roles.html?theme=uplift&variant=light for comparison
- Compare the contrast between the font color and the background color in both samples.  The colors are not the same between the versions due to color palette adjustments, but the text in the application menu should be legible in all Vibrant theme color variants.

**Included in this Pull Request**:
- [x] A note to the change log.
