### PR TITLE
3509 - Add fix on misalignment of process indicator icons

### DIFF
--- a/src/components/processindicator/_processindicator-uplift.scss
+++ b/src/components/processindicator/_processindicator-uplift.scss
@@ -1,19 +1,87 @@
 // Uplift Process Indicator
 //================================================== //
+.process-indicator {
+  .indicator {
+    &.more-info {
+      &::before {
+        top: 0.11em;
+      }
+    }
+  }
 
-.indicator {
-  &.more-info {
-    &::before {
-      top: 0.11em;
+  &.compact {
+    .indicator {
+      &.rejected {
+        &::before,
+        &::after {
+          width: ($indicator-size * 0.78);
+        }
+      }
+    }
+  }
+}
+
+.is-safari {
+  .process-indicator {
+    .indicator {
+      &.current {
+        &.rejected {
+          &::before,
+          &::after {
+            width: ($indicator-size * 0.78);
+          }
+        }
+      }
+
+      &.more-info {
+        &::before {
+          left: 0.02em;
+          top: 0.1em;
+        }
+      }
+    }
+
+    &.compact {
+      .indicator {
+        &.rejected {
+          &::before,
+          &::after {
+            width: ($indicator-size * 0.82);
+          }
+        }
+      }
     }
   }
 }
 
 .is-firefox {
-  .indicator {
-    &.more-info {
-      &::before {
-        top: 0.11em;
+  .process-indicator {
+    &.compact {
+      .indicator {
+        &.rejected {
+          &::before,
+          &::after {
+            width: ($indicator-size * 0.78);
+          }
+        }
+      }
+    }
+
+    .indicator {
+      &.more-info {
+        &::before {
+          top: 0.11em;
+        }
+      }
+
+      &.rejected {
+        &.current {
+          &::before,
+          &::after {
+            left: 0.52em;
+            top: 0.98em;
+          }
+        }
       }
     }
   }

--- a/src/components/processindicator/_processindicator.scss
+++ b/src/components/processindicator/_processindicator.scss
@@ -152,7 +152,7 @@ $indicator-current-size: ($indicator-size * 1.6);
       content: '';
       display: inline-block;
       height: 0.15em;
-      left: 0.12em;
+      left: 0.16em;
       position: absolute;
       top: 0.57em;
       width: ($indicator-size * 0.78);
@@ -247,13 +247,21 @@ $indicator-current-size: ($indicator-size * 1.6);
       &.rejected {
         &::before,
         &::after {
+          left: 0.12em;
           width: ($indicator-size * 0.82);
+        }
+
+        &.current {
+          &::before,
+          &::after {
+            left: 0.5em;
+          }
         }
       }
 
       &.more-info {
         &::before {
-          right: 0.05em;
+          right: 0.02em;
         }
       }
     }
@@ -288,6 +296,18 @@ $indicator-current-size: ($indicator-size * 1.6);
 }
 
 .is-firefox {
+  .process-indicator {
+    &.compact {
+      .indicator {
+        &.more-info {
+          &::before {
+            right: 0;
+          }
+        }
+      }
+    }
+  }
+
   .indicator {
     &.more-info {
       &::before {
@@ -296,11 +316,6 @@ $indicator-current-size: ($indicator-size * 1.6);
     }
 
     &.rejected {
-      &::before,
-      &::after {
-        width: ($indicator-size * 0.82);
-      }
-
       &.current {
         &::before,
         &::after {
@@ -323,6 +338,13 @@ $indicator-current-size: ($indicator-size * 1.6);
     &.current {
       height: 2.02em;
       width: 2.02em;
+
+      &.rejected {
+        &::before,
+        &::after {
+          width: ($indicator-size * 0.83);
+        }
+      }
     }
 
     &.more-info {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This is an additional fix for #3509 failed QA ticket. Some icons on other devices and browsers (probably on Edge).

**Related github/jira issue (required)**:
Closes #3509 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Test and open to different devices or use browserstack. Test also to all browsers
- Navigate to http://localhost:4000/components/processindicator/example-index.html
- Process indicator icons should centered/aligned properly in circle indicators
- Test this also on uplift theme

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
