### PR TITLE
3639 - Prevent Autocomplete List from opening after its Input field loses focus

### DIFF
--- a/app/views/components/autocomplete/test-focus.html
+++ b/app/views/components/autocomplete/test-focus.html
@@ -1,0 +1,19 @@
+<div class="row">
+  <div class="six columns">
+    <h2>Autocomplete Test: Don't Steal Focus</h2>
+    <p>Github Issue: <a class="hyperlink" href="https://github.com/infor-design/enterprise/issues/3639" target="_blank">#3639</a></p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+    <div class="field">
+      <label for="autocomplete-default">States</label>
+      <input type="text" autocomplete="off" class="autocomplete" data-options="{source: '{{basepath}}api/states?term='}" placeholder="Type to Search" id="autocomplete-default"/>
+    </div>
+    <div class="field">
+      <label for="tab-to-this">Junk Input</label>
+      <input id="tab-to-this" />
+    </div>
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - `[Application Menu]` Fixed the icons on breaking apart it's appearance when zooming out the browser in IE11, uplift theme. ([#3070](https://github.com/infor-design/enterprise/issues/3070))
 - `[Application Menu]` Fixed misalignment/size of bullet icons in the accordion on Android devices. ([#1429](http://localhost:4000/components/applicationmenu/test-six-levels.html))
+- `[Autocomplete]` Added a check to prevent the autocomplete from incorrectly stealing form focus, by checking for inner focus before opening a list on typeahead. ([#3639](https://github.com/infor-design/enterprise/issues/3070))
 - `[Bubble Chart]` Fixed an issue where an extra axis line was shown when using the domain formatter. ([#501](https://github.com/infor-design/enterprise/issues/501))
 - `[Bullet Chart]` Added support to format ranges and difference values. ([#3447](https://github.com/infor-design/enterprise/issues/3447))
 - `[Charts]` Fixed an issue where selected items were being deselected after resizing the page. ([#323](https://github.com/infor-design/enterprise/issues/323))

--- a/src/components/autocomplete/autocomplete.js
+++ b/src/components/autocomplete/autocomplete.js
@@ -201,6 +201,20 @@ Autocomplete.prototype = {
     this.handleEvents();
   },
 
+  /**
+   * @returns {boolean} whether or not this component instance has an element that is focused.
+   */
+  get isFocused() {
+    const active = document.activeElement;
+    const input = this.element[0];
+    const $list = this.list;
+
+    if (input.isEqualNode(active) || ($list && $list.length && $list[0].contains(active))) {
+      return true;
+    }
+    return false;
+  },
+
   addMarkup() {
     this.element.addClass('autocomplete').attr({
       role: 'combobox',
@@ -623,7 +637,7 @@ Autocomplete.prototype = {
     }
 
     this.loadingTimeout = setTimeout(() => {
-      if (self.isLoading()) {
+      if (self.isLoading() || !self.isFocused) {
         return;
       }
 

--- a/test/components/autocomplete/autocomplete.e2e-spec.js
+++ b/test/components/autocomplete/autocomplete.e2e-spec.js
@@ -153,3 +153,25 @@ describe('Autocomplete keyword tests', () => {
     expect(await element.all(by.css('#autocomplete-list li')).count()).toEqual(7);
   });
 });
+
+describe('Autocomplete focus tests', () => {
+  beforeEach(async () => {
+    await browser.waitForAngularEnabled(false);
+    await browser.driver.get(`${browser.baseUrl}/components/autocomplete/example-ajax`);
+  });
+
+  it('Should not steal focus away from other components if the user has tabbed out', async () => {
+    await clickOnAutocomplete();
+
+    // Type "Utah" and immediately tab to the next field
+    await browser.actions()
+      .sendKeys('utah')
+      .sendKeys(protractor.Key.TAB).perform();
+
+    // Wait for the amount of time necessary that would normally be needed for the list to open.
+    await browser.driver.sleep(config.sleepLonger);
+
+    // Make sure the list isn't there
+    expect(await element(by.id('autocomplete-list')).isPresent()).toBeFalsy();
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes an issue on the Autocomplete list where it was previously possible for the Autocomplete list to incorrectly open after the input field has already lost focus, causing focus to become stolen by the autocomplete list.

**Related github/jira issue (required)**:
Closes #3639

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the demoapp
- Open http://localhost:4000/components/autocomplete/test-focus
- Focus the first input field
- Type "utah", then immediately press the Tab key.
- Focus should change to and remain on the second input field, and the Autocomplete list should not open.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.