### PR TITLE
3569 - Fix responsive layout of datepicker in uplift

### DIFF
--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -775,7 +775,8 @@ DatePicker.prototype = {
         if (window.innerHeight < 400 && this.popupClosestScrollable) {
           this.popup.find('.arrow').hide();
           this.popup.css({
-            'min-height': `${(this.popupClosestScrollable[0].scrollHeight - 521)}px`,
+            'min-height': $('html').hasClass('theme-uplift-light') ? ''
+              : `${(this.popupClosestScrollable[0].scrollHeight - 521)}px`,
             height: ''
           });
           this.popupClosestScrollable.css('min-height', '375px');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
A follow up fix for failed QA ticket. Issue has been reproduced via uplift theme.

Issue:
- Datepicker extends it's height on mobile view in uplift theme

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/3569

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Open in browserstack in iPhone 11 Pro, safari browser
- Navigate to http://localhost:4000/components/datepicker/example-range.html?theme=uplift&variant=light
- Scroll to the bottom of the page
- Select/Click Range - Max (2) Days input field
- Then click datepicker icon
- The datepicker monthview shouldn't look odd (Issue: datepicker expand height)
- Test the remaining fields at the bottom and follow the same steps
- Test it also on Windows 10 Edge
- Resize the browser down to 371 x 606
- Scroll to the bottom of the page
- Select/Click Range - Max (2) Days input field
- Then click datepicker icon
- The datepicker monthview shouldn't look odd (Issue: datepicker expand height)


<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
