### PR TITLE
3490 - Add shortcut display to contextmenu

### DIFF
--- a/app/views/components/popupmenu/example-icons.html
+++ b/app/views/components/popupmenu/example-icons.html
@@ -19,6 +19,7 @@
           <use href="#icon-folder"></use>
         </svg>
         <span>Create new folder</span>
+        <span class="shortcut-text">Cmd+R</span>
       </a></li>
 
       <li class="separator"></li>
@@ -30,6 +31,7 @@
           <use href="#icon-edit"></use>
         </svg>
         <span>Edit folder settings</span>
+        <span class="shortcut-text">Ctrl+Shift+Right</span>
       </a></li>
 
       <li class="separator"></li>
@@ -39,6 +41,7 @@
           <use href="#icon-delete"></use>
         </svg>
         <span>Delete folder</span>
+        <span class="shortcut-text">Ctrl+Option+Shift</span>
       </a></li>
     </ul>
 

--- a/app/views/components/popupmenu/example-icons.html
+++ b/app/views/components/popupmenu/example-icons.html
@@ -19,7 +19,6 @@
           <use href="#icon-folder"></use>
         </svg>
         <span>Create new folder</span>
-        <span class="shortcut-text">Cmd+R</span>
       </a></li>
 
       <li class="separator"></li>
@@ -31,7 +30,6 @@
           <use href="#icon-edit"></use>
         </svg>
         <span>Edit folder settings</span>
-        <span class="shortcut-text">Ctrl+Shift+Right</span>
       </a></li>
 
       <li class="separator"></li>
@@ -41,7 +39,6 @@
           <use href="#icon-delete"></use>
         </svg>
         <span>Delete folder</span>
-        <span class="shortcut-text">Ctrl+Option+Shift</span>
       </a></li>
     </ul>
 

--- a/app/views/components/popupmenu/example-shortcut-text.html
+++ b/app/views/components/popupmenu/example-shortcut-text.html
@@ -1,0 +1,56 @@
+<div class="row">
+  <div class="six columns">
+
+    <h2>Popupmenu Test: Has Icons</h2>
+    <p>Shows some popup menus that contain various types of icons to test alignment, sizing, positioning, etc.</p>
+    <br />
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+
+    <button type="button" class="btn-menu" id="icon-menu-button">
+      <span>Icon Menu</span>
+    </button>
+    <ul class="popupmenu has-icons is-selectable">
+      <li><a href="#">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-folder"></use>
+          </svg>
+          <span>Create new folder</span>
+          <span class="shortcut-text">⌘+R</span>
+        </a></li>
+      <li><a href="#">
+          <span>Previous</span>
+          <span class="shortcut-text">⌘+⇧+←</span>
+        </a></li>
+      <li><a href="#">
+          <span>Next</span>
+          <span class="shortcut-text">⌘+⇧+→</span>
+        </a></li>
+      <li class="separator"></li>
+      <li><a href="#"><span>Copy To...</span></a></li>
+      <li><a href="#"><span>Move To...</span></a></li>
+
+      <li><a href="#">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-edit"></use>
+          </svg>
+          <span>Long form shortcut text</span>
+          <span class="shortcut-text">Cmd+Shift+R</span>
+        </a></li>
+
+      <li class="separator"></li>
+
+      <li><a href="#">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-delete"></use>
+          </svg>
+          <span>Delete folder</span>
+          <span class="shortcut-text">⌘+⌥+⇧</span>
+        </a></li>
+    </ul>
+
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### v4.28.0 Features
 
 - `[Datepicker]` Added support for custom api callback to disable passed dates and to disable dates by years. ([#3462](https://github.com/infor-design/enterprise/issues/3462))
+- `[Contextmenu]` Added support for shortcut display in menus. ([#3490](https://github.com/infor-design/enterprise/issues/3490))
 
 ### v4.28.0 Fixes
 

--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -408,6 +408,11 @@
     font-size: $theme-size-font-base;
   }
 
+  .shortcut-text {
+    float: right;
+    margin-left: $theme-number-spacing-base * 2;
+  }
+
   //Text Underline on Terms
   i {
     color: $font-color-extrahighcontrast;

--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -616,6 +616,11 @@ html[dir='rtl'] {
       padding: 0 10px 0 30px;
     }
 
+    .shortcut-text {
+      float: left;
+      margin-right: $theme-number-spacing-base * 2;
+    }
+
     &.has-icons,
     &.is-selectable {
       > li a {

--- a/src/components/popupmenu/readme.md
+++ b/src/components/popupmenu/readme.md
@@ -15,6 +15,8 @@ demo:
     slug: example-icons
   - name: Invoking Popupmenu immediately
     slug: example-trigger-immediate
+  - name: Popupmenu with shortcut text
+    slug: example-shortcut-text
 ---
 
 ## Code Example


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adds a css class `shortcut-text` to display shortcut keys in contextmenu

**Related github/jira issue (required)**:
closes #3490 

**Steps necessary to review your pull request (required)**:
- pull branch
- go to http://localhost:4000/components/popupmenu/example-shortcut-text.html
- open menu and you should see examples, ie `Ctrl+Shift+Right`

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
