### PR TITLE
2867 - Fix expandable rows and frozen columns with datagrid

### DIFF
--- a/app/views/components/datagrid/test-expandable-row-frozen-columns-bothsides.html
+++ b/app/views/components/datagrid/test-expandable-row-frozen-columns-bothsides.html
@@ -1,0 +1,72 @@
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+{{={{{ }}}=}}
+
+<script>
+  $('body').one('initialized', function () {
+
+      var grid,
+        columns = [],
+        data = [];
+
+      // Some Sample Data
+      data.push({ id: 1, productId: 2142201, sku: '<b>SKU #9000001-237</b>', productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+      data.push({ id: 2, productId: 2241202, sku: '<b>SKU #9000001-236</b>', productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+      data.push({ id: 3, productId: 2342203, sku: '<b>SKU #9000001-235</b>', productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+      data.push({ id: 4, productId: 2445204, sku: '<b>SKU #9000001-234</b>', productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+      data.push({ id: 5, productId: 2542205, sku: '<b>SKU #9000001-233</b>', productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+      data.push({ id: 5, productId: 2642205, sku: '<b>SKU #9000001-232</b>', productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+      data.push({ id: 6, productId: 2642206, sku: '<b>SKU #9000001-231</b>', productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+
+      // Define Columns for the Grid.
+
+      columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Expander, filterType: 'text', textOverflow: 'ellipsis', width: 150, hideable: false});
+      columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', filterType: 'text', formatter: Formatters.Hyperlink});
+      columns.push({ id: 'activity', name: 'Activity', field: 'activity', filterType: 'text'});
+      columns.push({ id: 'quantity1', name: 'Quantity 1', field: 'quantity'});
+      columns.push({ id: 'quantity2', name: 'Quantity 2', field: 'quantity'});
+      columns.push({ id: 'quantity3', name: 'Quantity 3', field: 'quantity'});
+      columns.push({ id: 'quantity4', name: 'Quantity 4', field: 'quantity'});
+      columns.push({ id: 'quantity5', name: 'Quantity 5', field: 'quantity'});
+      columns.push({ id: 'quantity6', name: 'Quantity 6', field: 'quantity'});
+      columns.push({ id: 'quantity7', name: 'Quantity 7', field: 'quantity'});
+      columns.push({ id: 'quantity8', name: 'Quantity 8', field: 'quantity'});
+      columns.push({ id: 'quantity9', name: 'Quantity 9', field: 'quantity'});
+      columns.push({ id: 'quantity10', name: 'Quantity 10', field: 'quantity'});
+
+      var rowTemplate = '<div class="datagrid-cell-layout"><div class="img-placeholder"><svg class="icon" focusable="false" aria-hidden="true" role="presentation"><use xlink:href="#icon-camera"></use></svg></div></div>'+
+                        '<div class="datagrid-cell-layout"><p class="datagrid-row-heading">Expandable Content Area</p>' +
+                        '<p class="datagrid-row-micro-text">{{{sku}}}</p>'+
+                        '<span class="datagrid-wrapped-text">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only...</span>'+
+                        '<a class="hyperlink" href="https://design.infor.com/" target="_blank" >Read more</a>';
+
+      // Init and get the api for the grid
+      grid = $('#datagrid').datagrid({
+        columns: columns,
+        idProperty:'officeId',
+        dataset: data,
+        filterable: true,
+        // Required for Frozen Columns and Expandable Areas to sync the areas
+        rowTemplateHeight: 168,
+        rowTemplate: rowTemplate,
+        frozenColumns: { left: ['productId'], right:['quantity10'] },
+        toolbar: {title: 'Data Grid Header Title', collapsibleFilter: true,
+          results: true, keywordFilter: true, actions: true, exportToExcel: true, rowHeight: true, personalize: true}
+      });
+
+      grid.on('expandrow', function (e, args) {
+        console.log('expandrow', args);
+      });
+
+      grid.on('collapserow', function (e, args) {
+        console.log('collapserow', args);
+      });
+
+});
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `[Colors]` Fixed an incorrect ruby06 color, and made the background change on theme change now (again). ([#3448](https://github.com/infor-design/enterprise/issues/3448))
 - `[Datagrid]` Fixed an issue where focus on reload data was forced to be on active cell. ([#358](https://github.com/infor-design/enterprise-ng/issues/358))
 - `[Datagrid]` Fixed a bug where if a filter row column is frozen the mask and editor options would not be applied. ([#2553](https://github.com/infor-design/enterprise-ng/issues/2553))
+- `[Datagrid]` Fixed an issue where using rowTemplate/expandableRows and frozenColumns was not rendered properly. ([#2867](https://github.com/infor-design/enterprise/issues/2867))
 - `[Datagrid]` Fixed hover color should not be similar to alternate rows when hovering in uplift high contrast. ([#3338](https://github.com/infor-design/enterprise/issues/3338))
 - `[Datagrid]` Fixed a demo app issue filtering decimal fields in some examples. ([#3351](https://github.com/infor-design/enterprise/issues/3351))
 - `[Datagrid]` Fixed an issue where some columns were disappear after resizing the browser or after changing themes. ([#3434](https://github.com/infor-design/enterprise/issues/3434))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,7 +24,7 @@
 - `[Colors]` Fixed an incorrect ruby06 color, and made the background change on theme change now (again). ([#3448](https://github.com/infor-design/enterprise/issues/3448))
 - `[Datagrid]` Fixed an issue where focus on reload data was forced to be on active cell. ([#358](https://github.com/infor-design/enterprise-ng/issues/358))
 - `[Datagrid]` Fixed a bug where if a filter row column is frozen the mask and editor options would not be applied. ([#2553](https://github.com/infor-design/enterprise-ng/issues/2553))
-- `[Datagrid]` Fixed an issue where using rowTemplate/expandableRows and frozenColumns was not rendered properly. ([#2867](https://github.com/infor-design/enterprise/issues/2867))
+- `[Datagrid]` Fixed an issue where when using rowTemplate/expandableRows and frozenColumns on both sides the right side did not render properly. ([#2867](https://github.com/infor-design/enterprise/issues/2867))
 - `[Datagrid]` Fixed hover color should not be similar to alternate rows when hovering in uplift high contrast. ([#3338](https://github.com/infor-design/enterprise/issues/3338))
 - `[Datagrid]` Fixed a demo app issue filtering decimal fields in some examples. ([#3351](https://github.com/infor-design/enterprise/issues/3351))
 - `[Datagrid]` Fixed an issue where some columns were disappear after resizing the browser or after changing themes. ([#3434](https://github.com/infor-design/enterprise/issues/3434))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3914,6 +3914,7 @@ Datagrid.prototype = {
     if (self.settings.rowTemplate) {
       const tmpl = self.settings.rowTemplate;
       const item = rowData;
+      const height = self.settings.rowTemplateHeight || 107;
       let renderedTmpl = '';
 
       if (Tmpl && item) {
@@ -3922,27 +3923,33 @@ Datagrid.prototype = {
 
       if (this.hasLeftPane) {
         containerHtml.left += `<tr class="datagrid-expandable-row no-border"><td colspan="${visibleColumnsLeft}">
-          <div class="datagrid-row-detail"><div style="height: ${self.settings.rowTemplateHeight || '107'}px"></div></div>
+          <div class="datagrid-row-detail"><div style="height: ${height}px"></div></div>
           </td></tr>`;
       }
       containerHtml.center += `<tr class="datagrid-expandable-row"><td colspan="${visibleColumnsCenter}">
         <div class="datagrid-row-detail"><div class="datagrid-row-detail-padding">${renderedTmpl}</div></div>
         </td></tr>`;
       if (this.hasRightPane) {
-        containerHtml.right += `<tr class="datagrid-expandable-row"><td colspan="${visibleColumnsLeft}">
+        containerHtml.right += `<tr class="datagrid-expandable-row no-border"><td colspan="${visibleColumnsRight}">
+          <div class="datagrid-row-detail"><div style="height: ${height}px"></div></div>
           </td></tr>`;
       }
     }
 
     if (self.settings.expandableRow) {
       if (this.hasLeftPane) {
-        containerHtml.left += `<tr class="datagrid-expandable-row"><td colspan="${visibleColumnsLeft}">` +
-          '<div class="datagrid-row-detail"><div class="datagrid-row-detail-padding"></div></div>' +
-          '</td></tr>';
+        containerHtml.left += `<tr class="datagrid-expandable-row"><td colspan="${visibleColumnsLeft}">
+          <div class="datagrid-row-detail"><div class="datagrid-row-detail-padding"></div></div>
+          </td></tr>`;
       }
-      containerHtml.center += `<tr class="datagrid-expandable-row"><td colspan="${visibleColumnsCenter}">` +
-        '<div class="datagrid-row-detail"><div class="datagrid-row-detail-padding"></div></div>' +
-        '</td></tr>';
+      containerHtml.center += `<tr class="datagrid-expandable-row"><td colspan="${visibleColumnsCenter}">
+        <div class="datagrid-row-detail"><div class="datagrid-row-detail-padding"></div></div>
+        </td></tr>`;
+      if (this.hasRightPane) {
+        containerHtml.right += `<tr class="datagrid-expandable-row no-border"><td colspan="${visibleColumnsRight}">
+          <div class="datagrid-row-detail"><div class="datagrid-row-detail-padding"></div></div>
+          </td></tr>`;
+      }
     }
 
     // Render Tree Children
@@ -10097,7 +10104,8 @@ Datagrid.prototype = {
 
     if (self.settings.allowOneExpandedRow && self.settings.groupable === null) {
       // collapse any other expandable rows
-      const prevExpandRow = self.tableBody.find('tr.is-expanded');
+      const tableBody = self.tableBody.add(self.tableBodyLeft).add(self.tableBodyRight);
+      const prevExpandRow = tableBody.find('tr.is-expanded');
       const prevExpandButton = prevExpandRow.prev().find('.datagrid-expand-btn');
       const parentRow = prevExpandRow.prev();
       const parentRowIdx = self.actualRowNode(parentRow);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed using rowTemplate/expandableRows and frozenColumns was not rendered properly with Datagrid.

**Related github/jira issue (required)**:
Closes #2867

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/test-expandable-row-frozen-columns.html
- Click on `+` button in row-1
- Row should expands including the left pane
- Click on `+` button in row-4
- Row-1 should collapse and this row-4 should expands including the left pane
- http://localhost:4000/components/datagrid/test-expandable-row-frozen-columns-bothsides.html
- Use same steps for frozen left and right side

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
