### PR TITLE
3512 - Add support to max files limit with file upload advanced

### DIFF
--- a/app/views/components/fileupload-advanced/test-max-files.html
+++ b/app/views/components/fileupload-advanced/test-max-files.html
@@ -1,7 +1,7 @@
 <div class="row top-padding">
   <div class="six columns">
     <h2>Fileupload Advanced</h2>
-    <p>Max two(2) files can be uploads.</p>
+    <p>Maximum of two(2) files can be upload in total.</p>
   </div>
 </div>
 

--- a/app/views/components/fileupload-advanced/test-max-files.html
+++ b/app/views/components/fileupload-advanced/test-max-files.html
@@ -1,0 +1,12 @@
+<div class="row top-padding">
+  <div class="six columns">
+    <h2>Fileupload Advanced</h2>
+    <p>Max two(2) files can be uploads.</p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="four columns">
+    <div class="fileupload-advanced" data-options="{maxFiles: 2}"></div>
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Contextmenu]` Added support for shortcut display in menus. ([#3490](https://github.com/infor-design/enterprise/issues/3490))
 - `[Datepicker]` Added support for custom api callback to disable passed dates and to disable dates by years. ([#3462](https://github.com/infor-design/enterprise/issues/3462))
+- `[FileUploadAdvanced]` Added support to api settings `maxFiles` to limit number of uploads. ([#3512](https://github.com/infor-design/enterprise/issues/3512))
 - `[Modal]` Improved handling of multiple Modal windows stemming from a single trigger element. ([ng#705](https://github.com/infor-design/enterprise-ng/issues/705))
 
 ### v4.28.0 Fixes

--- a/src/components/fileupload/_fileupload-uplift.scss
+++ b/src/components/fileupload/_fileupload-uplift.scss
@@ -19,7 +19,7 @@
         button {
           .icon {
             left: 0;
-            top: -4px;
+            top: -3px;
           }
         }
       }
@@ -41,6 +41,27 @@
 
 // Firefox needs some hand-holding
 .is-firefox {
+  &.is-mac {
+    .fileupload-wrapper {
+      .container {
+        .file-row,
+        .progress-row {
+          .status-icon {
+            button {
+              .icon {
+                top: -4px !important;
+              }
+            }
+
+            .icon {
+              top: -3px;
+            }
+          }
+        }
+      }
+    }
+  }
+
   .fileupload-wrapper {
     .container {
       .file-row,
@@ -49,6 +70,24 @@
           button {
             .icon {
               top: -3px;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// ie11
+.ie11 {
+  .fileupload-wrapper {
+    .container {
+      .file-row,
+      .progress-row {
+        .status-icon {
+          button {
+            .icon {
+              top: -7px;
             }
           }
         }

--- a/src/components/fileupload/_fileupload.scss
+++ b/src/components/fileupload/_fileupload.scss
@@ -286,7 +286,7 @@
         border-radius: 50%;
         float: left;
         height: 16px;
-        margin: 8px 10px 0;
+        margin: 10px 10px 0;
         width: 16px;
 
         .btn-icon {
@@ -297,13 +297,17 @@
           min-width: 18px;
           top: -1px;
           width: 18px;
+
+          .icon {
+            margin-top: -2px;
+          }
         }
 
         .icon {
           color: $fileupload-status-color;
-          height: 10px;
+          height: 10px !important;
           left: 3px;
-          top: 3px;
+          top: 2px;
           width: 10px;
         }
 
@@ -423,6 +427,30 @@
   .field-fileupload .trigger .icon,
   .field-fileupload .trigger-close .icon {
     top: 3px;
+  }
+}
+
+// Firefox needs some hand-holding
+.is-firefox {
+  &.is-mac {
+    .fileupload-wrapper {
+      .container {
+        .file-row,
+        .progress-row {
+          .status-icon {
+            button {
+              .icon {
+                margin-top: 0;
+              }
+            }
+
+            .icon {
+              top: 3px;
+            }
+          }
+        }
+      }
+    }
   }
 }
 

--- a/src/components/locale/cultures/en-US.js
+++ b/src/components/locale/cultures/en-US.js
@@ -160,7 +160,7 @@ Soho.Locale.addCulture('en-US', {
     Error: { id: 'Error', value: 'Error', comment: 'Title, Spoken Text describing fact an error has occured' },
     ErrorAllowedTypes: { id: 'ErrorAllowedTypes', value: 'File type is not allowed', comment: 'Error string for file-upload' },
     ErrorMaxFileSize: { id: 'ErrorMaxFileSize', value: 'Exceeded file size limit', comment: 'Error string for file-upload' },
-    ErrorMaxFiles: { id: 'ErrorMaxFiles', value: 'Exceeded maximum ({n}) files allowed limit', comment: 'Error string for file-upload' },
+    ErrorMaxFiles: { id: 'ErrorMaxFiles', value: 'Cannot upload more than the maximum number of files ({n}).', comment: 'Error string for file-upload' },
     ErrorMaxFilesInProcess: { id: 'ErrorMaxFilesInProcess', value: 'Exceeded maximum files allowed limit', comment: 'Error string for file-upload' },
     ErrorOnPage: { id: 'ErrorOnPage', value: 'Error message(s) on page', comment: 'Error message(s) on page n' },
     EmailValidation: { id: 'EmailValidation', value: 'Email address not valid', comment: 'This the rule for email validation' },

--- a/src/components/locale/cultures/en-US.js
+++ b/src/components/locale/cultures/en-US.js
@@ -160,6 +160,7 @@ Soho.Locale.addCulture('en-US', {
     Error: { id: 'Error', value: 'Error', comment: 'Title, Spoken Text describing fact an error has occured' },
     ErrorAllowedTypes: { id: 'ErrorAllowedTypes', value: 'File type is not allowed', comment: 'Error string for file-upload' },
     ErrorMaxFileSize: { id: 'ErrorMaxFileSize', value: 'Exceeded file size limit', comment: 'Error string for file-upload' },
+    ErrorMaxFiles: { id: 'ErrorMaxFiles', value: 'Exceeded maximum ({n}) files allowed limit', comment: 'Error string for file-upload' },
     ErrorMaxFilesInProcess: { id: 'ErrorMaxFilesInProcess', value: 'Exceeded maximum files allowed limit', comment: 'Error string for file-upload' },
     ErrorOnPage: { id: 'ErrorOnPage', value: 'Error message(s) on page', comment: 'Error message(s) on page n' },
     EmailValidation: { id: 'EmailValidation', value: 'Email address not valid', comment: 'This the rule for email validation' },

--- a/src/components/progress/progress.js
+++ b/src/components/progress/progress.js
@@ -79,10 +79,14 @@ Progress.prototype = {
   * @param {string} value  The percent value to use to fill. 0-100
   * @returns {void}
   */
-  update(value = 0) {
-    this.element.attr('data-value', value);
-    this.element[0].style.width = `${value.toString()}%`;
-    this.updateAria(value);
+  update(value) {
+    let percent = this.element[0].getAttribute('data-value') || 0;
+    if (/number|string/.test(typeof value)) {
+      this.element[0].setAttribute('data-value', value);
+      percent = value;
+    }
+    this.element[0].style.width = `${percent}%`;
+    this.updateAria(percent);
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added support to api settings `maxFiles` to limit number of uploads with FileUploadAdvanced.

**Related github/jira issue (required)**:
Closes #3512

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/fileupload-advanced/test-max-files.html
- Drag or use `Select Files` button to upload
- See max two files can be upload only

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
