### PR TITLE
3682 - Fix infinte loop in nested modals [v4.27.x]

### DIFF
--- a/app/views/components/lookup/test-custom-click.html
+++ b/app/views/components/lookup/test-custom-click.html
@@ -1,25 +1,20 @@
-
-
 <div class="row">
   <div class="twelve columns">
 
     <div class="field">
       <label for="product-lookup" class="label">Products</label>
-      <input id="product-lookup" data-init="false" class="lookup" name="product-lookup" type="text">
+      <input id="product-lookup" data-init="false" class="lookup" name="product-lookup" type="text"/>
     </div>
 
   </div>
 </div>
 
 <script>
-
-    //Init and get the api for the grid
-    $('#product-lookup').lookup({
-        //field: 'productId',
-        click: function (a, b, c) {
-          console.log(a, b, c);
-          alert('Open Popup');
-        }
-    });
-
+  // Init and get the api for the grid
+  $('#product-lookup').lookup({
+      click: function (a, b, c) {
+        console.log(a, b, c);
+        alert('Open Popup');
+      }
+  });
 </script>

--- a/app/views/components/lookup/test-custom-modal.html
+++ b/app/views/components/lookup/test-custom-modal.html
@@ -49,7 +49,6 @@
         }
     }).on('afterOpen', function () {
       $('#custom-lookup').tabs();
-      console.log('xx', document.activeElement)
     });
 
 </script>

--- a/app/views/components/lookup/test-custom-modal.html
+++ b/app/views/components/lookup/test-custom-modal.html
@@ -49,6 +49,7 @@
         }
     }).on('afterOpen', function () {
       $('#custom-lookup').tabs();
+      console.log('xx', document.activeElement)
     });
 
 </script>

--- a/app/views/components/lookup/test-multiple-custom-modals.html
+++ b/app/views/components/lookup/test-multiple-custom-modals.html
@@ -1,0 +1,79 @@
+<div class="page-container top-padding scrollable" id="maincontent" role="main">
+
+   <div class="row">
+      <div class="twelve columns">
+
+         <button class="btn-secondary" type="button" data-modal="modal-1">Select State</button>
+         <div class="modal" id="modal-1">
+            <div class="modal-content">
+
+               <div class="modal-header">
+                  <h1 class="modal-title" >Select State</h1>
+               </div>
+
+               <div class="modal-body">
+                  <div class="field">
+                     <label for="product-lookup" class="label">Products</label>
+                     <input id="product-lookup" data-init="false" class="lookup" name="product-lookup" type="text">
+                  </div>
+
+                  <div class="field">
+                     <label for="product-lookup2" class="label">Products2</label>
+                     <input id="product-lookup2" data-init="false" class="lookup" name="product-lookup2" type="text">
+                  </div>
+
+                  <div class="modal-buttonset">
+                     <button type="button" class="btn-modal" style="width:50%">Cancel</button>
+                     <button type="button" id="submit" class="btn-modal-primary" style="width:50%">Submit</button>
+                  </div>
+               </div>
+            </div>
+         </div>
+
+      </div>
+   </div>
+
+   <script>
+      var modal;
+
+      $('body').one('initialized', function () {
+         var grid,
+            columns = [],
+            data = [];
+
+         // Some Sample Data
+         data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+         data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+         data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+         data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+         data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+         data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+         data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+
+         //Define Columns for the Grid.
+         columns.push({ id: 'productId', name: 'Product Id', field: 'productId', width: 140});
+         columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', width: 250, formatter: Formatters.Hyperlink});
+         columns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', width: 125});
+         columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', width: 125});
+         columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, formatter: Formatters.Decimal});
+         columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+
+         //Init and get the api for the grid
+         grid = $('#product-lookup, #product-lookup2').lookup({
+            options: {
+               columns: columns,
+               dataset: data,
+               selectable: 'single', //multiselect or single
+               toolbar: {title: 'Products', results: true, dateFilter: false ,keywordFilter: false, actions: true, views: true , rowHeight: true}
+            }
+         });
+      });
+
+      // Close modal upon submit
+      $('#submit').on('click', function () {
+         console.log('Attempting to close modal...');
+         modal.close();
+      })
+   </script>
+
+</div>

