### PR TITLE
3410 - Fix tag text/icon alignment on Windows [v4.25.x]

### DIFF
--- a/src/components/badges/_badges-uplift.scss
+++ b/src/components/badges/_badges-uplift.scss
@@ -6,8 +6,64 @@
   font-size: 14px;
   line-height: 20px;
 
+  button {
+    .icon {
+      top: -1px;
+    }
+  }
+
   &.round {
     width: 30px;
+  }
+}
+
+html {
+  &.is-mac {
+    .tag,
+    .badge {
+      button {
+        .icon {
+          top: -1px;
+        }
+      }
+    }
+  }
+
+  &.ie11 {
+    .tag,
+    .badge {
+      button {
+        .icon {
+          top: -3px;
+        }
+      }
+    }
+  }
+
+  &.is-safari {
+    .tag,
+    .badge {
+      button {
+        .icon {
+          top: 0;
+        }
+      }
+    }
+  }
+
+  &.is-firefox {
+    .tag,
+    .badge {
+      button {
+        .icon {
+          top: 0;
+        }
+      }
+
+      .tag-content {
+        line-height: 19px;
+      }
+    }
   }
 }
 

--- a/src/components/badges/_badges.scss
+++ b/src/components/badges/_badges.scss
@@ -451,80 +451,27 @@ html.theme-uplift-contrast {
   }
 }
 
-html[class*='theme-soho-'] {
-  .tag,
-  .badge {
-    button {
-      .icon {
-        top: 1px;
-      }
-    }
-  }
-
-  &.ie {
-    .tag,
-    .badge {
-      .dismissible-btn,
-      .linkable-btn {
-        .icon {
-          top: 0;
-        }
-      }
-    }
-  }
-}
-
-html[class*='theme-uplift-'] {
-  .tag,
-  .badge {
-    .dismissible-btn,
-    .linkable-btn {
-      .icon {
-        top: -1px;
-      }
-    }
-  }
-
+// Bump all icons in tags by 1px on a Mac
+html {
+  &.is-mac,
   &.is-firefox {
     .tag,
     .badge {
-      &.is-linkable {
-        line-height: 19px;
-      }
-    }
-  }
-
-  &.is-firefox,
-  &.is-safari {
-    .dismissible-btn,
-    .linkable-btn {
-      .icon {
-        top: 0;
-      }
-    }
-  }
-
-  &.ie {
-    .tag,
-    .badge {
-      .dismissible-btn,
-      .linkable-btn {
+      button {
         .icon {
-          top: -3px;
+          top: 1px;
         }
       }
     }
   }
-}
 
-// IE
-html.ie {
-  .tag,
-  .badge {
-    .dismissible-btn,
-    .linkable-btn {
-      .icon {
-        top: 0;
+  &.ios {
+    .tag,
+    .badge {
+      button {
+        .icon {
+          top: 2px;
+        }
       }
     }
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR makes general across-the-board adjustments to the alignment of text/icons/line height on Tag components in all browsers.  This was due to misalignments found on this component in Windows Chrome, which uncovered a difference in line-height of the font between Windows/Mac platforms.

**Related github/jira issue (required)**:
Closes #3410

**Steps necessary to review your pull request (required)**:
Pull this branch, build, and run the app.  Then test the following pages in every browser/os combination you can think of:
- http://localhost:4000/components/tag/example-index.html
- http://localhost:4000/components/tag/example-index.html?theme=uplift&variant=light
- http://localhost:4000/components/multiselect/example-tags
- http://localhost:4000/components/multiselect/example-tags?theme=uplift&variant=light

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
