### PR TITLE
Fix for 3760, Hierarchy, Context menu fails to size correctly when dynamically loading actions.

### DIFF
--- a/app/data/hc-john-randolph-dynamic-actions.json
+++ b/app/data/hc-john-randolph-dynamic-actions.json
@@ -1,0 +1,70 @@
+{
+  "ancestorPath": null,
+  "centeredNode": {
+    "id": "1",
+    "name": "John Randolph",
+    "position": "CEO",
+    "employmentType": "FT",
+    "picture": "/images/4.jpg",
+    "menu" : {
+      "details": [
+        {"key": "Organization Unit", "value": "U.S Headquarters"},
+        {"key": "Position", "value": "Project Manager"},
+        {"key": "Work Phone", "value": "612-555-1212"},
+        {"key": "Location", "value": "St. Paul"},
+        {"key": "Position Family", "value": "ITS"},
+        {"key": "Position Category", "value": "PMO"},
+        {"key": "Position Sub Category", "value": "Some subcategory"},
+        {"key": "Position Level", "value": "Career"},
+        {"key": "Years of Service", "value": "4.33"}
+      ],
+      "actions": []
+    }
+  },
+  "children": [
+    {
+      "id": "2",
+      "name": "Barb Wire",
+      "position": "COO",
+      "employmentType": "FT",
+      "avatarInitials": "BW",
+      "childrenUrl": "hc-barb-wire.json",
+      "menu" : {
+        "details": [
+          {"key": "Organization Unit", "value": "U.S Headquarters"},
+          {"key": "Position", "value": "Project Manager"},
+          {"key": "Work Phone", "value": "612-555-1212"},
+          {"key": "Location", "value": "St. Paul"},
+          {"key": "Position Family", "value": "ITS"},
+          {"key": "Position Category", "value": "PMO"},
+          {"key": "Position Sub Category", "value": "Some subcategory"},
+          {"key": "Position Level", "value": "Career"},
+          {"key": "Years of Service", "value": "4.33"}
+        ],
+        "actions": []
+      }
+    },
+    {
+      "id": "3",
+      "name": "Greg Ford",
+      "position": "CTO",
+      "employmentType": "FT",
+      "avatarInitials": "GF",
+      "childrenUrl": "hc-greg-ford.json",
+      "menu" : {
+        "details": [
+          {"key": "Organization Unit", "value": "U.S Headquarters"},
+          {"key": "Position", "value": "Project Manager"},
+          {"key": "Work Phone", "value": "612-555-1212"},
+          {"key": "Location", "value": "St. Paul"},
+          {"key": "Position Family", "value": "ITS"},
+          {"key": "Position Category", "value": "PMO"},
+          {"key": "Position Sub Category", "value": "Some subcategory"},
+          {"key": "Position Level", "value": "Career"},
+          {"key": "Years of Service", "value": "4.33"}
+        ],
+        "actions": []
+      }
+    }
+  ]
+}

