### PR TITLE
3697 - Add a fix for incorrect empty message [v4.27.x]

### DIFF
--- a/app/views/components/datagrid/test-empty-message-two-rows.html
+++ b/app/views/components/datagrid/test-empty-message-two-rows.html
@@ -1,0 +1,75 @@
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+      var grid,
+        columns = [],
+        data = [];
+
+      // Define Some Sample Data
+      data.push({ id: 1, productId: undefined, productName: 'Compressor', inStock: true, activity:  'Assemble', quantity: 1, price: 410.99, orderDate: new Date(2014, 12, 8), time: '1:30:45 AM', action: 'Action', status: 'Error'});
+      data.push({ id: 2, productId: 2241202, productName: '1 Different Compressor', inStock: true, activity:  'Inspect and Repair', quantity: 2, price: 310.99, orderDate: new Date(2015, 7, 3), time: '2:00 AM', action: 'On Hold', status: 'Error'});
+
+      var statuses = [{id: '', value: '', label:'&nbsp;'},
+                      {id:'Confirmed', value:'Confirmed', label:'Confirmed'},
+                      {id:'Error', value:'Error', label:'Error'}];
+
+      var activities = [{id: 'Assemble Paint', value:'Assemble Paint', label: 'Assemble Paint'},
+                         {id: 'Inspect and Repair', value:'Inspect and Repair', label: 'Inspect and Repair'}];
+
+    var lookupOptions = {
+      field: function (row, field, grid) {
+        return row.productId;
+      },
+      match: function (value, row, field, grid) {
+        return (row.productId) === value;
+      },
+      beforeShow: function (api, response) {
+        var url = '{{basepath}}api/lookupInfo';
+
+        $.getJSON(url, function(data) {
+          api.settings.options.columns = data[0].columns;
+          api.settings.options.dataset = data[0].dataset;
+          response();
+        });
+      },
+      options: {
+        selectable: 'single',
+        toolbar: {title: 'Products', results: true, dateFilter: false ,keywordFilter: false, actions: true, views: true , rowHeight: true}
+      }
+    };
+
+      // Define Columns for the Grid.
+      columns.push({ id: 'id', name: 'Id', field: 'id', formatter: Formatters.Readonly, filterType: 'text'});
+      columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, editorOptions: lookupOptions, filterType: 'lookup', mask: '#######' });
+      columns.push({ id: 'productName', name: 'Product Name', field: 'productName',  formatter: Formatters.Hyperlink, filterType: 'text'});
+      columns.push({ id: 'activity', name: 'Activity', field: 'activity', formatter: Formatters.Dropdown, filterType: 'multiselect', options: activities, editorOptions: {showSelectAll: true}});
+      columns.push({ id: 'quantity', name: 'Qty', field: 'quantity', align: 'right', filterType: 'integer'});
+      columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'MM/dd/yyyy', filterType: 'date', editorOptions: {showMonthYearPicker: true}, width: 250});
+      columns.push({ id: 'time', name: 'Time', field: 'time', formatter: Formatters.Time, editor: Editors.Time, width: 160, filterType: 'time' });
+      columns.push({ id: 'inStock', name: 'In Stock', field: 'inStock', formatter: Formatters.Checkbox, align: 'center', filterType: 'checkbox'});
+      columns.push({ id: 'status', name: 'Status', field: 'status', formatter: Formatters.Alert, filterType: 'select', editorOptions: {clearable: true}, options: statuses, ranges: [{'value':'Confirmed', 'classes': 'success', text: 'Confirmed'}, {'value':'Error', 'classes': 'error', text: 'Error'}]});
+      columns.push({ id: 'price',  name: 'Price', field: 'price', formatter: Formatters.Decimal, filterType: 'decimal', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###,####.000'});
+
+      // Init and get the api for the grid
+      $('#datagrid').datagrid({
+        columns: columns,
+        dataset: data,
+        filterable: true,
+        filterWhenTyping: false,
+        selectable: 'single',
+        editable: true,
+        frozenColumns: {left: ['id', 'productId']},
+        emptyMessage: {title: Locale.translate('NoData'), info: Locale.translate('NoDataFilter'), icon: 'icon-empty-no-data'},
+        toolbar: {title: 'Filterable Datagrid', filterRow: true, results: true, dateFilter: false ,keywordFilter: false, actions: true, views: false, rowHeight: true, collapsibleFilter: false}
+      }).on('filtered', function (e, args) {
+        console.log('filter ran', args);
+      });
+ });
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,7 @@
 - `[Datagrid]` Fixed an issue where the overlay was closing after close Modal. ([#735](https://github.com/infor-design/enterprise-ng/issues/735))
 - `[Datagrid]` Fixed a misaligned drag and drop column icon on IE 11. ([#3648](https://github.com/infor-design/enterprise/issues/3648))
 - `[Datagrid]` Fixed an issue when using the colspan column option along with frozenColumns. ([#3416](https://github.com/infor-design/enterprise/issues/3416))
+- `[Datagrid]` Fixed an issue where the empty message might still show if the amount of rows dont fill the page. ([#3697](https://github.com/infor-design/enterprise/issues/3697))
 - `[Datepicker]` Fixed popover height and datepicker layout on mobile view. ([#2569](https://github.com/infor-design/enterprise/issues/3569))
 - `[Datepicker]` Fixed an issue where date range with minimum range was not working. ([#3268](https://github.com/infor-design/enterprise/issues/3268))
 - `[Datepicker]` Fixed an issue where date range was reverting to initial values after clearing. ([#1306](https://github.com/infor-design/enterprise/issues/1306))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3414,7 +3414,6 @@ Datagrid.prototype = {
     // Set UI elements after dataload
     if (!self.settings.source) {
       self.displayCounts();
-      self.checkEmptyMessage();
     }
 
     self.setAlternateRowShading();
@@ -5731,12 +5730,12 @@ Datagrid.prototype = {
   },
 
   /**
-  * See if the empty message object should be shown.
+  * Hide/Show the empty message object should be shown.
   * @private
   */
   checkEmptyMessage() {
     if (this.emptyMessage && this.emptyMessageContainer) {
-      if (this.filteredCount === this.recordCount || this.recordCount === 0) {
+      if (this.recordCount === 0) {
         this.emptyMessageContainer.show();
         this.element.addClass('is-empty');
       } else {

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -1976,6 +1976,36 @@ describe('Datagrid Empty Message Tests After Load', () => {
   }
 });
 
+describe('Datagrid Empty Message with two rows', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/test-empty-message-two-rows?layout=nofrills');
+
+    const datagridEl = await element(by.css('#datagrid .datagrid-wrapper'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not show empty indicator on load', async () => {
+    expect(await element(by.css('.empty-message')).isDisplayed()).toEqual(false);
+  });
+
+  it('Should show empty indicator on filtering zero', async () => {
+    await element(by.id('test-empty-message-two-rows-datagrid-1-header-filter-1')).sendKeys('33');
+    await element(by.id('test-empty-message-two-rows-datagrid-1-header-filter-1')).sendKeys(protractor.Key.ENTER);
+
+    expect(await element(by.css('.empty-message')).isDisplayed()).toEqual(true);
+    expect(await element(by.css('.datagrid-result-count')).getText()).toEqual('(0 of 2 Results)');
+  });
+
+  it('Should not show empty indicator on filtering one', async () => {
+    await element(by.id('test-empty-message-two-rows-datagrid-1-header-filter-1')).sendKeys('22');
+    await element(by.id('test-empty-message-two-rows-datagrid-1-header-filter-1')).sendKeys(protractor.Key.ENTER);
+
+    expect(await element(by.css('.empty-message')).isDisplayed()).toEqual(false);
+    expect(await element(by.css('.datagrid-result-count')).getText()).toEqual('(1 of 2 Results)');
+  });
+});
+
 describe('Datagrid Empty Message Tests After Load in Scrollable Flex', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-empty-message-after-load-in-scrollable-flex?layout=nofrills');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Added an important bug to 4.27. The empty message was showing in some incorrect cases, specifically when the number of filter elements equals the number of visible elements. Fixed this

**Related github/jira issue (required)**:
Fixes #3597

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-empty-message-two-rows.html
- filter on Product id - contains - 22 
- one of one record should show 
- no empty message should show
- test any samples in http://localhost:4000/components/datagrid with "empty + message" in the name

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
