### PR TITLE
3315 - Fix standard inputs not allowing leading zeroes in Number Masks [v4.25.x]

### DIFF
--- a/app/views/components/mask/test-input-type-numeric.html
+++ b/app/views/components/mask/test-input-type-numeric.html
@@ -9,7 +9,7 @@
   <div class="six columns">
     <div class="field">
       <label for="test-input">Numeric Input</label>
-      <input id="test-input" type="number" class="new-mask" data-options='{ "process": "number", "patternOptions": { "allowLeadingZeroes": true, "allowThousandsSeparator": false, "allowDecimal": true, "allowNegative": true, "integerLimit": 7, "decimalLimit": 2 } }' placeholder="-#######.00" step="0.01"/>
+      <input id="test-input" type="number" class="new-mask" data-options='{ "process": "number", "patternOptions": { "allowLeadingZeros": true, "allowThousandsSeparator": false, "allowDecimal": true, "allowNegative": true, "integerLimit": 7, "decimalLimit": 2 } }' placeholder="-#######.00" step="0.01"/>
     </div>
   </div>
 </div>

--- a/app/views/components/mask/test-number-leading-zeroes.html
+++ b/app/views/components/mask/test-number-leading-zeroes.html
@@ -20,12 +20,12 @@
 
     <div class="field">
       <label for="test2">Number Mask on Text Input with Leading Zeroes</label>
-      <input type="text" id="test2" data-mask data-options="{ process: 'number', patternOptions: { allowLeadingZeroes: true, allowDecimal: true, allowThousandsSeparator: true, integerLimit: 7, decimalLimit: 3 }}" placeholder="#,###,###.000" />
+      <input type="text" id="test2" data-mask data-options="{ process: 'number', patternOptions: { allowLeadingZeros: true, allowDecimal: true, allowThousandsSeparator: true, integerLimit: 7, decimalLimit: 3 }}" placeholder="#,###,###.000" />
     </div>
 
     <div class="field">
       <label for="test3">Negative Number Mask on Text Input with Leading Zeroes</label>
-      <input type="text" id="test3" data-mask data-options="{ process: 'number', patternOptions: { allowLeadingZeroes: true, allowDecimal: true, allowNegative: true, allowThousandsSeparator: true, integerLimit: 7, decimalLimit: 3 }}" placeholder="-#,###,###.000" />
+      <input type="text" id="test3" data-mask data-options="{ process: 'number', patternOptions: { allowLeadingZeros: true, allowDecimal: true, allowNegative: true, allowThousandsSeparator: true, integerLimit: 7, decimalLimit: 3 }}" placeholder="-#,###,###.000" />
     </div>
   </div>
   <div class="six columns">
@@ -38,12 +38,12 @@
 
     <div class="field">
       <label for="test5">Number Mask on Number Input with Leading Zeroes</label>
-      <input type="number" id="test5" data-mask data-options="{ process: 'number', patternOptions: { allowLeadingZeroes: true, allowDecimal: true, allowThousandsSeparator: false, integerLimit: 7, decimalLimit: 3 }}" placeholder="#######.000" step="0.001" />
+      <input type="number" id="test5" data-mask data-options="{ process: 'number', patternOptions: { allowLeadingZeros: true, allowDecimal: true, allowThousandsSeparator: false, integerLimit: 7, decimalLimit: 3 }}" placeholder="#######.000" step="0.001" />
     </div>
 
     <div class="field">
       <label for="test6">Negative Number Mask on Number Input with Leading Zeroes</label>
-      <input type="number" id="test6" data-mask data-options="{ process: 'number', patternOptions: { allowLeadingZeroes: true, allowDecimal: true, allowThousandsSeparator: false, allowNegative: true, integerLimit: 7, decimalLimit: 3 }}" placeholder="-#######.000" step="0.001" />
+      <input type="number" id="test6" data-mask data-options="{ process: 'number', patternOptions: { allowLeadingZeros: true, allowDecimal: true, allowThousandsSeparator: false, allowNegative: true, integerLimit: 7, decimalLimit: 3 }}" placeholder="-#######.000" step="0.001" />
     </div>
   </div>
 </div>

