### PR TITLE
2565 - Fix ie drag columns and icon placement

### DIFF
--- a/app/views/components/datagrid/example-fixed-header.html
+++ b/app/views/components/datagrid/example-fixed-header.html
@@ -29,6 +29,7 @@
         //Init and get the api for the grid
         $('#datagrid').datagrid({
           columns: columns,
+          columnReorder: true,
           dataset: data,
           paging: true,
           pagesize: 100,

--- a/app/views/components/datagrid/example-reorder.html
+++ b/app/views/components/datagrid/example-reorder.html
@@ -44,12 +44,14 @@
           pagesizes: [5, 10, 15],
           filterable: true,
           saveColumns: false,  //deprecated
-          saveUserSettings: {columns: true,
-                             rowHeight: true,
-                             sortOrder: true,
-                             pagesize: true,
-                             filter: true},
-          toolbar: {title: 'Compressors', actions: true, results: true, personalize: true, filterRow: true, results: true, resetLayout: true}
+          saveUserSettings: {
+            columns: true,
+            rowHeight: true,
+            sortOrder: true,
+            pagesize: true,
+            filter: true
+          },
+          toolbar: {title: 'Compressors', actions: true, results: true, personalize: true, filterRow: true, results: true, rowHeight: true, resetLayout: true}
         }).on('settingschanged', function (e, args) {
           console.log('Settings Changed', args);
         });

--- a/src/components/datagrid/_datagrid-uplift.scss
+++ b/src/components/datagrid/_datagrid-uplift.scss
@@ -144,6 +144,19 @@
   &.medium-rowheight th.text-ellipsis .datagrid-header-text {
     margin: 5px 0 0 !important;
   }
+
+  th .handle {
+    margin-top: -2px;
+  }
+
+  &.short-rowheight th .handle {
+    margin-top: -3px;
+  }
+
+  &.medium-rowheight th .handle {
+    font-size: 1.6em;
+    margin-top: -1px;
+  }
 }
 
 .datagrid.short-rowheight tbody tr td.datagrid-trigger-cell .icon {

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -3792,11 +3792,9 @@ html[dir='rtl'] {
       display: none;
       font-size: 3rem;
       height: $datagrid-header-height;
-      left: 0;
       margin: 0;
       padding: 0 0 0 5px;
       position: absolute;
-      top: 0;
 
       &.is-draggable-target {
         &.last {

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -441,9 +441,9 @@ $datagrid-short-row-height: 25px;
 
       .handle,
       .is-draggable-target {
-        @include font-size(22);
-
+        font-size: 24px;
         height: $datagrid-short-header-height;
+        margin-top: -1px;
         padding: 0 0 0 2px;
       }
 
@@ -547,9 +547,10 @@ $datagrid-short-row-height: 25px;
 
       .handle,
       .is-draggable-target {
-        font-size: 2.3em;
+        font-size: 2em;
         height: $datagrid-medium-header-height;
-        padding: 0 0 0 5px;
+        margin-top: -1px;
+        padding: 0 0 0 4px;
         width: 16px;
       }
 
@@ -3874,14 +3875,14 @@ html[dir='rtl'] {
   .has-draggable-columns {
     th {
       .handle {
-        padding: 6px 0 0 7px;
+        padding: 4px 0 0 5px;
       }
     }
 
     &.short-rowheight {
       th {
         .handle {
-          padding: 3px 0 0 1.5px;
+          padding: 3px 0 0 2px;
         }
       }
     }
@@ -3889,7 +3890,7 @@ html[dir='rtl'] {
     &.medium-rowheight {
       th {
         .handle {
-          padding: 3px 0 0 3px;
+          padding: 4px 0 0 3px;
         }
       }
     }
@@ -4180,7 +4181,13 @@ html[dir='rtl'] {
 
 // IE 11 Hacks
 .ie11 {
-  .datagrid-header th {
-    z-index: auto;
+  .datagrid-header {
+    .datagrid-filter-wrapper input {
+      padding: 0 5px;
+    }
+
+    th {
+      z-index: auto;
+    }
   }
 }

--- a/src/components/textarea/textarea.js
+++ b/src/components/textarea/textarea.js
@@ -139,7 +139,7 @@ Textarea.prototype = {
   /**
   * Resizes the texarea based on the content.
   * @private
-  * @param {obkect} self The textaarea api
+  * @param {object} self The textaarea api
   * @param {event} e The resive event object
   */
   handleResize(self, e) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

A bug in css caused drag drop of columns to not work in IE11. Fixed this and also sorted out some icon placement issues on the header row.

**Related github/jira issue (required)**:
Fixes #2565 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-reorder.html?theme=uplift&variant=light
- hover the columns and check the drag drop icon placement in both filter row and no filter row
- open http://localhost:4000/components/datagrid/example-grouped-headers (or same issue really on http://localhost:4000/components/datagrid/example-reorder.html) in IE. Should be able to drag the columns in IE as well. 
