### PR TITLE
Fix for issues found in #3760. IE11 fails to load, context menu arrow does not center on action menu button

### DIFF
--- a/app/views/components/hierarchy/example-stacked-ajax-popupmenu.html
+++ b/app/views/components/hierarchy/example-stacked-ajax-popupmenu.html
@@ -31,7 +31,7 @@
     }
 
     if (eventInfo.isActionsEvent) {
-      $.when(getActionsAsync()).then((actions) => {
+      $.when(getActionsAsync()).then(function (actions) {
         hierarchyControl.updateActions(eventInfo, actions);
       });
     }

--- a/src/components/hierarchy/_hierarchy-base.scss
+++ b/src/components/hierarchy/_hierarchy-base.scss
@@ -436,15 +436,16 @@
   }
 
   .popupmenu.has-detail-fields + .arrow {
-    border-bottom-color: $theme-color-palette-slate-80;
+    border-bottom-color: $popupmenu-border-color;
   }
 
   .popupmenu.has-detail-fields + .arrow::after {
-    border-bottom-color: $theme-color-palette-slate-80;
+    border-bottom-color: $theme-color-palette-white;
   }
 
   .detail-fields {
-    background: $theme-color-palette-slate-80;
+    background: $theme-color-palette-white;
+    border-bottom: thin solid $theme-color-palette-slate-30;
     padding: 10px;
 
     .dt-fields-row {
@@ -462,7 +463,7 @@
     }
 
     .dt-fields-cell {
-      color: $theme-color-palette-white;
+      color: $theme-color-palette-slate-80;
       display: table-cell;
       font-size: $theme-size-font-sm;
       line-height: 1.4rem;

--- a/src/components/hierarchy/hierarchy.js
+++ b/src/components/hierarchy/hierarchy.js
@@ -331,6 +331,11 @@ Hierarchy.prototype = {
     popupMenu.append(this.getActionMenuItems(nodeData));
 
     popupMenuControl.open();
+    popupMenuControl.handleAfterPlace(null, {
+      element: popupMenu.parent(),
+      parent: $(leaf).find('.btn-actions'),
+      placement: 'bottom'
+    });
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
-Fixed detail fields background color and arrow so it looks better when context menu has overflow.
-Fixed IE11 not loading error
-Fixed context menu arrow position so it centers on action menu button.

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise/issues/3760

**Steps necessary to review your pull request (required)**:
1. Get new example from PR https://github.com/infor-design/enterprise/pull/3761
2. Go to http://localhost:4000/components/hierarchy/example-stacked-ajax-popupmenu.html
3. Click on action menu button to get actions.

- Menu should size properly
- Menu arrow should center on action button
- Example should load properly in IE11

Example with fix:
![3760-fixed](https://user-images.githubusercontent.com/1056684/79911077-61d01e00-83e5-11ea-86b2-f7ad725e6a90.gif)
