### PR TITLE
588 - Fix selected values with lookup

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@
 - `[Editor]` Added a font color for rest/none swatch. ([#2035](https://github.com/infor-design/enterprise/issues/2035))
 - `[Field Filter]` Fixed an issue where switching to In Range filter type with a value in the field was causesing an error. ([#3515](https://github.com/infor-design/enterprise/issues/3515))
 - `[Field Filter]` Fixed an issue where date range was not working after using other filter. ([#2764](https://github.com/infor-design/enterprise/issues/2764))
+- `[Lookup]` Fixed an issue where selected values were clearing when use server side data. ([#588](https://github.com/infor-design/enterprise-ng/issues/588))
 - `[Masthead]` Fixed layout and color issues in uplift theme. ([#3526](https://github.com/infor-design/enterprise/issues/3526))
 - `[Modal]` Fixed an iOS bug where after opening several Modals/Messages, it would occasionally be impossible to scroll a scrollable page area. ([#3389](https://github.com/infor-design/enterprise/issues/3389))
 - `[Process Indicator]` Fixed icons that are not centered inside the circle indicators. ([#3509](https://github.com/infor-design/enterprise/issues/3509))


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed selected values were clearing when use server side data with Lookup.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#588

**Steps necessary to review your pull request (required)**:
- Pull and build this branch
- Pull and build NG branch ([588-lookup-selected-serverside](https://github.com/infor-design/enterprise-ng/tree/588-lookup-selected-serverside))
- Copy and replace "dist" folder from `enterprise` to `⁨enterprise-ng⁩/node_modules⁩/ids-enterprise`
- Navigate to http://localhost:4200/ids-enterprise-ng-demo/lookup
- Open lookup `Products (Async Results) Multi Select` (last one on the page)
- Select the first value (or any value)
- Click Apply
- Re-open lookup and click Apply without changing anything
- Previously selected value should not lost on 2nd `Apply`
- Try some other combinations as select/deselect or paging etc
- Also test EP links:
- http://localhost:4000/components/lookup/example-index.html
- http://localhost:4000/components/lookup/example-multiselect-paging-serverside.html

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
