### PR TITLE
3119 - Fix arrow placement on tooltip/popovers in some RTL situations [v4.26.x]

### DIFF
--- a/src/components/place/place.js
+++ b/src/components/place/place.js
@@ -921,15 +921,7 @@ Place.prototype = {
 
     arrow[0].removeAttribute('style');
 
-    // if (placementObj.attemptedFlips) { TJM Removed for pager bug. Seems to work.
     element.removeClass('top right bottom left').addClass(dir);
-    // }
-
-    // Flip the arrow if we're in RTL mode
-    if (env.rtl && isXCoord) {
-      const opposite = dir === 'right' ? 'left' : 'right';
-      element.removeClass('right left').addClass(opposite);
-    }
 
     // Custom target for some scenarios
     if (target.is('.colorpicker')) {

--- a/src/components/place/place.js
+++ b/src/components/place/place.js
@@ -908,7 +908,6 @@ Place.prototype = {
     let target = placementObj.parent;
     const arrow = element.find('div.arrow');
     const dir = placementObj.placement;
-    const isXCoord = ['left', 'right'].indexOf(dir) > -1;
     let targetRect = {};
     const elementRect = element[0].getBoundingClientRect();
     let arrowRect = {};


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a Q/A issue that cropped up due to changes on #3119, where using an RTL-based locale was sometimes incorrectly making tooltips/popovers set the position of their arrows on the wrong side of the element.  This issue has been fixed.

**Related github/jira issue (required)**:
Closes #3119

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the app
- Open http://localhost:4000/components/popover/example-alternate-positions.html?locale=ar-EG
- Click both buttons and ensure the arrow appears on the side of the popover that faces the button.
