### PR TITLE
3822 - Prevent double import of modal manager during custom builds with Modals

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -183,6 +183,7 @@ const customLocations = {
   masks: 'rules',
   'mask-api': '',
   'mask-input': 'foundational',
+  'modal.manager': '',
   _tabs: 'mid',
   '_tabs-horizontal': 'mid',
   '_tabs-vertical': 'mid',

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -1,6 +1,9 @@
 // Modal Dialog and Messages
 //================================================== //
 
+@import '../button/button';
+@import '../icons/icons';
+
 // NOTE:  this element gets a margin dynamically set in the "resize" method of modal.js
 .modal-wrapper {
   align-items: center;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a recent regression in custom builds where the new Modal Manager was incorrectly being imported into `components.js` when it shouldn't (Modal Manager is part of core, and doesn't need to be written into this file as an import).

**Related github/jira issue (required)**:
Closes #3822

**Steps necessary to review your pull request (required)**:
- Pull this branch
- Run `npm run build -- --components=modal --dry-run`
- Navigate to the enterprise project folder, and open `temp/components.js` in a text editor.  It should only include one export for `modal.js`.
- In the terminal run `npm run build -- --components=modal`.  The build should complete with no errors.
- Run the demoapp and open http://localhost:4000/components/modal/example-index.html?layout=nofrills in a browser.
- Click the "Show Modal" button.  The Modal should launch as expected.  The contents will not look correct because other components are not included by default.

----
@awbuboltz