### PR TITLE
2650 - Allow Dropdowns to close their lists when scrolling a custom Modal region

### DIFF
--- a/app/views/components/dropdown/test-in-modal-content.html
+++ b/app/views/components/dropdown/test-in-modal-content.html
@@ -1,0 +1,151 @@
+<div class="row">
+  <div class="six columns">
+    <h2>Test: Dropdown Inside Modal Content</h2>
+    <p>Github Issue: <a class="hyperlink" href="https://github.com/infor-design/enterprise/issues/2650">#2650</a></p>
+    <p>Scrolling inside of this Modal component should cause the Dropdown list to close, if the list is open when attempting to scroll.</p>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="six columns">
+    <div class="field">
+      <button id="create-modal" class="btn-secondary">
+        <span>Create Modal</span>
+      </button>
+    </div>
+    <div class="field">
+      <fieldset class="radio-group">
+        <legend>Scrollable Area Type:</legend>
+        <input type="radio" class="radio" name="wrapper-type" id="wrapper-type-modal" value="modal" checked />
+        <label for="wrapper-type-modal" class="radio-label">`modal-body-wrapper` (default)</label>
+        <br/>
+        <input type="radio" class="radio" name="wrapper-type" id="wrapper-type-scrollable-y" value="scrollable-y" />
+        <label for="wrapper-type-scrollable-y" class="radio-label">`test-content` (`scrollable-y` section)</label>
+      </fieldset>
+    </div>
+  </div>
+</div>
+
+<style id="test-style" type="text/css">
+  /**
+   * In order to control the scrolling in the custom scrollable section
+   * (and prevent false positives from the standard Modal setup), we need to
+   * set the height on the outer wrappers to inherit height.
+   */
+  .custom-scrollable-modal .modal-body,
+  .custom-scrollable-modal .test-content-wrapper,
+  .custom-scrollable-modal .test-content {
+    max-height: inherit;
+  }
+
+  /* Fixes the padding in the custom mode */
+  .custom-scrollable-modal .modal-content .modal-body-wrapper {
+    padding: 5px 0;
+  }
+  .custom-scrollable-modal .test-content {
+    padding: 0 20px;
+  }
+
+  /* Sets a min-width on the `#h1-title` just for this sample, since we make it dynamic */
+  #h1-title {
+    min-width: 400px;
+  }
+</style>
+
+<script id="test-script">
+  var usableContent = '<div id="modal-test-content" class="test-content">' +
+    '<p style="height: 500px;">Scroll down to see a dropdown...</p>' +
+    '<div class="field">' +
+      '<label for="states" class="label">Choose a State:</label>' +
+      '<select id="states" name="states" class="dropdown" data-options="{ source: \'{{basepath}}api/states\' }"></select>' +
+    '</div>' +
+    '<p style="height: 500px;"></p>' +
+    '<p style="padding-bottom: 20px;">Scroll up to see a dropdown...</p>' +
+    '<div class="field">' +
+      '<label for="extra" class="label">Extra Info:</label>' +
+      '<input id="extra" type="text"/>' +
+    '</div>' +
+  '</div>';
+
+  var body = $('body');
+  var createBtn = $('#create-modal');
+  var baseModalSettings = {
+    title: 'Modal with Dropdown',
+    showCloseBtn: true
+  };
+
+  // Updates the title text of the Modal.
+  function renderModalTitleText($elem) {
+    var scrollTopVal = $elem.scrollTop();
+    var type = $elem[0].tagName.toLowerCase();
+    $elem[0].classList.forEach(function (cssClass) {
+      type += '.' + cssClass;
+    });
+
+    var msg = '' + type + ' scrollTop: ' + scrollTopVal + 'px';
+    $('#h1-title').text(msg);
+  }
+
+  // Gets the current scrollable element inside the Modal.
+  function getScrollableElem() {
+    var scrollableType = $('[name="wrapper-type"]:checked').val();
+    if (scrollableType === 'scrollable-y') {
+      return $('#modal-test-content');
+    }
+    return $('.modal-body-wrapper');
+  }
+
+  createBtn.on('click.test', function () {
+    var thisUsableContent = '' + usableContent;
+
+    // Adds a scrollable wrapper section to the modal content.
+    // This tests that the Dropdown code is correctly checking for the presence
+    // of a sub-scrollable section inside the Modal Content area.
+    var scrollableType = $('[name="wrapper-type"]:checked').val();
+    if (scrollableType === 'scrollable-y') {
+      thisUsableContent = '<div class="test-content-wrapper no-scroll">' +
+        usableContent +
+      '</div>';
+    }
+
+    // For `scrollable-y` type, remove the main scrolling areas and bolster the inner scrollable area.
+    var $thisUsableContent = $(thisUsableContent);
+    if (scrollableType === 'scrollable-y') {
+      $thisUsableContent
+        .children('.test-content')
+        .addClass('scrollable-y');
+    }
+
+    // Setup the modal and initialize the content
+    var settings = $.extend({}, baseModalSettings, {
+      content: $thisUsableContent
+    });
+    body.modal(settings);
+    var api = body.data('modal');
+    api.element.initialize();
+
+    // Make the `.modal-body-wrapper` element not scroll
+    // (forces the inner area we built to scroll instead)
+    if (scrollableType === 'scrollable-y') {
+      api.element.addClass('custom-scrollable-modal');
+      api.element.find('.modal-body-wrapper').addClass('no-scroll');
+    }
+
+    // As the Modal's scrolling area is scrolled, update the Title text on the Modal
+    // with the current `scrollTop` value.
+    var scrollableElem = getScrollableElem();
+    renderModalTitleText(scrollableElem);
+    scrollableElem.on('scroll.test', function () {
+      renderModalTitleText($(this));
+    });
+
+    // After the Modal closes, we destroy it.
+    // We will create a new one if the button's clicked again.
+    body.on('afterclose.test', function() {
+      api.destroy();
+      scrollableElem.off('scroll.test');
+      body.off('afterclose.test');
+      createBtn.focus();
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@
 - `[Datepicker]` Fixed an issue where change would fire twice or when the value is still blank. ([#3423](https://github.com/infor-design/enterprise/issues/3423))
 - `[Datepicker]` Fixed an issue where time would be reset to 12:00 AM when setting the time and clicking today. ([#3202](https://github.com/infor-design/enterprise/issues/3202))
 - `[Datepicker]` Fixed popover height and datepicker layout on mobile view. ([#2569](https://github.com/infor-design/enterprise/issues/3569))
+- `[Dropdown]` Fixed a bug where it was not possible for Dropdowns in certain scrollable Modal regions to close on scroll. ([#2650](https://github.com/infor-design/enterprise/issues/2650))
 - `[Editor]` Added a font color for rest/none swatch. ([#2035](https://github.com/infor-design/enterprise/issues/2035))
 - `[Field Filter]` Fixed an issue where switching to In Range filter type with a value in the field was causesing an error. ([#3515](https://github.com/infor-design/enterprise/issues/3515))
 - `[Field Filter]` Fixed an issue where date range was not working after using other filter. ([#2764](https://github.com/infor-design/enterprise/issues/2764))

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1961,13 +1961,17 @@ Dropdown.prototype = {
       .on('touchend.dropdown touchcancel.dropdown', touchEndCallback)
       .on('click.dropdown', clickDocument);
 
-    const modalScroll = $('.modal.is-visible .modal-body-wrapper');
-    let parentScroll = self.element.closest('.scrollable').length ? self.element.closest('.scrollable') : $(document);
-    parentScroll = self.element.closest('.scrollable-y').length ? self.element.closest('.scrollable-y') : parentScroll;
-    parentScroll = modalScroll.length ? modalScroll : parentScroll;
-    parentScroll.on('scroll.dropdown', scrollDocument);
-
-    $('.datagrid-wrapper').on('scroll.dropdown', scrollDocument);
+    // When the Dropdown is located within a scrollable section,
+    // the dropdown must close if that section is scrolled.
+    let parentScrollableArea = $('.modal.is-visible .modal-body-wrapper');
+    const subScrollableSection = self.element.closest('.scrollable, .scrollable-x, .scrollable-y', '.datagrid-wrapper');
+    if (subScrollableSection.length) {
+      parentScrollableArea = subScrollableSection;
+    }
+    if (parentScrollableArea.length) {
+      this.parentScrollableArea = parentScrollableArea;
+      this.parentScrollableArea.on('scroll.dropdown', scrollDocument);
+    }
 
     $('body').on('resize.dropdown', () => {
       self.position();
@@ -2259,12 +2263,10 @@ Dropdown.prototype = {
         `touchend.${COMPONENT_NAME}`,
         `touchcancel.${COMPONENT_NAME}`].join(' '));
 
-    const modalScroll = $('.modal.is-visible .modal-body-wrapper');
-    let parentScroll = this.element.closest('.scrollable').length ? this.element.closest('.scrollable') : $(document);
-    parentScroll = this.element.closest('.scrollable-y').length ? this.element.closest('.scrollable-y') : parentScroll;
-    parentScroll = modalScroll.length ? modalScroll : parentScroll;
-    parentScroll.off('scroll.dropdown');
-    $('.datagrid-wrapper').off('scroll.dropdown');
+    if (this.parentScrollableArea) {
+      this.parentScrollableArea.off('scroll.dropdown');
+      delete this.parentScrollableArea;
+    }
 
     $('body').off('resize.dropdown');
     $(window).off('orientationchange.dropdown');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR makes changes to the Dropdown component's calculation of surrounding scrollable regions when invoked inside a Modal. Previously, a custom scrollable area would not be detected by the Dropdown, causing its list to remain open if the scrolling region was scrolled by the user.  This bug is now fixed.

**Related github/jira issue (required)**:
Closes #2650

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the demoapp
- Open http://localhost:4000/components/dropdown/test-in-modal-content.html
- Check the radio button that says "`test-content` (`scrollable-y` section)"
- Click "Create Modal".
- When the modal opens, click the Dropdown to open the list.
- Try to scroll the section of the modal outside of the Dropdown's list.  The Dropdown list should close as expected.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
