### PR TITLE
3750 - Add follow up fix to time picker

### DIFF
--- a/src/components/timepicker/timepicker.js
+++ b/src/components/timepicker/timepicker.js
@@ -736,6 +736,17 @@ TimePicker.prototype = {
       parts = [parts[1], parts[2], parts[0]];
     }
 
+    // Fix am/pm
+    const periods = this.currentCalendar.dayPeriods;
+    if (parts[2] && (periods[0].indexOf('.') > -1 || periods[1].indexOf('.') > -1)) {
+      if (periods[0].replace('.', '') === parts[2]) {
+        parts[2] = periods[0];
+      }
+      if (periods[1].replace('.', '') === parts[2]) {
+        parts[2] = periods[1];
+      }
+    }
+
     // Check the last element in the array for a time period, and add it as an array
     // member if necessary
     if (!this.is24HourFormat() && !isAmFirst) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adds a follow up fix found by QA i missed. For 3750 / the am/pm is not working in some cases

**Related github/jira issue (required)**:
Fixes #3750 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datepicker/test-12hr-time.html?locale=af-ZA
- open the picker and pick a date and time with `nm.`
- renter the picker and `nm.` should be selected
- always reopening the picker should match am/pm in the field
