### PR TITLE
NG#321 - Allow click events attached to accordion headers to propagate

### DIFF
--- a/app/views/components/applicationmenu/test-click-event-propagation.html
+++ b/app/views/components/applicationmenu/test-click-event-propagation.html
@@ -1,0 +1,84 @@
+{{> includes/head}}
+
+<body class="no-scroll">
+  <a href="#maincontent" class="skip-link" data-translate="text">SkipToMain</a>
+  {{> includes/svg-inline-refs}}
+  <nav id="application-menu" class="application-menu is-personalizable" data-options="{ 'openOnLarge': true }">
+
+    <div class="accordion panel inverse" data-options="{'allowOnePane': true}" >
+
+      <div class="accordion-header is-selected">
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use xlink:href="#icon-home"></use>
+        </svg>
+        <a href="#"><span>Item One</span></a>
+      </div>
+
+      <div class="accordion-header">
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use xlink:href="#icon-tools"></use>
+        </svg>
+        <a href="#"><span>Item Two</span></a>
+      </div>
+
+      <div class="accordion-header">
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use xlink:href="#icon-columns"></use>
+        </svg>
+        <a href="#"><span>Item Three</span></a>
+      </div>
+    </div>
+  </nav>
+
+  <div class="page-container no-scroll">
+    <header class="header is-personalizable">
+      <a href="#maincontent" class="skip-link" data-translate="text">SkipToMain</a>
+
+      <div class="flex-toolbar">
+        <div class="toolbar-section static">
+          <button class="btn-icon application-menu-trigger" type="button">
+            <span class="audible">Show navigation</span>
+            <span class="icon app-header">
+              <span class="one"></span>
+              <span class="two"></span>
+              <span class="three"></span>
+            </span>
+          </button>
+        </div>
+        <div class="toolbar-section title">
+          <h1>Test: Click Event Propagation</h1>
+        </div>
+        <div class="toolbar-section buttonset"></div>
+        {{> includes/header-actionbutton}}
+      </div>
+    </header>
+    <div class="page-container scrollable" role="main" id="maincontent">
+      <div class="row">
+        <div class="six columns">
+          <p>Related Github Issue: <a class="hyperlink" href="https://github.com/infor-design/enterprise-ng/issues/321" target="_blank">NG #321</a></p>
+          <p>The headers inside the application menu on this page should cause a Toast to appear when clicked.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {{> includes/footer}}
+</body>
+
+<script id="test-script">
+  // Simulates the original test's method of immediately setting up a click listener,
+  // presumably before the component instance has been intialized internally.  This helps demonstrate
+  // that the order in which events are stacked doesn't matter, and all events propagate.
+  $('.accordion-header').on('click.test', function () {
+    const header = $(this);
+    const logEntry = '' + header.text().trim() + ' was clicked!';
+
+    $('body').toast({
+      title: 'It works!',
+      message: logEntry,
+      timeout: 1000
+    });
+  });
+</script>
+
+</html>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### v4.27.0 Fixes
 
