### PR TITLE
3544 - Fix error icon too close to the border upon focus state

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[Searchfield]` Correct the background color of toolbar search fields. ([#3527](https://github.com/infor-design/enterprise/issues/3527))
 - `[Spinbox]` Corrected an issue in the enable method, where it did not fully remove the readonly state. ([#3527](https://github.com/infor-design/enterprise/issues/3527))
 - `[Swaplist]` Fixed an issue where lists were overlapping on uplift theme. ([#3452](https://github.com/infor-design/enterprise/issues/3452))
+- `[Tabs]` Fixed the position of error icon too close to the border on focus state. ([#3544](https://github.com/infor-design/enterprise/issues/3544))
 
 ## v4.26.0
 

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -369,8 +369,10 @@
           }
 
           .icon-error {
-            right: -3px;
-            top: 14px;
+            margin-left: 0;
+            position: relative;
+            right: 4px;
+            top: 0;
           }
         }
       }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixing the position of the error icon that's too close to the border upon focus state.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/3544

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Navigate to http://localhost:4000/components/tabs/example-dropdown-tabs.html
- Click the Plastic tab and go to Plates
- Tab out each input field to show the error/validation
- The Plastic tab should also display the error icon beside of it
- Click other tab until the focus show
- Then go back to the Plastic tab (This should highlight/focus)
- Error icon should have enough space and not too close to the border of the focus

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
