### PR TITLE
711 - Made addMessage show the error on the parent

### DIFF
--- a/app/views/components/validation/test-error-on-tab-with-addmessage.html
+++ b/app/views/components/validation/test-error-on-tab-with-addmessage.html
@@ -1,0 +1,68 @@
+<div class="row top-padding">
+  <div class="twelve columns">
+
+    <div id="tabs-normal" class="tab-container">
+      <ul class="tab-list">
+        <li class="tab"><a href="#tabs-normal-contracts">Contracts</a></li>
+        <li class="tab"><a href="#tabs-normal-opportunities">Opportunities</a></li>
+        <li class="tab"><a href="#tabs-normal-attachments">Attachments</a></li>
+        <li class="tab"><a href="#tabs-normal-contacts">Contacts</a></li>
+        <li class="tab"><a href="#tabs-normal-notes">Notes</a></li>
+      </ul>
+    </div>
+    <div class="tab-panel-container">
+      <div id="tabs-normal-contracts" class="tab-panel">
+        <div class="row">
+          <div class="twelve columns">
+            <div class="compound-field">
+              <div class="field">
+               <label class="required" for="email-address">Email Address <span class="audible">Required</span></label>
+               <input type="text" id="email-address" name="email-address"/>
+              </div>
+              <div class="field">
+                <button id="show-error" class="btn-secondary no-ripple hide-focus" type="button">Show Error</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div id="tabs-normal-opportunities" class="tab-panel">
+        <p>Facilitate cultivate monetize, seize e-services peer-to-peer content integrateAJAX-enabled user-centric strategize. Mindshare; repurpose integrate global addelivery leading-edge frictionless, harness real-time plug-and-play standards-compliant 24/7 enterprise strategize robust infomediaries: functionalities back-end. Killer disintermediate web-enabled ubiquitous empower relationships, solutions, metrics architectures.</p>
+      </div>
+      <div id="tabs-normal-attachments" class="tab-panel">
+        <p>Frictionless webservices, killer open-source innovate, best-of-breed, whiteboard interactive back-end optimize capture dynamic front-end. Initiatives ubiquitous 24/7 enhance channels B2B drive frictionless web-readiness generate recontextualize widgets applications. Sexy sticky matrix, user-centred, rich user-centric: peer-to-peer podcasting networking addelivery optimize streamline integrated proactive: granular morph.</p>
+      </div>
+      <div id="tabs-normal-contacts" class="tab-panel top-padding">
+        <p>Bricks-and-clicks? Evolve ubiquitous matrix B2B 24/365 vertical 24/365 platforms standards-compliant global leverage dynamic 24/365 intuitive ROI seamless rss-capable. Cutting-edge grow morph web services leverage; ROI, unleash reinvent innovative podcasts citizen-media networking.</p>
+      </div>
+      <div id="tabs-normal-notes" class="tab-panel">
+        <p>Post incentivize; rich-clientAPIs customized revolutionize 24/365 killer incentivize integrate intuitive utilize!</p>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+
+<script>
+  var isErrorVisible = false;
+
+  $('#show-error').on('click', function() {
+    if (!isErrorVisible) {
+      $('#email-address').addMessage({
+        message : 'A have an error :(',
+        type: 'error',
+        inline: true
+      });
+      $(this).text('Hide Error');
+      isErrorVisible = true;
+      return;
+    }
+
+    $('#email-address').removeMessage({
+      type: 'error',
+      inline: true
+    });
+    isErrorVisible = false;
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,6 +66,7 @@
 - `[Tabs-Vertical]` Fixed an issue where the content cannot scroll on mobile view. ([#3542](https://github.com/infor-design/enterprise/issues/3542))
 - `[Tags]` Fixed a regression on Tag Buttons, where they were visually, vertically misaligned with Tag text. ([#3604](https://github.com/infor-design/enterprise/issues/3604))
 - `[Week-View]` Changed the look of the week-view and day-view day of the week so its a 3 (or 2) letter abbreviation and emphasizes the date and spans two lines. This makes all the days of the week the same length. ([#3262](https://github.com/infor-design/enterprise/issues/3262))
+- `[Validation]` Fixed a bug where addMessage did not add messages to the parent. ([#711](https://github.com/infor-design/enterprise-ng/issues/711))
 
 ## v4.26.2
 

--- a/src/components/tabs/_tabs-uplift.scss
+++ b/src/components/tabs/_tabs-uplift.scss
@@ -28,4 +28,11 @@
   }
 }
 
+.tab-container.horizontal > .tab-list-container .tab:not(.last-child).is-error .icon-error,
+.tab-container.header-tabs > .tab-list-container .tab:not(.last-child).is-error .icon-error {
+  height: 15px;
+  margin-top: -3px;
+  width: 15px;
+}
+
 @import '../tabs-module/tabs-module-uplift';

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -365,7 +365,7 @@
       padding: 0;
 
       &:not(.last-child) {
-        margin-right: 5px;
+        margin-right: 10px;
 
         &.is-error {
           a[role='tab'] {

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -365,18 +365,18 @@
       padding: 0;
 
       &:not(.last-child) {
-        margin-right: 10px;
+        margin-right: 5px;
 
         &.is-error {
           a[role='tab'] {
-            padding: 12px 17px 12px 5px;
+            padding: 12px 20px 12px 5px;
           }
 
           .icon-error {
             margin-left: 0;
-            position: relative;
-            right: 4px;
-            top: 0;
+            margin-right: 11px;
+            margin-top: -4px;
+            position: absolute;
           }
         }
       }

--- a/src/components/validation/validation.jquery.js
+++ b/src/components/validation/validation.jquery.js
@@ -134,13 +134,16 @@ $.fn.addMessage = function (settings) {
       id: settings.id || settings.message,
     };
 
+    const field = $(this);
     instance.addMessage(
-      $(this),
+      field,
       rule,
       settings.inline,
       settings.showTooltip,
       settings.isAlert
     );
+
+    instance.setIconOnParent(field, settings.type);
   });
 };
 

--- a/src/components/validation/validator.js
+++ b/src/components/validation/validator.js
@@ -422,7 +422,7 @@ Validator.prototype = {
    * @returns {void}
    */
   setIconOnParent(field, type) {
-    const errorIcon = $.createIcon({ classes: [`icon-${type}`], icon: type });
+    const errorIcon = $.createIcon({ classes: [`icon-${type}`], icon: `${type}-alert` });
     const parent = field.closest('.tab-panel, .expandable-pane');
     const flexRow = field.closest('.row.flex-align-bottom');
     let iconTarget = parent.attr('id');

--- a/test/components/colorpicker/colorpicker-aria.func-spec.js
+++ b/test/components/colorpicker/colorpicker-aria.func-spec.js
@@ -44,6 +44,6 @@ describe('ColorPicker ARIA', () => {
       expect(parent.querySelector('.colorpicker[aria-haspopup="true"]')).toBeTruthy();
       expect(parent.querySelector('.colorpicker[aria-controls="colorpicker-menu"]')).toBeTruthy();
       done();
-    }, 350);
+    }, 450);
   });
 });

--- a/test/components/validation/validation.e2e-spec.js
+++ b/test/components/validation/validation.e2e-spec.js
@@ -212,6 +212,22 @@ describe('Validation alert on tab', () => {
   });
 });
 
+describe('Validation alert on tab with add message', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/validation/test-error-on-tab-with-addmessage');
+  });
+
+  it('Should render icon on tab on add message', async () => {
+    expect(await element(by.css('.tab .icon-error')).isPresent()).toBe(false);
+    await element(by.id('show-error')).click();
+
+    expect(await element(by.css('.tab .icon-error')).isPresent()).toBe(true);
+    await element(by.id('show-error')).click();
+
+    expect(await element(by.css('.tab .icon-error')).isPresent()).toBe(false);
+  });
+});
+
 describe('Validation on date year', () => {
   beforeEach(async () => {
     await utils.setPage('/components/validation/test-invalid-date-events');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When calling addMessage the api would not call setIconOnParent and populate the parent tab with an error icon.

**Related github/jira issue (required)**:
Fixes infor-design/enterprise-ng#711 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/validation/test-error-on-tab-with-addmessage.html
- toggle the button and the icon should hide and show on both the field and the tab
- check the styling on both themes

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
