### PR TITLE
801 - Fix nested caps and memory leaks

### DIFF
--- a/app/views/components/contextualactionpanel/test-destroy.html
+++ b/app/views/components/contextualactionpanel/test-destroy.html
@@ -13,38 +13,38 @@
 
     <div class="field">
       <button type="button" id="contextual-panel-trigger" class="btn-secondary contextual-action-panel-trigger">
-        <span>Show Me Potato Salad</span>
+        <span>Show CAP</span>
       </button>
       <div class="contextual-action-panel">
-  	    <div class="row">
-    			<div class="twelve columns">
-    				<div class="field">
-    				  <label for="cool-dropdown">Cool Dropdown</label>
-    				  <select class="dropdown" id="cool-dropdown">
-    					<option value="1">One</option>
-    					<option value="2">Two</option>
-    					<option value="3">Three</option>
-    					<option value="4">Four</option>
-    				  </select>
-    				</div>
+        <div class="row">
+        <div class="twelve columns">
+        <div class="field">
+        <label for="cool-dropdown">Cool Dropdown</label>
+        <select class="dropdown" id="cool-dropdown">
+        <option value="1">One</option>
+        <option value="2">Two</option>
+        <option value="3">Three</option>
+        <option value="4">Four</option>
+        </select>
+        </div>
 
-    				<div class="field">
-    				  <button type="button" id="destroy-contextual" class="btn-primary">
-    					<svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-    					  <use href="#icon-delete"></use>
-    					</svg>
-    					<span>Destroy CAP</span>
-    				  </button>
-    				</div>
-    			</div>
-    		</div>
+        <div class="field">
+        <button type="button" id="destroy-contextual" class="btn-primary">
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use href="#icon-delete"></use>
+        </svg>
+        <span>Destroy CAP</span>
+        </button>
+        </div>
+        </div>
+        </div>
       </div>
 
       <button type="button" id="invoke-contextual" class="btn-primary" disabled>
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use href="#icon-refresh"></use>
         </svg>
-        <span>Invoke CAP</span>
+        <span>Re-Invoke CAP</span>
       </button>
     </div>
 
@@ -107,14 +107,14 @@
 
       contextualApi = $('#contextual-panel-trigger').data('contextualactionpanel');
 
-      setupDestroy();
-
       $('body').toast({
         title: 'Contextual Panel Rebuilt!',
         message: 'Contextual Action Panel has been rebuilt and re-invoked.'
       });
       $('#invoke-contextual').prop('disabled', true);
       $('#contextual-panel-trigger').prop('disabled', false);
+
+      setupDestroy();
     });
 
   });

--- a/app/views/components/contextualactionpanel/test-nested.html
+++ b/app/views/components/contextualactionpanel/test-nested.html
@@ -1,8 +1,12 @@
 <div class="row">
   <div class="six columns">
 
-    <button type="button" id="trigger-1" class="btn-secondary">
-      Contextual Action Panel
+    <button type="button" id="button-1" class="btn-secondary">
+      Contextual Action Panel 1
+    </button>
+
+    <button type="button" id="button-2" class="btn-secondary">
+      Contextual Action Panel 2
     </button>
 
   </div>
@@ -95,9 +99,86 @@
       </div>
 
       <div class="field">
-        <button class="btn-secondary" type="button" id="trigger-2">Show Nested Modal</button>
+        <button class="btn-secondary" type="button" id="trigger-1">Show Nested Modal</button>
+      </div>
+      <div class="field">
+        <button class="btn-secondary" type="button" id="trigger-2">Show Nested CAP</button>
       </div>
 
