### PR TITLE
2669 - Fix resize with bar chart

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### v4.27.0 Fixes
 
+- `[Bar Chart]` Fixed an issue where chart was not resizing on homepage widget resize. ([#2669](https://github.com/infor-design/enterprise/issues/2669))
 - `[Colorpicker]` Fixed the dropdown icon position is too close to the right edge of the field. ([#3508](https://github.com/infor-design/enterprise/issues/3508))
 - `[Datagrid]` Fixed an issue where date range filter was unable to filter data. ([#3503](https://github.com/infor-design/enterprise/issues/3503))
 - `[Datagrid]` Fixed a bug were datagrid tree would have very big text in the tree nodes on IOS. ([#3347](https://github.com/infor-design/enterprise/issues/3347))

--- a/src/components/bar/bar.js
+++ b/src/components/bar/bar.js
@@ -871,17 +871,23 @@ Bar.prototype = {
    * @returns {void}
    */
   handleResize() {
-    if (this.width === this.element.width()) {
-      return;
+    const resize = () => {
+      if (this.width === this.element.width()) {
+        return;
+      }
+      this.width = this.element.width();
+      if (!this.element.is(':visible')) {
+        return;
+      }
+      this.updated();
+    };
+    // Waiting to complete the animatin on some elements
+    const waitingElems = $('.homepage');
+    if (waitingElems.length) {
+      setTimeout(() => resize(), 300);
+    } else {
+      resize();
     }
-
-    this.width = this.element.width();
-
-    if (!this.element.is(':visible')) {
-      return;
-    }
-
-    this.updated();
   },
 
   /**

--- a/src/components/bar/bar.js
+++ b/src/components/bar/bar.js
@@ -881,9 +881,8 @@ Bar.prototype = {
       }
       this.updated();
     };
-    // Waiting to complete the animatin on some elements
-    const waitingElems = $('.homepage');
-    if (waitingElems.length) {
+    // Waiting to complete the animatin on widget
+    if (this.element.closest('.homepage').length) {
       setTimeout(() => resize(), 300);
     } else {
       resize();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed bar chart was not resizing on homepage widget resize.

**Related github/jira issue (required)**:
Closes #2669

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/homepage/example-filled
- Resize the page, so the widget size changes
- See chart should resize fine

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
