### PR TITLE
3363 - Fix formate date for es-419 with locale

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Input]` Added the ability to line up data labels with inputs by adding class `field-height` to the `data` element and placing it in a responsive grid. ([#987](https://github.com/infor-design/enterprise/issues/987))
 - `[Input]` Added the ability to use standalone required spans, this will help on responsive fields if they are cut off. ([#3115](https://github.com/infor-design/enterprise/issues/3115))
 - `[Input/Forms]` Added the ability to add a class to rows to align the fields on the bottom, this will line up fields if they have wrapping labels or long labels with required fields. To enable this add class `flex-align-bottom` to the grid `row`. ([#443](https://github.com/infor-design/enterprise/issues/443))
+- `[Locale]` Fixed an issue where formatDate() method was not working for es-419. ([#3363](https://github.com/infor-design/enterprise/issues/3363))
 - `[Pie]` Fixed an issue where initial selection was getting error. ([#3157](https://github.com/infor-design/enterprise/issues/3157))
 - `[Popupmenu]` Fixed an issue where list separators were disappearing when reduced the browser zoom level e.g. 70-80%. ([#3407](https://github.com/infor-design/enterprise/issues/3407))
 - `[Radar Chart]` Fixed an issue where labels was cut off for some screen sizes. ([#3320](https://github.com/infor-design/enterprise/issues/3320))

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -579,6 +579,10 @@ const Locale = {  // eslint-disable-line
       pattern = cal.dateFormat[options.date];
     }
 
+    if (typeof options === 'string' && options !== '') {
+      pattern = options;
+    }
+
     if (!pattern) {
       pattern = cal.dateFormat.short;
     }
@@ -939,6 +943,9 @@ const Locale = {  // eslint-disable-line
     const isUTC = (dateString.toLowerCase().indexOf('z') > -1);
     let i;
     let l;
+    const hasDot = (dateFormat.match(/M/g) || []).length === 3 && thisLocaleCalendar &&
+      thisLocaleCalendar.months && thisLocaleCalendar.months.abbreviated &&
+        thisLocaleCalendar.months.abbreviated.filter(v => /\./.test(v)).length;
 
     if (isDateTime) {
       // Remove Timezone
@@ -949,8 +956,9 @@ const Locale = {  // eslint-disable-line
       dateFormat = dateFormat.replace(' zzzz', '').replace(' zz', '');
 
       // Replace [space & colon & dot] with "/"
-      dateFormat = dateFormat.replace(/[T\s:.-]/g, '/').replace(/z/i, '');
-      dateString = dateString.replace(/[T\s:.-]/g, '/').replace(/z/i, '');
+      const regex = hasDot ? /[T\s:-]/g : /[T\s:.-]/g;
+      dateFormat = dateFormat.replace(regex, '/').replace(/z/i, '');
+      dateString = dateString.replace(regex, '/').replace(/z/i, '');
     }
 
     // Remove spanish de
@@ -975,8 +983,9 @@ const Locale = {  // eslint-disable-line
     }
 
     if (dateFormat.indexOf(' ') !== -1) {
-      dateFormat = dateFormat.replace(/[\s:.]/g, '/');
-      dateString = dateString.replace(/[\s:.]/g, '/');
+      const regex = hasDot ? /[\s:]/g : /[\s:.]/g;
+      dateFormat = dateFormat.replace(regex, '/');
+      dateString = dateString.replace(regex, '/');
     }
 
     // Extra Check incase month has spaces

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -250,6 +250,27 @@ describe('Locale API', () => { //eslint-disable-line
     expect(Locale.formatDate(new Date(2018, 10, 10), { date: 'year' })).toEqual('Noviembre de 2018');
   });
 
+  it('Should format datetime in es-419', () => {
+    Locale.set('es-419');
+
+    expect(Locale.formatDate(new Date(2018, 10, 10), { date: 'short' })).toEqual('10/11/2018');
+    expect(Locale.formatDate(new Date(2018, 10, 10), { date: 'medium' })).toEqual('10 nov. 2018');
+    expect(Locale.formatDate(new Date(2018, 10, 10), { date: 'long' })).toEqual('10 de noviembre de 2018');
+    expect(Locale.formatDate(new Date(2018, 10, 10), { date: 'full' })).toEqual('sábado, 10 de noviembre de 2018');
+    expect(Locale.formatDate(new Date(2018, 10, 10), { date: 'month' })).toEqual('10 de noviembre');
+    expect(Locale.formatDate(new Date(2018, 10, 10), { date: 'year' })).toEqual('noviembre de 2018');
+    expect(Locale.formatDate(new Date(2018, 10, 10, 14, 15, 12), { date: 'timestamp' })).toEqual('14:15:12');
+    expect(Locale.formatDate(new Date(2018, 10, 10, 14, 15, 12), { date: 'hour' })).toEqual('14:15');
+    expect(Locale.formatDate('10 nov. 2018 14:15', { date: 'datetime' })).toEqual('10 nov. 2018 14:15');
+    expect(Locale.formatDate(new Date(2018, 10, 10, 14, 15, 12), { date: 'timezone' })).toEqual('10 nov. 2018 14:15 GT-');
+    expect(Locale.formatDate(new Date(2018, 10, 10, 14, 15, 12), { date: 'timezoneLong' })).toEqual('10 nov. 2018 14:15 hora estándar oriental');
+    expect(Locale.formatDate(new Date(2018, 10, 10), 'd MMM yyyy HH:mm')).toEqual('10 nov. 2018 00:00');
+    expect(Locale.formatDate(new Date(2018, 10, 10, 14, 15), 'd MMM yyyy HH:mm')).toEqual('10 nov. 2018 14:15');
+    expect(Locale.formatDate(new Date(2018, 10, 10, 14, 15), 'd MMM yyyy h:mm a')).toEqual('10 nov. 2018 2:15 p.m.');
+    expect(Locale.formatDate(new Date(2018, 10, 10, 14, 15), 'd MMM yyyy hh:mm a')).toEqual('10 nov. 2018 02:15 p.m.');
+    expect(Locale.formatDate('10 nov. 2018 14:15', Locale.calendar().dateFormat.datetime)).toEqual('10 nov. 2018 14:15');
+  });
+
   it('Should format year in da-DK', () => {
     Locale.set('da-DK');
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed formatDate() method was not working for es-419 with Locale.

**Related github/jira issue (required)**:
Closes #3363

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datepicker/example-index?locale=es-419
- Open developer tools
- Run in console `Soho.Locale.formatDate('22 ene. 2020 00:00', Soho.Locale.calendar().dateFormat.datetime);`
- It should return `"22 ene. 2020 00:00"`

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
