### PR TITLE
3131 - Fix app menu accordion filtering issues

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,10 +7,11 @@
 ### v4.26.0 Features
 
 - `[Icons]` Added new icons `icon-play, icon-stop, icon-record, icon-pause` for video players. ([#397](https://github.com/infor-design/design-system/issues/397))
-- `[Searchfield]` Added a setting that makes it possible to adjust the "collapsed" size of a Toolbar Searchfield to better accomodate some use cases. ([#3296](https://github.com/infor-design/enterprise-ng/issues/3296))
+- `[Searchfield]` Added a setting that makes it possible to adjust the "collapsed" size of a Toolbar Searchfield to better accommodate some use cases. ([#3296](https://github.com/infor-design/enterprise-ng/issues/3296))
 
 ### v4.26.0 Fixes
 
+- `[Application Menu]` Fixed bugs with filtering where it was not possible to have the filter match text within content areas, as well as general expand/collapse bugs with filtering. ([#3131](https://github.com/infor-design/enterprise/issues/3131))
 - `[Application Menu]` Fixed overlap button when label is too long, and aligned dropdown icon in application menu uplift theme. ([#3133](https://github.com/infor-design/enterprise/issues/3133))
 - `[Contextual Action Panel]` - Fixed shade colors of text and icon buttons in uplift theme high contrast. ([#3394](https://github.com/infor-design/enterprise/issues/3394))
 - `[Calendar]` Fixed an issue where link was not working on monthview to switch to day view when clicked on more events on that day. ([#3181](https://github.com/infor-design/enterprise/issues/3181))

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -682,6 +682,10 @@
       font-size: $theme-size-font-base;
       -webkit-text-size-adjust: 100%;
     }
+
+    &.filtered {
+      display: none;
+    }
   }
 
   @include left-align-cascade-styles-pane(20px, 40px, 40px);

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -1425,37 +1425,39 @@ Accordion.prototype = {
       headerElems = this.headers;
       globalEventTeardown = true;
     }
-    const anchors = headerElems.find('a');
 
-    headerElems
-      .off('touchend.accordion click.accordion focusin.accordion focusout.accordion keydown.accordion mousedown.accordion mouseup.accordion')
-      .each(function () {
-        const header = $(this);
-        const icon = header.children('.icon');
+    if (headerElems && headerElems.length) {
+      headerElems
+        .off('touchend.accordion click.accordion focusin.accordion focusout.accordion keydown.accordion mousedown.accordion mouseup.accordion')
+        .each(function () {
+          const header = $(this);
+          const icon = header.children('.icon');
 
-        const hideFocus = header.data('hidefocus');
-        if (hideFocus) {
-          hideFocus.destroy();
-        }
-
-        if (icon.length) {
-          const iconAPI = icon.data('icon');
-          if (iconAPI) {
-            iconAPI.destroy();
+          const hideFocus = header.data('hidefocus');
+          if (hideFocus) {
+            hideFocus.destroy();
           }
-        }
 
-        const expander = header.data('addedExpander');
-        if (expander) {
-          expander.remove();
-          $.removeData(this, 'addedExpander');
-        }
-      });
+          if (icon.length) {
+            const iconAPI = icon.data('icon');
+            if (iconAPI) {
+              iconAPI.destroy();
+            }
+          }
 
-    anchors.off('touchend.accordion keydown.accordion click.accordion');
+          const expander = header.data('addedExpander');
+          if (expander) {
+            expander.remove();
+            $.removeData(this, 'addedExpander');
+          }
+        });
 
-    headerElems.children('[class^="btn"]')
-      .off('touchend.accordion click.accordion keydown.accordion');
+      const anchors = headerElems.not('.accordion-content').find('a');
+      anchors.off('touchend.accordion keydown.accordion click.accordion');
+
+      headerElems.children('[class^="btn"]')
+        .off('touchend.accordion click.accordion keydown.accordion');
+    }
 
     if (globalEventTeardown) {
       this.element.off('updated.accordion selected.accordion');

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -263,11 +263,11 @@ Accordion.prototype = {
       targetsToExpand.next('.accordion-pane').removeClass('no-transition');
     }
 
-    // Setup correct ARIA for accordion panes, and auto-collapse them
     panes.each(function addPaneARIA() {
       const pane = $(this);
       const header = pane.prev('.accordion-header');
 
+      // Setup correct ARIA for accordion panes
       header.children('a').attr({ 'aria-haspopup': 'true', role: 'button' });
 
       // double-check the contents of the pane. If all children are filtered out,
@@ -275,15 +275,24 @@ Accordion.prototype = {
       const children = pane.children();
       let allChildrenFiltered = true;
       children.each((i, child) => {
-        if ($(child).is('.accordion-header') && !$(child).hasClass('filtered')) {
+        if ($(child).is('.accordion-header, .accordion-content') && !$(child).hasClass('filtered')) {
           allChildrenFiltered = false;
         }
       });
       pane[allChildrenFiltered ? 'addClass' : 'removeClass']('all-children-filtered');
 
-      if (!self.isExpanded(header)) {
+      if (allChildrenFiltered) {
         pane.data('ignore-animation-once', true);
         self.collapse(header, false);
+      }
+
+      // Preset the "expand/collase" on initial render, if applicable
+      if (!noFilterReset) {
+        let heightAttr = '0px';
+        if (self.isExpanded(header)) {
+          heightAttr = 'auto';
+        }
+        pane.attr('style', `height: ${heightAttr}`);
       }
     });
 
@@ -561,64 +570,68 @@ Accordion.prototype = {
     const data = [];
     const topHeaders = this.element.children('.accordion-header');
 
-    function buildHeaderJSON(el, index, parentNesting, parentArr) {
+    function buildElementJSON(el, index, parentNesting, parentArr) {
       const $el = $(el);
       const pane = $(el).next('.accordion-pane');
-      const headerData = {
-        text: $(el).children('a, span').text().trim(),
-        index: `${parentNesting !== undefined ? `${parentNesting}.` : ''}${index}`
+      const isContentArea = el.classList.contains('accordion-content');
+
+      const elemData = {
+        index: `${parentNesting !== undefined ? `${parentNesting}.` : ''}${index}`,
+        type: isContentArea ? 'content' : 'header'
       };
 
+      if (addElementReference) {
+        elemData.element = el;
+      }
+
       if (el.getAttribute('id')) {
-        headerData.id = el.getAttribute('id');
+        elemData.id = el.getAttribute('id');
+      }
+
+      if (isContentArea) {
+        elemData.content = `${$el.html()}`;
+        elemData.contentText = `${$el.text().trim().replace(/\n|\s{2,}/g, '')}`;
+      } else {
+        elemData.text = $el.children('a, span').text().trim();
       }
 
       const icon = $el.children('.icon');
       if (icon.length) {
-        headerData.icon = icon[0].tagName.toLowerCase() === 'svg' ?
+        elemData.icon = icon[0].tagName.toLowerCase() === 'svg' ?
           icon[0].getElementsByTagName('use')[0].getAttribute('xlink:href') :
           '';
       }
 
-      if (addElementReference) {
-        headerData.element = el;
-      }
-
       if ($el.hasClass('is-disabled')) {
-        headerData.disabled = true;
+        elemData.disabled = true;
       }
 
       if (pane.length) {
-        const content = pane.children('.accordion-content');
-        const subheaders = pane.children('.accordion-header');
-        const subheaderData = [];
+        const subElems = pane.children('.accordion-header, .accordion-content');
+        const subElementData = [];
 
-        if (content.length) {
-          headerData.content = `${content.html()}`;
-        }
-
-        if (subheaders.length) {
+        if (subElems.length) {
           // Normally this will nest.
           // If "flatten" is true, don't nest and add straight to the parent array.
-          let targetArray = subheaderData;
+          let targetArray = subElementData;
           if (flatten) {
             targetArray = parentArr;
           }
 
-          subheaders.each((j, subitem) => {
-            buildHeaderJSON(subitem, j, headerData.index, targetArray);
+          subElems.each((j, subitem) => {
+            buildElementJSON(subitem, j, elemData.index, targetArray);
           });
 
-          headerData.children = subheaderData;
+          elemData.children = subElementData;
         }
       }
 
-      parentArr.push(headerData);
+      parentArr.push(elemData);
     }
 
     // Start traversing the accordion
     topHeaders.each((i, item) => {
-      buildHeaderJSON(item, i, undefined, data);
+      buildElementJSON(item, i, undefined, data);
     });
 
     return data;
@@ -1236,58 +1249,57 @@ Accordion.prototype = {
   },
 
   /**
-   * @param {jQuery[]} headers element references representing accordion headers.
-   * @param {boolean} [doReset] if defined, causes the filtering system to reset.
+   * @param {jQuery[]} targets element references representing accordion headers.
    */
-  filter(headers, doReset) {
-    if (!headers || !headers.length) {
+  filter(targets) {
+    if (!targets || !targets.length) {
       return;
     }
 
     const self = this;
 
-    if (doReset) {
-      this.headers.removeClass('filtered has-filtered-children hide-focus is-expanded');
-      this.panes.removeClass('all-children-filtered is-expanded').removeAttr('style');
-
-      this.currentlyFiltered = $();
-      this.build(undefined, true);
-      this.filter(headers);
-      return;
-    }
+    // Reset all the things
+    this.headers.removeClass('filtered has-filtered-children hide-focus');
+    this.panes.removeClass('all-children-filtered no-transition');
+    this.contentAreas.removeClass('filtered');
+    this.currentlyFiltered = $();
 
     // If headers are included in the currentlyFiltered storage, removes the ones that
     // have previously been filtered
-    const contentAreas = this.contentAreas;
-    const toFilter = headers.add(contentAreas).not(this.currentlyFiltered);
-    let panes = toFilter.next('.accordion-pane');
+    const toFilter = targets.not(this.currentlyFiltered);
 
     // Store a list of all modified parent headers
     let allParentHeaders = $();
+    const allContentAreas = $();
 
     // Perform filtering
-    this.headers.not(toFilter).addClass('filtered');
-    toFilter.each((i, header) => {
-      const parentPanes = $(header).parents('.accordion-pane');
-      if (parentPanes.length) {
-        panes = panes.add(parentPanes.filter((j, item) => panes.index(item) === -1));
-        // only add headers that weren't already in the collection
-        const parentHeaders = parentPanes.prev('.accordion-header').filter((j, item) => allParentHeaders.index(item) === -1);
-        allParentHeaders = allParentHeaders.add(parentHeaders);
+    this.headers.add(this.contentAreas).not(toFilter).addClass('filtered');
+    toFilter.each((i, target) => {
+      const isContentArea = $(target).is('.accordion-content');
+      const allParentPanes = $(target).parents('.accordion-pane');
+
+      // Handle Content Areas
+      if (isContentArea) {
+        allContentAreas.push($(target));
+        const thisParentPane = $(allParentPanes[0]);
+        const thisParentHeader = thisParentPane.prev('.accordion-header').filter((j, item) => allParentHeaders.index(item) === -1);
+        if (thisParentHeader.length) {
+          allParentHeaders = allParentHeaders.add(thisParentHeader);
+        }
       }
-    });
-    this.contentAreas.each((i, contentArea) => {
-      const header = $(contentArea).parent('.accordion-pane').prev('.accordion-header').filter((j, item) => allParentHeaders.index(item) === -1);
-      if (header.length) {
-        allParentHeaders = allParentHeaders.add(header);
+
+      // Handle Labeling of Parent Headers
+      if (allParentPanes.length) {
+        const parentHeaders = allParentPanes.prev('.accordion-header').filter((j, item) => allParentPanes.index(item) === -1);
+        allParentHeaders = allParentHeaders.add(parentHeaders);
       }
     });
 
     allParentHeaders.addClass('has-filtered-children');
-    const expandPromise = this.expand(allParentHeaders.add(panes.prev('.accordion-header')), true);
+    const expandPromise = this.expand(allParentHeaders, true);
 
     $.when(expandPromise).done(() => {
-      this.currentlyFiltered = this.currentlyFiltered.add(toFilter);
+      this.currentlyFiltered = toFilter;
       self.build(undefined, true);
     });
   },
@@ -1309,7 +1321,11 @@ Accordion.prototype = {
     // Store a list of all modified parent headers
     let allParentHeaders = $();
 
-    this.headers.removeClass('filtered');
+    // Reset all the things
+    this.headers.removeClass('filtered has-filtered-children hide-focus');
+    this.panes.removeClass('all-children-filtered no-transition');
+    this.contentAreas.removeClass('filtered');
+
     headers.each((i, header) => {
       const parentPanes = $(header).parents('.accordion-pane');
       if (parentPanes.length) {
@@ -1327,7 +1343,6 @@ Accordion.prototype = {
 
     $.when(collapseDfds).done(() => {
       this.currentlyFiltered = this.currentlyFiltered.not(headers);
-      this.build(undefined, true);
     });
   },
 

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -590,7 +590,7 @@ Accordion.prototype = {
 
       if (isContentArea) {
         elemData.content = `${$el.html()}`;
-        elemData.contentText = `${$el.text().trim().replace(/\n|\s{2,}/g, '')}`;
+        elemData.contentText = `${$el.text().trim().replace(/\n|\s{2,}/g, ' ')}`;
       } else {
         elemData.text = $el.children('a, span').text().trim();
       }

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -97,6 +97,7 @@ Accordion.prototype = {
   build(headers, noFilterReset) {
     let anchors;
     let panes;
+    let contentAreas;
     const self = this;
     let isGlobalBuild = true;
 
@@ -104,18 +105,22 @@ Accordion.prototype = {
       this.headers = this.element.find('.accordion-header');
       headers = this.element.find('.accordion-header');
       this.anchors = headers.children('a');
-      anchors = headers.children('a');
+      anchors = this.anchors;
       this.panes = headers.next('.accordion-pane');
-      panes = headers.next('.accordion-pane');
+      panes = this.panes;
+      this.contentAreas = panes.children('.accordion-content');
+      contentAreas = this.contentAreas;
     } else {
       anchors = headers.children('a');
       panes = headers.next('.accordion-pane');
+      contentAreas = panes.children('.accordion-content');
       isGlobalBuild = false;
 
       // update internal refs
       this.headers = this.headers.add(headers);
       this.anchors = this.anchors.add(anchors);
       this.panes = this.panes.add(panes);
+      this.contentAreas = this.contentAreas.add(contentAreas);
     }
 
     let headersHaveIcons = false;
@@ -1253,7 +1258,8 @@ Accordion.prototype = {
 
     // If headers are included in the currentlyFiltered storage, removes the ones that
     // have previously been filtered
-    const toFilter = headers.not(this.currentlyFiltered);
+    const contentAreas = this.contentAreas;
+    const toFilter = headers.add(contentAreas).not(this.currentlyFiltered);
     let panes = toFilter.next('.accordion-pane');
 
     // Store a list of all modified parent headers
@@ -1268,6 +1274,12 @@ Accordion.prototype = {
         // only add headers that weren't already in the collection
         const parentHeaders = parentPanes.prev('.accordion-header').filter((j, item) => allParentHeaders.index(item) === -1);
         allParentHeaders = allParentHeaders.add(parentHeaders);
+      }
+    });
+    this.contentAreas.each((i, contentArea) => {
+      const header = $(contentArea).parent('.accordion-pane').prev('.accordion-header').filter((j, item) => allParentHeaders.index(item) === -1);
+      if (header.length) {
+        allParentHeaders = allParentHeaders.add(header);
       }
     });
 
@@ -1433,6 +1445,11 @@ Accordion.prototype = {
     if (globalEventTeardown) {
       this.element.off('updated.accordion selected.accordion');
     }
+
+    delete this.anchors;
+    delete this.headers;
+    delete this.panes;
+    delete this.contentAreas;
 
     return this;
   },

--- a/src/components/applicationmenu/applicationmenu.js
+++ b/src/components/applicationmenu/applicationmenu.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-underscore-dangle, prefer-arrow-callback */
 import { utils } from '../../utils/utils';
-import { xssUtils } from '../../utils/xss';
 import { Environment as env } from '../../utils/environment';
 import { breakpoints } from '../../utils/breakpoints';
 import { Locale } from '../locale/locale';

--- a/src/components/autocomplete/autocomplete.js
+++ b/src/components/autocomplete/autocomplete.js
@@ -68,6 +68,12 @@ const DEFAULT_AUTOCOMPLETE_RESULT_ITERATOR_CALLBACK = function resultIterator(it
   return dataset;
 };
 
+/*
+ * Provides a method for highlighting or calling out the matching search term
+ * within rendered filter results.  Note that this method will not be run by the
+ * Autocomplete if the component is configured with an external `displayResultsCallback` method
+ * for handling the display of filter results.
+ */
 const DEFAULT_AUTOCOMPLETE_HIGHLIGHT_CALLBACK = function highlightMatch(item, options) {
   let targetProp = item;
   let hasAlias = false;
@@ -273,7 +279,11 @@ Autocomplete.prototype = {
           if (result.highlightTarget) {
             filterOpts.alias = result.highlightTarget;
           }
-          result = self.settings.highlightCallback(result, filterOpts);
+          // Only render highlight results if we don't do this manually
+          // in another component's rendering method.
+          if (!self.settings.displayResultsCallback) {
+            result = self.settings.highlightCallback(result, filterOpts);
+          }
         }
 
         modifiedFilterResults.push(result);
@@ -287,7 +297,7 @@ Autocomplete.prototype = {
     if (typeof this.settings.displayResultsCallback === 'function') {
       this.settings.displayResultsCallback(modifiedFilterResults, () => {
         self.element.trigger('listopen', [modifiedFilterResults]);
-      });
+      }, term);
       return;
     }
 

--- a/test/components/accordion/accordion-api.func-spec.js
+++ b/test/components/accordion/accordion-api.func-spec.js
@@ -143,13 +143,11 @@ describe('Accordion API (settings)', () => {
   });
 });
 
-fdescribe('Accordion API (data)', () => {
+describe('Accordion API (data)', () => {
   beforeEach(() => {
     accordionEl = null;
     accordionObj = null;
     document.body.insertAdjacentHTML('afterbegin', svg);
-    document.body.insertAdjacentHTML('afterbegin', accordionHTML);
-    accordionEl = document.body.querySelector('.accordion');
   });
 
   afterEach(() => {
@@ -162,13 +160,15 @@ fdescribe('Accordion API (data)', () => {
   });
 
   it('can create a data representation of itself', () => {
+    document.body.insertAdjacentHTML('afterbegin', accordionHTML);
+    accordionEl = document.body.querySelector('.accordion');
     accordionObj = new Accordion(accordionEl);
     const data = accordionObj.toData();
 
     expect(Array.isArray(data)).toBeTruthy();
     expect(data.length).toBe(4);
     expect(data[0].text).toBe('Warehouse Location');
-    expect(data[0].content).toBeDefined();
-    debugger;
+    expect(data[0].type).toBe('header');
+    expect(Array.isArray(data[0].children)).toBeTruthy();
   });
 });

--- a/test/components/accordion/accordion-api.func-spec.js
+++ b/test/components/accordion/accordion-api.func-spec.js
@@ -142,3 +142,33 @@ describe('Accordion API (settings)', () => {
     expect(accordionObj.settings.expanderDisplay).toEqual('classic');
   });
 });
+
+fdescribe('Accordion API (data)', () => {
+  beforeEach(() => {
+    accordionEl = null;
+    accordionObj = null;
+    document.body.insertAdjacentHTML('afterbegin', svg);
+    document.body.insertAdjacentHTML('afterbegin', accordionHTML);
+    accordionEl = document.body.querySelector('.accordion');
+  });
+
+  afterEach(() => {
+    accordionObj.destroy();
+    cleanup([
+      '.accordion',
+      '.svg-icons',
+      '.row',
+    ]);
+  });
+
+  it('can create a data representation of itself', () => {
+    accordionObj = new Accordion(accordionEl);
+    const data = accordionObj.toData();
+
+    expect(Array.isArray(data)).toBeTruthy();
+    expect(data.length).toBe(4);
+    expect(data[0].text).toBe('Warehouse Location');
+    expect(data[0].content).toBeDefined();
+    debugger;
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a handful of bugs in the App Menu's Accordion when combined with a Searchfield for filtering available headers.

**Related github/jira issue (required)**:
Closes #3131 

**Steps necessary to review your pull request (required)**:
Pull this branch, build, run the app.  Then check the following:

*Issue 1 - Check visibility of parent headers that don't match the filter, but contain children that do:*
- Open http://localhost:4000/components/applicationmenu/example-filterable.html
- In the input, type "role".  The accordion headers not containing the word "role" should all be filtered out.  The ones containing the word "role" should all be expanded, despite this accordion being configured to only expand one parent header at a time.
- Use the "x" to clear the filter.  All headers should collapse.
- In the input, type "user". 
- Click on "User Settings" to select it.  Notice that "My Account" is still visible, but grayed out and tougher to read.  This is because it doesn't match the filter.  (Check this on Vibrant theme as well).

*Issue 2 - Check that accordion headers that match the filter are displayed, but their children that don't match the header are not:*
- Open http://localhost:4000/components/applicationmenu/example-filterable.html
- Type 'My' into the input.  Notice that "My Account" and "My Roles" are shown.  Neither of the headers' children are displayed and they should remain hidden if clicked, since they don't match the filter.

*Issue 3 - Accordion Content areas should be filterable:*
- Open http://localhost:4000/components/applicationmenu/example-filterable.html
- Click on "My Account".  Notice there are four headers and a content area at the top containing an avatar, info about the user, and a link.
- Using the input, type "Homepages".  
- When the filter occurs, the content area underneath "My Account" should disappear since nothing inside matches the filter.
- Using the input, type "User".
- When the filter occurs, the content area underneath "My Account" should reappear, along with another header underneath which also contains the word "User"

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
