### PR TITLE
2266 - Fix Colorpicker swatches shifting in small viewport

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Application Menu]` Fixed the icons on breaking apart it's appearance when zooming out the browser in IE11, uplift theme. ([#3070](https://github.com/infor-design/enterprise/issues/3070))
 - `[Bubble Chart]` Fixed an issue where an extra axis line was shown when using the domain formatter. ([#501](https://github.com/infor-design/enterprise/issues/501))
 - `[Charts]` Fixed an issue where selected items were being deselected after resizing the page. ([#323](https://github.com/infor-design/enterprise/issues/323))
+- `[Colorpicker]` Fixed an issue where the color swatches shift when the colorpicker has a scrollbar. ([#2266](https://github.com/infor-design/enterprise/issues/2266))
 - `[Datagrid]` Fixed a css issue in dark uplift mode where the group row lines were not visible. ([#3649](https://github.com/infor-design/enterprise/issues/3649))
 - `[Datagrid]` Fixed some styling issues in alerts and tags, and made clickable tags available in the formatter. ([#3631](https://github.com/infor-design/enterprise/issues/3631))
 - `[Datagrid]` Fixed a css issue in dark uplift mode where the group row lines were not visible . ([#3649](https://github.com/infor-design/enterprise/issues/3649))

--- a/src/components/colorpicker/_colorpicker.scss
+++ b/src/components/colorpicker/_colorpicker.scss
@@ -224,6 +224,10 @@
   padding: 10px 0 10px 10px;
   width: 322px;
 
+  &.has-scrollbar {
+    width: calc(322px + 17px);
+  }
+
   li {
     display: inline-block;
     height: 20px;

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -1427,6 +1427,8 @@ PopupMenu.prototype = {
       return;
     }
 
+    console.log(this.menu[0].offsetHeight);
+
     // Make the field the same size
     const elemWidth = this.element[0].offsetWidth;
     if (this.settings.trigger === 'click' && elemWidth > menuDimensions.width) {
@@ -1556,6 +1558,13 @@ PopupMenu.prototype = {
   handleAfterPlace(e, placementObj) {
     const wrapper = this.menu.parent('.popupmenu-wrapper');
     this.wrapperPlace.setArrowPosition(e, placementObj, wrapper);
+
+
+    if (placementObj.height < this.menu[0].offsetHeight) {
+      if (this.menu[0].classList.contains('colorpicker')) {
+        this.menu[0].classList.add('has-scrollbar');
+      }
+    }
 
     if (placementObj.height) {
       wrapper[0].style.height = '';

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -1427,7 +1427,6 @@ PopupMenu.prototype = {
       return;
     }
 
-
     // Make the field the same size
     const elemWidth = this.element[0].offsetWidth;
     if (this.settings.trigger === 'click' && elemWidth > menuDimensions.width) {

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -1427,7 +1427,6 @@ PopupMenu.prototype = {
       return;
     }
 
-    console.log(this.menu[0].offsetHeight);
 
     // Make the field the same size
     const elemWidth = this.element[0].offsetWidth;

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -1559,7 +1559,8 @@ PopupMenu.prototype = {
     const wrapper = this.menu.parent('.popupmenu-wrapper');
     this.wrapperPlace.setArrowPosition(e, placementObj, wrapper);
 
-
+    // Check if colorpicker has scrollbar
+    // Use CSS class to modify width of popupmenu.
     if (placementObj.height < this.menu[0].offsetHeight) {
       if (this.menu[0].classList.contains('colorpicker')) {
         this.menu[0].classList.add('has-scrollbar');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes an issue where the color swatches shift when the colorpicker has a scrollbar. Adds a check for the colorpicker height and adds a class to modify the width to accommodate the scrollbar.

**Related github/jira issue (required)**:
closes #2266

**Steps necessary to review your pull request (required)**:
- pull branch
- go to http://localhost:4000/components/colorpicker/example-index.html and make sure the swatches don't shift over in a short viewport.

<img width="385" alt="Screen Shot 2020-04-21 at 11 16 40 AM" src="https://user-images.githubusercontent.com/1084735/79883280-b5c90b80-83c1-11ea-8101-1813d413da06.png">


**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
