### PR TITLE
804 - Fix change event with autocomplete

### DIFF
--- a/app/views/components/autocomplete/test-on-change.html
+++ b/app/views/components/autocomplete/test-on-change.html
@@ -1,0 +1,18 @@
+<div class="row">
+  <div class="twelve columns">
+    <div class="field">
+      <label for="autocomplete-default">States</label>
+      <input type="text" autocomplete="off" class="autocomplete" data-options="{source: '{{basepath}}api/states?term='}" placeholder="Type to Search" id="autocomplete-default"/>
+    </div>
+  </div>
+</div>
+
+<script>
+  $('#autocomplete-default')
+    .on('selected', function (e) {
+      console.log('selected:', $(this).val());
+    })
+    .on('change', function (e) {
+      console.log('change:', $(this).val());
+    });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[Application Menu]` Fixed misalignment/size of bullet icons in the accordion on Android devices. ([#1429](http://localhost:4000/components/applicationmenu/test-six-levels.html))
 - `[Application Menu]` Add keyboard support for closing Role Switcher panel ([#3477](https://github.com/infor-design/enterprise/issues/3477))
 - `[Autocomplete]` Added a check to prevent the autocomplete from incorrectly stealing form focus, by checking for inner focus before opening a list on typeahead. ([#3639](https://github.com/infor-design/enterprise/issues/3070))
+- `[Autocomplete]` Fixed an issue where an change event was not firing while navigating list. ([#804](https://github.com/infor-design/enterprise/issues/804))
 - `[Bubble Chart]` Fixed an issue where an extra axis line was shown when using the domain formatter. ([#501](https://github.com/infor-design/enterprise/issues/501))
 - `[Bullet Chart]` Added support to format ranges and difference values. ([#3447](https://github.com/infor-design/enterprise/issues/3447))
 - `[Button]` Fixed the button disabled method to no longer use class `is-disabled`. ([#3447](https://github.com/infor-design/enterprise-ng/issues/799))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,7 +22,7 @@
 - `[Application Menu]` Fixed misalignment/size of bullet icons in the accordion on Android devices. ([#1429](http://localhost:4000/components/applicationmenu/test-six-levels.html))
 - `[Application Menu]` Add keyboard support for closing Role Switcher panel ([#3477](https://github.com/infor-design/enterprise/issues/3477))
 - `[Autocomplete]` Added a check to prevent the autocomplete from incorrectly stealing form focus, by checking for inner focus before opening a list on typeahead. ([#3639](https://github.com/infor-design/enterprise/issues/3070))
-- `[Autocomplete]` Fixed an issue where an change event was not firing while navigating list. ([#804](https://github.com/infor-design/enterprise/issues/804))
+- `[Autocomplete]` Fixed an issue where an change event was not firing when selecting from the menu. ([#804](https://github.com/infor-design/enterprise/issues/804))
 - `[Bubble Chart]` Fixed an issue where an extra axis line was shown when using the domain formatter. ([#501](https://github.com/infor-design/enterprise/issues/501))
 - `[Bullet Chart]` Added support to format ranges and difference values. ([#3447](https://github.com/infor-design/enterprise/issues/3447))
 - `[Button]` Fixed the button disabled method to no longer use class `is-disabled`. ([#3447](https://github.com/infor-design/enterprise-ng/issues/799))

--- a/src/components/autocomplete/autocomplete.js
+++ b/src/components/autocomplete/autocomplete.js
@@ -777,6 +777,7 @@ Autocomplete.prototype = {
    * @returns {void}
    */
   highlight(anchor, allAnchors) {
+    const val = this.element.val();
     let text = anchor.text().trim();
 
     if (anchor.find('.display-value').length > 0) {
@@ -790,6 +791,9 @@ Autocomplete.prototype = {
 
     this.noSelect = true;
     this.element.val(text).focus();
+    if (val !== text) {
+      this.element.triggerHandler('change');
+    }
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fix change event was not firing while navigating list with Autocomplete.

**Related github/jira issue (required)**:
Closes #804 

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/autocomplete/test-on-change.html
- Open developer tools
- Type `a` and an list with available option will open
- Press arrow down/up keys to navigate list
- See change event in console while navigating list (First time it looks fire twice, but its not -it fire one for search field leave and one for content change)

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
