### PR TITLE
3826 - Fix Accordion lifecycle to allow individual header updates without a full teardown [v4.28.x]

### DIFF
--- a/app/views/components/accordion/test-add-dynamically.html
+++ b/app/views/components/accordion/test-add-dynamically.html
@@ -1,0 +1,64 @@
+<div class="row">
+  <div class="six columns">
+    <p>Github Issue: <a class="hyperlink" href="https://github.com/infor-design/enterprise/issues/3826" target="_blank">#3826</a></p>
+    <p>In this test, clicking the "Add to favorites" button will add a new menu item in the Favorites content panel.</p>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="six columns">
+    <div class="field">
+      <button class="btn" id="addFavs">Add new favorite</button>
+    </div>
+
+    <div data-init="false" id="test-accordion" class="accordion panel inverse">
+
+      <!-- general -->
+      <div class="accordion-header">
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-user"></use>
+        </svg>
+        <a href="#"><span>General</span></a>
+      </div>
+      <div class="accordion-pane">
+        <div class="accordion-header">
+          <a href="#" id="preferencesLink1"><span>User Options</span></a>
+        </div>
+        <div class="accordion-header">
+          <a href="#" id="preferencesLink2"><span>Change Password</span></a>
+        </div>
+      </div>
+
+      <!-- favorites -->
+      <div class="accordion-header">
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-star-filled"></use>
+        </svg>
+        <a href="#"><span>Favorites</span></a>
+      </div>
+      <div class="accordion-pane" id="favorites-pane">
+        <div class="accordion-header">
+          <a href="#"><span>AC02.1 - Status</span></a>
+        </div>
+        <div class="accordion-header">
+          <a href="#"><span>Distribution Group Definitions</span></a>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+​
+<script>
+  // init the accordion
+  var accordionApi = $('#test-accordion').accordion({ allowOnePane: false }).data('accordion');
+
+  $('#addFavs').on('click', function() {
+    var $favoritesPane = $('#favorites-pane');
+
+    $favoritesPane.append('<div class="accordion-header hide-focus no-icon"><a href="#"><span>Dynamically added favorite</span></a></div>');
+
+    accordionApi.updated($favoritesPane.find('.accordion-header'));
+  });
+
+</script>

--- a/app/views/components/accordion/test-add-dynamically.html
+++ b/app/views/components/accordion/test-add-dynamically.html
@@ -49,16 +49,27 @@
   </div>
 </div>
 ​
-<script>
-  // init the accordion
-  var accordionApi = $('#test-accordion').accordion({ allowOnePane: false }).data('accordion');
+<script id="test-script">
+  var headerCount = 0;
+  var $accordionEl = $('#test-accordion');
 
+  // Initialize the Accordion
+  $accordionEl.accordion({
+    allowOnePane: false
+  });
+  var accordionAPI = $accordionEl.data('accordion');
+
+  // When button is clicked, add a new header and update the Accordion.
   $('#addFavs').on('click', function() {
     var $favoritesPane = $('#favorites-pane');
+    var newHeaderTmpl = '<div class="accordion-header hide-focus no-icon">' +
+      '<a href="#">' +
+        '<span>Dynamically-Added Favorite ('+ headerCount +')</span>' +
+      '</a>' +
+    '</div>';
 
-    $favoritesPane.append('<div class="accordion-header hide-focus no-icon"><a href="#"><span>Dynamically added favorite</span></a></div>');
-
-    accordionApi.updated($favoritesPane.find('.accordion-header'));
+    $favoritesPane.append(newHeaderTmpl);
+    accordionAPI.updated($favoritesPane.find('.accordion-header'));
+    headerCount++;
   });
-
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### v4.28.0 Fixes
 
