### PR TITLE
3481 - Datagrid: firstrender and getStretchColumnIdx

### DIFF
--- a/app/views/components/datagrid/test-columns-stretch-column.html
+++ b/app/views/components/datagrid/test-columns-stretch-column.html
@@ -9,6 +9,7 @@
   $('body').one('initialized', function () {
 
       var grid,
+        centerWidth = null,
         columns = [],
         data = [];
 
@@ -28,6 +29,7 @@
       columns.push({ id: 'drilldown', name: '', field: '', formatter: Formatters.Drilldown, align: 'center', resizable: false, sortable: false});
       columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, filterType: 'text'});
       columns.push({ id: 'activity', name: 'Activity', field: 'activity', filterType: 'text'});
+      columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'MM/dd/yyyy', filterType: 'date', editorOptions: {showMonthYearPicker: true}});
       columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', filterType: 'text'});
       columns.push({ id: 'price', name: 'Price', field: 'price', formatter: Formatters.Decimal, filterType: 'decimal'});
 
@@ -41,9 +43,18 @@
         dataset: data
       });
 
-      $('#datagrid').on('afterrender', function() {
+      $('#datagrid').on('afterrender', function(e) {
         var gridAPI = $(this).data('datagrid');
-        console.log(gridAPI.totalWidths);
+        if (centerWidth === null) {
+          centerWidth = gridAPI.totalWidths.center;
+          console.log(`Capture initial center Width: ${gridAPI.totalWidths.center}`);
+        }
+        
+        if (centerWidth !== gridAPI.totalWidths.center) {
+          console.log(`center Width is different form initial value: ${gridAPI.totalWidths.center}`);
+        }
+        
+        
       });
 });
 

--- a/app/views/components/datagrid/test-columns-stretch-column.html
+++ b/app/views/components/datagrid/test-columns-stretch-column.html
@@ -20,22 +20,31 @@
       data.push({ id: 5, productId: 2542205, sku: 'SKU #9000001-233', productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
       data.push({ id: 5, productId: 2642205, sku: 'SKU #9000001-232', productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
       data.push({ id: 6, productId: 2642206, sku: 'SKU #9000001-231', productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
-
+      data.push({ id: 7, productId: null, productName: null, activity:  '', quantity: null, price: null, orderDate: null, action: 'Blank Row', status: 'Confirmed'});
+      data.push({ id: 8, productId: null, productName: null, activity:  null, quantity: null, price: null, orderDate: null, action: 'Blank Row', status: 'Confirmed'});
+      
       //Define Columns for the Grid.
 
       columns.push({ id: 'drilldown', name: '', field: '', formatter: Formatters.Drilldown, align: 'center', resizable: false, sortable: false});
-      columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink});
-      columns.push({ id: 'activity', name: 'Activity', field: 'activity'});
-      columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity'});
-      columns.push({ id: 'price', name: 'Price', field: 'price', formatter: Formatters.Decimal});
+      columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, filterType: 'text'});
+      columns.push({ id: 'activity', name: 'Activity', field: 'activity', filterType: 'text'});
+      columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', filterType: 'text'});
+      columns.push({ id: 'price', name: 'Price', field: 'price', formatter: Formatters.Decimal, filterType: 'decimal'});
 
       //Init and get the api for the grid
       grid = $('#datagrid').datagrid({
+        filterable: true,
+        paging: true,
+        pagesize: 5,
         columns: columns,
         stretchColumn: 'productName',
         dataset: data
       });
 
+      $('#datagrid').on('afterrender', function() {
+        var gridAPI = $(this).data('datagrid');
+        console.log(gridAPI.totalWidths);
+      });
 });
 
 </script>

--- a/app/views/components/datagrid/test-columns-stretch-column.html
+++ b/app/views/components/datagrid/test-columns-stretch-column.html
@@ -21,7 +21,7 @@
       data.push({ id: 5, productId: 2542205, sku: 'SKU #9000001-233', productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
       data.push({ id: 5, productId: 2642205, sku: 'SKU #9000001-232', productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
       data.push({ id: 6, productId: 2642206, sku: 'SKU #9000001-231', productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
-      data.push({ id: 7, productId: null, productName: null, activity:  '', quantity: null, price: null, orderDate: null, action: 'Blank Row', status: 'Confirmed'});
+      data.push({ id: 7, productId: null, productName: 'Some Compressor with a longer name', activity:  '', quantity: null, price: null, orderDate: null, action: 'Blank Row', status: 'Confirmed'});
       data.push({ id: 8, productId: null, productName: null, activity:  null, quantity: null, price: null, orderDate: null, action: 'Blank Row', status: 'Confirmed'});
       
       //Define Columns for the Grid.

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -925,7 +925,7 @@ Datagrid.prototype = {
       this.renderRows();
     } else {
       // Filter field is open so do not resize
-      //this.clearCache();
+      this.clearCache();
       this.renderRows();
     }
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -925,7 +925,7 @@ Datagrid.prototype = {
       this.renderRows();
     } else {
       // Filter field is open so do not resize
-      this.clearCache();
+      //this.clearCache();
       this.renderRows();
     }
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -925,6 +925,7 @@ Datagrid.prototype = {
       this.renderRows();
     } else {
       // Filter field is open so do not resize
+      this.clearCache();
       this.renderRows();
     }
 
@@ -4410,6 +4411,7 @@ Datagrid.prototype = {
 
     if (this.settings.stretchColumn !== 'last' && this.settings.stretchColumn !== null &&
       this.settings.stretchColumn === col.id) {
+      this.stretchColumnIdx = index;
       this.stretchColumnWidth = colWidth;
       return ' style="width: 99%"';
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
1. Correct the stretchcolumnidx on firstrender
2. Correct an issue with some filter types types (date, dropdown) and the totalWidths value

**Related github/jira issue (required)**:
Closes #3481 

**Steps necessary to review your pull request (required)**:
1) 
1. http://localhost:4000/components/datagrid/test-columns-stretch-column.html
2. Take note of how wide the last column is set
3. reduce the size of the browser window
4. Refresh the page.
2)
(comment out line 928 of datagrid.js to show the original behaviour)
1. http://localhost:4000/components/datagrid/test-columns-stretch-column.html
2. Open the order date and filter and select a value
(The width is outputted to the console, the first render width and then any one that does not match)

![image](https://user-images.githubusercontent.com/39749678/75294688-fc463200-5878-11ea-93cc-fd0617585307.png)


**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
