### PR TITLE
3709 - Fix disabled swap buttons color in dark variant

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Datagrid]` Fixed a css issue in dark uplift mode where the group row lines were not visible . ([#3649](https://github.com/infor-design/enterprise/issues/3649))
 - `[Datagrid/Hyperlink]` Fixed layout issues with links in right text align mode. To do this refactored links to not use a psuedo element for the focus style. ([#3680](https://github.com/infor-design/enterprise/issues/3680))
 - `[Hierarchy]` Added support for separators in the actions menu on a hierarchy leaf. ([#3636](https://github.com/infor-design/enterprise/issues/3636))
+- `[Swaplist]` Fixed disabled swap buttons color in dark variant subtle theme. ([#3709](https://github.com/infor-design/enterprise/issues/3709))
 
 ## v4.27.0
 

--- a/src/themes/theme-soho-dark.scss
+++ b/src/themes/theme-soho-dark.scss
@@ -299,6 +299,8 @@ $swaplist-bg-color-hover: $theme-color-palette-slate-60;
 $swaplist-border-color-card: $theme-color-palette-slate-50;
 $swaplist-icon-color: $theme-color-palette-slate-30;
 $swaplist-icon-color-hover: $theme-color-palette-white;
+$swaplist-icon-color-disabled: $theme-color-palette-slate-50;
+$swaplist-icon-svg-color-disabled: $theme-color-palette-slate-50;
 $swaplist-icon-svg-color: $theme-color-palette-slate-10;
 $swaplist-icon-svg-color-hover: $theme-color-palette-white;
 $swaplist-border-color-hover: $theme-color-palette-white;

--- a/src/themes/theme-uplift-dark.scss
+++ b/src/themes/theme-uplift-dark.scss
@@ -285,6 +285,8 @@ $swaplist-bg-color-hover: $theme-color-palette-slate-60;
 $swaplist-border-color-card: $theme-color-palette-slate-50;
 $swaplist-icon-color: $theme-color-palette-slate-30;
 $swaplist-icon-color-hover: $theme-color-palette-white;
+$swaplist-icon-color-disabled: $theme-color-palette-slate-40;
+$swaplist-icon-svg-color-disabled: $theme-color-palette-slate-40;
 $swaplist-icon-svg-color: $theme-color-palette-slate-10;
 $swaplist-icon-svg-color-hover: $theme-color-palette-white;
 $swaplist-border-color-hover: $theme-color-palette-white;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
 Make the swap buttons color more noticeable as a disabled button in dark variant subtle theme. This fix shouldn't affect other themes/variants.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/3709

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Navigate to http://localhost:4000/components/swaplist/example-disable-dragging.html
- Theme should be `Subtle` and the Variant should be `Dark`
- The disabled swap buttons should now look disabled and not same as the active

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