--- a/app/views/components/hierarchy/example-stacked-ajax-popupmenu.html
+++ b/app/views/components/hierarchy/example-stacked-ajax-popupmenu.html
@@ -1,0 +1,125 @@
+<figure class="hierarchy" id="hierarchy"></figure>
+
+<script id="hierarchy-init-script">
+
+  const options = {
+    templateId: 'hierarchyChartTemplate',
+    legendKey: 'employmentType',
+    legend: [
+      { 'value' : 'FT', 'label' : 'Full Time'     },
+      { 'value' : 'PT', 'label' : 'Part Time'     },
+      { 'value' : 'C',  'label' : 'Contractor'    },
+      { 'value' : 'O',  'label' : 'Open Position' }
+    ],
+    dataset: [],
+    layout: 'stacked'
+  };
+
+  // Initial load
+  $.getJSON('{{basepath}}api/hc-john-randolph-dynamic-actions', function(data) {
+    options.dataset = [data];
+    $('#hierarchy').hierarchy(options);
+  });
+
+  $('#hierarchy').on('selected', function(event, eventInfo) {
+    const hierarchyControl = $('#hierarchy').data('hierarchy');
+
+    if (eventInfo.eventType === 'expand' || eventInfo.eventType === 'back') {
+      $.getJSON('{{basepath}}api/'+ eventInfo.data.childrenUrl, function(newData) {
+        reload(eventInfo, hierarchyControl, newData);
+      });
+    }
+
+    beforeOpen(eventInfo, hierarchyControl);
+  });
+
+  function reload(eventInfo, hierarchyControl, newData) {
+    eventInfo.data.children = newData;
+    options.dataset = [eventInfo.data.children];
+    hierarchyControl.reload(options);
+  }
+
+  function beforeOpen(eventInfo, hierarchyControl) {
+    if (eventInfo.isActionsEvent) {
+      $.when(getActionsAsync()).then((actions) => {
+        hierarchyControl.updateActions(eventInfo, actions);
+      });
+    }
+  }
+
+  // Emulate a call to the server to get actions for popupmenu
+  function getActionsAsync() {
+      const defer = $.Deferred();
+      const actions = [
+        {"value": "Profile", "url": "#", "data": {"id":"Profile","label":"Profile","type":"action","index":1}},
+        {"value": "Change Pay Rate", "url": "#", "data": {}, "disabled": true},
+        {"value": "Add work assignment", "url" : "#", "data": {}},
+        {"value": "Promote", "url" : "#", "data": {}},
+        {"value": "Transfer", "url" : "#", "data": {}},
+        {"value": "Terminate", "url" : "#", "data": {}},
+        {"value": "Update", "url" : "#", "data": {}},
+        {"value": "Options", "url" : "#", "data": {}, "menu": [{"value": "Sub Item", "url" : "#", "data": {}}]},
+        {"value": "Item1", "url" : "#", "data": {}},
+        {"value": "Item2", "url" : "#", "data": {}},
+        {"value": "Item3", "url" : "#", "data": {}},
+        {"value": "Item4", "url" : "#", "data": {}},
+        {"value": "Item5", "url" : "#", "data": {}},
+        {"value": "Item6", "url" : "#", "data": {}},
+        {"value": "Item7", "url" : "#", "data": {}},
+        {"value": "Item8", "url" : "#", "data": {}},
+        {"value": "Item9", "url" : "#", "data": {}},
+        {"value": "Item10", "url" : "#", "data": {}},
+        {"value": "Item11", "url" : "#", "data": {}}
+      ];
+
+      defer.resolve(actions);
+      // setTimeout(() => defer.resolve(actions), 500);
+
+      return defer.promise();
+  }
+
+</script>
+
+
+{{={{{ }}}=}}
+<script type="text/html" id="hierarchyChartTemplate">
+  <div class="leaf {{colorClass}}" id="{{id}}">
+
+    {{#picture}}
+    <img src="{{picture}}" class="image" alt="Image of {{name}}"/>
+    {{/picture}}
+    {{^picture}}
+
+    {{#avatarInitials}}
+    <div class="image-initials">{{avatarInitials}}</div>
+    {{/avatarInitials}}
+    {{^avatarInitials}}
+    <span class="image-placeholder"></span>
+    {{/avatarInitials}}
+
+    {{/picture}}
+
+    <div class="detail">
+      <p class="heading">{{name}}</p>
+      <p class="subheading">{{position}}</p>
+      <p class="micro">{{employmentType}}</p>
+    </div>
+
+    {{#menu}}
+    <button class="btn-actions btn-icon" type="button" data-init="false" id="btn-{{id}}">
+      <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
+        <use href="#icon-more"></use>
+      </svg>
+      <span class="audible">More Info & Additional Actions</span>
+    </button>
+    <ul class="popupmenu"></ul>
+    {{/menu}}
+
+    <button class="btn btn-icon" type="button">
+      <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
+        <use href="#icon-caret-up"></use>
+      </svg>
+      <span class="audible">Expand/Collapse</span>
+    </button>
+  </div>
+</script>

--- a/app/views/components/hierarchy/example-stacked-ajax-popupmenu.html
+++ b/app/views/components/hierarchy/example-stacked-ajax-popupmenu.html
@@ -30,21 +30,17 @@
       });
     }
 
-    beforeOpen(eventInfo, hierarchyControl);
+    if (eventInfo.isActionsEvent) {
+      $.when(getActionsAsync()).then((actions) => {
+        hierarchyControl.updateActions(eventInfo, actions);
+      });
+    }
   });
 
   function reload(eventInfo, hierarchyControl, newData) {
     eventInfo.data.children = newData;
     options.dataset = [eventInfo.data.children];
     hierarchyControl.reload(options);
-  }
-
-  function beforeOpen(eventInfo, hierarchyControl) {
-    if (eventInfo.isActionsEvent) {
-      $.when(getActionsAsync()).then((actions) => {
-        hierarchyControl.updateActions(eventInfo, actions);
-      });
-    }
   }
 
   // Emulate a call to the server to get actions for popupmenu
@@ -73,7 +69,6 @@
       ];
 
       defer.resolve(actions);
