### PR TITLE
3483 - Fix fileupload alignment with forms compact

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,7 @@
 - `[Form Compact Layout]` Added support for `form-compact-layout` the remaining components. ([#3008](https://github.com/infor-design/enterprise/issues/3329))
 - `[Dropdown]` Fixed a bug that was causing the `selectValue()` method not to update the visual display of the in-page Dropdown element. ([#3432](https://github.com/infor-design/enterprise/issues/3432))
 - `[Forms]` Fixed an issue where radio group was overlapping fields. ([#3466](https://github.com/infor-design/enterprise/issues/3466))
+- `[Forms Compact]` Fixed an issue where fileupload was not aligning and the checkboxes were not aligning for RTL in Uplift/Vivrant theme. ([#3483](https://github.com/infor-design/enterprise/issues/3483))
 - `[Icons]` Fixed color inconsistencies of the icons when the fields are in readonly state. ([#3176](https://github.com/infor-design/enterprise/issues/3176))
 - `[Input]` Added the ability to line up data labels with inputs by adding class `field-height` to the `data` element and placing it in a responsive grid. ([#987](https://github.com/infor-design/enterprise/issues/987))
 - `[Input]` Added the ability to use standalone required spans, this will help on responsive fields if they are cut off. ([#3115](https://github.com/infor-design/enterprise/issues/3115))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,7 +45,7 @@
 - `[Form Compact Layout]` Added support for `form-compact-layout` the remaining components. ([#3008](https://github.com/infor-design/enterprise/issues/3329))
 - `[Dropdown]` Fixed a bug that was causing the `selectValue()` method not to update the visual display of the in-page Dropdown element. ([#3432](https://github.com/infor-design/enterprise/issues/3432))
 - `[Forms]` Fixed an issue where radio group was overlapping fields. ([#3466](https://github.com/infor-design/enterprise/issues/3466))
-- `[Forms Compact]` Fixed an issue where fileupload was not aligning and the checkboxes were not aligning for RTL in Uplift/Vivrant theme. ([#3483](https://github.com/infor-design/enterprise/issues/3483))
+- `[Forms Compact]` Fixed an issue where fileupload was misaligned in RTL mode in uplift theme. ([#3483](https://github.com/infor-design/enterprise/issues/3483))
 - `[Icons]` Fixed color inconsistencies of the icons when the fields are in readonly state. ([#3176](https://github.com/infor-design/enterprise/issues/3176))
 - `[Input]` Added the ability to line up data labels with inputs by adding class `field-height` to the `data` element and placing it in a responsive grid. ([#987](https://github.com/infor-design/enterprise/issues/987))
 - `[Input]` Added the ability to use standalone required spans, this will help on responsive fields if they are cut off. ([#3115](https://github.com/infor-design/enterprise/issues/3115))

--- a/src/components/form-compact/_form-compact-uplift.scss
+++ b/src/components/form-compact/_form-compact-uplift.scss
@@ -19,20 +19,6 @@
       padding: 0 8px 4px;
     }
   }
-
-  // FileUploader has different field heights depending on browser/font
-  .fileuploader {
-    max-height: 25px;
-  }
-}
-
-// Reset the rule governing IE11 fileuploader max-height
-html.ie11:not([dir='rtl']) {
-  .form-compact {
-    .fileuploader {
-      max-height: 28px;
-    }
-  }
 }
 
 html[dir='rtl'] {
@@ -48,10 +34,12 @@ html[dir='rtl'] {
       input:not(.radio) {
         padding: 0 8px 7px;
       }
+    }
 
-      .fileuploader {
-        max-height: 29px;
-      }
+    input.checkbox:checked + label::after,
+    input.checkbox:checked + input[type='hidden'] + label::after,
+    span.checkbox > input:checked + label::after {
+      top: 15px;
     }
   }
 
@@ -69,10 +57,12 @@ html[dir='rtl'] {
         input:not(.radio) {
           padding: 3px 8px 8px;
         }
+      }
 
-        .fileuploader {
-          max-height: 31px;
-        }
+      input.checkbox:checked + label::after,
+      input.checkbox:checked + input[type='hidden'] + label::after,
+      span.checkbox > input:checked + label::after {
+        top: 16px;
       }
     }
   }

--- a/src/components/form-compact/_form-compact.scss
+++ b/src/components/form-compact/_form-compact.scss
@@ -240,13 +240,6 @@
   }
 
   // =============================================
-  // Form-Compact File Uploader Styles
-  // =============================================
-  .fileuploader {
-    max-height: 29px;
-  }
-
-  // =============================================
   // Form-Compact Checkbox Styles
   // =============================================
   .field.field-checkbox {
@@ -372,11 +365,6 @@
     textarea {
       line-height: normal;
     }
-
-    // `input[type="file"]` is taller in Firefox.
-    .fileuploader {
-      max-height: 28px;
-    }
   }
 }
 
@@ -388,15 +376,6 @@
       &.form-section-header {
         padding: 16px 8px 15px;
       }
-    }
-  }
-}
-
-// `input[type="file"]` is taller in IE11.
-.ie11 {
-  .form-compact {
-    .fileuploader {
-      max-height: 29px;
     }
   }
 }
@@ -456,12 +435,6 @@ html[dir='rtl'] {
       }
     }
 
-    // Font family changes on RTL affect the height of the FileUploader.
-    .fileuploader {
-      line-height: normal;
-      max-height: 30px;
-    }
-
     // Reverse padding on radios
     .radio-label {
       padding-left: 0;
@@ -479,7 +452,7 @@ html[dir='rtl'] {
 
     // Checkboxes
     .checkbox-label {
-      padding-right: 41px;
+      padding-right: 41px !important;
     }
 
     input.checkbox:checked,
@@ -494,23 +467,6 @@ html[dir='rtl'] {
     label.inline .checkbox:checked ~ .label-text::after {
       left: auto;
       right: 22px;
-    }
-  }
-
-  // Fix the FileUploader styles
-  &.ie11 {
-    .form-compact {
-      .fileuploader {
-        max-height: 28px;
-      }
-    }
-  }
-
-  &.is-firefox {
-    .form-compact {
-      .fileuploader {
-        max-height: 32px;
-      }
     }
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed fileupload was not aligning with Forms Compact. Also fixed the checkboxes were not aligning for RTL in Uplift/Vibrant theme.

**Related github/jira issue (required)**:
Closes #3483

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/form-compact/example-index.html
- Check the alignment for fileupload
- Check checkboxes http://localhost:4000/components/form-compact/example-index.html?locale=ar-EG

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
