### PR TITLE
3769 - Fix button was flow off on mobile

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -770,10 +770,11 @@ html[lang^='fr-'] {
 // Special case to target buttons that are inside of the page container only
 .page-container {
   button {
-    &.btn {
+    &.btn,
+    &.btn-secondary {
       @media (max-width: $breakpoint-big-phone) {
+        max-width: 100%;
         text-overflow: ellipsis;
-        width: 100%;
       }
     }
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixd button was flow off on mobile.

**Related github/jira issue (required)**:
Closes #3769

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/button/example-index.html
- Resize browser window to small viewport (iPhone 5/SE on chrome devtools)
- See last `Action` button in `Tertiary`
- Should aligned fine

http://localhost:4000/components/contextualactionpanel/example-jquery.html
http://localhost:4000/components/contextualactionpanel/example-markup.html?theme=uplift&variant=light
- On small viewport
- See the button should have `...` ellipsis
- Button width not more than viewport width