### PR TITLE
3636 - Add separator support in Hierarchy action menus

### DIFF
--- a/app/data/orgstructure-original.json
+++ b/app/data/orgstructure-original.json
@@ -36,7 +36,16 @@
           {"value": "Transfer", "url" : "#", "data": {}},
           {"value": "Terminate", "url" : "#", "data": {}},
           {"value": "Update", "url" : "#", "data": {}},
-          {"value": "Options", "url" : "#", "data": {}, "menu": [{"value": "Sub Item", "url" : "#", "data": {}}]}
+          {"value": "Options", "url" : "#", "data": {}, "menu": [{"value": "Sub Item", "url" : "#", "data": {}}]},
+          {
+            "value": "",
+            "url": "#",
+            "data": {
+              "id": "separator",
+              "label": "",
+              "type": "separator"
+            }
+          }
         ]
       }
     },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Bubble Chart]` Fixed an issue where an extra axis line was shown when using the domain formatter. ([#501](https://github.com/infor-design/enterprise/issues/501))
 - `[Datagrid]` Fixed a css issue in dark uplift mode where the group row lines were not visible . ([#3649](https://github.com/infor-design/enterprise/issues/3649))
 - `[Datagrid/Hyperlink]` Fixed layout issues with links in right text align mode. To do this refactored links to not use a psuedo element for the focus style. ([#3680](https://github.com/infor-design/enterprise/issues/3680))
+- `[Hierarchy]` Added support for separators in the actions menu on a hierarchy leaf. ([#3636](https://github.com/infor-design/enterprise/issues/3636))
 
 ## v4.27.0
 

--- a/src/components/hierarchy/hierarchy.js
+++ b/src/components/hierarchy/hierarchy.js
@@ -376,22 +376,31 @@ Hierarchy.prototype = {
     // Ignoring next line. Eslint expects template literals vs string concat.
     // However template literals break JSON.stringify() in this case
     /* eslint-disable */
-    return `${actions.map(a => `
-      <li data-disabled='${a.disabled}' class='${a.menu ? 'submenu' : ''}'>
-        <a href='${a.url}' data-action-reference='` + JSON.stringify(a.data) + `'>
-          ${a.value}
-          ${a.menu ? '<svg class="arrow icon-dropdown icon" focusable="false" aria-hidden="true" role="presentation"><use href="#icon-dropdown"></use></svg>' : ''}
-        </a>
-        ${a.menu ? `<div class="wrapper" role="application" aria-hidden="true">
-          <ul class="popupmenu">
-            ${a.menu.map(i => `
-            <li data-disabled='${a.disabled}'>
-              <a href='${a.url}' data-action-reference='` + JSON.stringify(a.data) + `'>${i.value}</a>
-            </li>`).join('')}
-          </ul>
-        </div>` : ''}
-      </li>`).join('')}`;
+    const actionMarkup = actions.map(a => {
+      if (a.hasOwnProperty('data')) {
+        if (a.data.type === 'separator') {
+          return `<li class="separator"></li>`
+        }
+      }
+      return `
+        <li data-disabled='${a.disabled}' class='${a.menu ? 'submenu' : ''}'>
+          <a href='${a.url}' data-action-reference='` + JSON.stringify(a.data) + `'>
+            ${a.value}
+            ${a.menu ? '<svg class="arrow icon-dropdown icon" focusable="false" aria-hidden="true" role="presentation"><use href="#icon-dropdown"></use></svg>' : ''}
+          </a>
+          ${a.menu ? `<div class="wrapper" role="application" aria-hidden="true">
+            <ul class="popupmenu">
+              ${a.menu.map(i => `
+              <li data-disabled='${a.disabled}'>
+                <a href='${a.url}' data-action-reference='` + JSON.stringify(a.data) + `'>${i.value}</a>
+              </li>`).join('')}
+            </ul>
+          </div>` : ''}
+        </li>`
+    }).join('');
     /* eslint-enable */
+
+    return actionMarkup;
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added a check  in `getActionMenuItems` (`src/components/hierarchy/hierarchy.js`). If `a.data.type === 'separator'` the function will render a list item with a class of separator in the action menu list.

**Related github/jira issue (required)**:
closes #3636 

**Steps necessary to review your pull request (required)**:
- pull this branch
- navigate to http://localhost:4000/components/hierarchy/example-context-menu-with-details.html
- click the action menu in the first card. You should now see a separator above the "Delete" menu item.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
