### PR TITLE
3447 - Add support to format values with bullet chart

### DIFF
--- a/app/views/components/bullet/example-format.html
+++ b/app/views/components/bullet/example-format.html
@@ -81,7 +81,7 @@ $('body').on('initialized', function () {
     // Example 3 - Format values with callback function by Dataset
     var dataset3 = [{
         data: [{
-          title: 'Format values with callback function by Dataset',
+          title: 'Format values with callback function in the dataset',
           ranges: [1500000, 2250000, 3000000, 4000000, 6000000],
           measures: [2200000, 2700000],
           markers: [2500000]

--- a/app/views/components/bullet/example-format.html
+++ b/app/views/components/bullet/example-format.html
@@ -55,7 +55,7 @@ $('body').on('initialized', function () {
      // Example 2 - Format values with d3 formatter string by Settings
      var dataset2 = [{
         data: [{
-          title: 'Format values with formatter in the settings',
+          title: 'Format values with formatter string in the settings',
           ranges: [20000, 25000, 30000],
           measures: [17000, 21000],
           markers: [26000]

--- a/app/views/components/bullet/example-format.html
+++ b/app/views/components/bullet/example-format.html
@@ -27,7 +27,7 @@ $('body').on('initialized', function () {
     // Example 1 - Format values with d3 formatter string by Dataset
     var dataset1 = [{
         data: [{
-          title: 'Format values with d3 formatter string by Dataset',
+          title: 'Format values with formatter string in the settings dataset',
           ranges: [1500000, 2250000, 3000000, 4000000, 6000000],
           measures: [2200000, 2700000],
           markers: [2500000]

--- a/app/views/components/bullet/example-format.html
+++ b/app/views/components/bullet/example-format.html
@@ -1,0 +1,163 @@
+<div class="row">
+  <div class="full column center">
+    <div id="bullet-example1" class="chart-container"></div>
+  </div>
+</div>
+<div class="row">
+  <div class="full column center">
+    <div id="bullet-example2" class="chart-container"></div>
+  </div>
+</div>
+<div class="row">
+  <div class="full column center">
+    <div id="bullet-example3" class="chart-container"></div>
+  </div>
+</div>
+<div class="row">
+  <div class="full column center">
+    <div id="bullet-example4" class="chart-container"></div>
+  </div>
+</div>
+
+<script>
+$('body').on('initialized', function () {
+  var initCharts = function () {
+    var palette = Soho.theme.themeColors().palette;
+
+    // Example 1 - Format values with d3 formatter string by Dataset
+    var dataset1 = [{
+        data: [{
+          title: 'Format values with d3 formatter string by Dataset',
+          ranges: [1500000, 2250000, 3000000, 4000000, 6000000],
+          measures: [2200000, 2700000],
+          markers: [2500000]
+        }],
+        barColors: [
+          palette.turquoise[Soho.theme.uplift ? '20': '10'].value,
+          palette.turquoise[Soho.theme.uplift ? '30': '30'].value,
+          palette.turquoise[Soho.theme.uplift ? '60': '50'].value,
+          palette.turquoise[Soho.theme.uplift ? '80': '70'].value,
+          palette.turquoise[Soho.theme.uplift ? '100': '90'].value
+        ],
+        format: {
+          ranges: '.1s',
+          difference: '.1s'
+        },
+        lineColors: ['#000000', '#000000', '#000000'],
+        markerColors: ['#000000']
+      }];
+
+    $('#bullet-example1').chart({
+      type: 'bullet',
+      dataset: dataset1
+    });
+
+     // Example 2 - Format values with d3 formatter string by Settings
+     var dataset2 = [{
+        data: [{
+          title: 'Format values with d3 formatter string by Settings',
+          ranges: [20000, 25000, 30000],
+          measures: [17000, 21000],
+          markers: [26000]
+        }],
+        barColors: [
+          palette.azure[Soho.theme.uplift ? '30': '20'].value,
+          palette.azure[Soho.theme.uplift ? '50': '40'].value,
+          palette.azure[Soho.theme.uplift ? '70': '60'].value
+        ],
+        lineColors: ['#000000', '#000000', '#000000'],
+        markerColors: ['#000000']
+      }];
+
+    $('#bullet-example2').chart({
+      type: 'bullet',
+      dataset: dataset2,
+      format: {
+        ranges: '.1s',
+        difference: '.1s'
+      }
+    });
+
+    // Example 3 - Format values with callback function by Dataset
+    var dataset3 = [{
+        data: [{
+          title: 'Format values with callback function by Dataset',
+          ranges: [1500000, 2250000, 3000000, 4000000, 6000000],
+          measures: [2200000, 2700000],
+          markers: [2500000]
+        }],
+        barColors: [
+          palette.turquoise[Soho.theme.uplift ? '20': '10'].value,
+          palette.turquoise[Soho.theme.uplift ? '30': '30'].value,
+          palette.turquoise[Soho.theme.uplift ? '60': '50'].value,
+          palette.turquoise[Soho.theme.uplift ? '80': '70'].value,
+          palette.turquoise[Soho.theme.uplift ? '100': '90'].value
+        ],
+        format: {
+          ranges: function (d, i) {
+            return formatToUnits(d);
+          },
+          difference: function (d) {
+            return formatToUnits(d);
+          }
+        },
+        lineColors: ['#000000', '#000000', '#000000'],
+        markerColors: ['#000000']
+      }];
+
+    $('#bullet-example3').chart({
+      type: 'bullet',
+      dataset: dataset3
+    });
+
+     // Example 4 - Format values with callback function by Settings
+     var dataset4 = [{
+        data: [{
+          title: 'Format values with callback function by Settings',
+          ranges: [20000, 25000, 30000],
+          measures: [17000, 21000],
+          markers: [26000]
+        }],
+        barColors: [
+          palette.azure[Soho.theme.uplift ? '30': '20'].value,
+          palette.azure[Soho.theme.uplift ? '50': '40'].value,
+          palette.azure[Soho.theme.uplift ? '70': '60'].value
+        ],
+        lineColors: ['#000000', '#000000', '#000000'],
+        markerColors: ['#000000']
+      }];
+
+    $('#bullet-example4').chart({
+      type: 'bullet',
+      dataset: dataset4,
+      format: {
+        ranges: function (d, i) {
+          return formatToUnits(d);
+        },
+        difference: function (d) {
+          return formatToUnits(d);
+        }
+      }
+    });
+  };
+
+  // Initialize
+  $('html').on('themechanged', function() {
+    initCharts();
+  });
+  initCharts();
+});
+
+// Helper Function ===================================
+function formatToUnits(num, digits) {
+  var units = ['k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
+  var decimal;
+  for (var i = units.length - 1; i >= 0; i--) {
+    decimal = Math.pow(1000, (i + 1));
+    if (num <= -decimal || num >= decimal) {
+      return +(num / decimal).toFixed(digits) + units[i];
+    }
+  }
+  return num;
+}
+</script>

--- a/app/views/components/bullet/example-format.html
+++ b/app/views/components/bullet/example-format.html
@@ -55,7 +55,7 @@ $('body').on('initialized', function () {
      // Example 2 - Format values with d3 formatter string by Settings
      var dataset2 = [{
         data: [{
-          title: 'Format values with d3 formatter string by Settings',
+          title: 'Format values with formatter in the settings',
           ranges: [20000, 25000, 30000],
           measures: [17000, 21000],
           markers: [26000]

--- a/app/views/components/bullet/example-format.html
+++ b/app/views/components/bullet/example-format.html
@@ -113,7 +113,7 @@ $('body').on('initialized', function () {
      // Example 4 - Format values with callback function by Settings
      var dataset4 = [{
         data: [{
-          title: 'Format values with callback function by Settings',
+          title: 'Format values with callback function in the settings',
           ranges: [20000, 25000, 30000],
           measures: [17000, 21000],
           markers: [26000]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # What's New with Enterprise
 
+## v4.28.0
+
+### v4.28.0 Deprecation
+
+### v4.28.0 Features
+
+- `[Bullet Chart]` Added support to format ranges and difference values. ([#3447](https://github.com/infor-design/enterprise/issues/3447))
+
+### v4.28.0 Fixes
+
+### v4.28.0 Chores & Maintenance
+
 ## v4.27.0
 
 ### v4.27.0 Features

--- a/test/components/bullet/bullet-api.func-spec.js
+++ b/test/components/bullet/bullet-api.func-spec.js
@@ -37,6 +37,31 @@ const dataset2 = [{
   markerColors: ['#000000']
 }];
 
+const dataset3 = [{
+  data: [{
+    title: 'Revenue (New)',
+    subtitle: 'DKK$, in thousands',
+    ranges: [1500000, 2250000, 3000000, 4000000, 6000000],
+    measures: [2200000, 2700000],
+    markers: [2500000]
+  }],
+  barColors: ['#C0EDE3', '#8ED1C6', '#69ADA3', '#448D83', '#206B62'],
+  lineColors: ['#000000', '#000000', '#000000'],
+  markerColors: ['#000000']
+}];
+
+function formatToUnits(num, digits) {
+  const units = ['k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
+  let decimal;
+  for (let i = units.length - 1; i >= 0; i--) {
+    decimal = Math.pow(1000, (i + 1));
+    if (num <= -decimal || num >= decimal) {
+      return +(num / decimal).toFixed(digits) + units[i];
+    }
+  }
+  return num;
+}
+
 describe('Bullet Chart API', () => {
   beforeEach((done) => {
     bulletEl = null;
@@ -87,5 +112,83 @@ describe('Bullet Chart API', () => {
     triggerContextmenu(document.body.querySelector('.range'));
 
     expect(spyEvent).toHaveBeenTriggered();
+  });
+
+  it('Should format values with d3 formatter string by Dataset', (done) => {
+    const ds = JSON.parse(JSON.stringify(dataset3));
+    ds[0].format = {
+      ranges: '.1s',
+      difference: '.1s'
+    };
+    bulletObj.destroy();
+    bulletObj = new Bullet(bulletEl, { dataset: ds, animate: false });
+
+    setTimeout(() => {
+      expect(document.body.querySelectorAll('.tick').length).toEqual(7);
+      expect(document.body.querySelectorAll('.tick')[0].textContent).toEqual('0');
+      expect(document.body.querySelectorAll('.tick')[6].textContent).toEqual('6M');
+      expect(document.body.querySelector('.inverse').textContent).toEqual('200k');
+      done();
+    }, 300);
+  });
+
+  it('Should format values with d3 formatter string by Settings', (done) => {
+    const ds = JSON.parse(JSON.stringify(dataset3));
+    bulletObj.destroy();
+    bulletObj = new Bullet(bulletEl, {
+      dataset: ds,
+      animate: false,
+      format: {
+        ranges: '.1s',
+        difference: '.1s'
+      }
+    });
+
+    setTimeout(() => {
+      expect(document.body.querySelectorAll('.tick').length).toEqual(7);
+      expect(document.body.querySelectorAll('.tick')[0].textContent).toEqual('0');
+      expect(document.body.querySelectorAll('.tick')[6].textContent).toEqual('6M');
+      expect(document.body.querySelector('.inverse').textContent).toEqual('200k');
+      done();
+    }, 300);
+  });
+
+  it('Should format values with callback function by Dataset', (done) => {
+    const ds = JSON.parse(JSON.stringify(dataset3));
+    ds[0].format = {
+      ranges: d => formatToUnits(d),
+      difference: d => formatToUnits(d)
+    };
+    bulletObj.destroy();
+    bulletObj = new Bullet(bulletEl, { dataset: ds, animate: false });
+
+    setTimeout(() => {
+      expect(document.body.querySelectorAll('.tick').length).toEqual(7);
+      expect(document.body.querySelectorAll('.tick')[0].textContent).toEqual('0');
+      expect(document.body.querySelectorAll('.tick')[6].textContent).toEqual('6M');
+      expect(document.body.querySelector('.inverse').textContent).toEqual('200k');
+      done();
+    }, 300);
+  });
+
+  it('Should format values with callback function by Settings', (done) => {
+    const ds = JSON.parse(JSON.stringify(dataset3));
+    bulletObj.destroy();
+    bulletObj = new Bullet(bulletEl, {
+      dataset: ds,
+      animate: false,
+      format: {
+        ranges: d => formatToUnits(d),
+        difference: d => formatToUnits(d)
+      }
+    });
+
+    setTimeout(() => {
+      expect(document.body.querySelectorAll('.tick').length).toEqual(7);
+      expect(document.body.querySelectorAll('.tick')[0].textContent).toEqual('0');
+      expect(document.body.querySelectorAll('.tick')[6].textContent).toEqual('6M');
+      expect(document.body.querySelector('.inverse').textContent).toEqual('200k');
+      done();
+    }, 300);
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added support to format ranges and difference values with Bullet Chart.

**Related github/jira issue (required)**:
Closes #3447

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/bullet/test-formate-axis.html
- See the values should formatted like `1M` or `200k` etc.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
