### PR TITLE
2035 - Added font color for none/rest swatch

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `[Datepicker]` Fixed an issue where dates would be invalid in zh-TW locale. ([#3473](https://github.com/infor-design/enterprise/issues/3473))
 - `[Datepicker]` Fixed an issue where AM/PM could not be set in hi-IN locale. ([#3474](https://github.com/infor-design/enterprise/issues/3474))
 - `[Datepicker]` Fixed an issue where time would be reset to 12:00 AM when setting the time and clicking today. ([#3202](https://github.com/infor-design/enterprise/issues/3202))
+- `[Editor]` Added a font color for rest/none swatch. ([#2035](https://github.com/infor-design/enterprise/issues/2035))
 - `[Field Filter]` Fixed an issue where switching to In Range filter type with a value in the field was causesing an error. ([#3515](https://github.com/infor-design/enterprise/issues/3515))
 - `[Field Filter]` Fixed an issue where date range was not working after using other filter. ([#2764](https://github.com/infor-design/enterprise/issues/2764))
 - `[Masthead]` Fixed layout and color issues in uplift theme. ([#3526](https://github.com/infor-design/enterprise/issues/3526))

--- a/src/components/colorpicker/colorpicker.js
+++ b/src/components/colorpicker/colorpicker.js
@@ -572,9 +572,10 @@ ColorPicker.prototype = {
       // Add clearable swatch to popupmenu
       if (s.clearable) {
         const li = $('<li></li>');
+        const resetColorValue = this.element.attr('data-action') === 'foreColor' ? '000000' : '';
         const a = $(`<a href="#" title="${s.clearableText}"><span class="swatch is-empty${isBorderAll ? ' is-border' : ''}"></span></a>`).appendTo(li);
         a.data('label', s.clearableText)
-          .data('value', '000000')
+          .data('value', resetColorValue)
           .tooltip();
         menu.append(li);
       }

--- a/src/components/colorpicker/colorpicker.js
+++ b/src/components/colorpicker/colorpicker.js
@@ -573,7 +573,9 @@ ColorPicker.prototype = {
       if (s.clearable) {
         const li = $('<li></li>');
         const a = $(`<a href="#" title="${s.clearableText}"><span class="swatch is-empty${isBorderAll ? ' is-border' : ''}"></span></a>`).appendTo(li);
-        a.data('label', s.clearableText).data('value', '').tooltip();
+        a.data('label', s.clearableText)
+          .data('value', '000000')
+          .tooltip();
         menu.append(li);
       }
 

--- a/test/components/colorpicker/colorpicker.e2e-spec.js
+++ b/test/components/colorpicker/colorpicker.e2e-spec.js
@@ -79,11 +79,11 @@ describe('Colorpicker example-index tests', () => {
     expect(await element.all(by.className('swatch')).first().getAttribute('style')).toBe('background-color: rgb(137, 137, 137);');
   });
 
-  it('Should pick clear color from picker', async () => {
+  fit('Should pick clear color from picker', async () => {
     await element(by.css('#background-color + .trigger .icon')).click();
     await element(by.css('#colorpicker-menu li:last-child a:first-child')).click();
 
-    expect(await element(by.id('background-color')).getAttribute('value')).toEqual('#000000');
+    expect(await element(by.id('background-color')).getAttribute('value')).toEqual('');
     expect(await element(by.css('.swatch.is-invalid')).isDisplayed()).toBe(true);
   });
 
@@ -103,14 +103,14 @@ describe('Colorpicker example-index tests', () => {
     expect(await element(by.id('background-color')).getAttribute('value')).toEqual('#1A1A1A');
   });
 
-  it('Should pick clear color from picker with keypress', async () => {
+  fit('Should pick clear color from picker with keypress', async () => {
     await element(by.id('background-color')).sendKeys(protractor.Key.ARROW_DOWN);
 
     expect(await element(by.css('#background-color.is-open')).isDisplayed()).toBe(true);
 
     await element(by.css('#colorpicker-menu li:last-child a:first-child')).sendKeys(protractor.Key.SPACE);
 
-    expect(await element(by.id('background-color')).getAttribute('value')).toEqual('#000000');
+    expect(await element(by.id('background-color')).getAttribute('value')).toEqual('');
     expect(await element(by.css('.swatch.is-invalid')).isDisplayed()).toBe(true);
   });
 

--- a/test/components/colorpicker/colorpicker.e2e-spec.js
+++ b/test/components/colorpicker/colorpicker.e2e-spec.js
@@ -79,7 +79,7 @@ describe('Colorpicker example-index tests', () => {
     expect(await element.all(by.className('swatch')).first().getAttribute('style')).toBe('background-color: rgb(137, 137, 137);');
   });
 
-  fit('Should pick clear color from picker', async () => {
+  it('Should pick clear color from picker', async () => {
     await element(by.css('#background-color + .trigger .icon')).click();
     await element(by.css('#colorpicker-menu li:last-child a:first-child')).click();
 
@@ -103,7 +103,7 @@ describe('Colorpicker example-index tests', () => {
     expect(await element(by.id('background-color')).getAttribute('value')).toEqual('#1A1A1A');
   });
 
-  fit('Should pick clear color from picker with keypress', async () => {
+  it('Should pick clear color from picker with keypress', async () => {
     await element(by.id('background-color')).sendKeys(protractor.Key.ARROW_DOWN);
 
     expect(await element(by.css('#background-color.is-open')).isDisplayed()).toBe(true);

--- a/test/components/colorpicker/colorpicker.e2e-spec.js
+++ b/test/components/colorpicker/colorpicker.e2e-spec.js
@@ -83,7 +83,7 @@ describe('Colorpicker example-index tests', () => {
     await element(by.css('#background-color + .trigger .icon')).click();
     await element(by.css('#colorpicker-menu li:last-child a:first-child')).click();
 
-    expect(await element(by.id('background-color')).getAttribute('value')).toEqual('');
+    expect(await element(by.id('background-color')).getAttribute('value')).toEqual('#000000');
     expect(await element(by.css('.swatch.is-invalid')).isDisplayed()).toBe(true);
   });
 
@@ -110,7 +110,7 @@ describe('Colorpicker example-index tests', () => {
 
     await element(by.css('#colorpicker-menu li:last-child a:first-child')).sendKeys(protractor.Key.SPACE);
 
-    expect(await element(by.id('background-color')).getAttribute('value')).toEqual('');
+    expect(await element(by.id('background-color')).getAttribute('value')).toEqual('#000000');
     expect(await element(by.css('.swatch.is-invalid')).isDisplayed()).toBe(true);
   });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Reset/none swatch doesn't have a default value to change the text color when selecting it. Added a `000000` value as a default color.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/2035

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Navigate to http://localhost:4000/components/editor/example-index.html
- Select some amount of text then change the text color you want
- Select it again then change it to none swatch
- Text should change to black

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
