### PR TITLE
3548 - Add support to fire event file removed with fileuploadadvanced

### DIFF
--- a/app/views/components/fileupload-advanced/test-file-removed.html
+++ b/app/views/components/fileupload-advanced/test-file-removed.html
@@ -1,0 +1,32 @@
+<div class="row top-padding">
+  <div class="six columns">
+    <h2>Fileupload Advanced</h2>
+    <p>Event `fileremoved` Fires when attached file removed.</p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="four columns">
+    <div id="test-1" class="fileupload-advanced"></div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    $('#test-1')
+      // Fires when attached file aborted.
+      .on('fileaborted', function (e, file) {
+        $('body').toast({
+          title: 'File aborted',
+          message: file && file.name ? file.name : ''
+        });
+      })
+      // Fires when attached file removed.
+      .on('fileremoved', function (e, file) {
+        $('body').toast({
+          title: 'File removed',
+          message: file && file.name ? file.name : ''
+        });
+      });
+    });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Contextmenu]` Added support for shortcut display in menus. ([#3490](https://github.com/infor-design/enterprise/issues/3490))
 - `[Datepicker]` Added support for custom api callback to disable passed dates and to disable dates by years. ([#3462](https://github.com/infor-design/enterprise/issues/3462))
 - `[FileUploadAdvanced]` Added support to api settings `maxFiles` to limit number of uploads. ([#3512](https://github.com/infor-design/enterprise/issues/3512))
+- `[FileUploadAdvanced]` Added support to fire event `fileremoved` for attached file removed. ([#3548](https://github.com/infor-design/enterprise/issues/3548))
 - `[Line Chart]` Added support to ellipsis for yaxis labels. ([#3702](https://github.com/infor-design/enterprise/issues/3702))
 - `[Modal]` Improved handling of multiple Modal windows stemming from a single trigger element. ([ng#705](https://github.com/infor-design/enterprise-ng/issues/705))
 

--- a/src/components/fileupload-advanced/fileupload-advanced.js
+++ b/src/components/fileupload-advanced/fileupload-advanced.js
@@ -411,9 +411,20 @@ FileUploadAdvanced.prototype = {
 
         // TODO: server call for removing data
         data.remove();
+
+        /**
+         * Fires when attached file removed.
+         *
+         * @event fileremoved
+         * @memberof FileUploadAdvanced
+         * @property {object} event - The jquery event object
+         * @property {object} file uploaded
+         */
+        self.element.triggerHandler('fileremoved', [file]);
       });
 
       // Remove Cancel button and progress-bar area
+      progressBar.destroy();
       btnCancel.off('click.fileuploadadvanced');
       btnCancel.add(progressBar.closest('.progress-row')).remove();
 

--- a/src/components/progress/progress.js
+++ b/src/components/progress/progress.js
@@ -56,11 +56,24 @@ Progress.prototype = {
     this.element.attr({ role: 'progressbar', 'aria-valuenow': value, 'aria-valuemax': '100' });
 
     const container = this.element.parent();
-    if (container.data('tooltip')) {
-      container.data('tooltip').content = `${value}%`;
+    this.tooltipApi = this.tooltipApi || container.data('tooltip');
+    if (this.tooltipApi) {
+      this.tooltipApi.content = `${value}%`;
+      if (this.tooltipApi.visible && value <= 100 && this.tooltipApi.tooltip.hasClass(`process${this.tooltipId}`)) {
+        this.tooltipApi.tooltip.find('.tooltip-content').text(this.tooltipApi.content);
+      }
     } else {
       container[0].setAttribute('title', `${value}%`);
       container.tooltip();
+      this.tooltipApi = container.data('tooltip');
+      this.tooltipId = this.tooltipApi.uniqueId;
+      container
+        .on('aftershow.progress', () => {
+          this.tooltipApi.tooltip.addClass(`process${this.tooltipId}`);
+        })
+        .on('hide.progress mouseout.progress', () => {
+          this.tooltipApi.tooltip.removeClass(`process${this.tooltipId}`);
+        });
     }
   },
 
@@ -70,6 +83,17 @@ Progress.prototype = {
    * @returns {object} The object for chaining.
    */
   unbind() {
+    const container = this.element.parent();
+    container.off('aftershow.progress hide.progress mouseout.progress');
+    this.tooltipApi = this.tooltipApi || container.data('tooltip');
+    if (this.tooltipApi) {
+      this.tooltipApi.destroy();
+      delete this.tooltipApi;
+    }
+    if (this.tooltipId) {
+      delete this.tooltipId;
+    }
+
     this.element.off('updated.progress');
     return this;
   },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added support to fire event `fileremoved` for attached file removed with FileUploadAdvanced.

**Related github/jira issue (required)**:
Closes #3548

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/fileupload-advanced/test-file-removed.html
- Drag or use `Select Files` button to upload
- After file complete uploading, next to file name `x` button will show
- Click on that `x` button to remove attached file
- A toast should show stating that file removed

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