+    </div>
+  </div>
+</div>
+
+<div id="panel-2" style="display: none;">
+  <div class="toolbar">
+    <div class="title">Supplier Information</div>
+    <div class="buttonset">
+      <button class="btn" type="button">
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-save"></use>
+        </svg>
+        <span>Save and Return</span>
+      </button>
+      <div class="separator"></div>
+      <button name="close" class="btn" type="button">
+        <svg class="icon icon-close" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-close"></use>
+        </svg>
+        <span>Close and Return</span>
+      </button>
+    </div>
+  </div>
+  <div class="row">
+    <div class="six columns">
+
+      <div class="field">
+        <label for="supplier-name">Supplier Name</label>
+        <select id="supplier-name" name="supplier-name" class="dropdown">
+          <option value="">None</option>
+          <option value="jawbone" selected>Jawbone, Inc.</option>
+          <option value="infor">Infor</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="packaging-form">Packaging</label>
+        <select id="packaging-form" name="packaging-form" class="dropdown">
+          <option value="">None</option>
+          <option value="3567" selected>3567</option>
+          <option value="3568">3568</option>
+          <option value="3569">3569</option>
+        </select>
+      </div>
+    </div>
+    <div class="six columns">
+
+      <div class="field">
+        <label for="details-terms">Details Terms</label>
+        <select id="details-terms" name="details-terms" class="dropdown">
+          <option value="">None</option>
+          <option value="default" selected>Default</option>
+          <option value="alternate">Alternate</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="billing-via">Billing Via</label>
+        <select id="billing-via" name="billing-via" class="dropdown">
+          <option value="">None</option>
+          <option value="freight" selected>Freight</option>
+          <option value="air">USPS Air</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="control-method">Control Method</label>
+        <select id="control-method" name="control-method" class="dropdown">
+          <option value="">None</option>
+          <option value="phone">Telephone</option>
+          <option value="email" selected>E-mail</option>
+          <option value="sms">SMS Message</option>
+        </select>
+      </div>
     </div>
   </div>
 </div>
@@ -119,7 +200,7 @@
 
 <script>
 
-  $('#trigger-1').on('click', function () {
+  $('#button-1').on('click', function () {
     $('body').contextualactionpanel({
       title: 'Expenses: $50,000.00',
       content: $('#panel-1'),
@@ -152,8 +233,26 @@
     });
   });
 
-  $('#trigger-2').on('click', function () {
+  $('#trigger-1').on('click', function () {
     $('body').modal({'title': 'Add Context', 'content': $('#modal-2')});
   });
 
+  $('#button-2, #trigger-2').on('click', function () {
+    $('body').contextualactionpanel({
+      title: 'Expenses: $50,000.00',
+      content: $('#panel-2'),
+      trigger: 'immediate',
+      buttons: [
+        {
+          text: 'Close',
+          cssClass: 'btn',
+          icon: '#icon-close',
+          click: function() {
+            var api = $(this).data('modal');
+            api.close();
+          }
+        }
+      ]
+    });
+  });
 </script>

--- a/app/views/components/contextualactionpanel/test-nested.html
+++ b/app/views/components/contextualactionpanel/test-nested.html
@@ -204,8 +204,10 @@
     $('body').contextualactionpanel({
       title: 'Expenses: $50,000.00',
       content: $('#panel-1'),
-      trigger: 'immediate',
-      buttons: [
+      modalSettings: {
+        trigger: 'immediate',
+        id: 'cap-1',
+        buttons: [
         {
           type: 'input',
           text: 'Keyword',
@@ -224,12 +226,14 @@
           text: 'Close',
           cssClass: 'btn',
           icon: '#icon-close',
+          id: 'close-button',
           click: function() {
             var api = $(this).data('modal');
             api.close();
           }
         }
       ]
+      }
     });
   });
 
@@ -242,10 +246,14 @@
       title: 'Expenses: $50,000.00',
       content: $('#panel-2'),
       trigger: 'immediate',
-      buttons: [
+      modalSettings: {
+        trigger: 'immediate',
+        id: 'cap-2',
+        buttons: [
         {
           text: 'Close',
           cssClass: 'btn',
+          id: 'close-button',
           icon: '#icon-close',
           click: function() {
             var api = $(this).data('modal');
@@ -253,6 +261,7 @@
           }
         }
       ]
+      }
     });
   });
 </script>

