### PR TITLE
Fix embedded layout to use uplift [v4.26.x]

### DIFF
--- a/app/views/layout-embedded.html
+++ b/app/views/layout-embedded.html
@@ -2,9 +2,9 @@
 <body class="scrollable layout-embedded">
   {{> includes/svg-inline-refs}}
   <header class="custom-header">
-    <button type="button" class="js-change-theme custom-active" title="Light" data-theme="theme-soho-light" data-init="false">Light</button>
-    <button type="button" class="js-change-theme" title="Dark" data-theme="theme-soho-dark" data-init="false">Dark</button>
-    <button type="button" class="js-change-theme" title="Contrast" data-theme="theme-soho-contrast" data-init="false">Contrast</button>
+    <button type="button" class="js-change-theme custom-active" title="Light" data-theme="theme-uplift-light" data-init="false">Light</button>
+    <button type="button" class="js-change-theme" title="Dark" data-theme="theme-uplift-dark" data-init="false">Dark</button>
+    <button type="button" class="js-change-theme" title="Contrast" data-theme="theme-uplift-contrast" data-init="false">Contrast</button>
   </header>
   <div class="container" role="main">
     {{> content}}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

We are changing the demos to use uplift but this change is needed for when you switch tabs.

**Related github/jira issue (required)**:
https://github.com/infor-design/website/issues/861

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/typography/example-index.html?theme=uplift&variant=light&layout=embedded
- hit the tabs
- theme should stay as uplift
