### PR TITLE
3741- Add a fix for resizing the first frozen column

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `[Datagrid]` Fixed an issue the selected row header icon is the wrong state when using allowSelectAcrossPages. ([#3043](https://github.com/infor-design/enterprise/issues/3043)
 - `[Datagrid]` Improved the `datagrid-default-modal-width` concept if setting a modal datagrid default with so it works on any parent. [3562](https://github.com/infor-design/enterprise/issues/3562))
 - `[Datagrid]` Fixed a bug in the indeterminate paging example, that the select checkbox would not work and be out of sync when changing pages. [2230](https://github.com/infor-design/enterprise/issues/2230))
+- `[Datagrid]` Fixed a bug when resizing the first column of the center pane when using frozen columns, the resize would jump out the size of the frozen section. [3741](https://github.com/infor-design/enterprise/issues/3741))
 - `[Datagrid/General]` Fixed a bug where when loading the datagrid with a columns object that contain recursive objects the grid would crash. [3759](https://github.com/infor-design/enterprise/issues/3759))
 - `[Datepicker]` Fixed a bug where for some locales like `af-ZA` and `fi_FI` with dots in the day periods, setting 24 hr time to AM did not work. [3750](https://github.com/infor-design/enterprise/issues/3750))
 - `[Demoapp]` Fixed incorrect directory list hyperlinks in listview and listbuilder components. ([1783](https://github.com/infor-design/enterprise/issues/1783))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5528,11 +5528,15 @@ Datagrid.prototype = {
         }
         const offsetParentLeft = parseFloat(self.currentHeader.offsetParent().offset().left);
         const offsetLeft = parseFloat(self.currentHeader.offset().left);
-        const leftOffset = (idx === 0 ? 0 : (offsetLeft - offsetParentLeft - 2));
+        let leftOffset = (idx === 0 ? 0 : (offsetLeft - offsetParentLeft - 2));
+        if (self.hasLeftPane && self.settings.frozenColumns.left.length && idx === 0) {
+          leftOffset = (offsetLeft - offsetParentLeft - 2);
+        }
         const diff = currentColWidth - (left - leftOffset);
 
         // Enforce Column or Default min and max widths
         widthToSet = cssWidth - diff;
+
         if (widthToSet < minWidth || widthToSet > maxWidth) {
           self.resizeHandle.css('cursor', 'inherit');
           return;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Resizing the first column when frozen will jump. This PR fixes it.

**Related github/jira issue (required)**:
Fixes #3741

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-index
- resize between the first and second column (id) - should work nice
- go to http://localhost:4000/components/datagrid/example-frozen-columns.html
- resize between the first and second column (activity) - should work nice

**Included in this Pull Request**:
- [x] A note to the change log.