--- a/app/views/components/mask/test-number-leading-zeroes.html
+++ b/app/views/components/mask/test-number-leading-zeroes.html
@@ -14,7 +14,7 @@
     <h2 class="fieldset-title">Text Inputs</h2>
 
     <div class="field">
-      <label for="test1">Negative Number Mask on Text Input (Standard)</label>
+      <label for="test1">Number Mask on Text Input (Standard)</label>
       <input type="text" id="test1" data-mask data-options="{ process: 'number', patternOptions: { allowDecimal: true, allowThousandsSeparator: true, integerLimit: 7, decimalLimit: 3 }}" placeholder="#,###,###.000" />
     </div>
 
@@ -25,25 +25,25 @@
 
     <div class="field">
       <label for="test3">Negative Number Mask on Text Input with Leading Zeroes</label>
-      <input type="text" id="test3" data-mask data-options="{ process: 'number', patternOptions: { allowLeadingZeroes: true, allowDecimal: true, allowNegative: true, allowThousandsSeparator: true, integerLimit: 7, decimalLimit: 3 }}" placeholder="#,###,###.000" />
+      <input type="text" id="test3" data-mask data-options="{ process: 'number', patternOptions: { allowLeadingZeroes: true, allowDecimal: true, allowNegative: true, allowThousandsSeparator: true, integerLimit: 7, decimalLimit: 3 }}" placeholder="-#,###,###.000" />
     </div>
   </div>
   <div class="six columns">
     <h2 class="fieldset-title">Number Inputs</h2>
 
     <div class="field">
-      <label for="test4">Negative Number Mask on Number Input (Standard)</label>
-      <input type="number" id="test4" data-mask data-options="{ process: 'number', patternOptions: { allowDecimal: true, allowThousandsSeparator: false, integerLimit: 7, decimalLimit: 3 }}" placeholder="#,###,###.000" step="0.001"/>
+      <label for="test4">Number Mask on Number Input (Standard)</label>
+      <input type="number" id="test4" data-mask data-options="{ process: 'number', patternOptions: { allowDecimal: true, allowThousandsSeparator: false, integerLimit: 7, decimalLimit: 3 }}" placeholder="#######.000" step="0.001"/>
     </div>
 
     <div class="field">
       <label for="test5">Number Mask on Number Input with Leading Zeroes</label>
-      <input type="number" id="test5" data-mask data-options="{ process: 'number', patternOptions: { allowLeadingZeroes: true, allowDecimal: true, allowThousandsSeparator: false, integerLimit: 7, decimalLimit: 3 }}" placeholder="#,###,###.000"  />
+      <input type="number" id="test5" data-mask data-options="{ process: 'number', patternOptions: { allowLeadingZeroes: true, allowDecimal: true, allowThousandsSeparator: false, integerLimit: 7, decimalLimit: 3 }}" placeholder="#######.000" step="0.001" />
     </div>
 
     <div class="field">
       <label for="test6">Negative Number Mask on Number Input with Leading Zeroes</label>
-      <input type="number" id="test6" data-mask data-options="{ process: 'number', patternOptions: { allowLeadingZeroes: true, allowDecimal: true, allowThousandsSeparator: false, allowNegative: true, integerLimit: 7, decimalLimit: 3 }}" placeholder="#,###,###.000" />
+      <input type="number" id="test6" data-mask data-options="{ process: 'number', patternOptions: { allowLeadingZeroes: true, allowDecimal: true, allowThousandsSeparator: false, allowNegative: true, integerLimit: 7, decimalLimit: 3 }}" placeholder="-#######.000" step="0.001" />
     </div>
   </div>
 </div>

