### PR TITLE
3079 - Fix add event in safari with calendar

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `[Calendar]` Fixed issue where on month view in events info `Date` and `Duration` fields were not working with some events and `Duration` field. Now `Duration` field support `Days, Hours and Minutes` text. ([#2777](https://github.com/infor-design/enterprise/issues/2777))
 - `[Calendar]` Fixed an issue where link was not working on monthview to switch to day view when clicked on more events on that day. ([#3181](https://github.com/infor-design/enterprise/issues/3181))
 - `[Calendar]` Fixed a calendar event where the start date today is not displaying as upcoming event in different timezone. ([#2776](https://github.com/infor-design/enterprise/issues/2776))
+- `[Calendar]` Fixed an issue where adding an event was inconsistent in Safari. ([#3079](https://github.com/infor-design/enterprise/issues/3079))
 - `[Calendar]` Fixed an issue where any event was not rendering in day and week view. ([#3222](https://github.com/infor-design/enterprise/issues/3222))
 - `[Calendar]` Fixed an issue where date selection was not persist when switching from month view to week view to day view. ([#3319](https://github.com/infor-design/enterprise/issues/3319))
 - `[Colors]` Fixed an incorrect ruby06 color, and made the background change on theme change now (again). ([#3448](https://github.com/infor-design/enterprise/issues/3448))

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -541,7 +541,7 @@ Calendar.prototype = {
     const self = this;
 
     // Check for events starting on this day , or only on this day.
-    const startDate = new Date(event.starts);
+    const startDate = Locale.newDateObj(event.starts);
     const startKey = stringUtils.padDate(
       startDate.getFullYear(),
       startDate.getMonth(),
@@ -549,7 +549,7 @@ Calendar.prototype = {
     );
 
     // Check for events extending onto this day
-    const endDate = new Date(event.ends);
+    const endDate = Locale.newDateObj(event.ends);
     const endKey = stringUtils.padDate(
       endDate.getFullYear(),
       endDate.getMonth(),

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -530,14 +530,8 @@ const Locale = {  // eslint-disable-line
     }
 
     // Convert if a timezone string.
-    if (!(value instanceof Date) && typeof value === 'string' && value.indexOf('Z') > -1) {
-      const tDate1 = new Date(value);
-      value = tDate1;
-    }
-
-    if (!(value instanceof Date) && typeof value === 'string' && value.indexOf('T') > -1) {
-      const tDate1 = new Date(value);
-      value = tDate1;
+    if (typeof value === 'string' && /T|Z/g.test(value)) {
+      value = this.newDateObj(value);
     }
 
     // Convert if a string..
@@ -684,6 +678,23 @@ const Locale = {  // eslint-disable-line
     }
 
     return ret.trim();
+  },
+
+  /**
+   * Get date object by given date string.
+   * @private
+   * @param {string} dateStr The date string
+   * @returns {object} The date object.
+   */
+  newDateObj(dateStr) {
+    let date = new Date(dateStr);
+    // Safari was not render the right date/time with timezone string
+    if (env.browser.name === 'safari' && typeof dateStr === 'string' && /T|Z/g.test(dateStr)) {
+      let arr = dateStr.replace(/Z/, '').replace(/T|:/g, '-').split('-');
+      arr = arr.map((x, i) => +(i === 1 ? x - 1 : x));
+      date = new Date(...arr);
+    }
+    return date;
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed adding an event was inconsistent in Safari with Calendar.

**Related github/jira issue (required)**:
Closes #3079

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Use Safari
- Navigate to http://localhost:4000/components/calendar/example-index.html
- Click `Today`
- Click `+` button and Click `Add Event (Modal)`
- Make sure the picked date in `From` and `To` both today's date and the All day is checked
- See the added event should only be for today's date

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