+- `[Accordion]` Fixed a regression where updating individual headers within an Accordion was no longer working ([#3826](https://github.com/infor-design/enterprise/issues/3070))
 - `[Application Menu]` Fixed the icons on breaking apart it's appearance when zooming out the browser in IE11, uplift theme. ([#3070](https://github.com/infor-design/enterprise/issues/3070))
 - `[Application Menu]` Fixed misalignment/size of bullet icons in the accordion on Android devices. ([#1429](http://localhost:4000/components/applicationmenu/test-six-levels.html))
 - `[Application Menu]` Add keyboard support for closing Role Switcher panel ([#3477](https://github.com/infor-design/enterprise/issues/3477))

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -1002,8 +1002,11 @@ Accordion.prototype = {
       pane
     };
 
-    function response() {
-      self.updated();
+    function response(skipUpdated, headers) {
+      if (skipUpdated !== true) {
+        self.updated(headers);
+      }
+
       setTimeout(() => {
         animationCallback.apply(self);
       }, 1);
@@ -1408,7 +1411,7 @@ Accordion.prototype = {
   * @returns {void}
   */
   teardown(headers) {
-    let globalEventTeardown = false;
+    let globalTeardown = false;
     let headerElems = headers;
 
     if (this.currentlyFiltered) {
@@ -1417,7 +1420,7 @@ Accordion.prototype = {
 
     if (!headers || !(headers instanceof jQuery)) {
       headerElems = this.headers;
-      globalEventTeardown = true;
+      globalTeardown = true;
     }
 
     if (headerElems && headerElems.length) {
@@ -1453,14 +1456,14 @@ Accordion.prototype = {
         .off('touchend.accordion click.accordion keydown.accordion');
     }
 
-    if (globalEventTeardown) {
+    if (globalTeardown) {
       this.element.off('updated.accordion selected.accordion');
-    }
 
-    delete this.anchors;
-    delete this.headers;
-    delete this.panes;
-    delete this.contentAreas;
+      delete this.anchors;
+      delete this.headers;
+      delete this.panes;
+      delete this.contentAreas;
+    }
 
     return this;
   },

--- a/test/components/accordion/accordion.e2e-spec.js
+++ b/test/components/accordion/accordion.e2e-spec.js
@@ -205,3 +205,35 @@ describe('Accordion expand multiple tests', () => {
     });
   });
 });
+
+describe('Accordion adding headers dynamically tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/accordion/test-add-dynamically.html?layout=nofrills');
+  });
+
+  it('should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('can dynamically add and navigate to new accordion headers', async () => {
+    // Add two headers
+    const addBtn = await element(by.id('addFavs'));
+    await addBtn.click();
+    await addBtn.click();
+
+    // Expand the "Favorites" header
+    await element.all(by.css('#test-accordion > .accordion-header')).last().click();
+    await browser.driver.sleep(config.sleep);
+
+    // Tab to the last of the new headers and check its content
+    await browser.driver.actions()
+      .sendKeys(protractor.Key.TAB)
+      .sendKeys(protractor.Key.TAB)
+      .sendKeys(protractor.Key.TAB)
+      .sendKeys(protractor.Key.TAB)
+      .perform();
+    const focusedElem = browser.driver.switchTo().activeElement();
+
+    expect(focusedElem.getText()).toEqual('Dynamically-Added Favorite (1)');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a regression in the Accordion that was preventing consumers from updating individual accordion headers without doing a full teardown of the entire accordion.  Script errors were being thrown when attempting this previously.

Additionally, there is now a demo for this test case, along with new e2e/functional tests.

**Related github/jira issue (required)**:
Closes #3826

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the demoapp
- Open http://localhost:4000/components/accordion/test-add-dynamically.html?layout=nofrills
- Expand the Accordion Header labeled "Favorites"
- Click the "Add new favorite" button several times.
- See that new accordion headers should populate underneath the Favorites header.  If you open a developer tools console, there should be no Javascript errors.
- Try keyboard navigation on the new headers - it should be possible to use the Arrow keys and Tab/Shift+Tab on the new ones.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.