### PR TITLE
3181/3319 - Fix more event link and selected date on week view with calendar

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@
 ### v4.26.0 Fixes
 
 - `[Application Menu]` Fixed overlap button when label is too long, and aligned dropdown icon in application menu uplift theme. ([#3133](https://github.com/infor-design/enterprise/issues/3133))
+- `[Calendar]` Fixed an issue where link was not working on monthview to switch to day view when clicked on more events on that day. ([#3181](https://github.com/infor-design/enterprise/issues/3181))
+- `[Calendar]` Fixed an issue where date selection was not persist when switching from month view to week view to day view. ([#3319](https://github.com/infor-design/enterprise/issues/3319))
 - `[Datagrid]` Fixed an issue where focus on reload data was forced to be on active cell. ([#358](https://github.com/infor-design/enterprise-ng/issues/358))
 - `[Datagrid]` Fixed hover color should not be similar to alternate rows when hovering in uplift high contrast. ([#3338](https://github.com/infor-design/enterprise/issues/3338))
 - `[Datepicker]` Fixed an issue where setting date format with comma character was not working. ([#3008](https://github.com/infor-design/enterprise/issues/3008))

--- a/src/components/calendar/_calendar.scss
+++ b/src/components/calendar/_calendar.scss
@@ -66,12 +66,15 @@
     @include font-size(11);
 
     color: $font-color-extrahighcontrast;
-    cursor: pointer;
     display: block;
     height: 18px;
     margin: 4px 10px;
     text-align: left;
     width: auto;
+
+    span {
+      cursor: pointer;
+    }
   }
 
   // The upcoming event details section

--- a/src/components/week-view/week-view.js
+++ b/src/components/week-view/week-view.js
@@ -679,6 +679,7 @@ WeekView.prototype = {
 
     this.element.off(`click.${COMPONENT_NAME}`).on(`click.${COMPONENT_NAME}`, '.calendar-event', (e) => {
       fireEvent(e.currentTarget, 'eventclick');
+      e.preventDefault();
     });
 
     this.element.off(`dblclick.${COMPONENT_NAME}`).on(`dblclick.${COMPONENT_NAME}`, '.calendar-event', (e) => {
@@ -733,6 +734,27 @@ WeekView.prototype = {
 
     this.settings.events.push(event);
     this.renderEvent(event);
+  },
+
+  /**
+   * Select header for given date
+   * @private
+   * @param {object|string} d The date or key use for attribute in header `data-kay`.
+   * @returns {void}
+   */
+  selectHeader(d) {
+    const key = d instanceof Date ?
+      stringUtils.padDate(d.getFullYear(), d.getMonth(), d.getDate()) : d;
+    const selector = { all: '.week-view-table-header th' };
+    selector.current = `${selector.all}[data-key="${key}"]`;
+    const headers = [].slice.call(this.element[0].querySelectorAll(selector.all));
+    headers.forEach((header) => {
+      header.classList.remove('is-selected');
+    });
+    const thisHeader = this.element[0].querySelector(selector.current);
+    if (thisHeader) {
+      thisHeader.classList.add('is-selected');
+    }
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed some issues with Calendar.
 - Link was not working on monthview to switch to day view when clicked on more events.
 - Date selection was not persist when switching from month view to week view to day view.
 - On week or day view, clicking on any event was adding `#` to the url.

**Related github/jira issue (required)**:
Closes #3181
Closes #3319

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/calendar/test-ajax-events.html
- It should land on month of `August 2018`
- Click on `+3 more` link for date `22nd`
- It should switch to day view to show all the events on that day

- Refresh the page, it should load back month view
- Click on a date such as: August 15th, 2018 to select
- Click on view changer and switch to week view
- Then click on view changer again to switch to day view
- Day view should show August 15th, 2018 the date selected from month view

- Refresh the page, it should load back month view
- Switch to week view or day view
- Check the url not having any `#`
- Click on any event, the check the url again should not contain any `#`

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
