### PR TITLE
3508 - Fix color picker icon position

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### v4.27.0 Fixes
 
+- `[Colorpicker]` Fixed the dropdown icon position is too close to the right edge of the field. ([#3508](https://github.com/infor-design/enterprise/issues/3508))
 - `[Datagrid]` Fixed a bug were datagrid tree would have very big text in the tree nodes on IOS. ([#3347](https://github.com/infor-design/enterprise/issues/3347))
 - `[Datagrid]` Fixed a bug when setting the UI indicator with `setSortIndicator` then it would take two clicks to sort the inverse direction. ([#3391](https://github.com/infor-design/enterprise/issues/3391))
 - `[Searchfield]` Correct the background color of toolbar search fields. ([#3527](https://github.com/infor-design/enterprise/issues/3527))

--- a/src/components/colorpicker/_colorpicker-uplift.scss
+++ b/src/components/colorpicker/_colorpicker-uplift.scss
@@ -1,9 +1,9 @@
 .colorpicker-container .trigger {
-  margin-left: -12px;
+  margin-left: -7px;
   margin-top: -2px;
 
   .icon {
-    left: 14px;
+    left: 8px;
   }
 
   .colorpicker {
@@ -28,5 +28,11 @@ html[dir='rtl'] {
       left: -3px;
       top: 10px;
     }
+  }
+}
+
+.modal-body {
+  .colorpicker-container .trigger {
+    margin-top: 1px;
   }
 }

--- a/src/components/colorpicker/_colorpicker.scss
+++ b/src/components/colorpicker/_colorpicker.scss
@@ -123,7 +123,7 @@
       cursor: default;
 
       &:hover {
-        color: $colorpicker-readonly-icon-color;
+        color: $trigger-hover-color;
       }
     }
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The colorpicker icon caret is too much close to the right edge of the field. Added also some fix in modal section where it appears that the caret icon is not vertically align.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/3508

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Navigate to http://localhost:4000/components/colorpicker/example-sizes.html?theme=uplift&variant=light
- Caret icons should not too close to the right edge of the field
- Test also the modal sample of colorpicker
- http://localhost:4000/components/colorpicker/test-modal.html?theme=uplift&variant=light
- Open the modal
- Caret icon should place correctly

**Included in this Pull Request**:
- [x] A note to the change log.

