### PR TITLE
3339 - Change background color in uplift

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise
 
+## v4.27.0
+
+### v4.27.0 Fixes
+
+- `[Searchfield]` Correct the background color of toolbar search fields. ([#3527](https://github.com/infor-design/enterprise/issues/3527))
+
 ## v4.26.0
 
 ### v4.26.0 Features

--- a/src/themes/theme-soho-dark.scss
+++ b/src/themes/theme-soho-dark.scss
@@ -614,7 +614,7 @@ $wizard-focus-box-shadow: 0 0 0 1px $theme-color-brand-primary-base;
 $hierarchy-line-color: $theme-color-palette-slate-40;
 
 // Searchfield Colors
-$searchfield-bg-color: $theme-color-palette-slate-90;
+$searchfield-bg-color: $theme-color-palette-slate-70;
 $searchfield-border-color: $theme-color-palette-slate-100;
 $searchfield-icon-color: $button-color-tertiary-initial-font;
 $searchfield-text-color: $button-color-tertiary-initial-font;

--- a/src/themes/theme-uplift-dark.scss
+++ b/src/themes/theme-uplift-dark.scss
@@ -609,7 +609,7 @@ $wizard-toolbar-border-color: $theme-color-palette-slate-70;
 $hierarchy-line-color: $theme-color-palette-slate-40;
 
 // Searchfield Colors
-$searchfield-bg-color: $theme-color-palette-slate-90;
+$searchfield-bg-color: $theme-color-palette-slate-70;
 $searchfield-border-color: $theme-color-palette-slate-100;
 $searchfield-icon-color: $button-color-tertiary-initial-font;
 $searchfield-text-color: $button-color-tertiary-initial-font;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
https://github.com/infor-design/enterprise/issues/3339
Changes the  background color in uplift dark for expandable searchfields when in a toolbar.

**Related github/jira issue (required)**:
Fixes #3339

**Steps necessary to review your pull request (required)**:
- open http://localhost:4000/components/datagrid/example-custom-toolbar.html?theme=soho&variant=dark
- expand the search 
- should have a background subtle fille
- open http://localhost:4000/components/datagrid/example-custom-toolbar.html?theme=uplift&variant=dark
- expand the search 
- should have a background subtle fille

**Included in this Pull Request**:
- [x] A note to the change log.
