### PR TITLE
3772 fix lookup keyword filter

### DIFF
--- a/app/views/components/lookup/example-filter-lookup.html
+++ b/app/views/components/lookup/example-filter-lookup.html
@@ -1,0 +1,73 @@
+<div class="page-container scrollable" id="maincontent" role="main">
+
+  <div class="row">
+    <div class="twelve columns">
+
+      <div class="field">
+        <label for="product-lookup" class="label required">Products</label>
+        <input id="product-lookup" data-init="false" data-validate="required" class="lookup" name="product-lookup"
+          type="text">
+      </div>
+
+      <div class="field">
+        <label for="lookup-field-small" class="label">Lookup Field (Xtra - Small)</label>
+        <input id="lookup-field-small" class="input-xs lookup" name="lookup-field-small" type="text" value="DA">
+        <span class="data-description">Danonics 123 Group</span>
+      </div>
+
+      <div class="field">
+        <label for="lookup-field-disabled" class="label">Lookup Field (Disabled)</label>
+        <input id="lookup-field-disabled" class="lookup" disabled name="lookup-field-disabled" type="text"
+          value="2241202">
+      </div>
+
+    </div>
+  </div>
+
+  <script>
+    var grid,
+      columns = [],
+      data = [];
+
+    // Some Sample Data
+    data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity: 'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action' });
+    data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity: 'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold' });
+    data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity: 'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action' });
+    data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity: 'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action' });
+    data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity: 'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold' });
+    data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity: 'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold' });
+    data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity: 'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold' });
+
+    //Define Columns for the Grid.
+    columns.push({ id: 'productId', name: 'Product Id', field: 'productId', filterType: 'integer' });
+    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, filterType: 'text' });
+    columns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', filterType: 'text' });
+    columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', filterType: 'integer', filterType: 'integer' });
+    columns.push({ id: 'price', name: 'Price', field: 'price', formatter: Formatters.Decimal, filterType: 'decimal' });
+
+    //Init and get the api for the grid
+    grid = $('#product-lookup').lookup({
+      autoApply: false,
+      field: 'productId',
+      options: {
+        columns: columns,
+        dataset: data,
+        filterable: true,
+        selectable: 'single', //multiselect or single
+        toolbar: {
+          results: true,
+          keywordFilter: true,
+          filterRow: true,
+          actions: true,
+          views: true,
+          rowHeight: false,
+          collapsibleFilter: false,
+          fullWidth: true
+        }
+      }
+    }).on('change', function (e, args) {
+      console.log(args);
+    });
+
+  </script>
+</div>

--- a/app/views/components/lookup/example-filter-row.html
+++ b/app/views/components/lookup/example-filter-row.html
@@ -54,7 +54,7 @@
             selectable: 'single', //multiselect or single
             toolbar: {
                results: true,
-               keywordFilter: false,
+               keywordFilter: true,
                filterRow: true,
                actions: true,
                views: true,

--- a/app/views/components/lookup/example-filter-row.html
+++ b/app/views/components/lookup/example-filter-row.html
@@ -54,7 +54,7 @@
             selectable: 'single', //multiselect or single
             toolbar: {
                results: true,
-               keywordFilter: true,
+               keywordFilter: false,
                filterRow: true,
                actions: true,
                views: true,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,8 @@
 - `[EmptyMessage]` Updated the text to be more subtle. ([#3476](https://github.com/infor-design/enterprise/issues/3476))
 - `[Fieldset]` Fixed fieldset text data overlapping in compact mode on mobile view. ([#3627](https://github.com/infor-design/enterprise/issues/3627))
 - `[Hierarchy]` Added support for separators in the actions menu on a hierarchy leaf. ([#3636](https://github.com/infor-design/enterprise/issues/3636))
+- `[Lookup]` Fixed an issue where `keywordFilter: true` and `filterable: true` used together cause the lookup modal to break. ([#3772](https://github.com/infor-design/enterprise/issues/3772))
+- `[Masthead]` Fixed layout and color issues in uplift theme. ([#3526](https://github.com/infor-design/enterprise/issues/3526))
 - `[Modal]` Fixed modal title to a two line with ellipsis when it's too long. ([#3479](https://github.com/infor-design/enterprise/issues/3479))
 - `[Multiselect]` Fixed tags dismiss button on mobile devices. ([#3640](https://github.com/infor-design/enterprise/issues/3640))
 - `[Icons]` Added new locked/unlocked icons in ids-identity [#3732](https://github.com/infor-design/enterprise/issues/3732)

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1972,7 +1972,7 @@ Datagrid.prototype = {
         const columnDef = self.columnById(conditions[i].columnId)[0];
 
         if (columnDef === undefined) {
-          return;
+          return false;
         }
 
         let rowValue = rowData && rowData[columnDef.field] !== undefined ?
@@ -6742,7 +6742,7 @@ Datagrid.prototype = {
 
       const checkColumn = function (columnId) {
         const column = self.columnById(columnId)[0];
-        console.log(column);
+
         const fieldValue = self.fieldValue(data, column.field);
         let value;
         const cell = self.settings.columns.indexOf(column);

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1971,6 +1971,10 @@ Datagrid.prototype = {
       for (let i = 0; i < conditions.length; i++) {
         const columnDef = self.columnById(conditions[i].columnId)[0];
 
+        if (columnDef === undefined) {
+          return;
+        }
+
         let rowValue = rowData && rowData[columnDef.field] !== undefined ?
           rowData[columnDef.field] : self.fieldValue(rowData, columnDef.field);
         let rowValueStr = (rowValue === null || rowValue === undefined) ? '' : rowValue.toString().toLowerCase();
@@ -6738,6 +6742,7 @@ Datagrid.prototype = {
 
       const checkColumn = function (columnId) {
         const column = self.columnById(columnId)[0];
+        console.log(column);
         const fieldValue = self.fieldValue(data, column.field);
         let value;
         const cell = self.settings.columns.indexOf(column);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes and issue where using `filterable: true` and `keywordFilter: true` together breaks the lookup modal. This PR adds a check to cancel the `checkRow` function if `columnDef` is `undefined`

**Related github/jira issue (required)**:
closes #3772 

**Steps necessary to review your pull request (required)**:
- Pull Branch
- go to http://localhost:4000/components/lookup/example-filter-lookup.html
- Open the lookup modal, select a row and click apply.
- Make sure you can open the lookup modal again

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
