### PR TITLE
3147 - Fix checkbox alignment in checkboxes and dirty indicators

### DIFF
--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -209,7 +209,11 @@ label.inline .checkbox ~ .label-text,
   label.inline .checkbox ~ .label-text,
   .checkbox-label {
     display: inline-block;
-    line-height: 19px;
+    line-height: 17px;
+  }
+
+  .field-checkbox .icon-dirty {
+    left: 0;
   }
 }
 

--- a/src/components/icons/_icons-uplift.scss
+++ b/src/components/icons/_icons-uplift.scss
@@ -31,5 +31,5 @@
 }
 
 .icon-dirty.dirty-checkbox.is-checked {
-  top: 3px;
+  top: 2px;
 }

--- a/src/components/icons/_icons-uplift.scss
+++ b/src/components/icons/_icons-uplift.scss
@@ -33,3 +33,9 @@
 .icon-dirty.dirty-checkbox.is-checked {
   top: 2px;
 }
+
+.is-firefox {
+  .icon-dirty.dirty-checkbox.is-checked {
+    top: 2px !important;
+  }
+}

--- a/src/components/icons/_icons.scss
+++ b/src/components/icons/_icons.scss
@@ -215,8 +215,8 @@ svg.icon-logo {
   &.dirty-checkbox {
     &.is-checked {
       border-width: 4px;
-      left: 1px;
-      top: 1px;
+      left: 0;
+      top: 0;
       z-index: 2;
     }
   }
@@ -645,4 +645,11 @@ html[dir='rtl'] {
     margin: 1px 1px 0 0;
   }
 
+}
+
+.is-firefox {
+  .icon-dirty.dirty-checkbox.is-checked {
+    left: 0;
+    top: 2px;
+  }
 }

--- a/src/components/icons/_icons.scss
+++ b/src/components/icons/_icons.scss
@@ -650,6 +650,6 @@ html[dir='rtl'] {
 .is-firefox {
   .icon-dirty.dirty-checkbox.is-checked {
     left: 0;
-    top: 2px;
+    top: 0;
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed additional layout issues in firefox and ios.

**Related github/jira issue (required)**:
Fixes #3147 

**Steps necessary to review your pull request (required)**:
- open http://localhost:4000/components/checkboxes/example-index.html
- test the dirty indicator in Chrome, Firefox and IOS (ipad)

If its close i'm leaving this not worrying about a half pixel
