### PR TITLE
3833 - Add fix for date first month and day validation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -51,6 +51,7 @@
 - `[Datepicker]` Fixed a bug where date picker erred on arabic dates. [3804](https://github.com/infor-design/enterprise/issues/3804))
 - `[Datepicker]` Fixed a bug where date picker could not change arabic dates. [3819](https://github.com/infor-design/enterprise/issues/3819))
 - `[Datepicker]` Fixed a bug the month only picker would error the second time opened. [3817](https://github.com/infor-design/enterprise/issues/3817))
+- `[Datepicker]` Added fix for dates with month and day only format where day is first, this was incorrectly validating as invalid. ([#3833](https://github.com/infor-design/enterprise/issues/3833))
 - `[Demoapp]` Fixed incorrect directory list hyperlinks in listview and listbuilder components. ([1783](https://github.com/infor-design/enterprise/issues/1783))
 - `[Demoapp]` Did cleanup on the icons and patterns links. ([3790](https://github.com/infor-design/enterprise/issues/3790))
 - `[Demoapp]` When deployed on a proxy the icons page would not change contents when changing theme. ([3790](https://github.com/infor-design/enterprise/issues/3790))

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -1611,7 +1611,7 @@ DatePicker.prototype = {
 
     // Check and fix two digit year for main input element
     const dateFormat = self.pattern;
-    const isStrict = !(dateFormat === 'MMMM d' || dateFormat === 'yyyy' ||
+    const isStrict = !(dateFormat === 'MMMM d' || dateFormat === 'd MMMM' || dateFormat === 'yyyy' ||
       dateFormat === 'MMMM' || dateFormat === 'MMM' || dateFormat === 'MM');
     const fieldValueTrimmed = self.element.val().trim();
 

--- a/src/components/validation/validation.js
+++ b/src/components/validation/validation.js
@@ -125,6 +125,7 @@ function ValidationRules() {
           dateFormat === 'MMM' ||
           dateFormat === 'MM' ||
           dateFormat === 'MMMM d' ||
+          dateFormat === 'd MMMM' ||
           dateFormat === 'yyyy'
         );
         if (dtApi) {

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -343,6 +343,24 @@ describe('Datepicker Anniversary tests', () => {
     expect(await datepickerEl.getAttribute('value')).toEqual(testDate.toLocaleDateString('en-US', { month: 'long', day: 'numeric' }));
   });
 
+  it('Should populate month day in en-GB', async () => {
+    await utils.setPage('/components/datepicker/example-anniversary-format?locale=en-GB');
+
+    const datepickerEl = await element(by.id('MMMMd-date'));
+    await element(by.css('#MMMMd-date + .icon')).click();
+
+    const testDate = new Date();
+    testDate.setHours(0);
+    testDate.setMinutes(0);
+    testDate.setSeconds(0);
+
+    await element(by.css('#monthview-popup td.is-selected')).click();
+
+    const resultDate = `${testDate.toLocaleDateString('en-US', { day: 'numeric' })} ${testDate.toLocaleDateString('en-US', { month: 'long' })}`;
+
+    expect(await datepickerEl.getAttribute('value')).toEqual(resultDate);
+  });
+
   it('Should populate just year', async () => {
     const datepickerEl = await element(by.id('yyyy-date'));
     await element(by.css('#yyyy-date + .icon')).click();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When using en-GB on the Month format picker the date would incorrect be marked as invalid.

**Related github/jira issue (required)**:
Fixes #3833

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datepicker/example-anniversary-format.html?locale=en-GB
- open Month Day picker and hit apply to insert todays date + month
- tab
- should be no validation error

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
