### PR TITLE
3470/3473 - Fix korean and chinese locale date format

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,8 @@
 - `[Datagrid]` Added a `filterType` option to the filter event data so the type can be determined. ([#826](https://github.com/infor-design/enterprise/issues/826))
 - `[Datagrid]` Add options to `toolbar.filterRow` so that instead of true/false you can set `showFilter, clearFilter, runFilter` independently. ([#1479](https://github.com/infor-design/enterprise/issues/1479))
 - `[Datagrid]` Added fixes to improve the usage of the textarea editor. ([#3417](https://github.com/infor-design/enterprise/issues/3417))
+- `[Datepicker]` Fixed korean locale date format that makes it invalid after selecting date on datepicker field. ([#3470](https://github.com/infor-design/enterprise/issues/3470))
+- `[Datepicker]` Fixed chinese locale date format that makes it invalid after selecting date on datepicker field([#3473](https://github.com/infor-design/enterprise/issues/3473))
 - `[Datepicker]` Fixed an issue where setting date format with comma character was not working. ([#3008](https://github.com/infor-design/enterprise/issues/3008))
 - `[Fileupload]` Fixed an issue where tabbing out of a fileupload in was causing the modal dialog to disappear. ([#3458](https://github.com/infor-design/enterprise/issues/3458))
 - `[Form Compact Layout]` Added support for `form-compact-layout` the remaining components. ([#3008](https://github.com/infor-design/enterprise/issues/3329))

--- a/src/components/locale/cultures/ko-KR.js
+++ b/src/components/locale/cultures/ko-KR.js
@@ -11,19 +11,19 @@ Soho.Locale.addCulture('ko-KR', {
     name: 'gregorian',
     // ca-gregorian/main/dates/calendars/gregorian/dateFormats/
     dateFormat: {
-      separator: '. ', // Infered
+      separator: '-', // Infered
       timeSeparator: ':',
-      short: 'yyyy-MM-dd', // Uses custom format
-      medium: 'yyyy-MM-dd',
+      short: 'MM-d-yyyy', // Uses custom format
+      medium: 'MM-d-yyyy',
       long: 'yyyy년 M월 d일',
       full: 'yyyy년 M월 d일 EEEE',
       month: 'M월 d일',
       year: 'yyyy년 M월',
       timestamp: 'a h:mm:ss',
-      hour: 'a h:mm',
-      datetime: 'yyyy-MM-dd a h:mm',
-      timezone: 'yyyy-MM-dd a h:mm zz',
-      timezoneLong: 'yyyy-MM-dd a h:mm zzzz'
+      hour: 'h:mm a',
+      datetime: 'MM-d-yyyy h:mm a',
+      timezone: 'MM-d-yyyy h:mm a',
+      timezoneLong: 'MM-d-yyyy h:mm a'
     }, // Infered short + short gregorian/dateTimeFormats
     // ca-gregorian/main/dates/calendars/gregorian/days/format/short or abbreviated (2 digit)
     days: {
@@ -37,7 +37,7 @@ Soho.Locale.addCulture('ko-KR', {
       abbreviated: ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월']
     },
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
-    timeFormat: 'a h:mm',
+    timeFormat: 'h:mm a',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
     dayPeriods: ['오전', '오후'],
     firstDayofWeek: 0 // Starts on Sun

--- a/src/components/locale/cultures/zh-CN.js
+++ b/src/components/locale/cultures/zh-CN.js
@@ -19,11 +19,11 @@ Soho.Locale.addCulture('zh-CN', {
       full: 'yyyy年M月d日EEEE',
       month: 'M月d日',
       year: 'yyyy年 M月',
-      timestamp: 'HH:mm:ss',
-      hour: 'HH:mm',
-      datetime: 'yyyy/M/d ah:mm',
-      timezone: 'yyyy/M/d ah:mm zz',
-      timezoneLong: 'yyyy/M/d ah:mm zzzz'
+      timestamp: 'HH:mm:ss a',
+      hour: 'HH:mm a',
+      datetime: 'yyyy/M/d h:mm',
+      timezone: 'yyyy/M/d h:mm zz',
+      timezoneLong: 'yyyy/M/d h:mm zzzz'
     }, // Infered short + short gregorian/dateTimeFormats
     // ca-gregorian/main/dates/calendars/gregorian/days/format/short or abbreviated (2 digit)
     days: {
@@ -37,7 +37,7 @@ Soho.Locale.addCulture('zh-CN', {
       abbreviated: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']
     },
     // ca-gregorian/main/dates/calendars/gregorian/timeFormats/short
-    timeFormat: 'ah:mm',
+    timeFormat: 'h:mm a',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
     dayPeriods: ['上午', '下午'],
     firstDayofWeek: 0 // Starts on Sun


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes korean and chinese locale format. It makes it invalid after selecting date and out focusing in the field. It seems that the current date format for both locale doesn't work when parsing the date.

This is still WIP as I bump into an issue.
- Selecting PM will not work, it will still choose AM.

**Related github/jira issue (required)**:
Closes 
- https://github.com/infor-design/enterprise/issues/3470
- https://github.com/infor-design/enterprise/issues/3473

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Navigate to http://localhost:4000/components/datepicker/example-timeformat.html?locale=ko-KR for Korean
- Then http://localhost:4000/components/datepicker/example-timeformat.html?locale=zh-CN for Chinese
- Click the calendar icon
- Select today or any date
- Click apply or click outside to focus out the field
- It shouldn't invalid the value
- Play all the fields to make sure it's working properly

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
