### PR TITLE
3649 - Fix darkmode uplfit group line color

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### v4.28.0 Fixes
 
+- `[Datagrid]` Fixed a css issue in dark uplift mode where the group row lines were not visible . ([#3649](https://github.com/infor-design/enterprise/issues/3649))
+
 ## v4.27.0
 
 ### v4.27.0 Features

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -2829,7 +2829,7 @@ $datagrid-short-row-height: 25px;
   td {
     background-color: $datagrid-rowgroup-header;
     border: 1px solid transparent;
-    border-bottom: 1px solid $datagrid-cell-border-color;
+    border-bottom: 1px solid $datagrid-group-row-border-color;
     border-right: 1px solid $datagrid-cell-border-color;
     padding: 0 20px;
     -webkit-text-size-adjust: none; //Prevent huge text on IOS

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -621,6 +621,7 @@ $datagrid-cell-editing-bg-color: $theme-color-palette-white;
 $datagrid-cell-readonly-bg-color: $theme-color-palette-graphite-10;
 $datagrid-cell-readonly-color: $theme-color-font-base;
 $datagrid-cell-border-color: $theme-color-palette-graphite-30;
+$datagrid-group-row-border-color: $theme-color-palette-graphite-30;
 $datagrid-cell-focus-box-shadow: 0 0 4px 1px rgba(54, 138, 192, 0.4);
 $datagrid-data-color: $font-color-extrahighcontrast;
 $datagrid-row-selected-color: #d8f0f7;

--- a/src/themes/theme-soho-contrast.scss
+++ b/src/themes/theme-soho-contrast.scss
@@ -535,6 +535,7 @@ $datagrid-cell-editing-bg-color: $theme-color-palette-white;
 $datagrid-cell-readonly-bg-color: $input-color-readonly-background;
 $datagrid-cell-readonly-color: $font-color;
 $datagrid-cell-border-color: $theme-color-palette-graphite-60;
+$datagrid-group-row-border-color: $theme-color-palette-graphite-60;
 $datagrid-cell-focus-box-shadow: 0 0 4px 1px rgba(80, 83, 90, 0.4);
 $datagrid-data-color: $font-color-extrahighcontrast;
 $datagrid-row-selected-color: #b3ccdb;

--- a/src/themes/theme-soho-dark.scss
+++ b/src/themes/theme-soho-dark.scss
@@ -518,6 +518,7 @@ $datagrid-cell-editing-bg-color: $panel-bg-color;
 $datagrid-cell-readonly-bg-color: $theme-color-palette-slate-70;
 $datagrid-cell-readonly-color: $theme-color-palette-white;
 $datagrid-cell-border-color: $theme-color-palette-slate-50;
+$datagrid-group-row-border-color: $theme-color-palette-slate-50;
 $datagrid-cell-focus-box-shadow: 0 0 4px 1px rgba(101, 104, 113, 0.4);
 $datagrid-data-color: $font-color-extrahighcontrast;
 $datagrid-row-selected-color: #334d60;

--- a/src/themes/theme-uplift-contrast.scss
+++ b/src/themes/theme-uplift-contrast.scss
@@ -541,6 +541,7 @@ $datagrid-cell-editing-bg-color: $theme-color-palette-white;
 $datagrid-cell-readonly-bg-color: $input-color-readonly-background;
 $datagrid-cell-readonly-color: $font-color;
 $datagrid-cell-border-color: $theme-color-palette-graphite-60;
+$datagrid-group-row-border-color: $theme-color-palette-graphite-60;
 $datagrid-cell-focus-box-shadow: 0 0 4px 1px rgba(80, 83, 90, 0.4);
 $datagrid-data-color: $font-color-extrahighcontrast;
 $datagrid-row-selected-color: #b3ccdb;

--- a/src/themes/theme-uplift-dark.scss
+++ b/src/themes/theme-uplift-dark.scss
@@ -510,6 +510,8 @@ $datagrid-cell-editing-bg-color: $panel-bg-color;
 $datagrid-cell-readonly-bg-color: $theme-color-palette-slate-70;
 $datagrid-cell-readonly-color: $theme-color-palette-white;
 $datagrid-cell-border-color: $theme-color-palette-slate-70;
+$datagrid-group-row-border-color: $theme-color-palette-slate-70;
+$datagrid-group-row-border-color: $theme-color-palette-slate-50;
 $datagrid-cell-focus-box-shadow: 0 0 4px 1px rgba(101, 104, 113, 0.4);
 $datagrid-data-color: $font-color-extrahighcontrast;
 $datagrid-row-selected-color: #334d60;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The group line color was not visibile in uplift dark mode so made a new variable.

**Related github/jira issue (required)**:
Fixes #3649

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-grouping-totals.html?theme=uplift&variant=dark
- close some group rows
- should be a visible line between the group rows now
- test all six modes

**Included in this Pull Request**:
- [x] A note to the change log.

