### PR TITLE
3640 - Fix Multiselect tags dismiss button on mobile 

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[Fieldset]` Fixed fieldset text data overlapping in compact mode on mobile view. ([#3627](https://github.com/infor-design/enterprise/issues/3627))
 - `[Hierarchy]` Added support for separators in the actions menu on a hierarchy leaf. ([#3636](https://github.com/infor-design/enterprise/issues/3636))
 - `[Modal]` Fixed modal title to a two line with ellipsis when it's too long. ([#3479](https://github.com/infor-design/enterprise/issues/3479))
+- `[Multiselect]` Fixed tags dismiss button on mobile devices. ([#3640](https://github.com/infor-design/enterprise/issues/3640))
 - `[Icons]` Added new locked/unlocked icons in ids-identity [#3732](https://github.com/infor-design/enterprise/issues/3732)
 - `[Radar Chart]` Fixed an issue where labels were cutoff at desktop view. ([#3510](https://github.com/infor-design/enterprise/issues/3510))
 - `[Swaplist]` Fixed disabled swap buttons color in dark variant subtle theme. ([#3709](https://github.com/infor-design/enterprise/issues/3709))

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -3219,33 +3219,7 @@ Dropdown.prototype = {
   handleEvents() {
     const self = this;
 
-    this.pseudoElem
-      .on('keydown.dropdown', e => this.handlePseudoElemKeydown(e))
-      .on('click.dropdown touchstart.dropdown', (e) => {
-
-        // Would like the click event to bubble up if ctrl and shift are pressed
-        if (!(e.originalEvent.ctrlKey && e.originalEvent.shiftKey)) {
-          e.stopPropagation();
-        }
-      }).on('mouseup.dropdown touchend.dropdown', (e) => {
-        if (e.button === 2) {
-          return;
-        }
-        if (isTag(e)) {
-          return;
-        }
-        self.toggle();
-      })
-      .on('touchcancel.dropdown', (e) => {
-        if (isTag(e)) {
-          return;
-        }
-        e.stopPropagation();
-        self.toggle();
-        e.preventDefault();
-      });
-
-    function isTag(e) {
+    function isTagEl(e) {
       // If the element clicked is a tag, ignore and let the tag handle it.
       const containedByTag = $(e.target).parents('.tag').length > 0;
       let isTag = false;
@@ -3255,10 +3229,35 @@ Dropdown.prototype = {
 
       if (isTag || containedByTag) {
         return true;
-      } else {
-        return false;
       }
+
+      return false;
     }
+
+    this.pseudoElem
+      .on('keydown.dropdown', e => this.handlePseudoElemKeydown(e))
+      .on('click.dropdown touchstart.dropdown', (e) => {
+        // Would like the click event to bubble up if ctrl and shift are pressed
+        if (!(e.originalEvent.ctrlKey && e.originalEvent.shiftKey)) {
+          e.stopPropagation();
+        }
+      }).on('mouseup.dropdown touchend.dropdown', (e) => {
+        if (e.button === 2) {
+          return;
+        }
+        if (isTagEl(e)) {
+          return;
+        }
+        self.toggle();
+      })
+      .on('touchcancel.dropdown', (e) => {
+        if (isTagEl(e)) {
+          return;
+        }
+        e.stopPropagation();
+        self.toggle();
+        e.preventDefault();
+      });
 
     self.element.on('activated.dropdown', () => {
       self.label.trigger('click');

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -3236,7 +3236,7 @@ Dropdown.prototype = {
         }
         self.toggle();
       })
-      .on('touchend.dropdown touchcancel.dropdown', (e) => {
+      .on('touchcancel.dropdown', (e) => {
         if (isTag(e)) {
           return;
         }

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -3221,32 +3221,44 @@ Dropdown.prototype = {
 
     this.pseudoElem
       .on('keydown.dropdown', e => this.handlePseudoElemKeydown(e))
-      .on('click.dropdown', (e) => {
+      .on('click.dropdown touchstart.dropdown', (e) => {
+
         // Would like the click event to bubble up if ctrl and shift are pressed
         if (!(e.originalEvent.ctrlKey && e.originalEvent.shiftKey)) {
           e.stopPropagation();
         }
-      }).on('mouseup.dropdown', (e) => {
+      }).on('mouseup.dropdown touchend.dropdown', (e) => {
         if (e.button === 2) {
           return;
         }
-
-        // If the element clicked is a tag, ignore and let the tag handle it.
-        const containedByTag = $(e.target).parents('.tag').length > 0;
-        let isTag = false;
-        if (e.target instanceof HTMLElement && typeof e.target.className === 'string') {
-          isTag = e.target.classList.contains('tag');
-        }
-        if (isTag || containedByTag) {
+        if (isTag(e)) {
           return;
         }
         self.toggle();
       })
       .on('touchend.dropdown touchcancel.dropdown', (e) => {
+        if (isTag(e)) {
+          return;
+        }
         e.stopPropagation();
         self.toggle();
         e.preventDefault();
       });
+
+    function isTag(e) {
+      // If the element clicked is a tag, ignore and let the tag handle it.
+      const containedByTag = $(e.target).parents('.tag').length > 0;
+      let isTag = false;
+      if (e.target instanceof HTMLElement && typeof e.target.className === 'string') {
+        isTag = e.target.classList.contains('tag');
+      }
+
+      if (isTag || containedByTag) {
+        return true;
+      } else {
+        return false;
+      }
+    }
 
     self.element.on('activated.dropdown', () => {
       self.label.trigger('click');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adds a function to check for tag element in the `touchend` and `touchcancel` event handler. If element being touched is a tag cancel the toggle and let the tag handle it.

**Related github/jira issue (required)**:
closes #3640 

**Steps necessary to review your pull request (required)**:
- pull branch
- check http://localhost:4000/components/multiselect/example-index.html or http://localhost:4000/components/multiselect/example-index.html?theme=uplift&variant=light on a mobile device browser.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