--- a/app/views/components/lookup/test-multiple-custom-modals.html
+++ b/app/views/components/lookup/test-multiple-custom-modals.html
@@ -142,6 +142,7 @@
               $('body').modal({
                 title: 'Add Item',
                 content: $('#modal-datagrid'),
+                autoFocus: false,
                 buttons: [{
                   text: 'Cancel',
                   id: 'modal-button-1',
@@ -152,6 +153,12 @@
                   text: 'Save',
                   id: 'modal-button-2',
                   click: function(e, modal) {
+                    const selectedRows = modal.element.find('#datagrid').data('datagrid').selectedRows();
+                    if (selectedRows.length === 0) {
+                      return;
+                    }
+
+                    $('#product-lookup3').val(selectedRows[0].data.productId).focus();
                     modal.close();
                   },
                   isDefault: true
@@ -160,12 +167,6 @@
             }
          });
       });
-
-      // Close modal upon submit
-      $('#submit').on('click', function () {
-         console.log('Attempting to close modal...');
-         modal.close();
-      })
    </script>
 
 </div>

--- a/app/views/components/lookup/test-multiple-custom-modals.html
+++ b/app/views/components/lookup/test-multiple-custom-modals.html
@@ -147,6 +147,7 @@
                   text: 'Cancel',
                   id: 'modal-button-1',
                   click: function(e, modal) {
+                    $('#product-lookup3').focus();
                     modal.close();
                   }
                 }, {

--- a/app/views/components/lookup/test-multiple-custom-modals.html
+++ b/app/views/components/lookup/test-multiple-custom-modals.html
@@ -157,9 +157,10 @@
                     if (selectedRows.length === 0) {
                       return;
                     }
-
-                    $('#product-lookup3').val(selectedRows[0].data.productId).focus();
+                    const value = selectedRows[0].data.productId;
                     modal.close();
+
+                    $('#product-lookup3').val(value).focus();
                   },
                   isDefault: true
                 }]

--- a/app/views/components/lookup/test-multiple-custom-modals.html
+++ b/app/views/components/lookup/test-multiple-custom-modals.html
@@ -12,9 +12,35 @@
                </div>
 
                <div class="modal-body">
+
+                  <div class="field">
+                    <label for="date-field-normal" class="label">Date Field</label>
+                    <input id="date-field-normal" class="datepicker" name="date-field" type="text"/>
+                  </div>
+
                   <div class="field">
                      <label for="product-lookup" class="label">Products</label>
                      <input id="product-lookup" data-init="false" class="lookup" name="product-lookup" type="text">
+                  </div>
+
+                  <div class="field">
+                    <label for="first-name">First Name</label>
+                    <input type="text" id="first-name" name="first-name" placeholder="Normal text Field"/>
+                  </div>
+
+                  <div class="field">
+                    <label for="last-name">Last Name</label>
+                    <input type="text" id="last-name" name="last-name"/>
+                  </div>
+
+                  <div class="field">
+                    <label for="email-address">Email Address</label>
+                    <input type="text" id="email-address"name="email-address"/>
+                  </div>
+
+                  <div class="field">
+                    <label for="email-address-ok">Email Address - Checker</label>
+                    <input type="text" id="email-address-ok" name="email-address-ok"/>
                   </div>
 
                   <div class="field">

--- a/app/views/components/lookup/test-multiple-custom-modals.html
+++ b/app/views/components/lookup/test-multiple-custom-modals.html
@@ -43,9 +43,14 @@
                     <input type="text" id="email-address-ok" name="email-address-ok"/>
                   </div>
 
-                  <div class="field">
-                     <label for="product-lookup2" class="label">Products2</label>
+                  <!--<div class="field">
+                     <label for="product-lookup2" class="label">Lookup (2)</label>
                      <input id="product-lookup2" data-init="false" class="lookup" name="product-lookup2" type="text">
