### PR TITLE
3413 - Improve the colors of custom scrollbars in windows [v4.25x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@
 - `[Datagrid]` Fixed a bug that made selecting blank items in lists in a dropdown not possible. ([#3313](https://github.com/infor-design/enterprise/issues/3313))
 - `[Editor]` Fixed an issue where line spacing was inconsistent. ([#3335](https://github.com/infor-design/enterprise/issues/3335))
 - `[General]` Added detection for wkWebView which is paired with safari. This caused issues with all black text as this browser had previously been unknown. ([#3336](https://github.com/infor-design/enterprise/issues/3336))
+- `[General]` Improved the colors of windows chrome custom scrollbars in uplift themes. ([#3413](https://github.com/infor-design/enterprise/issues/3413))
 - `[Homepage]` Fixed an issue where the DOM order was not working for triple width widgets. ([#3101](https://github.com/infor-design/enterprise/issues/3101))
 - `[Locale]` Fixed an issue where enter all digits was not working for fr-FR. ([#3217](https://github.com/infor-design/enterprise/issues/3217))
 - `[Locale]` Added the ability to set a 5 digit language (`fr-FR` and `fr-CA` vs `fr`) and added separate strings for `fr-CA` vs `fr-FR`. ([#3245](https://github.com/infor-design/enterprise/issues/3245))

--- a/src/components/cards/_cards-uplift.scss
+++ b/src/components/cards/_cards-uplift.scss
@@ -24,6 +24,10 @@
   .widget-group-action {
     border-top: 1px solid $listview-border-color;
   }
+
+  .listview li:first-child {
+    border-top: 1px solid $listview-border-color;
+  }
 }
 
 .card-header,

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -593,7 +593,6 @@ Header.prototype = {
     for (let i = 0; i < tags.length; i++) {
       tags[i].setAttribute('data-rgbcolor', colors[keys[i]].value);
     }
-    console.log(menu.html());
   },
 
   /**

--- a/src/components/listview/_listview.scss
+++ b/src/components/listview/_listview.scss
@@ -120,6 +120,7 @@
   }
 
   li {
+    background-color: $listview-bg-color;
     border: 1px solid transparent;
     border-bottom-color: $listview-border-color;
     color: $listview-color;
@@ -218,7 +219,7 @@
 
   &.disable-hover {
     li:hover {
-      background-color: transparent;
+      background-color: $listview-hover-bg-color;
     }
   }
 

--- a/src/themes/theme-soho-contrast.scss
+++ b/src/themes/theme-soho-contrast.scss
@@ -159,7 +159,7 @@ $popupmenu-bg-color: $theme-color-palette-white;
 $popupmenu-border-color: $theme-color-palette-graphite-60;
 $popupmenu-box-shadow: 0 2px 5px $drop-shadow-depth;
 $popupmenu-heading-color: $theme-color-palette-graphite-70;
-$popupmenu-hover-color: $theme-color-brand-secondary-alt;
+$popupmenu-hover-color: $theme-color-palette-graphite-30;
 $popupmenu-checked-color: $theme-color-palette-azure-90;
 $popupmenu-checked-color-inverse: $theme-color-brand-primary-base;
 
@@ -206,7 +206,7 @@ $trigger-disabled-color: $theme-color-brand-secondary-alt;
 //List View
 $listview-bg-color: $inverse-color;
 $listview-bg-color-alternate: $theme-color-palette-graphite-20;
-$listview-hover-bg-color: $theme-color-brand-secondary-alt;
+$listview-hover-bg-color: $theme-color-palette-graphite-30;
 $listview-border-color: $theme-color-palette-graphite-60;
 $listview-color: $theme-color-palette-black;
 $listview-secondary-color: $theme-color-palette-graphite-90;

--- a/src/themes/theme-uplift-contrast.scss
+++ b/src/themes/theme-uplift-contrast.scss
@@ -159,7 +159,7 @@ $popupmenu-bg-color: $theme-color-palette-white;
 $popupmenu-border-color: $theme-color-palette-graphite-60;
 $popupmenu-box-shadow: 0 2px 5px $drop-shadow-depth;
 $popupmenu-heading-color: $theme-color-palette-graphite-70;
-$popupmenu-hover-color: $theme-color-palette-graphite-30;
+$popupmenu-hover-color: $theme-color-palette-graphite-20;
 $popupmenu-checked-color: $theme-color-palette-azure-90;
 $popupmenu-checked-color-inverse: $theme-color-brand-primary-base;
 
@@ -204,9 +204,9 @@ $trigger-focus-color: $theme-color-brand-primary-base;
 $trigger-disabled-color: $theme-color-brand-secondary-alt;
 
 //List View
-$listview-bg-color: $inverse-color;
+$listview-bg-color: $theme-color-palette-white;
 $listview-bg-color-alternate: $theme-color-palette-graphite-20;
-$listview-hover-bg-color: $theme-color-palette-white;
+$listview-hover-bg-color: $theme-color-palette-graphite-10;
 $listview-border-color: $theme-color-palette-graphite-60;
 $listview-color: $theme-color-palette-black;
 $listview-secondary-color: $theme-color-palette-graphite-90;
@@ -527,7 +527,7 @@ $datagrid-sort-icon-sorted-color: $theme-color-palette-white;
 $datagrid-required-icon-color: $theme-color-palette-white;
 
 $datagrid-cell-color: $font-color;
-$datagrid-cell-bg-color: $theme-color-palette-graphite-10;
+$datagrid-cell-bg-color: $theme-color-palette-white;
 $datagrid-cell-editing-bg-color: $theme-color-palette-white;
 $datagrid-cell-readonly-bg-color: $input-color-readonly-background;
 $datagrid-cell-readonly-color: $font-color;
@@ -815,8 +815,12 @@ $uplift-appmenu-selected-border-color: $theme-color-palette-white;
 
 html.is-chrome:not(.is-mac) {
   ::-webkit-scrollbar-track {
-    background-color: $theme-color-body-base;
-    border-left: 1px solid $theme-color-brand-secondary-lighter;
+    background-color: $body-color-primary-background;
+    border: 1px solid $theme-color-palette-slate-20;
+  }
+
+  ::-webkit-scrollbar-corner {
+    background-color: $body-color-primary-background;
   }
 
   ::-webkit-scrollbar {
@@ -826,11 +830,11 @@ html.is-chrome:not(.is-mac) {
   }
 
   ::-webkit-scrollbar-thumb {
-    background: $theme-color-brand-secondary-base;
+    background: $theme-color-palette-slate-40;
     border-radius: 10px;
 
     &:hover {
-      background: $theme-color-brand-secondary-alt;
+      background: $theme-color-palette-slate-50;
     }
   }
 }

--- a/src/themes/theme-uplift-dark.scss
+++ b/src/themes/theme-uplift-dark.scss
@@ -504,7 +504,7 @@ $datagrid-cell-focus-box-shadow: 0 0 4px 1px rgba(101, 104, 113, 0.4);
 $datagrid-data-color: $font-color-extrahighcontrast;
 $datagrid-row-selected-color: #334d60;
 $datagrid-row-selected-color-dark: #3e586c;
-$datagrid-row-hover-color: $theme-color-palette-slate-70;
+$datagrid-row-hover-color: $theme-color-palette-slate-80;
 $datagrid-row-icon-color: $theme-color-palette-slate-30;
 
 $datagrid-header-focus-bg-color: $theme-color-brand-primary-base;
@@ -757,8 +757,13 @@ $uplift-appmenu-selected-border-color: $theme-color-palette-white;
 
 html.is-chrome:not(.is-mac) {
   ::-webkit-scrollbar-track {
-    background-color: $theme-color-body-base;
-    border-left: 1px solid $theme-color-brand-secondary-lighter;
+    background-color: $body-color-primary-background;
+    border-left: 1px solid $theme-color-palette-slate-60;
+    border-top: 1px solid $theme-color-palette-slate-60;
+  }
+
+  ::-webkit-scrollbar-corner {
+    background-color: $body-color-primary-background;
   }
 
   ::-webkit-scrollbar {
@@ -768,11 +773,11 @@ html.is-chrome:not(.is-mac) {
   }
 
   ::-webkit-scrollbar-thumb {
-    background: $theme-color-brand-secondary-base;
+    background: $theme-color-palette-slate-50;
     border-radius: 10px;
 
     &:hover {
-      background: $theme-color-brand-secondary-alt;
+      background: $theme-color-palette-slate-40;
     }
   }
 }

--- a/src/themes/theme-uplift-light.scss
+++ b/src/themes/theme-uplift-light.scss
@@ -82,8 +82,12 @@ $uplift-appmenu-selected-border-color: $theme-color-brand-primary-alt;
 
 html.is-chrome:not(.is-mac) {
   ::-webkit-scrollbar-track {
-    background-color: $theme-color-body-base;
-    border-left: 1px solid $theme-color-brand-secondary-lighter;
+    background-color: $body-color-primary-background;
+    border: 1px solid $theme-color-palette-slate-10;
+  }
+
+  ::-webkit-scrollbar-corner {
+    background-color: $body-color-primary-background;
   }
 
   ::-webkit-scrollbar {
@@ -93,11 +97,11 @@ html.is-chrome:not(.is-mac) {
   }
 
   ::-webkit-scrollbar-thumb {
-    background: $theme-color-brand-secondary-base;
+    background: $theme-color-palette-slate-20;
     border-radius: 10px;
 
     &:hover {
-      background: $theme-color-brand-secondary-alt;
+      background: $theme-color-palette-slate-30;
     }
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixed the scrollbars on windows, the changes to colors in uplift made them come out very ugly.
Also fixed a few minor things in list and datagrid in uplift themes to improve the contrast and display.

**Related github/jira issue (required)**:
Fixes #3413 

**Steps necessary to review your pull request (required)**:
- open a windows 10, chrome (latest) VM
- test http://localhost:4000/components/datagrid/example-frozen-columns.html - in all 6 themes, only in uplift mode (3 uplift themes) the scrollbars will change (not in soho)
- test http://localhost:4000/components/listview/example-index.html - in all 6 themes, only in uplift mode (3 uplift themes) the scrollbars will change (not in soho)

**Included in this Pull Request**:
- [x] A note to the change log.
