### PR TITLE
3659 - Fix Tooltip Trigger code to allow SVG triggers [v4.27.x]

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -89,8 +89,8 @@ Tooltip.prototype = {
    */
   get canBeShown() {
     return !this.reopenDelay &&
-      this.element[0].classList.contains('hidden') === false &&
-      this.element[0].classList.contains('is-hidden') === false &&
+      !DOM.hasClass(this.element[0], 'hidden') &&
+      !DOM.hasClass(this.element[0], 'is-hidden') &&
       this.element.parents('.hidden, .is-hidden').length < 1;
   },
 
@@ -179,7 +179,7 @@ Tooltip.prototype = {
     }
 
     this.isRTL = Locale.isRTL();
-    this.element[0].classList.add('has-tooltip');
+    DOM.addClass(this.element[0], 'has-tooltip');
   },
 
   /**
@@ -676,7 +676,7 @@ Tooltip.prototype = {
     this.tooltip[0].removeAttribute('style');
     this.tooltip[0].classList.add(this.settings.placement);
     this.tooltip[0].classList.add('is-open');
-    this.element[0].classList.add('has-open-tooltip');
+    DOM.addClass(this.element[0], 'has-open-tooltip');
 
     if (this.settings.isError || this.settings.isErrorColor) {
       this.tooltip[0].classList.add('is-error');
@@ -893,7 +893,7 @@ Tooltip.prototype = {
       return;
     }
 
-    this.element[0].classList.remove('has-open-tooltip');
+    DOM.removeClass(this.element[0], 'has-open-tooltip');
     this.tooltip[0].classList.remove('is-personalizable');
     this.tooltip[0].classList.remove('is-open');
     this.tooltip[0].classList.add('is-hidden');
@@ -1002,7 +1002,7 @@ Tooltip.prototype = {
       `focus.${COMPONENT_NAME}`,
       `blur.${COMPONENT_NAME}`].join(' '));
 
-    this.element[0].classList.remove('has-tooltip');
+    DOM.removeClass(this.element[0], 'has-tooltip');
 
     this.detachOpenEvents();
 

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -69,12 +69,19 @@ DOM.addClass = function addClass(el, ...className) {
   if (!el) {
     return;
   }
+  let classStr = '';
   for (let i = 0; i < className.length; i++) {
     if (el.classList) {
       el.classList.add(className[i]);
     } else if (!DOM.hasClass(el, [i])) {
-      el.className += ` ${className[i]}`;
+      if (classStr.length) {
+        classStr += ' ';
+      }
+      classStr += className[i];
     }
+  }
+  if (classStr.length) {
+    $(el).addClass(classStr);
   }
 };
 
@@ -89,19 +96,19 @@ DOM.removeClass = function removeClass(el, ...className) {
     return;
   }
 
+  let classStr = '';
   for (let i = 0; i < className.length; i++) {
     if (el.classList) {
       el.classList.remove(className[i]);
-    } else {
-      let newClassName = '';
-      const classes = el.className.split(' ');
-      for (let j = 0; j < classes.length; j++) {
-        if (classes[j] !== className[j]) {
-          newClassName += `${classes[i]} `;
-        }
+    } else if (!DOM.hasClass(el, [i])) {
+      if (classStr.length) {
+        classStr += ' ';
       }
-      this.className = newClassName;
+      classStr += className[i];
     }
+  }
+  if (classStr.length) {
+    $(el).removeClass(classStr);
   }
 };
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes some recent changes in Tooltip, which were using `HTMLElement.classList.add()/remove()` in some places where an SVG element may be present as the trigger element.  This is not supported in IE11 and was causing Javascript console errors, along with preventing higher level components like Datepicker from opening.  This has now been fixed.

**Related github/jira issue (required)**:
Closes #3659 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the demoapp
- Open http://localhost:4000/components/datepicker/example-timeformat.html in IE11
- Click any of the triggers to open the Datepickers. They should open with no issues.
- Inspect the developer tools console for any errors. There should be none.