### PR TITLE
3569 - Fix popover height and datepicker layout on smaller/mobile view

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `[Datepicker]` Fixed an issue where dates would be invalid in zh-TW locale. ([#3473](https://github.com/infor-design/enterprise/issues/3473))
 - `[Datepicker]` Fixed an issue where AM/PM could not be set in hi-IN locale. ([#3474](https://github.com/infor-design/enterprise/issues/3474))
 - `[Datepicker]` Fixed an issue where time would be reset to 12:00 AM when setting the time and clicking today. ([#3202](https://github.com/infor-design/enterprise/issues/3202))
+- `[Datepicker]` Fixed popover height and datepicker layout on mobile view. ([#2569](https://github.com/infor-design/enterprise/issues/3569))
 - `[Editor]` Added a font color for rest/none swatch. ([#2035](https://github.com/infor-design/enterprise/issues/2035))
 - `[Field Filter]` Fixed an issue where switching to In Range filter type with a value in the field was causesing an error. ([#3515](https://github.com/infor-design/enterprise/issues/3515))
 - `[Field Filter]` Fixed an issue where date range was not working after using other filter. ([#2764](https://github.com/infor-design/enterprise/issues/2764))

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -773,7 +773,10 @@ DatePicker.prototype = {
         // Horizontal view on mobile
         if (window.innerHeight < 400 && this.popupClosestScrollable) {
           this.popup.find('.arrow').hide();
-          this.popup.css('min-height', `${(this.popupClosestScrollable[0].scrollHeight + 2)}px`);
+          this.popup.css({
+            'min-height': `${(this.popupClosestScrollable[0].scrollHeight - 521)}px`,
+            height: ''
+          });
           this.popupClosestScrollable.css('min-height', '375px');
         }
 

--- a/src/components/monthview/_monthview.scss
+++ b/src/components/monthview/_monthview.scss
@@ -227,6 +227,22 @@
     height: 42px;
     width: 42px;
 
+    @media only screen
+      and (max-width: $breakpoint-phone-to-tablet - 1)
+      and (-webkit-min-device-pixel-ratio: 2)
+      and (orientation: landscape) {
+      height: 32px;
+      width: 32px;
+    }
+
+    @media only screen
+      and (max-width: $breakpoint-phone-to-tablet - 1)
+      and (-webkit-min-device-pixel-ratio: 2)
+      and (orientation: portrait) {
+      height: 32px;
+      width: 32px;
+    }
+
     .day-text {
       @include rem(font-size, 1.4rem);
 
@@ -239,6 +255,24 @@
       margin: 2px;
       transition: 0.2s background-color ease;
       width: 36px;
+
+      @media only screen
+        and (max-width: $breakpoint-phone-to-tablet - 1)
+        and (-webkit-min-device-pixel-ratio: 2)
+        and (orientation: landscape) {
+        height: 32px;
+        line-height: 32px;
+        width: 32px;
+      }
+
+      @media only screen
+        and (max-width: $breakpoint-phone-to-tablet - 1)
+        and (-webkit-min-device-pixel-ratio: 2)
+        and (orientation: portrait) {
+        height: 32px;
+        line-height: 32px;
+        width: 32px;
+      }
     }
 
     &.is-selected.range {
@@ -369,6 +403,20 @@
           position: absolute;
           width: 43px;
           z-index: -1;
+
+          @media only screen
+            and (max-width: $breakpoint-phone-to-tablet - 1)
+            and (-webkit-min-device-pixel-ratio: 2)
+            and (orientation: landscape) {
+            height: 32px;
+          }
+
+          @media only screen
+            and (max-width: $breakpoint-phone-to-tablet - 1)
+            and (-webkit-min-device-pixel-ratio: 2)
+            and (orientation: portrait) {
+            height: 32px;
+          }
         }
       }
 
@@ -400,6 +448,22 @@
           left: 0;
           position: absolute;
           width: 35px;
+
+          @media only screen
+            and (max-width: $breakpoint-phone-to-tablet - 1)
+            and (-webkit-min-device-pixel-ratio: 2)
+            and (orientation: landscape) {
+            height: 31px;
+            width: 31px;
+          }
+
+          @media only screen
+            and (max-width: $breakpoint-phone-to-tablet - 1)
+            and (-webkit-min-device-pixel-ratio: 2)
+            and (orientation: portrait) {
+            height: 31px;
+            width: 31px;
+          }
         }
       }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The popover adds height causing the datepicker to extend/expand. And also, the dates overlap in the monthview container on a smaller view. 

The solution supports portrait and landscape view. For some reason, testing it on landscape position, the datepicker (when open) doesn't behave the same way when it's in portrait.

Solution
- Removed height and adjust the min-height when the window height is less than 400
- Adjusted height and width on a smaller view via media queries.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/3569

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Open on browserstack , actual iphone device or resize the window browser to a smaller size http://10.88.52.51:4000/components/datepicker/example-range.html
- Scroll to the bottom of the page
- Select/Click `Range - Max (2) Days` input field
- Then click datepicker icon
- The datepicker monthview shouldn't look odd (Issue: datepicker expand height)
- The dates should not overlap the monthview container
- Try to play around the datepicker, you shouldn't see any odd look on focus, highlighted date/s etc.
- Test the remaining fields at the bottom and follow the same steps

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
