### PR TITLE
3416 - Add additional fixes for safari with frozen colspan [v4.27.x]

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3299,7 +3299,7 @@ Datagrid.prototype = {
 
       if (self.hasLeftPane) {
         self.bodyColGroupLeft = $(self.bodyColGroupHtmlLeft);
-        self.tableBodyLeft.before(self.bodyColGroupLeft);
+        (self.headerRowLeft || self.tableBodyLeft).before(self.bodyColGroupLeft);
       }
 
       self.bodyColGroup = $(self.bodyColGroupHtml);
@@ -3307,7 +3307,7 @@ Datagrid.prototype = {
 
       if (self.hasRightPane) {
         self.bodyColGroupRight = $(self.bodyColGroupHtmlRight);
-        self.tableBodyRight.before(self.bodyColGroupRight);
+        (self.headerRowLeft || self.tableBodyRight).before(self.bodyColGroupRight);
       }
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

QA didnt work well with frozen columns and colspans. This adds an additional fix and fixes the size of the columns in safari.

**Related github/jira issue (required)**:
Fixes #3416

**Steps necessary to review your pull request (required)**:
- as before try these in Mac Safari and Mac Chrome....
- go to http://localhost:4000/components/datagrid/test-frozen-columns-with-colspan.html
- in the example code edit the `frozenColumns` section temporarily..
- try with all 3 commented out
- try with each commented out
- in all cases the columns should render the same (QA can not test this just test the example)
```
      frozenColumns: {
        // left: ['selectionCheckbox'],
        left: ['selectionCheckbox', 'productType'],
        // left: ['selectionCheckbox', 'productType', 'productId']
      },
```