### PR TITLE
3607 - Add close button to example page with Datagrid inside a Modal

### DIFF
--- a/app/views/components/datagrid/example-modal-datagrid.html
+++ b/app/views/components/datagrid/example-modal-datagrid.html
@@ -90,6 +90,8 @@
 
     setModal = function (opt) {
       opt = $.extend({
+        autoFocus: true,
+        showCloseBtn: true,
         buttons: [{
           text: 'Cancel',
           id: 'modal-button-1',


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR simply adjusts one of the Datagrid examples to include a close button on the Modal.  This better demonstrates that the correct element is focused (first available grid cell) when the Modal opens.

**Related github/jira issue (required)**:
Closes #3607 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the app
- Navigate to http://localhost:4000/components/datagrid/example-modal-datagrid.html
- Click "Open Modal"
- When the Modal opens, ensure the focused element is the first checkbox in the first data row in the grid.

![Screen Shot 2020-04-24 at 2 27 04 PM](https://user-images.githubusercontent.com/3249601/80244892-c1256c80-8637-11ea-94bf-12226f8802e9.png)

----
@claudenbach 