### PR TITLE
3720 - Fix IE11 editor dirty tracking bug [v4.27.x]

### DIFF
--- a/src/components/trackdirty/trackdirty.js
+++ b/src/components/trackdirty/trackdirty.js
@@ -247,10 +247,7 @@ Trackdirty.prototype = {
           if (field.find('.editor-source').is(':visible')) {
             current = textArea.val();
           } else {
-            current = textArea.text();
-          }
-          if (this.isIe || this.isIeEdge) {
-            current = input[0].innerHTML;
+            current = this.isIe || this.isIeEdge ? input[0].innerHTML : textArea.text();
           }
           current = this.trimEditorText(current);
         }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The dirty tracking in editor did not work in source view in IE11. This is a fix

**Related github/jira issue (required)**:
Fixes #3720 

**Steps necessary to review your pull request (required)**:
- open IE 11
- go to http://localhost:4000/components/editor/test-dirty-tracking-reset.html
- switch to HTML view
- change text

(these are shorter steps than the issue - but that whole view didnt work in IE 11)