### PR TITLE
3670 - Additional fix for dirty editor reset [v4.27.x]

### DIFF
--- a/src/components/trackdirty/trackdirty.js
+++ b/src/components/trackdirty/trackdirty.js
@@ -57,8 +57,9 @@ Trackdirty.prototype = {
         return el.val();
       }
       default: {
-        if (element.is('textarea.editor')) {
-          return this.trimEditorText(element.text());
+        if (element.is('textarea') && element.closest('.editor-source').length === 1) {
+          const value = element.is(':visible') ? element.val() : element.text();
+          return this.trimEditorText(value);
         }
         return element.val();
       }

--- a/test/components/editor/editor.e2e-spec.js
+++ b/test/components/editor/editor.e2e-spec.js
@@ -248,14 +248,44 @@ describe('Editor reset dirty tracking tests', () => {
     expect(await element(by.css('.editor-container .icon-dirty')).isPresent()).toBe(false);
   });
 
-  it('Should render dirty tracker in the source view', async () => {
+  it('Should reset dirty tracker after switch', async () => {
+    await element(by.id('editor1')).clear();
+    await element(by.id('editor1')).sendKeys('Test');
+    await browser.driver.wait(protractor.ExpectedConditions
+      .visibilityOf(await element(by.css('.editor-container .icon-dirty'))), config.waitsFor);
+
+    expect(await element(by.css('.editor-container .icon-dirty')).isDisplayed()).toBe(true);
+    await element(by.id('reset-dirty')).click();
+    await browser.driver.wait(protractor.ExpectedConditions
+      .stalenessOf(await element(by.css('.editor-container .icon-dirty'))), config.waitsFor);
+
+    expect(await element(by.css('.editor-container .icon-dirty')).isPresent()).toBe(false);
+
     await element(by.css('button[data-action=source]')).click();
-    await element(by.tagName('textarea')).sendKeys('<b>Test</b>');
+    await element(by.tagName('textarea')).clear();
+    await element(by.tagName('textarea')).sendKeys('<p>2</p>');
 
     await browser.driver.wait(protractor.ExpectedConditions
       .visibilityOf(await element(by.css('.editor-container .icon-dirty'))), config.waitsFor);
 
     expect(await element(by.css('.editor-container .icon-dirty')).isDisplayed()).toBe(true);
+    await element(by.id('reset-dirty')).click();
+    await browser.driver.wait(protractor.ExpectedConditions
+      .stalenessOf(await element(by.css('.editor-container .icon-dirty'))), config.waitsFor);
+
+    expect(await element(by.css('.editor-container .icon-dirty')).isPresent()).toBe(false);
+    await element(by.css('button[data-action=visual]')).click();
+    await element(by.id('editor1')).clear();
+    await element(by.id('editor1')).sendKeys('3');
+    await browser.driver.wait(protractor.ExpectedConditions
+      .visibilityOf(await element(by.css('.editor-container .icon-dirty'))), config.waitsFor);
+
+    expect(await element(by.css('.editor-container .icon-dirty')).isDisplayed()).toBe(true);
+    await element(by.id('reset-dirty')).click();
+    await browser.driver.wait(protractor.ExpectedConditions
+      .stalenessOf(await element(by.css('.editor-container .icon-dirty'))), config.waitsFor);
+
+    expect(await element(by.css('.editor-container .icon-dirty')).isPresent()).toBe(false);
   });
 });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

LM QA found one more issue switching an extra time and reseting the dirty tracker on editor.

**Related github/jira issue (required)**:
Fixes #3670

**Steps necessary to review your pull request (required)**:
1. go to http://localhost:4000/components/editor/test-dirty-tracking-reset.html
1. change some text
1. dirty indicator will show
1. click the button and dirty indicator will reset
1. switch to HTML view
1. change some text
1. dirty indicator will show
1. click the button and dirty indicator will reset
1. switch to Visual mode
1. change some text
1. dirty indicator will show
1. click the button and dirty indicator is not resetting

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