+                  </div> -->
+
+                  <div class="field">
+                     <label for="product-lookup3" class="label">Custom Modal Lookup</label>
+                     <input id="product-lookup3" data-init="false" class="lookup" name="product-lookup3" type="text"/>
                   </div>
 
                   <div class="modal-buttonset">
@@ -58,6 +63,11 @@
 
       </div>
    </div>
+
+    <div id="modal-datagrid" class="datagrid-default-modal-width hidden">
+      <div id="datagrid">
+      </div>
+    </div>
 
    <script>
       var modal;
@@ -85,12 +95,68 @@
          columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
 
          //Init and get the api for the grid
-         grid = $('#product-lookup, #product-lookup2').lookup({
+         $('#product-lookup, #product-lookup2').lookup({
             options: {
                columns: columns,
                dataset: data,
                selectable: 'single', //multiselect or single
                toolbar: {title: 'Products', results: true, dateFilter: false ,keywordFilter: false, actions: true, views: true , rowHeight: true}
+            }
+         });
+
+         // Init and get the api for the grid
+         var grid, columns = [], data = [];
+
+         // Some Sample Data
+         data.push({ id: 1, productId: 'T100', productName: 'Compressor', phone: '191/2004', activity:  'Assemble Paint', quantity: 1, price: '800.9905673502324', percent: .10, status: 'OK', orderDate: '00000000', action: 'Action'});
+         data.push({ id: 2, productId: '200', productName: 'Different Compressor', phone: '(888) 888-8888', activity:  'Inspect and Repair', quantity: '2', percent: .10, price: null, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+         data.push({ id: 3, productId: '300', productName: 'Compressor', phone: '(888) 888-8888', activity:  'Inspect and Repair', quantity: 1, price: '120.99', percent: .10, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+         data.push({ id: 4, productId: 'Z400', productName: 'Another Compressor', phone: '(888) 888-8888', activity:  'Assemble Paint', quantity: 3, price: '2345', percent: .10, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+         data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: '2345', percent: .10, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+         data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: '210.99', percent: .10, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+         data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: '120.99', percent: .10, status: 'OK', orderDate:new Date(2017, 5, 5), action: 'On Hold'});
+         data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '123.99', percent: .10, status: 'OK', orderDate: null, action: 'On Hold'});
+
+         // Define Columns for the Grid.
+         columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
+         columns.push({ id: 'productId', name: 'Id', field: 'productId', formatter: Formatters.Text, sortable: false, filterType: 'text' });
+
+         // Init and get the api for the grid
+         $('#datagrid').datagrid({
+           columns: columns,
+           dataset: data,
+           saveColumns: false,
+           paging: true,
+           pagesize: 5,
+           enableTooltips: true,
+           filterWhenTyping: false,
+           filterable: true,
+           redrawOnResize: false,
+           rowHeight: 'short',
+           selectable: 'multiple',
+           toolbar: {title: 'Compressors', actions: true, rowHeight: true, personalize: true}
+         });
+
+         $('#product-lookup3').lookup({
+            click: function (a, b, c) {
+              $('body').modal({
+                title: 'Add Item',
+                content: $('#modal-datagrid'),
+                buttons: [{
+                  text: 'Cancel',
+                  id: 'modal-button-1',
+                  click: function(e, modal) {
+                    modal.close();
+                  }
+                }, {
+                  text: 'Save',
+                  id: 'modal-button-2',
+                  click: function(e, modal) {
+                    modal.close();
+                  },
+                  isDefault: true
+                }]
+              });
             }
          });
       });

--- a/app/views/components/modal/test-no-autofocus.html
+++ b/app/views/components/modal/test-no-autofocus.html
@@ -1,0 +1,63 @@
+<div class="page-container top-padding scrollable" id="maincontent" role="main">
+
+   <div class="row">
+      <div class="twelve columns">
+
+         <button class="btn-secondary" type="button" id="show-modal">Show Modal (no focus)</button>
+         <div class="modal" id="modal-1">
+            <div class="modal-content">
+
+               <div class="modal-header">
+                  <h1 class="modal-title" >Select State</h1>
+               </div>
+
+               <div class="modal-body">
+                  <div class="field">
+                    <label for="first-name">First Name</label>
+                    <input type="text" id="first-name" name="first-name"/>
+                  </div>
+
+                  <div class="field">
+                    <label for="last-name">Last Name</label>
+                    <input type="text" id="last-name" name="last-name"/>
+                  </div>
+
+                  <div class="field">
+                    <label for="email-address">Email Address</label>
+                    <input type="text" id="email-address"name="email-address"/>
+                  </div>
+
+                  <div class="modal-buttonset">
+                     <button type="button" class="btn-modal">Cancel</button>
+                     <button type="button" id="submit" class="btn-modal-primary">Submit</button>
+                  </div>
+               </div>
+            </div>
+         </div>
+
+      </div>
+   </div>
+
+<script>
+  $('#show-modal').click(function () {
+    $('body').modal({
+      title: 'Edit Details',
+      content: $('#modal-1'),
+      autoFocus: false,
+      buttons: [{
+        text: 'Cancel',
+        id: 'modal-button-1',
+        click: function(e, modal) {
+          modal.close();
+        }
+      }, {
+        text: 'Save',
+        id: 'modal-button-2',
+        click: function(e, modal) {
+          modal.close();
+        },
+        isDefault: true
+      }]
+    });
+  });
+</script>

--- a/src/components/lookup/lookup.js
+++ b/src/components/lookup/lookup.js
@@ -65,6 +65,16 @@ function Lookup(element, settings) {
 Lookup.prototype = {
 
   /**
+   * @returns {boolean} true if the Lookup is currently the active element.
+   */
+  get isFocused() {
+    const active = document.activeElement;
+    const inputIsActive = this.element.is(active);
+    const wrapperHasActive = this.element.parent('.lookup-wrapper')[0].contains(active);
+    return (inputIsActive || wrapperHasActive);
+  },
+
+  /**
    * @private
    * @returns {void}
    */

--- a/src/components/lookup/lookup.js
+++ b/src/components/lookup/lookup.js
@@ -213,6 +213,12 @@ Lookup.prototype = {
    */
   openDialog(e) {
     const self = this;
+
+    // Don't try to re-open the lookup if it's already open.
+    if (this.isOpen) {
+      return;
+    }
+
     /**
       * Fires before open dialog.
       *
@@ -221,7 +227,6 @@ Lookup.prototype = {
       * @property {object} event - The jquery event object
       */
     const canOpen = self.element.triggerHandler('beforeopen');
-
     if (canOpen === false) {
       return;
     }
@@ -234,6 +239,8 @@ Lookup.prototype = {
       self.settings.click(e, this, self.settings.clickArguments);
       return;
     }
+
+    this.isOpen = true;
 
     if (this.settings.beforeShow) {
       const response = function (grid) {
@@ -397,6 +404,7 @@ Lookup.prototype = {
       .off('close.lookup')
       .on('close.lookup', () => {
         self.element.focus();
+        delete self.isOpen;
         /**
           * Fires on close dialog.
           *

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1208,11 +1208,13 @@ Modal.prototype = {
     // In some cases, the `body` tag becomes the `document.activeElement` if the Overlay,
     // or a wrapping iframe element is clicked.  This will reset the focus.
     if (this.settings.autoFocus) {
-      $('body').on(`focusin.${self.namespace}`, () => {
+      $('body').on(`focusin.${self.namespace}`, (e) => {
         if (self.dontCheckFocus || !self.isOnTop) {
           return;
         }
-
+        if ($(e.target).closest(self.element).length === 1) {
+          return;
+        }
         if (!self.isFocused) {
           self.dontCheckFocus = true;
           const ignoreFocusCheckTimer = new RenderLoopItem({

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1217,7 +1217,6 @@ Modal.prototype = {
         });
         renderLoop.register(ignoreFocusCheckTimer);
         firstTabbable.removeClass('hide-focus').focus();
-        console.log('x', firstTabbable);
       }
     });
   },

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1113,6 +1113,11 @@ Modal.prototype = {
         componentHasFocus = $elem.parent().prev('select').data('dropdown')?.isFocused;
       }
 
+      // Lookup
+      if ($elem.is('.lookup')) {
+        componentHasFocus = $elem.data('lookup')?.isFocused;
+      }
+
       // Searchfield
       if ($elem.is('.searchfield')) {
         componentHasFocus = $elem.data('searchfield')?.isFocused;

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1110,12 +1110,12 @@ Modal.prototype = {
 
       // Dropdown/Multiselect
       if ($elem.is('div.dropdown, div.multiselect')) {
-        componentHasFocus = $elem.parent().prev('select').data('dropdown').isFocused;
+        componentHasFocus = $elem.parent().prev('select').data('dropdown')?.isFocused;
       }
 
       // Searchfield
       if ($elem.is('.searchfield')) {
-        componentHasFocus = $elem.data('searchfield').isFocused;
+        componentHasFocus = $elem.data('searchfield')?.isFocused;
       }
     });
 

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1203,7 +1203,7 @@ Modal.prototype = {
     // In some cases, the `body` tag becomes the `document.activeElement` if the Overlay,
     // or a wrapping iframe element is clicked.  This will reset the focus.
     $('body').on(`focusin.${self.namespace}`, () => {
-      if (self.dontCheckFocus) {
+      if (self.dontCheckFocus || !self.isOnTop) {
         return;
       }
 
@@ -1217,6 +1217,7 @@ Modal.prototype = {
         });
         renderLoop.register(ignoreFocusCheckTimer);
         firstTabbable.removeClass('hide-focus').focus();
+        console.log('x', firstTabbable);
       }
     });
   },

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -615,6 +615,34 @@ DOM.convertToHTMLElement = function convertToHTMLElement(item) {
 };
 
 /**
+ * Returns a list of all focusable elements contained within the current element.
+ * Somewhat lifted from https://gomakethings.com/how-to-get-the-first-and-last-focusable-elements-in-the-dom/
+ * @param {HTMLElement} el the element to search.
+ * @returns {array} containing the focusable elements.
+ */
+DOM.focusableElems = function focusableElems(el) {
+  const focusableElemSelector = [
+    'button',
+    '[href]',
+    'input',
+    'select',
+    'textarea',
+    '[focusable]:not([focusable="false"])',
+    '[tabindex]:not([tabindex="-1"])',
+    '[contenteditable]',
+    'iframe'
+  ];
+  const elems = el.querySelectorAll(focusableElemSelector.join(', '));
+  const arrElems = utils.getArrayFromList(elems);
+  return arrElems.filter((elem) => {
+    if (elem.tagName.toLowerCase() === 'use') {
+      return false;
+    }
+    return true;
+  });
+};
+
+/**
  * Object deep copy.
  * For now, alias jQuery.extend
  * Eventually we'll replace this with a non-jQuery extend method.

--- a/test/components/modal/modal.e2e-spec.js
+++ b/test/components/modal/modal.e2e-spec.js
@@ -269,6 +269,22 @@ describe('Modal manual content loading', () => {
   });
 });
 
+describe('Modal No Auto Focus', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/modal/test-no-autofocus.html');
+  });
+
+  it('Should not focus any fields with autoFocus false', async () => {
+    await element(by.id('show-modal')).click();
+
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(element(by.id('modal-1'))), config.waitsFor);
+    await browser.driver.sleep(config.sleep);
+
+    expect(await browser.driver.switchTo().activeElement().getAttribute('id')).toEqual('show-modal');
+  });
+});
+
 describe('Modal Full Content Tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/modal/example-full-content');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a bug introduced in #3633 that created an infinite loop related to a new `focusin` event listener in nested modals.

**Related github/jira issue (required)**:
Closes #3682 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the app
- Open http://localhost:4000/components/lookup/test-modal-lookup.html in IE11
- Click "Select State".  The Modal should open.
- Click the Lookup's trigger button.  The Lookup should open.
- When the Lookup is displayed, it should be possible to navigate quickly and navigate with the keyboard.  There should be no JS console errors.

Additionally, you can test this on this page in IE11.  There should be no console errors, and it should be possible to open/close the nested modals without issue.

----
@fitzorama 