### PR TITLE
3458 - Fix modal disappear on tabbing out with fileupload

### DIFF
--- a/app/views/components/modal/test-fileupload-scroll.html
+++ b/app/views/components/modal/test-fileupload-scroll.html
@@ -1,0 +1,155 @@
+
+<div class="row top-padding">
+  <div class="twelve columns">
+
+    <button class="btn-secondary" type="button" id="show">Show Modal</button>
+
+    <div id="modal" class="modal">
+       <div class="modal-content">
+
+          <div class="modal-header">
+            <h1 class="modal-title" >Add Comment</h1>
+          </div>
+
+          <div class="modal-body-wrapper">
+            <div class="modal-body">
+              <div class="field">
+                <label for="context-type1">Type</label>
+                <select class="dropdown" id="context-type1" name="type1">
+                  <option value="1">Context #1</option>
+                  <option value="2">Context #2</option>
+                  <option value="3">Context #3</option>
+                  <option value="4">Context #4</option>
+                  <option value="5">Context #5</option>
+                </select>
+              </div>
+
+              <div class="field">
+                <label for="context-name1" class="required">Name</label>
+                <input id="context-name1" aria-required="true" name="context-name1" type="text"/>
+              </div>
+
+              <div class="field">
+                <label for="context-desc1" class="required">Page Title</label>
+                <textarea id="context-desc1" aria-required="true" name="context-desc1" maxlength="50"></textarea>
+              </div>
+
+              <div class="field">
+                <label for="context-type2">Type</label>
+                <select class="dropdown" id="context-type2" name="type2">
+                  <option value="1">Context #1</option>
+                  <option value="2">Context #2</option>
+                  <option value="3">Context #3</option>
+                  <option value="4">Context #4</option>
+                  <option value="5">Context #5</option>
+                </select>
+              </div>
+
+              <div class="field">
+                <label for="context-name2" class="required">Name</label>
+                <input id="context-name2" aria-required="true" name="context-name2" type="text"/>
+              </div>
+
+              <div class="field">
+                <label for="context-desc2" class="required">Page Title</label>
+                <textarea id="context-desc2" aria-required="true" name="context-desc2" maxlength="50"></textarea>
+              </div>
+
+              <div class="field">
+                <label for="context-type3">Type</label>
+                <select class="dropdown" id="context-type3" name="type3">
+                  <option value="1">Context #1</option>
+                  <option value="2">Context #2</option>
+                  <option value="3">Context #3</option>
+                  <option value="4">Context #4</option>
+                  <option value="5">Context #5</option>
+                </select>
+              </div>
+
+              <div class="field">
+                <label for="context-name4" class="required">Name</label>
+                <input id="context-name4" aria-required="true" name="context-name4" type="text"/>
+              </div>
+
+              <div class="field">
+                <label for="context-desc4" class="required">Page Title</label>
+                <textarea id="context-desc4" aria-required="true" name="context-desc4" maxlength="50"></textarea>
+              </div>
+
+
+              <div class="field">
+                <label for="context-name5" class="required">Name</label>
+                <input id="context-name5" aria-required="true" name="context-name5" type="text"/>
+              </div>
+
+              <div class="field">
+                <label for="context-desc5" class="required">Page Title</label>
+                <textarea id="context-desc5" aria-required="true" name="context-desc5" maxlength="50"></textarea>
+              </div>
+
+              <div class="field">
+                <label for="context-name6" class="required">Name</label>
+                <input id="context-name6" aria-required="true" name="context-name6" type="text"/>
+              </div>
+
+              <div class="field">
+                <label for="context-desc6" class="required">Page Title</label>
+                <textarea id="context-desc6" aria-required="true" name="context-desc6" maxlength="50"></textarea>
+              </div>
+
+              <div class="field">
+                <label for="context-name7" class="required">Name</label>
+                <input id="context-name7" aria-required="true" name="context-name7" type="text"/>
+              </div>
+
+              <div class="field">
+                <label for="context-desc7" class="required">Page Title</label>
+                <textarea id="context-desc7" aria-required="true" name="context-desc7" maxlength="50"></textarea>
+              </div>
+
+              <div class="field">
+                <label for="context-name8" class="required">Name</label>
+                <input id="context-name8" aria-required="true" name="context-name8" type="text"/>
+              </div>
+
+              <div class="field">
+                <label for="context-desc8" class="required">Page Title</label>
+                <textarea id="context-desc8" aria-required="true" name="context-desc8" maxlength="50"></textarea>
+              </div>
+
+              <div class="field">
+                <label for="context-name9" class="required">Name</label>
+                <input id="context-name9" aria-required="true" name="context-name9" type="text"/>
+              </div>
+
+              <div class="field">
+                <label for="context-desc9" class="required">Page Title</label>
+                <textarea id="context-desc9" aria-required="true" name="context-desc9" maxlength="50"></textarea>
+              </div>
+
+              <div class="field">
+                <label for="fileupload">Upload a File</label>
+                <input type="file" class="fileupload" id="fileupload" name="fileupload">
+              </div>
+
+              <div class="modal-buttonset">
+                <button type="button" class="btn-modal">Cancel</button>
+                <button type="button" id="submit" class="btn-modal-primary">Submit</button>
+              </div>
+            </div>
+          </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<script>
+  $('#show').on('click', function () {
+
+    $('body').modal({
+      content: $('#modal')
+    });
+
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,7 +31,7 @@
 - `[Datagrid]` Add options to `toolbar.filterRow` so that instead of true/false you can set `showFilter, clearFilter, runFilter` independently. ([#1479](https://github.com/infor-design/enterprise/issues/1479))
 - `[Datagrid]` Added fixes to improve the usage of the textarea editor. ([#3417](https://github.com/infor-design/enterprise/issues/3417))
 - `[Datepicker]` Fixed an issue where setting date format with comma character was not working. ([#3008](https://github.com/infor-design/enterprise/issues/3008))
-- `[Fileupload]` Fixed an issue where tabbing out was causing to modal dialog disappear. ([#3458](https://github.com/infor-design/enterprise/issues/3458))
+- `[Fileupload]` Fixed an issue where tabbing out of a fileupload in was causing the modal dialog to disappear. ([#3458](https://github.com/infor-design/enterprise/issues/3458))
 - `[Form Compact Layout]` Added support for `form-compact-layout` the remaining components. ([#3008](https://github.com/infor-design/enterprise/issues/3329))
 - `[Dropdown]` Fixed a bug that was causing the `selectValue()` method not to update the visual display of the in-page Dropdown element. ([#3432](https://github.com/infor-design/enterprise/issues/3432))
 - `[Icons]` Fixed color inconsistencies of the icons when the fields are in readonly state. ([#3176](https://github.com/infor-design/enterprise/issues/3176))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `[Datagrid]` Add options to `toolbar.filterRow` so that instead of true/false you can set `showFilter, clearFilter, runFilter` independently. ([#1479](https://github.com/infor-design/enterprise/issues/1479))
 - `[Datagrid]` Added fixes to improve the usage of the textarea editor. ([#3417](https://github.com/infor-design/enterprise/issues/3417))
 - `[Datepicker]` Fixed an issue where setting date format with comma character was not working. ([#3008](https://github.com/infor-design/enterprise/issues/3008))
+- `[Fileupload]` Fixed an issue where tabbing out was causing to modal dialog disappear. ([#3458](https://github.com/infor-design/enterprise/issues/3458))
 - `[Form Compact Layout]` Added support for `form-compact-layout` the remaining components. ([#3008](https://github.com/infor-design/enterprise/issues/3329))
 - `[Dropdown]` Fixed a bug that was causing the `selectValue()` method not to update the visual display of the in-page Dropdown element. ([#3432](https://github.com/infor-design/enterprise/issues/3432))
 - `[Icons]` Fixed color inconsistencies of the icons when the fields are in readonly state. ([#3176](https://github.com/infor-design/enterprise/issues/3176))

--- a/src/components/fileupload/fileupload.js
+++ b/src/components/fileupload/fileupload.js
@@ -53,7 +53,7 @@ FileUpload.prototype = {
     elemClass = elemClass ? ` ${elemClass}` : '';
 
     const instructions = Locale.translate('FileUpload');
-    let label = $(`<label for="${id}-filename">${elem.text()} <span class="audible">${instructions}</span></label>`);
+    const label = $(`<label for="${id}-filename">${elem.text()} <span class="audible">${instructions}</span></label>`);
     const shadowField = $(`<input readonly id="${id}-filename" class="fileupload-background-transparent${elemClass}" type="text">`);
     const svg = `<span class="trigger" tabindex="-1">${$.createIcon('folder')}</span>`;
     const svgClose = `<span class="trigger-close" tabindex="-1">${$.createIcon('close')}</span>`;
@@ -66,16 +66,12 @@ FileUpload.prototype = {
         orgLabel = elem.parent().prev('label');
       }
 
-      label = $(`<label for="${(elem.attr('id') || elem.attr('name'))}-filename">${orgLabel.text()}</label>`);
-      elem.before(label, shadowField);
-      this.fileInput.after(svgClose);
-      this.fileInput.after(svg);
-      orgLabel.addClass('audible').append(`<span class="audible">${instructions}</span>`);
-    } else {
-      elem.before(label, shadowField);
-      this.fileInput.after(svgClose);
-      this.fileInput.after(svg);
+      label.html(`${orgLabel.text()} <span class="audible">${instructions}</span>`);
+      orgLabel.addClass('audible').add(this.fileInput).attr('tabindex', '-1');
     }
+
+    elem.before(label, shadowField);
+    this.fileInput.after(svg, svgClose);
 
     // if there is a value attribute, then this will be used as the current value since unable to set files[0].name
     // move it to the text input and remove it off the file input


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed tabbing out was causing to modal dialog disappear with Fileupload.

**Related github/jira issue (required)**:
Fixes #3458

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/modal/test-fileupload-scroll.html
- Click on the button `Show Modal`
- The modal should display and focus should be in the first field
- Use tab key to tab through all the fields, file upload in the last field
- Modal dialog should not disappears when tabbing out of the file upload field

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