-      // setTimeout(() => defer.resolve(actions), 500);
 
       return defer.promise();
   }

--- a/src/components/hierarchy/hierarchy.js
+++ b/src/components/hierarchy/hierarchy.js
@@ -24,7 +24,6 @@ const COMPONENT_NAME = 'hierarchy';
  * @param {number} [settings.leafHeight=null] Set the height of the leaf
  * @param {number} [settings.leafWidth=null] Set the width of the leaf
  * @param {string} [settings.beforeExpand=null] A callback that fires before node expansion of a node.
-
  * @param {boolean} [settings.renderSubLevel=false] If true elements with no children will be rendered detached
  * @param {boolean} [settings.layout=string] Which layout should be rendered {'horizontal', 'mobile-only', 'stacked', 'paging'}
  * @param {object} [settings.emptyMessage] An optional settings object for the empty message when there is no data.

--- a/src/components/hierarchy/hierarchy.js
+++ b/src/components/hierarchy/hierarchy.js
@@ -24,6 +24,7 @@ const COMPONENT_NAME = 'hierarchy';
  * @param {number} [settings.leafHeight=null] Set the height of the leaf
  * @param {number} [settings.leafWidth=null] Set the width of the leaf
  * @param {string} [settings.beforeExpand=null] A callback that fires before node expansion of a node.
+
  * @param {boolean} [settings.renderSubLevel=false] If true elements with no children will be rendered detached
  * @param {boolean} [settings.layout=string] Which layout should be rendered {'horizontal', 'mobile-only', 'stacked', 'paging'}
  * @param {object} [settings.emptyMessage] An optional settings object for the empty message when there is no data.
@@ -320,6 +321,7 @@ Hierarchy.prototype = {
     const leaf = $(eventInfo.targetInfo.target).closest('.leaf');
     const nodeData = eventInfo.data;
     const popupMenu = $(leaf).find('.popupmenu');
+    const popupMenuControl = popupMenu.data('trigger').data().popupmenu;
     const lineItemsToRemove = popupMenu.find('li').not(':eq(0)');
 
     $(lineItemsToRemove).each((idx, item) => {
@@ -328,6 +330,8 @@ Hierarchy.prototype = {
 
     nodeData.menu.actions = updatedActions;
     popupMenu.append(this.getActionMenuItems(nodeData));
+
+    popupMenuControl.open();
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fix for https://github.com/infor-design/enterprise/issues/3760. Added an example where actions are dynamically loaded into actions menu for hierarchy cards. This reproduces the issue reported in https://github.com/infor-design/enterprise/issues/3760.

**Related github/jira issue (required)**:
Closes #3760

**Steps necessary to review your pull request (required)**:

1. Get new example from PR
2. Go to http://localhost:4000/components/hierarchy/example-stacked-ajax-popupmenu.html
3. Click on action menu button to get actions.
4. Notice the menu now sizes properly on the initial click.
