### PR TITLE
3688 - Fix a bug switching themes in source mode [v4.27.x]

### DIFF
--- a/src/components/editor/_editor.scss
+++ b/src/components/editor/_editor.scss
@@ -636,6 +636,7 @@
 }
 
 .editor-source {
+  background-color: $editor-bg-color;
   border: 1px solid;
   border-color: transparent $editor-border-color $editor-border-color;
   border-radius: 0 0 2px 2px;

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -520,6 +520,9 @@ Editor.prototype = {
 
     $('html').on(`themechanged.${COMPONENT_NAME}`, () => {
       this.setRowsHeight();
+      if (!(this.sourceView.hasClass('hidden'))) {
+        this.adjustSourceLineNumbers();
+      }
     });
 
     this.setupTextareaEvents();
@@ -750,6 +753,11 @@ Editor.prototype = {
     return this;
   },
 
+  /**
+   * Set the heights and adjust the line number feature.
+   * @private
+   * @returns {void}
+   */
   adjustSourceLineNumbers() {
     const container = this.textarea.parent();
     const lineHeight = parseInt(getComputedStyle(this.textarea[0]).lineHeight, 10);
@@ -787,8 +795,9 @@ Editor.prototype = {
         numberList.find('li').slice(-(i)).remove();
       }
       this.lineNumbers = lineNumberCount;
-      container[0].style.width = `calc(100% - ${(numberList.outerWidth() + 2)}px)`;
     }
+
+    container[0].style.width = `calc(100% - ${(numberList.outerWidth() + 2)}px)`;
     if (scrollHeight !== this.textarea[0].scrollHeight) {
       this.adjustSourceLineNumbers();
       return;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

QA uncovered an issue when switching theme while the source view is open. This is a fix for that.

**Related github/jira issue (required)**:
Fixes #3688 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/editor/example-index.html?theme=soho&variant=contrast
- click the HTML button to go to source view
- change them to vibrant
- try combinations of themes , switching and having HTML vs VISUAL view open