+- `[Accordion]` Removed stoppage of event propagation when accordion headers are clicked, in order to allow external click event listeners to propagate. ([ng#321](https://github.com/infor-design/enterprise-ng/issues/321))
 - `[Bar Chart]` Fixed an issue where chart was not resizing on homepage widget resize. ([#2669](https://github.com/infor-design/enterprise/issues/2669))
 - `[Blockgrid]` Fixed an issue where there was no index if the data is empty, and removed deprecated internal calls. ([#748](https://github.com/infor-design/enterprise-ng/issues/748))
 - `[Busy Indicator]` Fixed an issue where it throws an error when a display delay, the busy-indicator parent removed and added via ngIf before the busyindicator shown. ([#703](https://github.com/infor-design/enterprise-ng/issues/703))

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -371,12 +371,6 @@ Accordion.prototype = {
       return false;
     }
 
-    // Stop propagation here because we don't want to bubble up to the Header and
-    // potentially click the it twice
-    if (e) {
-      e.stopPropagation();
-    }
-
     this.closePopups(e);
 
     /**

--- a/test/components/applicationmenu/applicationmenu.e2e-spec.js
+++ b/test/components/applicationmenu/applicationmenu.e2e-spec.js
@@ -5,12 +5,12 @@ requireHelper('rejection');
 
 jasmine.getEnv().addReporter(browserStackErrorReporter);
 
-describe('Applicationmenu index tests', () => {
+describe('Application Menu index tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/applicationmenu/example-index');
   });
 
-  it('Should show the app menu', async () => {
+  it('should open when the hamburger button is clicked', async () => {
     const button = await element(by.css('.application-menu-trigger'));
     await button.click();
     await browser.driver.sleep(config.sleepLonger);
@@ -18,12 +18,12 @@ describe('Applicationmenu index tests', () => {
     expect(await element(by.id('application-menu')).isDisplayed()).toBeTruthy();
   });
 
-  it('Should not have errors', async () => {
+  it('should not have errors', async () => {
     await utils.checkForErrors();
   });
 
   if (utils.isChrome() && utils.isCI()) {
-    it('Should not visual regress on example-index', async () => {
+    it('should not visually regress on example-index', async () => {
       const button = await element(by.css('.application-menu-trigger'));
       await button.click();
 
@@ -35,12 +35,12 @@ describe('Applicationmenu index tests', () => {
   }
 });
 
-describe('Applicationmenu filter tests', () => {
+describe('Application Menu filter tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/applicationmenu/example-filterable');
   });
 
-  it('Should filter', async () => {
+  it('should filter', async () => {
     const button = await element(by.css('#application-menu-searchfield'));
     await button.sendKeys('Role');
     await browser.driver
@@ -50,17 +50,17 @@ describe('Applicationmenu filter tests', () => {
     expect(await element.all(by.css('.accordion-header')).count()).toEqual(19);
   });
 
-  it('Should not have errors', async () => {
+  it('should not have errors', async () => {
     await utils.checkForErrors();
   });
 });
 
-describe('Applicationmenu menubutton tests', () => {
+describe('Application Menu MenuButton tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/applicationmenu/example-menubutton');
   });
 
-  it('Should have a working menu button', async () => {
+  it('should have a working menu button', async () => {
     await browser.driver
       .wait(protractor.ExpectedConditions.visibilityOf(await element.all(by.css('.btn-menu')).last()), config.waitsFor);
 
@@ -70,34 +70,34 @@ describe('Applicationmenu menubutton tests', () => {
     expect(await element(by.id('popupmenu-2')).isDisplayed()).toBeTruthy();
   });
 
-  it('Should not have errors', async () => {
+  it('should not have errors', async () => {
     await utils.checkForErrors();
   });
 });
 
-describe('Applicationmenu open on large tests', () => {
+describe('Application Menu open on large tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/applicationmenu/example-open-on-large');
     await browser.driver
       .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('application-menu'))), config.waitsFor);
   });
 
-  it('Should have menu open', async () => {
+  it('should be open on intialization', async () => {
     expect(await element(by.id('application-menu')).isDisplayed()).toBeTruthy();
   });
 
-  it('Should not have errors', async () => {
+  it('should not have errors', async () => {
     await utils.checkForErrors();
   });
 });
 
-describe('Applicationmenu container tests', () => {
+describe('Application Menu container tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/applicationmenu/test-container');
     await browser.driver.sleep(config.sleep);
   });
 
-  it('Should show the app menu', async () => {
+  it('should display without visual bugs', async () => {
     const button = await element(by.css('.application-menu-trigger'));
     await button.click();
     await browser.driver.sleep(config.sleep);
@@ -110,7 +110,7 @@ describe('Applicationmenu container tests', () => {
   });
 });
 
-describe('Applicationmenu accordion truncated text tooltip tests', () => {
+describe('Application Menu accordion truncated text tooltip tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/applicationmenu/test-tooltips');
 
@@ -119,11 +119,11 @@ describe('Applicationmenu accordion truncated text tooltip tests', () => {
       .wait(protractor.ExpectedConditions.presenceOf(truncatedText), config.waitsFor);
   });
 
-  it('Should not have errors', async () => {
+  it('should not have errors', async () => {
     await utils.checkForErrors();
   });
 
-  it('Should show tooltip on truncated text', async () => {
+  it('should show a tooltip on truncated text', async () => {
     await browser.actions().mouseMove(element(by.id('truncated-text'))).perform();
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(await element(by.id('tooltip'))), config.waitsFor);
@@ -132,21 +132,21 @@ describe('Applicationmenu accordion truncated text tooltip tests', () => {
   });
 });
 
-describe('Applicationmenu personalize tests', () => {
+describe('Application Menu personalize tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/applicationmenu/example-personalized');
   });
 
-  it('Should not have errors', async () => {
+  it('should not have errors', async () => {
     await utils.checkForErrors();
   });
 
-  it('Should show the app menu', async () => {
+  it('should show the app menu', async () => {
     expect(await element(by.id('application-menu')).isDisplayed()).toBeTruthy();
   });
 
   if (utils.isChrome() && utils.isCI()) {
-    it('Should not visually regress on personalize', async () => {
+    it('should not visually regress when personalized', async () => {
       const windowSize = await browser.driver.manage().window().getSize();
       await browser.driver.manage().window().setSize(1280, 718);
       const section = await element(by.css('body.no-scroll'));
@@ -158,22 +158,22 @@ describe('Applicationmenu personalize tests', () => {
   }
 });
 
-describe('Applicationmenu personalize roles tests', () => {
+describe('Application Menu personalize roles tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/applicationmenu/example-personalized-roles.html?colors=390567');
     await browser.driver.sleep(config.sleep);
   });
 
-  it('Should show the app menu', async () => {
+  it('should show the app menu', async () => {
     expect(await element(by.id('application-menu')).isDisplayed()).toBeTruthy();
   });
 
-  it('Should not have errors', async () => {
+  it('should not have errors', async () => {
     await utils.checkForErrors();
   });
 
   if (utils.isChrome() && utils.isCI()) {
-    it('Should not visually regress on personalize roles', async () => {
+    it('should not visually regress on personalize roles', async () => {
       const windowSize = await browser.driver.manage().window().getSize();
       await browser.driver.manage().window().setSize(1280, 718);
       const section = await element(by.css('body.no-scroll'));
@@ -185,21 +185,21 @@ describe('Applicationmenu personalize roles tests', () => {
   }
 });
 
-describe('Applicationmenu personalize roles switcher tests', () => {
+describe('Application Menu personalize roles switcher tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/applicationmenu/example-personalized-role-switcher');
   });
 
-  it('Should not have errors', async () => {
+  it('should not have errors', async () => {
     await utils.checkForErrors();
   });
 
-  it('Should show the app menu', async () => {
+  it('should show the app menu', async () => {
     expect(await element(by.id('application-menu')).isDisplayed()).toBeTruthy();
   });
 
   if (utils.isChrome() && utils.isCI()) {
-    it('Should not visually regress on personalize roles switcher', async () => {
+    it('should not visually regress on personalize roles switcher', async () => {
       const windowSize = await browser.driver.manage().window().getSize();
       await browser.driver.manage().window().setSize(1280, 718);
       const section = await element(by.css('body.no-scroll'));
@@ -210,7 +210,7 @@ describe('Applicationmenu personalize roles switcher tests', () => {
     });
   }
 
-  it('Should dismiss the application menu when clicking on a popupmenu trigger', async () => {
+  it('should dismiss the application menu when clicking on a popupmenu trigger', async () => {
     // NOTE: This only happens on mobile, and when `AppliationMenu.settings.dismissOnClickMobile: true;`
     const windowSize = await browser.driver.manage().window().getSize();
 
@@ -232,12 +232,12 @@ describe('Applicationmenu personalize roles switcher tests', () => {
   });
 });
 
-describe('Applicationmenu role switcher tests', () => {
+describe('Application Menu role switcher tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/applicationmenu/test-personalized-role-switcher-long-title');
   });
 
-  it('Should have a working role switcher with long title', async () => {
+  it('should have a working role switcher with long title', async () => {
     const btnSel = '.application-menu-switcher-trigger';
     await browser.driver
       .wait(protractor.ExpectedConditions.visibilityOf(await element.all(by.css(btnSel)).last()), config.waitsFor); // eslint-disable-line
@@ -248,21 +248,21 @@ describe('Applicationmenu role switcher tests', () => {
     expect(await element(by.css('.application-menu-switcher-panel')).isDisplayed()).toBeTruthy();
   });
 
-  it('Should not have errors', async () => {
+  it('should not have errors', async () => {
     await utils.checkForErrors();
   });
 });
 
-describe('Applicationmenu custom search tests', () => {
+describe('Application Menu custom search tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/applicationmenu/test-filterable-custom');
   });
 
-  it('Should show the search even though filterable is false', async () => {
+  it('should show the search even though filterable is false', async () => {
     expect(await element(by.css('#application-menu-searchfield')).isPresent()).toBeTruthy();
   });
 
-  it('Should have a search but not filter the menu when filterable is false', async () => {
+  it('should have a search but not filter the menu when filterable is false', async () => {
     const button = await element(by.css('#application-menu-searchfield'));
     await button.sendKeys('Role');
     await browser.driver.sleep(config.sleep);
@@ -270,17 +270,37 @@ describe('Applicationmenu custom search tests', () => {
     expect(await element.all(by.css('.accordion-header.filtered')).count()).toEqual(0);
   });
 
-  it('Should not have errors', async () => {
+  it('should not have errors', async () => {
     await utils.checkForErrors();
   });
 });
 
-describe('Applicationmenu Many Items tests', () => {
+describe('Application Menu Many Items tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/applicationmenu/test-filterable-many-items');
   });
 
-  it('Should not have errors', async () => {
+  it('should not have errors', async () => {
     await utils.checkForErrors();
+  });
+});
+
+describe('Application Menu Event Propagation Tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/applicationmenu/test-click-event-propagation');
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('#application-menu.is-open'))), config.waitsFor);
+  });
+
+  it('should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('should fire a toast when its accordion headers are clicked', async () => {
+    const thirdHeader = await element(by.css('#application-menu > div > div:nth-child(3)'));
+    await thirdHeader.click();
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('toast-container'))), config.waitsFor);
+
+    expect(await element(by.id('toast-container'))).toBeTruthy();
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR removes some code from Accordion headers that was stopping external click event handlers from propagating and ultimately running in most cases.  This was causing issues when developers attempted to run their own click handlers on accordion headers outside of the component, which was a problem in Angular environments.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#321

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the demoapp
- Open http://localhost:4000/components/applicationmenu/test-click-event-propagation.html
- Click any of the accordion headers.  They should correctly fire a toast containing their text contents.  The toast is driven by a simple click listener on their elements.

This test is also covered via a new e2e test.  Additionally, for further testing, you can set up the example provided by @anhallbe on the original ticket in his repo here: https://github.com/anhallbe/ids-repro/tree/accordion-click, and NPM link / symbolic link your Enterprise repo with this branch to see the changes working.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
