### PR TITLE
751 - Fire personalization on reset to default

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[Field Filter]` Fixed an issue where switching to In Range filter type with a value in the field was causesing an error. ([#3515](https://github.com/infor-design/enterprise/issues/3515))
 - `[Field Filter]` Fixed an issue where date range was not working after using other filter. ([#2764](https://github.com/infor-design/enterprise/issues/2764))
 - `[Masthead]` Fixed layout and color issues in uplift theme. ([#3526](https://github.com/infor-design/enterprise/issues/3526))
+- `[Personalize]` Fixed an issue that colorschanged events do not fire on set to default. ([#751](https://github.com/infor-design/enterprise-ng/issues/751))
 - `[Searchfield]` Correct the background color of toolbar search fields. ([#3527](https://github.com/infor-design/enterprise/issues/3527))
 - `[Spinbox]` Corrected an issue in the enable method, where it did not fully remove the readonly state. ([#3527](https://github.com/infor-design/enterprise/issues/3527))
 - `[Swaplist]` Fixed an issue where lists were overlapping on uplift theme. ([#3452](https://github.com/infor-design/enterprise/issues/3452))

--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -257,6 +257,7 @@ Personalize.prototype = {
     this.element.triggerHandler('colorschanged', {
       colors: this.settings.colors.header ||
         this.settings.colors || theme.themeColors().brand.primary.alt.value,
+      isDefault: false,
       theme: this.currentTheme || 'theme-soho-light'
     });
     return this;
@@ -271,6 +272,11 @@ Personalize.prototype = {
     if (sheet) {
       sheet.parentNode.removeChild(sheet);
     }
+    this.element.triggerHandler('colorschanged', {
+      colors: theme.themeColors().brand.primary.alt.value,
+      isDefault: true,
+      theme: this.currentTheme || 'theme-soho-light'
+    });
   },
 
   /**

--- a/test/components/personalize/personalize-api.func-spec.js
+++ b/test/components/personalize/personalize-api.func-spec.js
@@ -78,4 +78,20 @@ describe('Personalize API', () => {
 
     expect(document.documentElement.classList.contains('theme-uplift-dark')).toBeTruthy();
   });
+
+  it('Should fire colorschanged on setColors', () => {
+    personalization = new Personalize(document.documentElement, { theme: 'theme-uplift-light' });
+    const spyEvent = spyOnEvent('html', 'colorschanged');
+    personalization.setColors('personalization');
+
+    expect(spyEvent).toHaveBeenTriggered();
+  });
+
+  it('Should fire colorschanged on setColorsToDefault', () => {
+    personalization = new Personalize(document.documentElement, { theme: 'theme-uplift-light' });
+    const spyEvent = spyOnEvent('html', 'colorschanged');
+    personalization.setColorsToDefault();
+
+    expect(spyEvent).toHaveBeenTriggered();
+  });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Calling reset color to default to not fire the colorschanged event. I fixed this and aslo added an extra falg isDefault. This is needed in an NG issue.

**Related github/jira issue (required)**:
Fixes #ng-751 but that also needs a PR

**Steps necessary to review your pull request (required)**:
- covered by tests

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
