### PR TITLE
NG#745 - Allow theme switcher to work when implemented in a Flex Toolbar

### DIFF
--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -528,6 +528,13 @@ Header.prototype = {
     }
 
     this.changer.on('selected.header', (e, link) => {
+      e.preventDefault();
+
+      // handle `ToolbarFlexItem` types
+      if (link !== undefined && !(link instanceof $) && link.element instanceof HTMLElement) {
+        link = $(link.element);
+      }
+
       // Change Theme with Variant
       const themeNameAttr = link.attr('data-theme-name');
       const themeVariantAttr = link.attr('data-theme-variant');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a small bug in the implementation of the EP demoapp's theme switcher button (which is also used in the NG demoapp), which didn't properly support being used in a Flex Toolbar.  There was a previously a conflict when firing the `selected` event.  This PR fixes that issue.

**Related github/jira issue (required)**:
Related to infor-design/enterprise-ng#745

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, `npm link` or symbolic link to a working copy of [`enterprise-ng`](https://github.com/infor-design/enterprise-ng), and build/run NG.
- Open http://localhost:4200/ids-enterprise-ng-demo/
- Use the theme switcher to select a different theme/variant.  On the first try, the theme switch should work, and there should be no related JS errors in the console.