### PR TITLE
3490 - Fix IE11 shortcut text in context menu

### DIFF
--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -314,7 +314,6 @@
   li {
     cursor: pointer;
     line-height: normal;
-    overflow: auto;
     padding: 0;
     position: static;
     white-space: nowrap;

--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -278,6 +278,7 @@
 
     &.is-selectable {
       a {
+        overflow: auto;
         padding-left: 57px;
       }
 
@@ -313,6 +314,7 @@
   li {
     cursor: pointer;
     line-height: normal;
+    overflow: auto;
     padding: 0;
     position: static;
     white-space: nowrap;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes an IE11 issue that was found in QA

**Related github/jira issue (required)**:
related to #3490  

**Steps necessary to review your pull request (required)**:
- pull branch
- go to http://localhost:4000/components/popupmenu/example-shortcut-text.html in IE11
- Make sure the menu items with shortcut text are not broken into 2 lines. Here's a reference to the [bug](https://github.com/infor-design/enterprise/issues/3490#issuecomment-613909438) that was found

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
