### PR TITLE
Change the size of bullets on App Menu/Accordion on Android devices

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### v4.28.0 Fixes
 
 - `[Application Menu]` Fixed the icons on breaking apart it's appearance when zooming out the browser in IE11, uplift theme. ([#3070](https://github.com/infor-design/enterprise/issues/3070))
+- `[Application Menu]` Fixed misalignment/size of bullet icons in the accordion on Android devices. ([#1429](http://localhost:4000/components/applicationmenu/test-six-levels.html))
 - `[Bubble Chart]` Fixed an issue where an extra axis line was shown when using the domain formatter. ([#501](https://github.com/infor-design/enterprise/issues/501))
 - `[Charts]` Fixed an issue where selected items were being deselected after resizing the page. ([#323](https://github.com/infor-design/enterprise/issues/323))
 - `[Datagrid]` Fixed a css issue in dark uplift mode where the group row lines were not visible. ([#3649](https://github.com/infor-design/enterprise/issues/3649))

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -1410,6 +1410,19 @@ html[dir='rtl'] {
   }
 }
 
+// Fix size of the bullet icon on Android devices
+html.android {
+  .accordion-pane {
+    .accordion-header.list-item {
+      &::before {
+        font-size: 1rem;
+        padding-right: 8px;
+        padding-top: 4px;
+      }
+    }
+  }
+}
+
 // Windows-style popup for truncated text elements
 .tooltip {
   &.tooltip-accordion-style {

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -737,7 +737,7 @@
         content: '\25cf';
         display: inline-block;
         font-size: $theme-size-font-sm;
-        padding: 8px 10px 8px 21px;
+        padding: 4px 10px 8px 21px;
         vertical-align: middle;
       }
 
@@ -1415,9 +1415,7 @@ html.android {
   .accordion-pane {
     .accordion-header.list-item {
       &::before {
-        font-size: 1rem;
-        padding-right: 8px;
-        padding-top: 4px;
+        font-size: 0.7rem;
       }
     }
   }

--- a/src/components/applicationmenu/_applicationmenu-uplift.scss
+++ b/src/components/applicationmenu/_applicationmenu-uplift.scss
@@ -388,8 +388,9 @@
         &.list-item {
           &::before {
             color: inherit;
-            font-size: 0.6rem;
-            padding-right: 12px;
+            font-size: 0.4rem;
+            padding-right: 13px;
+            padding-top: 7px;
           }
         }
 
@@ -539,7 +540,7 @@ html[dir='rtl'] {
 
     // Level 2 Header
     .accordion-header {
-      @include left-align-cascade-styles-header(20px, 18px, 49px, 26px);
+      @include left-align-cascade-styles-header(20px, 18px, 49px, 29px);
     }
 
     // Level 2 Pane
@@ -548,7 +549,7 @@ html[dir='rtl'] {
 
       // Level 3 Header
       .accordion-header {
-        @include left-align-cascade-styles-header(40px, 44px, 72px, 52px);
+        @include left-align-cascade-styles-header(40px, 44px, 72px, 55px);
       }
 
       // Level 3 Pane
@@ -557,7 +558,7 @@ html[dir='rtl'] {
 
         // Level 4 Header
         .accordion-header {
-          @include left-align-cascade-styles-header(59px, 69px, 97px, 77px);
+          @include left-align-cascade-styles-header(59px, 69px, 97px, 80px);
         }
 
         // Level 4 Pane
@@ -566,7 +567,7 @@ html[dir='rtl'] {
 
           // Level 5 Header
           .accordion-header {
-            @include left-align-cascade-styles-header(78px, 94px, 122px, 102px);
+            @include left-align-cascade-styles-header(78px, 94px, 122px, 105px);
           }
 
           // Level 5 Pane
@@ -575,7 +576,7 @@ html[dir='rtl'] {
 
             // Level 6 Header
             .accordion-header {
-              @include left-align-cascade-styles-header(122px, 122px, 150px, 130px);
+              @include left-align-cascade-styles-header(122px, 122px, 150px, 133px);
 
               &.no-icon {
                 > a {
@@ -610,25 +611,25 @@ html[dir='rtl'] {
       @include left-align-cascade-styles-pane(55px, 78px, 56px);
 
       .accordion-header {
-        @include left-align-cascade-styles-header(54px, 50px, 78px, 60px);
+        @include left-align-cascade-styles-header(54px, 50px, 78px, 61px);
       }
 
       // Level 2 Pane
       .accordion-pane {
-        @include left-align-cascade-styles-pane(55px, 103px, 78px);
+        @include left-align-cascade-styles-pane(55px, 102px, 78px);
 
         // Level 3 Header
         .accordion-header {
-          @include left-align-cascade-styles-header(59px, 74px, 102px, 84px);
+          @include left-align-cascade-styles-header(59px, 74px, 102px, 85px);
         }
 
         // Level 3 Pane
         .accordion-pane {
-          @include left-align-cascade-styles-pane(79px, 127px, 103px);
+          @include left-align-cascade-styles-pane(79px, 127px, 102px);
 
           // Level 4 Header
           .accordion-header {
-            @include left-align-cascade-styles-header(59px, 99px, 127px, 109px);
+            @include left-align-cascade-styles-header(59px, 99px, 127px, 110px);
           }
 
           // Level 4 Pane
@@ -637,12 +638,12 @@ html[dir='rtl'] {
 
             // Level 5 Header
             .accordion-header {
-              @include left-align-cascade-styles-header(78px, 124px, 152px, 134px);
+              @include left-align-cascade-styles-header(78px, 124px, 152px, 135px);
             }
 
             // Level 5 Pane
             .accordion-pane {
-              @include left-align-cascade-styles-pane(130px, 150px, 153px);
+              @include left-align-cascade-styles-pane(130px, 152px, 153px);
 
               // Level 6 Header
               .accordion-header {
@@ -708,15 +709,15 @@ html[dir='rtl'] {
 
             // Level 5 Pane
             .accordion-pane {
-              @include right-align-cascade-styles-pane(122px, 150px, 122px);
+              @include right-align-cascade-styles-pane(122px, 152px, 122px);
 
               // Level 6 Header
               .accordion-header {
-                @include right-align-cascade-styles-header(122px, 122px, 150px, 130px);
+                @include right-align-cascade-styles-header(122px, 122px, 152px, 130px);
 
                 &.no-icon {
                   > a {
-                    padding-right: 150px;
+                    padding-right: 152px;
                   }
                 }
               }
@@ -752,7 +753,7 @@ html[dir='rtl'] {
 
         // Level 2 Pane
         .accordion-pane {
-          @include right-align-cascade-styles-pane(55px, 103px, 78px);
+          @include right-align-cascade-styles-pane(55px, 102px, 78px);
 
           // Level 3 Header
           .accordion-header {
@@ -761,7 +762,7 @@ html[dir='rtl'] {
 
           // Level 3 Pane
           .accordion-pane {
-            @include right-align-cascade-styles-pane(79px, 127px, 103px);
+            @include right-align-cascade-styles-pane(79px, 127px, 102px);
 
             // Level 4 Header
             .accordion-header {

--- a/src/components/applicationmenu/_applicationmenu-uplift.scss
+++ b/src/components/applicationmenu/_applicationmenu-uplift.scss
@@ -388,7 +388,7 @@
         &.list-item {
           &::before {
             color: inherit;
-            font-size: 0.8rem;
+            font-size: 0.6rem;
             padding-right: 12px;
           }
         }
@@ -510,6 +510,22 @@ html[dir='rtl'] {
       }
     }
   }
+
+  &.android {
+    .application-menu {
+      .accordion.panel.inverse {
+        .accordion-pane {
+          .accordion-header {
+            &.list-item {
+              &::before {
+                font-size: 0.6rem;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 }
 
 // Application Menu's Accordion alignment rules
@@ -594,7 +610,7 @@ html[dir='rtl'] {
       @include left-align-cascade-styles-pane(55px, 78px, 56px);
 
       .accordion-header {
-        @include left-align-cascade-styles-header(54px, 50px, 78px, 58px);
+        @include left-align-cascade-styles-header(54px, 50px, 78px, 60px);
       }
 
       // Level 2 Pane
@@ -603,7 +619,7 @@ html[dir='rtl'] {
 
         // Level 3 Header
         .accordion-header {
-          @include left-align-cascade-styles-header(59px, 74px, 102px, 82px);
+          @include left-align-cascade-styles-header(59px, 74px, 102px, 84px);
         }
 
         // Level 3 Pane
@@ -612,7 +628,7 @@ html[dir='rtl'] {
 
           // Level 4 Header
           .accordion-header {
-            @include left-align-cascade-styles-header(59px, 99px, 127px, 107px);
+            @include left-align-cascade-styles-header(59px, 99px, 127px, 109px);
           }
 
           // Level 4 Pane
@@ -621,7 +637,7 @@ html[dir='rtl'] {
 
             // Level 5 Header
             .accordion-header {
-              @include left-align-cascade-styles-header(78px, 124px, 152px, 132px);
+              @include left-align-cascade-styles-header(78px, 124px, 152px, 134px);
             }
 
             // Level 5 Pane
@@ -630,7 +646,7 @@ html[dir='rtl'] {
 
               // Level 6 Header
               .accordion-header {
-                @include left-align-cascade-styles-header(122px, 152px, 180px, 160px);
+                @include left-align-cascade-styles-header(122px, 152px, 180px, 162px);
 
                 &.no-icon {
                   > a {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a CSS bug on Android devices, where the bullet icon in the Application Menu appears larger and is not correctly aligned with text.

**Related github/jira issue (required)**:
Closes #1429

**Steps necessary to review your pull request (required)**:
- Open http://localhost:4000/components/applicationmenu/test-six-levels-icons.html on an Android device (I tested on a BrowserStack VM connected to a Samsung Galaxy S10)
- Use the hamburger to open the menu
- Open the "Level 1" header.  Find the "Level 2 List Item Header".  It should line up well versus the text, and the icons in the other adjacent headers.
- Keep navigating into "Level 2", "Level 3", etc. All the bulleted headers labeled "Level X List Item Header" should be sized correctly and aligned with the other headers in terms of icon/text placement.
- Also check Vibrant theme: http://localhost:4000/components/applicationmenu/test-six-levels-icons.html?theme=uplift

**Included in this Pull Request**:
- [x] A note to the change log.
