### PR TITLE
703 - Fix js error with busy indicator

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Bar Chart]` Fixed an issue where chart was not resizing on homepage widget resize. ([#2669](https://github.com/infor-design/enterprise/issues/2669))
 - `[Blockgrid]` Fixed an issue where there was no index if the data is empty, and removed deprecated internal calls. ([#748](https://github.com/infor-design/enterprise-ng/issues/748))
+- `[Busy Indicator]` Fixed an issue where it throws an error when a display delay, the busy-indicator parent removed and added via ngIf before the busyindicator shown. ([#703](https://github.com/infor-design/enterprise-ng/issues/703))
 - `[Colorpicker]` Fixed the dropdown icon position is too close to the right edge of the field. ([#3508](https://github.com/infor-design/enterprise/issues/3508))
 - `[Datagrid]` Fixed an issue where date range filter was unable to filter data. ([#3503](https://github.com/infor-design/enterprise/issues/3503))
 - `[Datagrid]` Fixed a bug were datagrid tree would have very big text in the tree nodes on IOS. ([#3347](https://github.com/infor-design/enterprise/issues/3347))

--- a/src/components/busyindicator/busyindicator.js
+++ b/src/components/busyindicator/busyindicator.js
@@ -351,15 +351,18 @@ BusyIndicator.prototype = {
     if (this.blockUI) {
       this.scrollParent = $(this.getScrollParent(this.element[0]));
       const scrollParentHeight = this.scrollParent.length ? this.scrollParent.outerHeight() : 0;
-      if (scrollParentHeight && (scrollParentHeight < this.element.outerHeight())) {
+      if (scrollParentHeight && this.container &&
+          (scrollParentHeight < this.element.outerHeight())) {
         const locTop = (scrollParentHeight / 2) - 58;
         this.container.css({ top: locTop });
 
         this.scrollParent
           .off('scroll.parent.busyindicator')
           .on('scroll.parent.busyindicator', () => {
-            const offset = locTop + this.scrollParent.scrollTop();
-            this.container.css({ top: offset });
+            if (this.container) {
+              const offset = locTop + this.scrollParent.scrollTop();
+              this.container.css({ top: offset });
+            }
           });
       }
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed js error was showing when a display delay, the busy-indicator parent removed and added via *ngIf before the busyindicator shown.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#703

**Steps necessary to review your pull request (required)**:
- Pull and build this branch
- Pull and build ([NG master](https://github.com/infor-design/enterprise-ng.git))
- Copy and replace "dist" folder from `enterprise` to `⁨enterprise-ng⁩/node_modules⁩/ids-enterprise`
- Replaced the [zipped files](https://github.com/infor-design/enterprise-ng/files/4052831/busyindicator.zip) provided in original issue infor-design/enterprise-ng#703 to `src/app/busyindicator/`
- Navigate to http://localhost:4200/ids-enterprise-ng-demo/busyindicator
- Open developer tools
- Steps below must be done within the display delay time of 3000ms.
- Click button `Toggle Busy`
- Click button `Toggle Area`
- Click button `Toggle Area`
- Click button `Toggle Busy`
- See console there should not be any error

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
