### PR TITLE
748 - Remove deprecated calls and default the index in Block grid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### v4.27.0 Fixes
 
 - `[Bar Chart]` Fixed an issue where chart was not resizing on homepage widget resize. ([#2669](https://github.com/infor-design/enterprise/issues/2669))
+- `[Blockgrid]` Fixed an issue where there was no index if the data is empty, and removed deprecated internal calls. ([#748](https://github.com/infor-design/enterprise-ng/issues/748))
 - `[Colorpicker]` Fixed the dropdown icon position is too close to the right edge of the field. ([#3508](https://github.com/infor-design/enterprise/issues/3508))
 - `[Datagrid]` Fixed an issue where date range filter was unable to filter data. ([#3503](https://github.com/infor-design/enterprise/issues/3503))
 - `[Datagrid]` Fixed a bug were datagrid tree would have very big text in the tree nodes on IOS. ([#3347](https://github.com/infor-design/enterprise/issues/3347))

--- a/src/components/blockgrid/blockgrid.js
+++ b/src/components/blockgrid/blockgrid.js
@@ -89,7 +89,7 @@ Blockgrid.prototype = {
       const isCheckbox = target.is('.checkbox-label') || target.is('.checkbox');
 
       setTimeout(() => {
-        self.selectBlock(activeBlock, isCheckbox);
+        self.select(activeBlock, isCheckbox);
       }, 0);
 
       e.stopPropagation();
@@ -112,7 +112,7 @@ Blockgrid.prototype = {
       }
 
       const activeBlock = $(e.target);
-      self.selectBlock(activeBlock, false);
+      self.select(activeBlock, false);
     });
 
     this.element.on(`updated.${COMPONENT_NAME}`, () => {
@@ -300,7 +300,7 @@ Blockgrid.prototype = {
       }
 
       blockelements += `<div class="block is-selectable${selected}" role="listitem" tabindex="0">
-        <input type="checkbox" aria-hidden="true" role="presentation" class="checkbox" id="checkbox${i}" tabindex="${tabindex}" data-idx="${data.id}"${checked}>
+        <input type="checkbox" aria-hidden="true" role="presentation" class="checkbox" id="checkbox${i}" tabindex="${tabindex}" data-idx="${data.id || i}"${checked}>
         <label for="checkbox${i}" class="checkbox-label">
           <span class="audible">${selectText}</span>
         </label>

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -1377,11 +1377,13 @@ const Locale = {  // eslint-disable-line
     }
     if (options && options.language && this.languages[options.language]) {
       const newData = utils.extend(true, {}, this.currentLocale.data);
-      newData.calendars[0] = this.calendar(
-        options.locale || this.currentLocale.name,
-        options.language
-      );
-      return newData;
+      if (newData.calendars) {
+        newData.calendars[0] = this.calendar(
+          options.locale || this.currentLocale.name,
+          options.language
+        );
+        return newData;
+      }
     }
     if (!localeData.numbers) {
       localeData.numbers = this.numbers();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The NG example did not set a data.id so the selection did not show any info within the events. To fix this i default the index to the count if its empty. Also changed internal calls to call the non-deprecated method.

**Related github/jira issue (required)**:
Fixes infor-design/enterprise-ng#748

**Steps necessary to review your pull request (required)**:
**Enterprise Testing**
- load http://localhost:4000/components/blockgrid/example-singleselect.html
- Select a block in the grid
- Check the console in browser developer tools
- Notice how selectedRows contains the idx attribute and it does have a proper value.
- notice no deprecated methods
- test http://localhost:4000/components/blockgrid/

**Optional Enterprise NG Testing**
- build and link this to the enterprise-ng project
- Go to blockgrid single select example
Select a block in the grid
- Check the console in browser developer tools
- Notice how selectedRows  nowcontains the idx attribute 
- notice no deprecated methods

**Included in this Pull Request**:
- [x] A note to the change log.