### PR TITLE
3070 - Fix applicationmenu icons breaks apart when zoomed out in IE11

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### v4.28.0 Fixes
 
+- `[Application Menu]` Fixed the icons on breaking apart it's appearance when zooming out the browser in IE11, uplift theme. ([#3070](https://github.com/infor-design/enterprise/issues/3070))
 - `[Bubble Chart]` Fixed an issue where an extra axis line was shown when using the domain formatter. ([#501](https://github.com/infor-design/enterprise/issues/501))
 - `[Charts]` Fixed an issue where selected items were being deselected after resizing the page. ([#323](https://github.com/infor-design/enterprise/issues/323))
 - `[Datagrid]` Fixed a css issue in dark uplift mode where the group row lines were not visible. ([#3649](https://github.com/infor-design/enterprise/issues/3649))

--- a/src/components/icons/_icons-uplift.scss
+++ b/src/components/icons/_icons-uplift.scss
@@ -39,3 +39,13 @@
     top: 2px !important;
   }
 }
+
+.ie,
+.ie11 {
+  .icon.plus-minus {
+    &::before,
+    &::after {
+      height: 2px;
+    }
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The `plus-minus` icon in application menu breaks apart when zooming out the browser in IE11, uplift theme.

When zooming in or out, you'll encounter issues because of round and text rendering. Making sure that the elements and or layouts must survive a bit of stretching without breaking down.

Add up a `1px` on icon's height to get through when zooming out in IE11 only.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/3070

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app.
- Navigate to http://localhost:4000/components/applicationmenu/test-six-levels.html?theme=uplift&variant=light and open in IE11.
- Expand Level 1 and it's children
- Hit `Ctrl -` to zoom out
- `+` icon should not turn into `|`

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
