### PR TITLE
3510 - Fix labels alignment with radar charts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `[EmptyMessage]` Updated the text to be more subtle. ([#3476](https://github.com/infor-design/enterprise/issues/3476))
 - `[Fieldset]` Fixed fieldset text data overlapping in compact mode on mobile view. ([#3627](https://github.com/infor-design/enterprise/issues/3627))
 - `[Hierarchy]` Added support for separators in the actions menu on a hierarchy leaf. ([#3636](https://github.com/infor-design/enterprise/issues/3636))
+- `[Radar Chart]` Fixed an issue where labels were cutoff at desktop view. ([#3510](https://github.com/infor-design/enterprise/issues/3510))
 - `[Swaplist]` Fixed disabled swap buttons color in dark variant subtle theme. ([#3709](https://github.com/infor-design/enterprise/issues/3709))
 
 ## v4.27.1

--- a/src/components/radar/radar.js
+++ b/src/components/radar/radar.js
@@ -177,6 +177,9 @@ Radar.prototype = {
     if (s.legendPlacement === 'right') {
       dims.w *= 0.75;
     }
+    if (theme.uplift && dims.w >= 420) {
+      dims.extra -= 0.12;
+    }
     // Manually adjust height to fit legend on mobile view
     if (s.showLegend && dims.w < 420 && !s.margin.bottom) {
       let adjust;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed labels were cutoff at desktop view with Radar Charts.

**Related github/jira issue (required)**:
Closes #3510

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/radar/example-hcm.html?theme=uplift&variant=light
- Resize browser window to desktop viewport
- See the labels should not cutoff

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