--- a/app/views/components/mask/test-number-leading-zeroes.html
+++ b/app/views/components/mask/test-number-leading-zeroes.html
@@ -1,0 +1,49 @@
+<div class="row">
+  <div class="six columns">
+
+    <h2>Mask Test: Leading Zeroes in Number Masks</h2>
+
+    <p><a class="hyperlink" href="http://jira.infor.com/browse/HFC-3800" target="_blank">Related JIRA Ticket</a>.  It should be possible to correctly handle positive numbers with decimals inside of numeric Mask-controlled input fields.  Using either of the two input fields below, entering "12345600" with negative or positive values should result in a correctly-masked value.</p>
+    <p></p>
+
+  </div>
+</div>
+
+<div class="row">
+  <div class="six columns">
+    <h2 class="fieldset-title">Text Inputs</h2>
+
+    <div class="field">
+      <label for="test1">Negative Number Mask on Text Input (Standard)</label>
+      <input type="text" id="test1" data-mask data-options="{ process: 'number', patternOptions: { allowDecimal: true, allowThousandsSeparator: true, integerLimit: 7, decimalLimit: 3 }}" placeholder="#,###,###.000" />
+    </div>
+
+    <div class="field">
+      <label for="test2">Number Mask on Text Input with Leading Zeroes</label>
+      <input type="text" id="test2" data-mask data-options="{ process: 'number', patternOptions: { allowLeadingZeroes: true, allowDecimal: true, allowThousandsSeparator: true, integerLimit: 7, decimalLimit: 3 }}" placeholder="#,###,###.000" />
+    </div>
+
+    <div class="field">
+      <label for="test3">Negative Number Mask on Text Input with Leading Zeroes</label>
+      <input type="text" id="test3" data-mask data-options="{ process: 'number', patternOptions: { allowLeadingZeroes: true, allowDecimal: true, allowNegative: true, allowThousandsSeparator: true, integerLimit: 7, decimalLimit: 3 }}" placeholder="#,###,###.000" />
+    </div>
+  </div>
+  <div class="six columns">
+    <h2 class="fieldset-title">Number Inputs</h2>
+
+    <div class="field">
+      <label for="test4">Negative Number Mask on Number Input (Standard)</label>
+      <input type="number" id="test4" data-mask data-options="{ process: 'number', patternOptions: { allowDecimal: true, allowThousandsSeparator: false, integerLimit: 7, decimalLimit: 3 }}" placeholder="#,###,###.000" step="0.001"/>
+    </div>
+
+    <div class="field">
+      <label for="test5">Number Mask on Number Input with Leading Zeroes</label>
+      <input type="number" id="test5" data-mask data-options="{ process: 'number', patternOptions: { allowLeadingZeroes: true, allowDecimal: true, allowThousandsSeparator: false, integerLimit: 7, decimalLimit: 3 }}" placeholder="#,###,###.000"  />
+    </div>
+
+    <div class="field">
+      <label for="test6">Negative Number Mask on Number Input with Leading Zeroes</label>
+      <input type="number" id="test6" data-mask data-options="{ process: 'number', patternOptions: { allowLeadingZeroes: true, allowDecimal: true, allowThousandsSeparator: false, allowNegative: true, integerLimit: 7, decimalLimit: 3 }}" placeholder="#,###,###.000" />
+    </div>
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### v4.25.1 Fixes
 
 - `[Datagrid]` Fixed a bug where if there was an editor datagrid might error when loading. ([#3313](https://github.com/infor-design/enterprise/issues/3313))
+- `[Mask]` Fixed a bug where leading zeroes were not possible to apply against Number Masks on standard input fields that also handled formatting for thousands separators. ([#3315](https://github.com/infor-design/enterprise/issues/3315))
 
 ## v4.25.0
 

--- a/src/components/mask/mask-input.js
+++ b/src/components/mask/mask-input.js
@@ -42,7 +42,7 @@ const COMPONENT_NAME = 'mask';
  * @param {number} [settings.patternOptions.decimalLimit] [number masks only] defines the number of characters allowed after the decimal point.
  * @param {number} [settings.patternOptions.integerLimit] [number masks only] defines the number of characters allowed before the decimal point.
  * @param {boolean} [settings.patternOptions.allowNegative] [number masks only] allows a number to be negative (adds/retains a "minus" symbol at the beginning of the value)
- * @param {boolean} [settings.patternOptions.allowLeadingZeroes] [number masks only] allows a zero be placed before a decimal or other numbers.
+ * @param {boolean} [settings.patternOptions.allowLeadingZeros] [number masks only] allows a zero be placed before a decimal or other numbers.
  * @param {string} [settings.placeholderChar='_'] If using the `settings.guide`, will be used as the placeholder
  *  for characters that are not yet typed.
  * @param {function} [settings.pipe] provides a way of adjusting the masked content, caret position,

--- a/src/components/mask/mask-input.js
+++ b/src/components/mask/mask-input.js
@@ -270,7 +270,7 @@ MaskInput.prototype = {
         if (rawValue === '') {
           rawValue = this.state.previousMaskResult;
           numberInputCorrections = true;
-        } else if (this.type === 'number' && e.data === definedDecimal && rawValue.indexOf(definedDecimal) > -1) {
+        } else if (e.data === definedDecimal && rawValue.indexOf(definedDecimal) > -1) {
           numberInputCorrections = true;
         }
       }

--- a/src/components/mask/masks.js
+++ b/src/components/mask/masks.js
@@ -92,17 +92,7 @@ const DEFAULT_NUMBER_MASK_OPTIONS = {
 // @param {string} formattedStr the string to be checked
 // @returns {number} containing the number of leading zeros.
 function getLeadingZeros(formattedStr) {
-  let count = 0;
-  if (typeof formattedStr !== 'string' || !formattedStr.length) {
-    return count;
-  }
-  for (let i = 0; i < formattedStr.length; i++) {
-    if (formattedStr[i] !== '0') {
-      break;
-    }
-    count++;
-  }
-  return count;
+  return `${formattedStr}`.match(/^0*/)[0].length;
 }
 
 // Converts a string representing a formatted number into a Number Mask.

--- a/src/components/mask/masks.js
+++ b/src/components/mask/masks.js
@@ -1,4 +1,5 @@
 import { utils } from '../../utils/utils';
+import { warnAboutDeprecation } from '../../utils/deprecated';
 import { stringUtils as str } from '../../utils/string';
 import { Locale } from '../locale/locale';
 
@@ -83,14 +84,14 @@ const DEFAULT_NUMBER_MASK_OPTIONS = {
   locale: '',
   requireDecimal: false,
   allowNegative: false,
-  allowLeadingZeroes: false,
+  allowLeadingZeros: false,
   integerLimit: null
 };
 
 // Gets the number of leading zeros in a string representing a formatted number.
 // @param {string} formattedStr the string to be checked
 // @returns {number} containing the number of leading zeros.
-function getLeadingZeroes(formattedStr) {
+function getLeadingZeros(formattedStr) {
   let count = 0;
   if (typeof formattedStr !== 'string' || !formattedStr.length) {
     return count;
@@ -129,8 +130,8 @@ function addThousandsSeparator(n, thousands, options, localeStringOpts) {
 
   // `Number.toLocaleString` does not account for leading zeroes, so we have to put them
   // back if we've configured this Mask to use them.
-  if (options && options.allowLeadingZeroes && n.indexOf('0') === 0) {
-    let zeros = getLeadingZeroes(n);
+  if (options && options.allowLeadingZeros && n.indexOf('0') === 0) {
+    let zeros = getLeadingZeros(n);
     if (formatted.indexOf('0') === 0) {
       formatted = formatted.substring(1);
     }
@@ -178,6 +179,12 @@ masks.numberMask = function sohoNumberMask(rawValue, options) {
   options = utils.mergeSettings(undefined, options, DEFAULT_NUMBER_MASK_OPTIONS);
   if (!options.locale || !options.locale.length) {
     options.locale = Locale.currentLocale.name;
+  }
+  // Deprecated in v4.25.1
+  if (options.allowLeadingZeroes) {
+    warnAboutDeprecation('allowLeadingZeros', 'allowLeadingZeroes', 'Number Mask');
+    options.allowLeadingZeros = options.allowLeadingZeroes;
+    options.allowLeadingZeroes = undefined;
   }
 
   const PREFIX = options.prefix;
@@ -242,7 +249,7 @@ masks.numberMask = function sohoNumberMask(rawValue, options) {
 
     integer = integer.replace(masks.NON_DIGITS_REGEX, masks.EMPTY_STRING);
 
-    if (!options.allowLeadingZeroes) {
+    if (!options.allowLeadingZeros) {
       integer = integer.replace(/^0+(0$|[^0])/, '$1');
     }
 

--- a/test/components/mask/mask.func-spec.js
+++ b/test/components/mask/mask.func-spec.js
@@ -315,6 +315,61 @@ describe('Mask API', () => {
     expect(result.conformedValue).toEqual('一二三四五六七七九');
   });
 
+  it('Should process number masks with leading zeros', () => {
+    const settings = DEFAULT_SETTINGS;
+    settings.process = 'number';
+    settings.pattern = masks.numberMask;
+    const api = new MaskAPI(settings);
+
+    // Handle big numbers with thousands separators
+    let textValue = '00001';
+    const opts = {
+      selection: {
+        start: 0
+      },
+      patternOptions: {
+        allowLeadingZeroes: true,
+        allowThousands: true,
+        allowDecimal: true,
+        allowNegative: true,
+        integerLimit: 10,
+        decimalLimit: 3,
+        locale: 'en-US'
+      }
+    };
+    let result = api.process(textValue, opts);
+
+    expect(result).toBeDefined();
+    expect(result).toEqual(jasmine.any(Object));
+    expect(result.conformedValue).toEqual(jasmine.any(String));
+    expect(result.conformedValue).toEqual('00001');
+
+    textValue = '10000';
+    result = api.process(textValue, opts);
+
+    expect(result.conformedValue).toEqual('10,000');
+
+    textValue = '00000.123';
+    result = api.process(textValue, opts);
+
+    expect(result.conformedValue).toEqual('00000.123');
+
+    textValue = '10000.123';
+    result = api.process(textValue, opts);
+
+    expect(result.conformedValue).toEqual('10,000.123');
+
+    textValue = '10000.100';
+    result = api.process(textValue, opts);
+
+    expect(result.conformedValue).toEqual('10,000.100');
+
+    textValue = '-00000.123';
+    result = api.process(textValue, opts);
+
+    expect(result.conformedValue).toEqual('-00000.123');
+  });
+
   it('Should process short dates', () => {
     const settings = DEFAULT_SETTINGS;
     settings.process = 'date';

--- a/test/components/mask/mask.func-spec.js
+++ b/test/components/mask/mask.func-spec.js
@@ -328,7 +328,7 @@ describe('Mask API', () => {
         start: 0
       },
       patternOptions: {
-        allowLeadingZeroes: true,
+        allowLeadingZeros: true,
         allowThousands: true,
         allowDecimal: true,
         allowNegative: true,
@@ -486,4 +486,38 @@ describe('Mask API', () => {
    *  2. run _conformToMask_ directly with mask, etc
    *});
    */
+});
+
+describe('Number Mask API', () => {
+  const DEFAULT_SETTINGS = {
+    process: 'number',
+    pattern: masks.numberMask,
+    pipe: undefined
+  };
+
+  it('Should convert legacy settings to current settings', () => {
+    spyOn(console, 'warn');
+
+    const api = new MaskAPI(DEFAULT_SETTINGS);
+    const opts = {
+      selection: {
+        start: 0
+      },
+      patternOptions: {
+        allowLeadingZeroes: true, // should be `allowLeadingZeros`
+        allowThousands: true,
+        allowDecimal: true,
+        allowNegative: true,
+        integerLimit: 10,
+        decimalLimit: 3,
+        locale: 'en-US'
+      }
+    };
+
+    const textValue = '00000.123';
+    const result = api.process(textValue, opts);
+
+    expect(result.conformedValue).toEqual('00000.123');
+    expect(console.warn).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a regression in the way Number Masks handle leading zeroes on standard input fields (read: not number input fields).  Previously it was not possible to add more than one zero to the integer part of a Number Mask on an input field that was configured to allow leading zeroes.  It was also not possible to type a zero, then any other number in these same fields.  These issues are now resolved.

**Related github/jira issue (required)**:
Closes #3315 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the app
- Open http://localhost:4000/components/mask/test-number-leading-zeroes
- In the "Text Inputs" section, choose either of the inputs that allow leading zeroes, and attempt to type a number with several leading zeroes.  Multiple zeroes should be allowed.  Additionally, typing a number of zeroes greater than the group size should not cause those zeroes to be formatted with a thousands separator (for example, typing "0000" should not result in "0,000").  However, typing a regular number should format properly in these fields.
- It should also be possible to type numbers like "0001234", and that would format to "0001,234".
- Check that multiple zeroes in the decimal area are also allowed.
- In the fields that allow it, check to make sure negative numbers are working.

There is a new functional test that extensively checks this feature, which should pass.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.