### PR TITLE
3347- Fix large IOS text in Datagrid Tree

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise
 
+## v4.27.0
+
+### v4.27.0 Fixes
+
+- `[Datagrid]` Fixed a bug were datagrid tree would have very big text in the tree nodes on IOS. ([#3347](https://github.com/infor-design/enterprise/issues/3347))
+
 ## v4.26.0
 
 ### v4.26.0 Features

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1694,6 +1694,7 @@ $datagrid-short-row-height: 25px;
     outline: none;
     overflow: hidden;
     text-overflow: ellipsis;
+    -webkit-text-size-adjust: none; //Prevent huge text on IOS
     white-space: nowrap;
 
     &:focus,


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When on IOS the tree text for the datagrid was very big because of -webkit-text-size-adjust: none; 
So did a reset on it here. Note that the bug is  inverse in reality. The tree text was too big, the other text was the normal / correct size.

**Related github/jira issue (required)**:
Fixes #3347 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-tree.html?theme=uplift&variant=contrast
- open it on IOS (iphone x for example)
- the tree text should be the same size as other text

**Included in this Pull Request**:
- [x] A note to the change log.