### PR TITLE
3479 - Fix multiline ellipsis in IE

### DIFF
--- a/app/views/components/modal/test-long-title-large-content.html
+++ b/app/views/components/modal/test-long-title-large-content.html
@@ -94,11 +94,16 @@
       $(this).focus();
       setModal(modals[this.id]);
 
-      if ($('.modal-title').height() > 35) {
-        setTimeout(function () {
+      var sohoTheme = (Soho.theme.currentTheme.name.lastIndexOf('Soho') !== -1 || Soho.theme.currentTheme.name === 'Soho Light') && $('.modal-title')[0].innerHTML.length > 68;
+
+      var upliftTheme = (Soho.theme.currentTheme.name.lastIndexOf('Uplift') !== -1 || Soho.theme.currentTheme.name === 'Soho Uplift') && $('.modal-title')[0].innerHTML.length > 47;
+
+      setTimeout(function () {
+        if (sohoTheme || upliftTheme) {
           $('.modal-title').tooltip(TOOLTIP_OPTIONS);
-        }, 500);
-      }
+        }
+      }, 100);
+
     });
   })
 

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -542,6 +542,43 @@ html.ie {
   }
 }
 
+// Solution for multi line with ellipsis
+.ie,
+.ie11 {
+  .modal {
+    &:not(.display-fullsize):not(.about) {
+      .modal-content {
+        h1 {
+          line-height: 1.2em;
+          margin-right: -1em;
+          max-height: 2.4em;
+          overflow: hidden;
+          padding-right: 1em;
+          position: relative;
+          text-align: justify;
+          white-space: normal;
+
+          &::before {
+            bottom: 0;
+            content: '...';
+            position: absolute;
+            right: 0;
+          }
+
+          &::after {
+            background-color: $modal-bg-color; // Covering up the ‘…’ if the text is less than the max number of lines.
+            content: '';
+            height: 1em;
+            position: absolute;
+            right: 0;
+            width: 1em;
+          }
+        }
+      }
+    }
+  }
+}
+
 // iOS has lots of issues regarding scrolling of elements that are
 // technically "behind" the modal.  This CSS, as well as some JS in the Modal component,
 // seek to stop scrolling behind the in-focus modal element.

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -543,7 +543,6 @@ html.ie {
 }
 
 // Solution for multi line with ellipsis
-.ie,
 .ie11 {
   .modal {
     &:not(.display-fullsize):not(.about) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This is a follow up fix for https://github.com/infor-design/enterprise/issues/3479. The `-webkit-line-clamp` is not supported in IE11, so I created a pure CSS that will fix this issue. 

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/3479

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Open in IE11 browser (via browserstack or windows) and navigate to http://localhost:4000/components/modal/test-long-title-large-content.html
- Click `Show Modal` button
- The title should be multi line with ellipsis
- Tooltip should also work

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