--- a/app/views/components/dropdown/test-2000-items.html
+++ b/app/views/components/dropdown/test-2000-items.html
@@ -10,7 +10,7 @@
   <div class="twelve columns">
 
     <div class="field">
-      <label for="big-dropdown">Show Me Potato Salad</label>
+      <label for="big-dropdown">Test Dropdown</label>
       <select id="big-dropdown" class="dropdown no-init"></select>
     </div>
 

--- a/app/views/components/modal/test-two-in-page.html
+++ b/app/views/components/modal/test-two-in-page.html
@@ -1,0 +1,98 @@
+<div class="row">
+	<div class="twelve columns">
+		<button class="btn-secondary" type="button" id="show-modal-one">Show Modal 1</button><br/><br/>
+		<button class="btn-secondary" type="button" id="show-modal-two">Show Modal 2</button><br/><br/>
+
+		<!-- Modal Example -->
+		<div id="modal-1" class="hidden">
+			<div class="field">
+				<label for="subject">Problem One</label>
+				<input type="text" id="subject" name="subject" />
+			</div>
+
+      <div class="field">
+        <label for="location" class="label">Location One</label>
+        <select id="location" name="location" class="dropdown">
+          <option value="N">North</option>
+          <option value="S">South</option>
+          <option value="E">East</option>
+          <option value="W">West</option>
+        </select>
+      </div>
+
+			<div class="field">
+				<label for="notes-max">Notes (maxlength) One</label>
+				<textarea id="notes-max" class="textarea" maxlength="90" name="notes-max">Line One</textarea>
+			</div>
+		</div>
+
+		<div id="modal-2" class="hidden">
+			<div class="field">
+				<label for="subject">Problem Two</label>
+				<input type="text" id="subject" name="subject" />
+			</div>
+
+      <div class="field">
+        <label for="location" class="label">Location Two</label>
+        <select id="location" name="location" class="dropdown">
+          <option value="N">North</option>
+          <option value="S">South</option>
+          <option value="E">East</option>
+          <option value="W">West</option>
+        </select>
+      </div>
+
+			<div class="field">
+				<label for="notes-max">Notes Two</label>
+				<textarea id="notes-max" class="textarea" maxlength="90" name="notes-max">Line One</textarea>
+			</div>
+		</div>
+	</div>
+</div>
+
+<script>
+
+  $('#show-modal-one').on('click', function () {
+		$('body').modal({
+      title: 'Modal 1',
+      id: 'my-id',
+      content: $('#modal-1'),
+      buttons: [{
+        text: 'Cancel',
+      //  id: 'modal-button-1',
+        click: function(e, modal) {
+          modal.close();
+        }
+      }, {
+        text: 'Save',
+      //  id: 'modal-button-2',
+        click: function(e, modal) {
+          modal.close();
+        },
+        validate: false,
+        isDefault: true
+      }]
+    });
+  });
+
+  $('#show-modal-two').on('click', function () {
+		$('body').modal({
+      title: 'Modal 2',
+      id: 'my-id',
+      content: $('#modal-2'),
+      buttons: [{
+        text: 'Cancel',
+        click: function(e, modal) {
+          modal.close();
+        }
+      }, {
+        text: 'Save',
+        click: function(e, modal) {
+          modal.close();
+        },
+        validate: false,
+        isDefault: true
+      }]
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,8 @@
 - `[Bullet Chart]` Added support to format ranges and difference values. ([#3447](https://github.com/infor-design/enterprise/issues/3447))
 - `[Charts]` Fixed an issue where selected items were being deselected after resizing the page. ([#323](https://github.com/infor-design/enterprise/issues/323))
 - `[Colorpicker]` Fixed an issue where the color swatches shift when the colorpicker has a scrollbar. ([#2266](https://github.com/infor-design/enterprise/issues/2266))
+- `[ContextualActionPanel]` Fixed an issue where toolbars in CAP are not torn down on destroy. ([#3785](https://github.com/infor-design/enterprise/issues/3785))
+- `[ContextualActionPanel]` Fixed an issue where nested caps or closing and reopening caps would not work. ([#801](https://github.com/infor-design/enterprise-ng/issues/801))
 - `[Datagrid]` Fixed a css issue in dark uplift mode where the group row lines were not visible. ([#3649](https://github.com/infor-design/enterprise/issues/3649))
 - `[Datagrid]` Fixed some styling issues in alerts and tags, and made clickable tags available in the formatter. ([#3631](https://github.com/infor-design/enterprise/issues/3631))
 - `[Datagrid]` Fixed a css issue in dark uplift mode where the group row lines were not visible . ([#3649](https://github.com/infor-design/enterprise/issues/3649))

--- a/src/components/contextualactionpanel/contextualactionpanel.jquery.js
+++ b/src/components/contextualactionpanel/contextualactionpanel.jquery.js
@@ -1,4 +1,5 @@
 import { ContextualActionPanel, COMPONENT_NAME } from './contextualactionpanel';
+import { modalManager } from '../modal/modal.manager';
 
 /**
  * jQuery Component Wrapper for Contextual Action Panel
@@ -7,11 +8,13 @@ import { ContextualActionPanel, COMPONENT_NAME } from './contextualactionpanel';
  */
 $.fn.contextualactionpanel = function (settings) {
   return this.each(function () {
-    let instance = $.data(this, COMPONENT_NAME);
+    const id = (settings?.modalSettings?.id) || settings?.content?.attr('id');
+    const instance = modalManager.findById(id);
+
     if (instance) {
       instance.updated(settings);
-    } else {
-      instance = $.data(this, COMPONENT_NAME, new ContextualActionPanel(this, settings));
+      return;
     }
+    $.data(this, COMPONENT_NAME, new ContextualActionPanel(this, settings));
   });
 };

--- a/src/components/contextualactionpanel/contextualactionpanel.js
+++ b/src/components/contextualactionpanel/contextualactionpanel.js
@@ -2,6 +2,7 @@ import * as debug from '../../utils/debug';
 import { utils } from '../../utils/utils';
 import { warnAboutDeprecation } from '../../utils/deprecated';
 import { Locale } from '../locale/locale';
+import { modalManager } from '../modal/modal.manager';
 
 import '../icons/icons.jquery';
 
@@ -30,7 +31,7 @@ const CONTEXTUALACTIONPANEL_DEFAULTS = {
   modalSettings: {
     buttons: null,
     centerTitle: false,
-    id: `contextual-action-modal-${parseInt($('.modal').length, 10) + 1}`,
+    id: null,
     showCloseBtn: false,
     trigger: 'click',
     useFlexToolbar: false
@@ -123,17 +124,16 @@ ContextualActionPanel.prototype = {
   */
   setup() {
     let existingPanel = this.element.next('.contextual-action-panel');
-    const dataModal = this.element.data('modal');
+    const modalId = this.id;
     const setPanel = (id) => {
       const panelFromID = $(`#${id}`);
       if (panelFromID.length) {
         existingPanel = panelFromID;
       }
     };
+
     if (typeof dataModal === 'string') {
-      setPanel(dataModal);
-    } else if (typeof dataModal === 'object') {
-      setPanel(this.element.attr('data-modal'));
+      setPanel(modalId);
     }
 
     // Handle case with popup triggered from a menu
@@ -158,6 +158,10 @@ ContextualActionPanel.prototype = {
   build() {
     const self = this;
     const modalContent = this.settings.content;
+    this.id = (this.settings?.modalSettings?.id) || modalContent?.attr('id') || utils.uniqueId(this.element, 'contextual-action-modal');
+    if (!this.settings?.modalSettings?.id) {
+      this.settings.modalSettings.id = this.id;
+    }
 
     // Build the Content if it's not present
     if (!this.panel || !this.panel.length) {
@@ -470,7 +474,6 @@ ContextualActionPanel.prototype = {
 
     const children = self.panel.find('.modal-body').children();
     children.first().unwrap().unwrap();
-
     self.element.removeAttr('data-modal');
 
     if (self.closeButton && self.closeButton.length) {
@@ -544,6 +547,20 @@ ContextualActionPanel.prototype = {
       this.modalAPI.close(true);
     }
     $.removeData(this.element[0], COMPONENT_NAME);
+    if (this.toolbar && this.toolbar.data('toolbar')) {
+      this.toolbar.data('toolbar').destroy();
+    }
+    if (this.toolbar && this.toolbar.data('toolbarFlex')) {
+      this.toolbar.data('toolbarFlex').destroy();
+    }
+  },
+
+  /**
+  * Destroy an and all active cap instances
+  * @returns {void}
+  */
+  destroyAll() {
+    modalManager.destroyAll(true);
   }
 };
 

--- a/src/components/contextualactionpanel/readme.md
+++ b/src/components/contextualactionpanel/readme.md
@@ -30,27 +30,30 @@ test:
 
 ## Code Example
 
-This example shows how to invoke a contextual action panel and pass in the content for the body. The `buttons` option lets you customize the contextual action panel's toolbar and functions.
+This example shows how to invoke a contextual action panel and pass in the content for the body. The `buttons` option lets you customize the contextual action panel's toolbar and functions. For best cleanup of memory its recommended to either add an id to the modalSettings option(`modalSettings.id`) or within the content property, the main div should have an ID `<div id="panel-1" style="display: none;">`. If not a unique one will be assigned and you should cleanup and destroy the CAP when done in that case because the component is not able to track open CAPs and reuse the same objects.
+
+It will still work without if but you may need to call CAP destroy or destroyAll to further clean memory up.
 
 ```javascript
 $('body').contextualactionpanel({
-  id: 'contextual-action-modal-id',
   title: 'Expenses: $50,000.00',
-  content: '<markup>',
+  content: $('#panel-2'),
   trigger: 'immediate',
-  buttons: [
+  modalSettings: {
+    trigger: 'immediate',
+    id: 'cap-2',
+    buttons: [
     {
-      type: 'input',
-      text: 'Keyword',
-      id: 'filter',
-      name: 'filter',
-      cssClass: 'searchfield'
-    }, {
       text: 'Close',
       cssClass: 'btn',
-      icon: '#icon-close'
+      icon: '#icon-close',
+      click: function() {
+        var api = $(this).data('modal');
+        api.close();
+      }
     }
   ]
+  }
 });
 ```
 

--- a/src/components/modal/modal.manager.js
+++ b/src/components/modal/modal.manager.js
@@ -258,6 +258,23 @@ ModalManager.prototype = {
   },
 
   /**
+   * Destroys all registered modals
+   * @param {boolean} [capsOnly=true] If true, nly destroy the caps.
+   * @returns {void}
+   */
+  destroyAll(capsOnly = false) {
+    this.modals.forEach((api) => {
+      const okToDestroy = !capsOnly || api.capAPI;
+      if (okToDestroy) {
+        api.close(undefined, true);
+        api.destroy();
+      }
+    });
+
+    this.refresh();
+  },
+
+  /**
    * Closes the last open modal in the stack
    * @param {boolean} [cancelled=false] passes along a flag that designates this close action as "cancelled" to the Modal API.
    * @returns {void}
@@ -276,6 +293,19 @@ ModalManager.prototype = {
       api.active = true;
     }
     return api;
+  },
+
+  /**
+   * Find a modal instance if the modal has been opened and not destroyed.
+   * @param  {string} id The id to look for
+   * @returns {object} The modal API instance
+   */
+  findById(id) {
+    if (!id) {
+      return undefined;
+    }
+    const results = this.modals.filter(api => api.id === id);
+    return results[0] || undefined;
   },
 
   /**

--- a/src/components/modal/modal.manager.js
+++ b/src/components/modal/modal.manager.js
@@ -298,7 +298,7 @@ ModalManager.prototype = {
   /**
    * Find a modal instance if the modal has been opened and not destroyed.
    * @param  {string} id The id to look for
-   * @returns {object} The modal API instance
+   * @returns {Modal|undefined} a matching Modal API instance, if available
    */
   findById(id) {
     if (!id) {

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -1452,7 +1452,7 @@ Toolbar.prototype = {
 
     $('body').off(`resize.toolbar-${this.id}`);
 
-    const moreMenuChildren = this.moreMenu.children('li');
+    const moreMenuChildren = this.moreMenu === undefined ? [] : this.moreMenu.children('li');
     moreMenuChildren.each(function () {
       self.teardownMoreActionsMenuItem($(this), true);
     });

--- a/test/components/contextualactionpanel/contextualactionpanel.e2e-spec.js
+++ b/test/components/contextualactionpanel/contextualactionpanel.e2e-spec.js
@@ -176,3 +176,40 @@ describe('Contextual Action Panel Locale Tests', () => {
     await utils.checkForErrors();
   });
 });
+
+describe('Contextual Action Panel Nested tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/contextualactionpanel/test-nested?layout=nofrills');
+  });
+
+  it('Should open two caps on a page', async () => {
+    await element(by.id('button-1')).click();
+    await browser.driver.sleep(config.sleepLonger);
+
+    expect(await element(by.css('#cap-1')).isDisplayed()).toBe(true);
+    expect(await element(by.css('#cap-1 .title')).getText()).toEqual('Company Information');
+    await element(by.css('#cap-1 #close-button')).click();
+    await browser.driver.sleep(config.sleepLonger);
+
+    await element(by.id('button-2')).click();
+    await browser.driver.sleep(config.sleepLonger);
+
+    expect(await element(by.css('#cap-2')).isDisplayed()).toBe(true);
+    expect(await element(by.css('#cap-2 .title')).getText()).toEqual('Supplier Information');
+    await element(by.css('#cap-2 #close-button')).click();
+  });
+
+  it('Should open nested caps on a page', async () => {
+    await element(by.id('button-1')).click();
+    await browser.driver.sleep(config.sleepLonger);
+
+    expect(await element(by.css('#cap-1')).isDisplayed()).toBe(true);
+    expect(await element(by.css('#cap-1 .title')).getText()).toEqual('Company Information');
+    await element(by.id('trigger-2')).click();
+    await browser.driver.sleep(config.sleepLonger);
+
+    expect(await element(by.css('#cap-2')).isDisplayed()).toBe(true);
+    expect(await element(by.css('#cap-2 .title')).getText()).toEqual('Supplier Information');
+    await element(by.css('#cap-2 #close-button')).click();
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

CAP did not work with nested CAPs anymore. I went back to check if this worked all the way to 4.18 on the new example here and could not find any evidence it ever worked. But maybe NG worked as it destroyed better.

**Related github/jira issue (required)**:
Fixes #3785
Fixes infor-design/enterprise-ng#801

**Steps necessary to review your pull request (required)**:

**Test 1**
- go to http://localhost:4000/components/contextualactionpanel/example-index.html
- this example and all examples in http://localhost:4000/components/contextualactionpanel should work ok still as before

**Test 2**
- go to http://localhost:4000/components/contextualactionpanel/test-destroy.html
- repeatedly open the cap and then destroy it
- then check the DOM - should not be an set of popupmenu wrappers left

**Test 3**
- go to http://localhost:4000/components/contextualactionpanel/test-nested.html
- click button one then close the cap
- click button two -> should be a different CAP
- click button one then the nested cap buttons and make sure nesting works

**Test 4**
- bring this branch over to enterprise-ng (Master has a change)
- go to http://localhost:4200/ids-enterprise-ng-demo/contextual-action-panel
- click panel
- click nested CAP -> should open a new cap -> close it
- click panel -> click save - should open a new cap as well

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
