### PR TITLE
3176 - Fix color inconsistencies of the icons

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@
 - `[Datagrid]` Fixed an issue where focus on reload data was forced to be on active cell. ([#358](https://github.com/infor-design/enterprise-ng/issues/358))
 - `[Datagrid]` Fixed hover color should not be similar to alternate rows when hovering in uplift high contrast. ([#3338](https://github.com/infor-design/enterprise/issues/3338))
 - `[Datepicker]` Fixed an issue where setting date format with comma character was not working. ([#3008](https://github.com/infor-design/enterprise/issues/3008))
+- `[Icons]` Fixed color inconsistencies of the icons when the fields are in readonly state. ([#3176](https://github.com/infor-design/enterprise/issues/3176))
+
 - `[Pie]` Fixed an issue where initial selection was getting error. ([#3157](https://github.com/infor-design/enterprise/issues/3157))
 - `[Validation/Checkboxes]` Fixed issues with making checkboxes required, the styling did not work for it and the scrollIntoView function and validation failed to fire. Note that to add required to the checkbox you need to add an extra span, adding a class to the label will not work because the checkbox is styled using the label already. ([#3147](https://github.com/infor-design/enterprise/issues/3147))
 - `[Splitter]` Fixed an issue in the destroy function where the expand button was not removed. ([#3371](https://github.com/infor-design/enterprise/issues/3371))

--- a/src/components/colorpicker/_colorpicker.scss
+++ b/src/components/colorpicker/_colorpicker.scss
@@ -94,7 +94,7 @@
 
   &.is-readonly {
     background-color: $input-color-readonly-background;
-    border-color: $input-color-readonly-border;
+    border-color: $input-color-readonly-border !important;
 
     &.is-not-editable {
       background-color: $input-color-initial-background;
@@ -118,10 +118,13 @@
       border-color: $input-color-focus-border !important;
     }
 
-    .icon:not(.icon-error),
-    .icon:hover {
-      color: $trigger-disabled-color;
+    .icon:not(.icon-error) {
+      color: $colorpicker-readonly-icon-color;
       cursor: default;
+
+      &:hover {
+        color: $colorpicker-readonly-icon-color;
+      }
     }
   }
 

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -192,6 +192,10 @@ div.multiselect {
       border-color: $input-color-readonly-border !important;
       box-shadow: none;
     }
+
+    + .icon {
+      color: $dropdown-readonly-icon-color;
+    }
   }
 
   &:focus {

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -234,6 +234,7 @@ $dropdown-menu-border-color: $theme-color-brand-primary-base;
 $dropdown-menu-separator-color: $theme-color-palette-graphite-40;
 $dropdown-menu-separator-border-color: $theme-color-palette-graphite-30;
 $dropdown-box-shadow-top: 0 0 5px $drop-shadow-depth;
+$dropdown-readonly-icon-color: $theme-color-palette-graphite-30;
 
 //List View
 $listview-bg-color: $theme-color-palette-white;
@@ -332,7 +333,7 @@ $datepicker-disabled-icon-color: $input-color-disabled-font;
 $datepicker-disabled-border-color: $input-color-disabled-border;
 $datepicker-disabled-bg-color: $theme-color-palette-graphite-10;
 $datepicker-disabled-color: $input-color-disabled-font;
-$datepicker-readonly-icon-color: $input-color-readonly-font;
+$datepicker-readonly-icon-color: $theme-color-palette-graphite-30;
 $datepicker-default-width: 150px;
 
 //Time Picker
@@ -346,6 +347,7 @@ $colorpicker-initial-bg-color: $theme-color-brand-secondary-base;
 $colorpicker-swatch-border-color: $theme-color-palette-graphite-20;
 $colorpicker-checkmark-one-color: $theme-color-palette-graphite-50;
 $colorpicker-checkmark-two-color: $theme-color-palette-white;
+$colorpicker-readonly-icon-color: $theme-color-palette-graphite-30;
 
 // Fileupload
 $fileupload-primary-color: $theme-color-font-base;

--- a/src/themes/theme-soho-contrast.scss
+++ b/src/themes/theme-soho-contrast.scss
@@ -264,6 +264,7 @@ $dropdown-menu-border-color: $theme-color-brand-primary-base;
 $dropdown-selected-bg-color: $theme-color-brand-primary-base;
 $dropdown-menu-separator-color: $theme-color-palette-slate-70;
 $dropdown-menu-separator-border-color: $theme-color-palette-slate-60;
+$dropdown-readonly-icon-color: $theme-color-palette-graphite-50;
 
 // Date Picker
 $datepicker-month-year-color: $theme-color-palette-black;
@@ -278,6 +279,7 @@ $datepicker-hover-bg-color: $theme-color-palette-graphite-30;
 $datepicker-disabled-border-color: $theme-color-brand-secondary-alt;
 $datepicker-disabled-bg-color: $theme-color-palette-graphite-20;
 $datepicker-disabled-color: $theme-color-brand-secondary-alt;
+$datepicker-readonly-icon-color: $theme-color-palette-graphite-50;
 
 .calendar-table .is-today {
   text-decoration: underline;
@@ -292,6 +294,7 @@ $colorpicker-initial-bg-color: $theme-color-palette-graphite-60;
 $colorpicker-swatch-border-color: $theme-color-palette-graphite-60;
 $colorpicker-checkmark-one-color: $theme-color-palette-black;
 $colorpicker-checkmark-two-color: $theme-color-palette-white;
+$colorpicker-readonly-icon-color: $theme-color-palette-graphite-50;
 
 // Fileupload
 $fileupload-border-color: $theme-color-palette-graphite-50;

--- a/src/themes/theme-soho-dark.scss
+++ b/src/themes/theme-soho-dark.scss
@@ -240,6 +240,7 @@ $contextual-panel-seperator-bg-color: $theme-color-palette-slate-30;
 $dropdown-menu-border-color: $theme-color-brand-primary-base;
 $dropdown-menu-separator-color: $theme-color-palette-slate-40;
 $dropdown-menu-separator-border-color: $theme-color-palette-slate-50;
+$dropdown-readonly-icon-color: $theme-color-palette-slate-50;
 
 // Date Picker
 $datepicker-month-year-color: $inverse-color;
@@ -254,6 +255,7 @@ $datepicker-disabled-icon-color: $theme-color-palette-slate-50;
 $datepicker-disabled-border-color: $theme-color-palette-slate-50;
 $datepicker-disabled-bg-color: $theme-color-palette-slate-60;
 $datepicker-disabled-color: $theme-color-palette-slate-40;
+$datepicker-readonly-icon-color: $theme-color-palette-slate-50;
 
 // Time Picker
 $timepicker-disabled-icon-color: $theme-color-palette-slate-50;
@@ -263,6 +265,7 @@ $timepicker-disabled-color: $theme-color-palette-slate-40;
 // Color Picker
 $colorpicker-initial-bg-color: $theme-color-palette-slate-40;
 $colorpicker-swatch-border-color: $theme-color-palette-slate-50;
+$colorpicker-readonly-icon-color: $theme-color-palette-slate-50;
 
 // Fileupload
 $fileupload-border-color: $theme-color-palette-slate-50;

--- a/src/themes/theme-uplift-contrast.scss
+++ b/src/themes/theme-uplift-contrast.scss
@@ -264,6 +264,7 @@ $dropdown-menu-border-color: $theme-color-brand-primary-base;
 $dropdown-selected-bg-color: $theme-color-brand-primary-base;
 $dropdown-menu-separator-color: $theme-color-palette-slate-70;
 $dropdown-menu-separator-border-color: $theme-color-palette-slate-60;
+$dropdown-readonly-icon-color: $theme-color-palette-slate-30;
 
 // Date Picker
 $datepicker-month-year-color: $theme-color-palette-black;
@@ -279,6 +280,7 @@ $datepicker-hover-bg-color: $theme-color-palette-graphite-30;
 $datepicker-disabled-border-color: $input-color-disabled-border;
 $datepicker-disabled-bg-color: $theme-color-palette-graphite-20;
 $datepicker-disabled-color: $theme-color-brand-secondary-alt;
+$datepicker-readonly-icon-color: $theme-color-palette-slate-30;
 
 .calendar-table .is-today {
   text-decoration: underline;
@@ -293,6 +295,7 @@ $colorpicker-initial-bg-color: $theme-color-palette-graphite-60;
 $colorpicker-swatch-border-color: $theme-color-palette-graphite-60;
 $colorpicker-checkmark-one-color: $theme-color-palette-black;
 $colorpicker-checkmark-two-color: $theme-color-palette-white;
+$colorpicker-readonly-icon-color: $theme-color-palette-slate-30;
 
 // Fileupload
 $fileupload-border-color: $theme-color-palette-graphite-50;

--- a/src/themes/theme-uplift-dark.scss
+++ b/src/themes/theme-uplift-dark.scss
@@ -220,6 +220,11 @@ $toolbar-separator-color: $theme-color-palette-slate-50;
 // Formatter Toolbar
 $formatter-toolbar-separator-color: $theme-color-palette-slate-30;
 
+// Color Picker
+$colorpicker-initial-bg-color: $theme-color-palette-slate-40;
+$colorpicker-swatch-border-color: $theme-color-palette-slate-50;
+$colorpicker-readonly-icon-color: $theme-color-palette-slate-60;
+
 // Contextual Toolbar
 $contextual-toolbar-color: $inverse-color;
 $contextual-toolbar-bg-color: $theme-color-brand-primary-base;
@@ -229,6 +234,7 @@ $contextual-panel-seperator-bg-color: $theme-color-palette-slate-30;
 $dropdown-menu-border-color: $theme-color-brand-primary-base;
 $dropdown-menu-separator-color: $theme-color-palette-slate-40;
 $dropdown-menu-separator-border-color: $theme-color-palette-slate-50;
+$dropdown-readonly-icon-color: $theme-color-palette-slate-60;
 
 // Date Picker
 $datepicker-month-year-color: $inverse-color;
@@ -241,15 +247,12 @@ $datepicker-today-color: $inverse-color;
 $datepicker-hover-bg-color: $theme-color-palette-slate-70;
 $datepicker-disabled-bg-color: $theme-color-palette-slate-70;
 $datepicker-disabled-color: $theme-color-palette-slate-10;
+$datepicker-readonly-icon-color: $theme-color-palette-slate-60;
 
 // Time Picker
 $timepicker-disabled-icon-color: $theme-color-palette-slate-50;
 $timepicker-disabled-border-color: $theme-color-palette-slate-50;
 $timepicker-disabled-color: $theme-color-palette-slate-40;
-
-// Color Picker
-$colorpicker-initial-bg-color: $theme-color-palette-slate-40;
-$colorpicker-swatch-border-color: $theme-color-palette-slate-50;
 
 // Fileupload
 $fileupload-border-color: $theme-color-palette-slate-50;

--- a/src/themes/theme-uplift-light.scss
+++ b/src/themes/theme-uplift-light.scss
@@ -45,9 +45,6 @@ $datagrid-sort-icon-color: $theme-color-palette-slate-50;
 $listview-border-color: $theme-color-palette-slate-20;
 $panel-border-color: $theme-color-palette-graphite-30;
 
-// Tabs
-$tab-text-color: $theme-color-palette-graphite-70;
-
 // Calendar
 $calendar-bg-color: $panel-bg-color;
 $calendar-line-color: $theme-color-palette-graphite-30;
@@ -58,6 +55,18 @@ $calendar-selected-bg-color: $theme-color-palette-graphite-20;
 $calendar-hover-bg-color: rgba(240, 240, 240, 0.5);
 $calendar-disabled-bg-color: $theme-color-palette-graphite-20;
 $calendar-disabled-color: $theme-color-brand-secondary-contrast;
+
+// Color Picker
+$colorpicker-readonly-icon-color: $theme-color-palette-slate-40;
+
+// Date Picker
+$datepicker-readonly-icon-color: $theme-color-palette-slate-40;
+
+// Dropdown
+$dropdown-readonly-icon-color: $theme-color-palette-slate-40;
+
+// Tabs
+$tab-text-color: $theme-color-palette-graphite-70;
 
 // Uplift-only Variables
 $uplift-acc-border-radius: 6px;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes color inconsistencies of the icons when the fields are in readonly state for dropdown, datepicker, and colorpicker. 

Additional fixes
- Hovering on icon color shouldn't look active. It should still be the same.
- Hovering on the field shouldn't change the border color.

Following the icon colors (for all themes) of the file upload example. 
See: https://design.infor.com/code/ids-enterprise/latest/demo/components/fileupload/example-index

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/3176

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app.

Open the three test pages from colorpicker, datepicker, and dropdown components.
- http://localhost:4000/components/colorpicker/test-states
- http://localhost:4000/components/datepicker/example-index
- http://localhost:4000/components/dropdown/example-readonly
---- 
- For colorpicker (http://localhost:4000/components/colorpicker/test-states) test page, hover the input field (**on the Readonly field**).
- It should not appear any border color and the icon shouldn't change the color.
- Validate and the color if it's the same as the [file upload test page](https://design.infor.com/code/ids-enterprise/latest/demo/components/fileupload/example-index) via inspecting the element.
- Test it to all on different themes and variants.
---
- For datepicker (http://localhost:4000/components/datepicker/example-index) test page, check the second input field, that is in readonly state.
- Validate and compare the color if it's the same as the [file upload test page](https://design.infor.com/code/ids-enterprise/latest/demo/components/fileupload/example-index) via inspecting the element.
---
- For dropdown (http://localhost:4000/components/dropdown/example-readonly) test page, check the second and third input fields that has readonly label.
- Validate and compare the color if it's the same as the [file upload test page](https://design.infor.com/code/ids-enterprise/latest/demo/components/fileupload/example-index) via inspecting the element.
- Also, click the "Remove Readonly Attribute" button repeatedly.
- Icon should be back to it's color when it's in readonly.

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
