### PR TITLE
3809 - Fix an error opening caps with string contents

### DIFF
--- a/src/components/contextualactionpanel/contextualactionpanel.jquery.js
+++ b/src/components/contextualactionpanel/contextualactionpanel.jquery.js
@@ -8,7 +8,11 @@ import { modalManager } from '../modal/modal.manager';
  */
 $.fn.contextualactionpanel = function (settings) {
   return this.each(function () {
-    const id = (settings?.modalSettings?.id) || settings?.content?.attr('id');
+    let id = (settings?.modalSettings?.id);
+    if (!id && settings?.content && settings?.content instanceof jQuery) {
+      id = settings?.content?.attr('id');
+    }
+
     const instance = modalManager.findById(id);
 
     if (instance) {

--- a/test/components/contextualactionpanel/contextualactionpanel.e2e-spec.js
+++ b/test/components/contextualactionpanel/contextualactionpanel.e2e-spec.js
@@ -30,6 +30,23 @@ describe('CAP jquery context tests', () => {
   });
 });
 
+describe('CAP trigger context tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/contextualactionpanel/example-trigger.html');
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should open popup on click', async () => {
+    await element(by.id('manual-contextual-panel')).click();
+    await browser.driver.sleep(config.sleepLonger);
+
+    expect(await element(by.css('#contextual-action-modal-xyz')).isDisplayed()).toBe(true);
+  });
+});
+
 describe('CAP jquery context tests no-flex', () => {
   beforeEach(async () => {
     await utils.setPage('/components/contextualactionpanel/test-jquery-no-flex.html');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

After a recent fix some CAP examples failed to work. Specifically saw it when the contents are a string. Example was also missing a regression test.

**Related github/jira issue (required)**:
Fixes #3809

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/contextualactionpanel/example-trigger.html
- click the button and a cap should open again with no errors in the console
- try the pages with example in them on http://localhost:4000/components/contextualactionpanel/ for good measure

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
