### PR TITLE
3482 - Fix dropdown selection position in modal

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[Field Filter]` Fixed an issue where switching to In Range filter type with a value in the field was causesing an error. ([#3515](https://github.com/infor-design/enterprise/issues/3515))
 - `[Field Filter]` Fixed an issue where date range was not working after using other filter. ([#2764](https://github.com/infor-design/enterprise/issues/2764))
 - `[Masthead]` Fixed layout and color issues in uplift theme. ([#3526](https://github.com/infor-design/enterprise/issues/3526))
+- `[Modal]` Fixed the position of the dropdown selection upon opening when the field is required. Added ellipsis when the modal title is too long. ([#3482](https://github.com/infor-design/enterprise/issues/3482))
 - `[Searchfield]` Correct the background color of toolbar search fields. ([#3527](https://github.com/infor-design/enterprise/issues/3527))
 - `[Spinbox]` Corrected an issue in the enable method, where it did not fully remove the readonly state. ([#3527](https://github.com/infor-design/enterprise/issues/3527))
 - `[Swaplist]` Fixed an issue where lists were overlapping on uplift theme. ([#3452](https://github.com/infor-design/enterprise/issues/3452))

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -87,6 +87,10 @@
     &:last-child .checkbox-label {
       margin-bottom: 1px;
     }
+
+    .error-message {
+      display: block !important;
+    }
   }
 
   .field:last-child input:not(.spinbox):not(.colorpicker):not(.searchfield),
@@ -213,6 +217,12 @@
       flex-direction: column;
       height: 100%;
       margin: 0;
+
+      .modal-header {
+        .modal-title {
+          width: 100%;
+        }
+      }
     }
 
     .modal-body-wrapper {
@@ -281,7 +291,11 @@ body.modal-engaged {
     font-size: $theme-size-font-lg;
     font-weight: $theme-number-font-weight-base;
     -webkit-margin-after: 0;
+    overflow: hidden;
     text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: 300px;
 
     > * {
       vertical-align: middle;
@@ -414,8 +428,10 @@ body.modal-engaged {
 //Toolbar Buttons
 .modal-buttonset {
   border-top: 1px solid $modal-btn-border-color;
+  bottom: 0;
   height: 50px;
-  margin-top: 20px;
+  position: relative;
+  width: 100%;
 
   button {
     @include css3(transition, color 0.3s ease 0s);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes the positioning of dropdown selection upon opening when there is validation. Additional fix: Add ellipsis to the modal title when it's too long.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/3482

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Navigate to http://localhost:4000/components/modal/example-validation.html
- Click/Open the `Add Context` button
- Tab in all fields
- Click the dropdown field
- The dropdown should not move to it's position

Additional Review/Test
- Change the title and make it longer
- Title should not overflow and it should have ellipsis
- Test also other pages for instance (http://localhost:4000/components/modal/example-fullsize-always.html)
- Change the text and make it longer
- Title should not overflow and it should have ellipsis

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
