### PR TITLE
3508 - colorpicker dropdown placement

### DIFF
--- a/app/views/components/datagrid/test-expandable-row-multiselect.html
+++ b/app/views/components/datagrid/test-expandable-row-multiselect.html
@@ -1,0 +1,63 @@
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+{{={{{ }}}=}}
+
+<script>
+  $('body').one('initialized', function () {
+
+      var grid,
+        columns = [],
+        data = [];
+
+      // Some Sample Data
+      data.push({ id: 1, productId: 2142201, sku: '<b>SKU #9000001-237</b>', productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+      data.push({ id: 2, productId: 2241202, sku: '<b>SKU #9000001-236</b>', productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+      data.push({ id: 3, productId: 2342203, sku: '<b>SKU #9000001-235</b>', productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+      data.push({ id: 4, productId: 2445204, sku: '<b>SKU #9000001-234</b>', productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+      data.push({ id: 5, productId: 2542205, sku: '<b>SKU #9000001-233</b>', productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+      data.push({ id: 5, productId: 2642205, sku: '<b>SKU #9000001-232</b>', productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+      data.push({ id: 6, productId: 2642206, sku: '<b>SKU #9000001-231</b>', productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+
+      // Define Columns for the Grid
+      columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
+      columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Expander, filterType: 'text', textOverflow: 'ellipsis', width: 150, hideable: false});
+      columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', filterType: 'text', formatter: Formatters.Hyperlink});
+      columns.push({ id: 'activity', name: 'Activity', field: 'activity', filterType: 'text'});
+      columns.push({ id: 'quantity1', name: 'Quantity 1', field: 'quantity'});
+      columns.push({ id: 'quantity2', name: 'Quantity 2', field: 'quantity'});
+      columns.push({ id: 'quantity3', name: 'Quantity 3', field: 'quantity'});
+
+      var rowTemplate = '<div class="datagrid-cell-layout"><div class="img-placeholder"><svg class="icon" focusable="false" aria-hidden="true" role="presentation"><use xlink:href="#icon-camera"></use></svg></div></div>'+
+                        '<div class="datagrid-cell-layout"><p class="datagrid-row-heading">Expandable Content Area</p>' +
+                        '<p class="datagrid-row-micro-text">{{{sku}}}</p>'+
+                        '<span class="datagrid-wrapped-text">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only...</span>'+
+                        '<a class="hyperlink" href="https://design.infor.com/" target="_blank" >Read more</a>';
+
+      // Init and get the api for the grid
+      grid = $('#datagrid').datagrid({
+        columns: columns,
+        idProperty:'officeId',
+        dataset: data,
+        filterable: true,
+        selectable: 'multiple',
+        rowTemplate: rowTemplate,
+        toolbar: {title: 'Data Grid Header Title', collapsibleFilter: true,
+          results: true, keywordFilter: true, actions: true, exportToExcel: true, rowHeight: true, personalize: true}
+      });
+
+      grid.on('expandrow', function (e, args) {
+        console.log('expandrow', args);
+      });
+
+      grid.on('collapserow', function (e, args) {
+        console.log('collapserow', args);
+      });
+
+});
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### v4.27.0 Fixes
 
+- `[Colorpicker]` Fixed the dropdown icon position is too close to the right edge of the field. ([#3508](https://github.com/infor-design/enterprise/issues/3508))
 - `[Datagrid]` Fixed a bug were datagrid tree would have very big text in the tree nodes on IOS. ([#3347](https://github.com/infor-design/enterprise/issues/3347))
 - `[Datagrid]` Fixed a bug when setting the UI indicator with `setSortIndicator` then it would take two clicks to sort the inverse direction. ([#3391](https://github.com/infor-design/enterprise/issues/3391))
 - `[Datagrid]` Fixed a bug when combining multiselect and expandable rows. If using the shift key to select multiple rows the selection would include incorrect rows. ([#2302](https://github.com/infor-design/enterprise/issues/2302))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Datagrid]` Fixed a bug were datagrid tree would have very big text in the tree nodes on IOS. ([#3347](https://github.com/infor-design/enterprise/issues/3347))
 - `[Datagrid]` Fixed a bug when setting the UI indicator with `setSortIndicator` then it would take two clicks to sort the inverse direction. ([#3391](https://github.com/infor-design/enterprise/issues/3391))
+- `[Datagrid]` Fixed a bug when combining multiselect and expandable rows. If using the shift key to select multiple rows the selection would include incorrect rows. ([#2302](https://github.com/infor-design/enterprise/issues/2302))
 - `[Searchfield]` Correct the background color of toolbar search fields. ([#3527](https://github.com/infor-design/enterprise/issues/3527))
 
 ## v4.26.0

--- a/src/components/colorpicker/_colorpicker-uplift.scss
+++ b/src/components/colorpicker/_colorpicker-uplift.scss
@@ -2,10 +2,6 @@
   margin-left: -12px;
   margin-top: -2px;
 
-  .icon {
-    left: 14px;
-  }
-
   .colorpicker {
     width: 126px;
   }
@@ -28,5 +24,11 @@ html[dir='rtl'] {
       left: -3px;
       top: 10px;
     }
+  }
+}
+
+.modal-body {
+  .colorpicker-container .trigger {
+    margin-top: 0;
   }
 }

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5914,7 +5914,7 @@ Datagrid.prototype = {
         // Then Activate
         if (!canSelect) {
           if (e.shiftKey && self.activatedRow().length) {
-            self.selectRowsBetweenIndexes([self.activatedRow()[0].row, target.closest('tr').index()]);
+            self.selectRowsBetweenIndexes([self.activatedRow()[0].row, target.closest('tr').attr('aria-rowindex') - 1]);
             e.preventDefault();
           }
 
@@ -5923,7 +5923,7 @@ Datagrid.prototype = {
       }
 
       if (canSelect && isMultiple && e.shiftKey) {
-        self.selectRowsBetweenIndexes([self.lastSelectedRow, target.closest('tr').index()]);
+        self.selectRowsBetweenIndexes([self.lastSelectedRow, target.closest('tr').attr('aria-rowindex') - 1]);
         e.preventDefault();
       } else if (canSelect) {
         self.toggleRowSelection(target.closest('tr'));
@@ -8201,7 +8201,7 @@ Datagrid.prototype = {
         }
 
         if (isMultiple && e.shiftKey) {
-          self.selectRowsBetweenIndexes([self.lastSelectedRow, row.index()]);
+          self.selectRowsBetweenIndexes([self.lastSelectedRow, row.attr('aria-rowindex') - 1]);
         } else {
           self.toggleRowSelection(row);
         }
@@ -10191,7 +10191,7 @@ Datagrid.prototype = {
       const eventData = [{ grid: self, row: dataRowIndex, detail, item }];
       self.element.triggerHandler('expandrow', eventData);
 
-      if (self.settings.allowOneExpandedRow) {
+      if (self.settings.allowOneExpandedRow && this.settings.selectable !== 'multiple') {
         rowElement.addClass('is-rowactivated');
       }
 

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -1694,7 +1694,7 @@ describe('Datagrid onKeyDown Tests', () => {
   });
 });
 
-describe('Datagrid Header Alignment With Ellipsis', () => {
+describe('Datagrid Header Alignment with Ellipsis', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-ellipsis-header-align?layout=nofrills');
 
@@ -1717,7 +1717,7 @@ describe('Datagrid Header Alignment With Ellipsis', () => {
   }
 });
 
-describe('Datagrid Header Alignment With Ellipsis and Sorting', () => {
+describe('Datagrid Header Alignment with Ellipsis and Sorting', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-ellipsis-sort-indicator?layout=nofrills');
 
@@ -1738,6 +1738,47 @@ describe('Datagrid Header Alignment With Ellipsis and Sorting', () => {
       expect(await browser.protractorImageComparison.checkElement(containerEl, 'datagrid-header-align-ellipsis-sort')).toEqual(0);
     });
   }
+});
+
+describe('Datagrid Expandable Row with multiselect', () => {e
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/test-expandable-row-multiselect');
+
+    const datagridEl = await element(by.css('#datagrid tr:nth-child(1)'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should work with shift key', async () => {
+    await element(by.css('#datagrid .datagrid-wrapper tbody tr:nth-child(3) td:nth-child(1)')).click();
+
+    expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(1);
+
+    const elem = await element(by.css('#datagrid .datagrid-wrapper tbody tr:nth-child(9) td:nth-child(1)'));
+
+    // Simulate Shift + Click
+    await browser.actions().sendKeys(protractor.Key.SHIFT).perform().then(async () => {
+      await elem.click();
+
+      expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(4);
+      // Release the shift key by toggling it
+      await browser.actions().sendKeys(protractor.Key.SHIFT).perform();
+    });
+  });
+
+  it('Should work with click key', async () => {
+    await element(by.css('#datagrid .datagrid-wrapper tbody tr:nth-child(3) td:nth-child(1)')).click();
+
+    expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(1);
+
+    await element(by.css('#datagrid .datagrid-wrapper tbody tr:nth-child(9) td:nth-child(1)')).click();
+
+    expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(2);
+  });
 });
 
 describe('Datagrid Empty Card Scrolling', () => {

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -1740,7 +1740,7 @@ describe('Datagrid Header Alignment with Ellipsis and Sorting', () => {
   }
 });
 
-describe('Datagrid Expandable Row with multiselect', () => {e
+describe('Datagrid Expandable Row with multiselect', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-expandable-row-multiselect');
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The colorpicker icon caret is too much close to the right edge of the field. Added also some fix in modal section where it appears that the caret icon is not vertically align.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/3508

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Navigate to http://localhost:4000/components/colorpicker/example-sizes.html?theme=uplift&variant=light
- Caret icons should not too close to the right edge of the field
- Test also the modal sample of colorpicker
- http://localhost:4000/components/colorpicker/test-modal.html?theme=uplift&variant=light
- Open the modal
- Caret icon should place correctly

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
