### PR TITLE
3487 - Fix reset to default with datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@
 - `[Datagrid]` Added a `filterType` option to the filter event data so the type can be determined. ([#826](https://github.com/infor-design/enterprise/issues/826))
 - `[Datagrid]` Add options to `toolbar.filterRow` so that instead of true/false you can set `showFilter, clearFilter, runFilter` independently. ([#1479](https://github.com/infor-design/enterprise/issues/1479))
 - `[Datagrid]` Added fixes to improve the usage of the textarea editor. ([#3417](https://github.com/infor-design/enterprise/issues/3417))
+- `[Datagrid]` Fixed an issue where reset to default was not working properly. ([#3487](https://github.com/infor-design/enterprise/issues/3487))
 - `[Datepicker]` Fixed an issue where setting date format with comma character was not working. ([#3008](https://github.com/infor-design/enterprise/issues/3008))
 - `[Fileupload]` Fixed an issue where tabbing out of a fileupload in was causing the modal dialog to disappear. ([#3458](https://github.com/infor-design/enterprise/issues/3458))
 - `[Form Compact Layout]` Added support for `form-compact-layout` the remaining components. ([#3008](https://github.com/infor-design/enterprise/issues/3329))

--- a/src/components/datagrid/_datagrid-uplift.scss
+++ b/src/components/datagrid/_datagrid-uplift.scss
@@ -205,4 +205,10 @@
       }
     }
   }
+
+  .modal.datagrid-columns-dialog {
+    .searchfield-wrapper {
+      height: auto;
+    }
+  }
 }

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -4037,9 +4037,22 @@ html[dir='rtl'] {
 
 }
 
-// Modal Lists
-.modal table {
-  width: auto;
+// Modal
+.modal {
+  &.datagrid-columns-dialog {
+    .listview-search.alternate-bg .searchfield-wrapper {
+      background-color: $listview-bg-color;
+    }
+
+    .listview.alternate-bg {
+      background-color: $listview-bg-color;
+    }
+  }
+
+  // Modal Lists
+  table {
+    width: auto;
+  }
 }
 
 // Popup Adjustments

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1000,7 +1000,7 @@ Datagrid.prototype = {
   updateColumnGroup() {
     const colGroups = this.settings.columnGroups;
     if (!this.originalColGroups) {
-      this.originalColGroups = this.deepCopy(colGroups);
+      this.originalColGroups = utils.deepCopy(colGroups);
     }
 
     if (this.settings.groupable) {
@@ -1094,7 +1094,7 @@ Datagrid.prototype = {
     }
 
     if (!this.originalColGroups) {
-      this.originalColGroups = this.deepCopy(colGroups);
+      this.originalColGroups = utils.deepCopy(colGroups);
     }
 
     const groups = colGroups.map(group => parseInt(group.colspan, 10));
@@ -4816,22 +4816,11 @@ Datagrid.prototype = {
   },
 
   /**
-   * Create deep copy for given array.
-   * @private
-   * @param  {array} arr The array to be copied.
-   * @returns {array} The copied array.
-   */
-  deepCopy(arr) {
-    const copy = items => items.map(item => (Array.isArray(item) ? copy(item) : item));
-    return copy(arr || []);
-  },
-
-  /**
    * Set the original column which may later be reloaded.
    * @private
    */
   setOriginalColumns() {
-    this.originalColumns = this.deepCopy(this.settings.columns);
+    this.originalColumns = utils.deepCopy(this.settings.columns);
   },
 
   /**

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -178,10 +178,6 @@
 
       li {
         border-color: transparent;
-
-        &:not(.is-selected):hover {
-          background-color: $listview-full-width-hover-color;
-        }
       }
     }
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1072,4 +1072,26 @@ utils.getScrollbarWidth = function () {
   return widthNoScroll - widthWithScroll;
 };
 
+/**
+ * Create deep copy for given array or object.
+ * @param  {array|object} arrayOrObject The array or object to be copied.
+ * @returns {array|object} The copied array or object.
+ */
+utils.deepCopy = function (arrayOrObject) {
+  const copy = (input) => {
+    if (typeof input !== 'object' || input === null) {
+      return input; // Return the value if input is not an object
+    }
+    // Create an array or object to hold the values
+    const output = Array.isArray(input) ? [] : {};
+    Object.keys(input).forEach((key) => {
+      const value = input[key];
+      // Recursively (deep) copy for nested objects, including arrays
+      output[key] = (typeof value === 'object' && value !== null) ? copy(value) : value;
+    });
+    return output;
+  };
+  return copy(arrayOrObject);
+};
+
 export { utils, math };


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed reset to default was not working properly with Datagrid.

**Related github/jira issue (required)**:
Closes #3487

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/example-custom-toolbar.html
- Click on `...` button in grid toolbar
- Select `Personalize Columns`
- Uncheck `Product ID`
- Click on modal button `Close`
- See column `Product ID` should be hidden
- Click again on `...` button in grid toolbar
- Select `Reset to Default`
- See column `Product ID` should show again

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
