### PR TITLE
3449 - Added typecheck for `destroy` functions in Toolbar teardown.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,7 @@
 - `[Searchfield]` Fixed a bug where changing filter results while the autocomplete is open may result in the menu being positioned incorrectly. ([#3243](https://github.com/infor-design/enterprise/issues/3243))
 - `[Splitter]` Fixed an issue in the destroy function where the expand button was not removed. ([#3371](https://github.com/infor-design/enterprise/issues/3371))
 - `[Swaplist]` Fixed an issue where top buttons were not aligned in Firefox. ([#3425](https://github.com/infor-design/enterprise/issues/3425))
+- `[Toolbar]` Fixed an issue where some `destroy()` methods being called in `teardown()` were not typechecking for the `destroy()` method, and sometimes would incorrectly try to call this on an object or data property defined as `button`. ([#3449](https://github.com/infor-design/enterprise/issues/3449))
 - `[Validation/Checkboxes]` Fixed issues with making checkboxes required, the styling did not work for it and the scrollIntoView function and validation failed to fire. Note that to add required to the checkbox you need to add an extra span, adding a class to the label will not work because the checkbox is styled using the label already. ([#3147](https://github.com/infor-design/enterprise/issues/3147))
 - `[Validation]` Fixed an issue where calling removeMessage would not remove a manually added error class. ([#3318](https://github.com/infor-design/enterprise/issues/3318))
 

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -1464,12 +1464,12 @@ Toolbar.prototype = {
 
     this.items.each((i, item) => {
       const tooltipAPI = $(item).data('tooltip');
-      if (tooltipAPI) {
+      if (tooltipAPI && typeof tooltipAPI.destroy === 'function') {
         tooltipAPI.destroy();
       }
 
       const buttonAPI = $(item).data('button');
-      if (buttonAPI) {
+      if (buttonAPI && typeof buttonAPI.destroy === 'function') {
         buttonAPI.destroy();
       }
 
@@ -1489,7 +1489,7 @@ Toolbar.prototype = {
 
     if (this.title && this.title.length) {
       const dataTooltip = this.title.off('beforeshow.toolbar').data('tooltip');
-      if (dataTooltip) {
+      if (dataTooltip && typeof dataTooltip.destroy === 'function') {
         dataTooltip.destroy();
       }
 
@@ -1507,7 +1507,8 @@ Toolbar.prototype = {
       // one update cycle, or until the setting is reset to `true`.
       if (!this.settings.noSearchfieldReinvoke && !this.keepSearchfield) {
         const searchFields = this.buttonset.children('.searchfield-wrapper').children('.searchfield');
-        if (searchFields.data('searchfield')) {
+        const searchFieldAPI = searchFields.data('searchfield');
+        if (searchFieldAPI && typeof searchFieldAPI.destroy === 'function') {
           searchFields.data('searchfield').destroy();
         }
       } else if (this.keepSearchfield) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes an issue where some `destroy()` methods being called in the Toolbar component's `teardown()` method were not typechecking for the method, and sometimes would incorrectly try to call it on an object or data property defined as `button`.  This PR adds a check for a function to these calls before they're run.

**Related github/jira issue (required)**:
Closes #3449

**Steps necessary to review your pull request (required)**:
- Need to run this PR against the latest NG to see the effect.
- Open http://localhost:4200/ids-enterprise-ng-demo/toolbar-state
- Open a developer tools console
- Use the Application menu to switch to another standard toolbar test, such as http://localhost:4200/ids-enterprise-ng-demo/toolbar-datadriven
- In the dev tools console, ensure that there are no Javascript errors thrown.  In the browser, ensure the page changes with no issues.

**Included in this Pull Request**:
- [x] A note to the change log.
