### PR TITLE
3477 - Allow App Menu's Role Switcher to be dismissed with Escape Key

### DIFF
--- a/app/views/components/applicationmenu/example-personalized-role-switcher.html
+++ b/app/views/components/applicationmenu/example-personalized-role-switcher.html
@@ -75,10 +75,19 @@
   {{> includes/footer}}
 
   <script>
-    // May need to do more here.
-    $('.application-menu-switcher-panel .accordion').on('selected', function (e, args) {
-      $('body').toast({title: 'Role ' + args.innerText + ' Selected',  message: 'In a real application, you could refresh the app menu with new contents for the selected role.'});
-       $('.application-menu').data('applicationmenu').closeSwitcherPanel();
+    $('body').on('initialized', function() {
+      const appMenuAPI = $('.application-menu').data('applicationmenu');
+      const switcherPanelAcc = $('.application-menu-switcher-panel .accordion');
+      const switcherPanelTriggerSpan = $('.application-menu-switcher-trigger span');
+
+      switcherPanelAcc.on('selected.test', function (e, args) {
+        $('body').toast({
+          title: 'Role ' + args.innerText + ' Selected',
+          message: 'In a real application, you could refresh the app menu with new contents for the selected role.'
+        });
+        switcherPanelTriggerSpan.text(args.innerText)
+        appMenuAPI.closeSwitcherPanel();
+      });
     });
   </script>
 </body>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - `[Application Menu]` Fixed the icons on breaking apart it's appearance when zooming out the browser in IE11, uplift theme. ([#3070](https://github.com/infor-design/enterprise/issues/3070))
 - `[Application Menu]` Fixed misalignment/size of bullet icons in the accordion on Android devices. ([#1429](http://localhost:4000/components/applicationmenu/test-six-levels.html))
+- `[Application Menu]` Add keyboard support for closing Role Switcher panel ([#3477](https://github.com/infor-design/enterprise/issues/3477))
 - `[Autocomplete]` Added a check to prevent the autocomplete from incorrectly stealing form focus, by checking for inner focus before opening a list on typeahead. ([#3639](https://github.com/infor-design/enterprise/issues/3070))
 - `[Bubble Chart]` Fixed an issue where an extra axis line was shown when using the domain formatter. ([#501](https://github.com/infor-design/enterprise/issues/501))
 - `[Bullet Chart]` Added support to format ranges and difference values. ([#3447](https://github.com/infor-design/enterprise/issues/3447))

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -1544,10 +1544,6 @@ Accordion.prototype = {
         headerWhereMouseDown = null;
       });
 
-    anchors.on('click.accordion', function (e) {
-      return clickInterceptor(e, $(this));
-    });
-
     headerElems.children('[class^="btn"]')
       .on('click.accordion', function (e) {
         return clickInterceptor(e, $(this));

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -1491,7 +1491,6 @@ Accordion.prototype = {
       headerElems = this.headers;
       globalEventSetup = true;
     }
-    const anchors = headerElems.find('a');
 
     // Returns "Header", "Anchor", or "Expander" based on the element's tag
     function getElementType(element) {

--- a/src/components/applicationmenu/_applicationmenu-uplift.scss
+++ b/src/components/applicationmenu/_applicationmenu-uplift.scss
@@ -99,9 +99,10 @@
     }
   }
 
-  .application-menu-footer {
-    .application-menu-toolbar {
-      padding: 10px 0 10px 19px;
+  .application-menu-toolbar {
+    .toolbar-section {
+      display: flex;
+      justify-content: center;
     }
   }
 

--- a/test/components/applicationmenu/applicationmenu.e2e-spec.js
+++ b/test/components/applicationmenu/applicationmenu.e2e-spec.js
@@ -237,6 +237,10 @@ describe('Application Menu role switcher tests', () => {
     await utils.setPage('/components/applicationmenu/test-personalized-role-switcher-long-title');
   });
 
+  it('should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
   it('should have a working role switcher with long title', async () => {
     const btnSel = '.application-menu-switcher-trigger';
     await browser.driver
@@ -248,8 +252,20 @@ describe('Application Menu role switcher tests', () => {
     expect(await element(by.css('.application-menu-switcher-panel')).isDisplayed()).toBeTruthy();
   });
 
-  it('should not have errors', async () => {
-    await utils.checkForErrors();
+  it('can dismiss the role switcher by pressing Escape', async () => {
+    const btnSel = '.application-menu-switcher-trigger';
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element.all(by.css(btnSel)).last()), config.waitsFor); // eslint-disable-line
+
+    const btnEl = await element(by.css(btnSel));
+    await btnEl.click();
+
+    expect(await element(by.css('.application-menu-switcher-panel')).isDisplayed()).toBeTruthy();
+
+    await browser.driver.actions().sendKeys(protractor.Key.ESCAPE).perform();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('.application-menu-switcher-panel')).isDisplayed()).toBeFalsy();
   });
 });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a usability issue around the Role Switcher menu inside Application Menus, where it was not previously possible to dismiss the switcher menu with the Escape key.  Additionally, this PR improves control of the menu by keyboard, and sets a focus target when the menu is initially opened, to allow the user to navigate with arrows/tab (or dismiss with Escape).

**Related github/jira issue (required)**:
Closes #3477

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the app
- Open http://localhost:4000/components/applicationmenu/example-personalized-role-switcher.html?theme=uplift&variant=light
- Use the Role Switcher button to open its menu.
- After it opens, press `Escape`.  The Menu should close
- Open it again
- When the menu is opened, the first available item should focus.  Use the arrows up/down to navigate within the role switcher menu.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.