### PR TITLE
3521 - Allow dismissal of Toasts with the Escape key

### DIFF
--- a/app/views/components/toast/test-modal.html
+++ b/app/views/components/toast/test-modal.html
@@ -1,0 +1,76 @@
+<div class="row">
+  <div class="six columns">
+    <p>Github Issue: <a class="hyperlink" href="https://github.com/infor-design/enterprise/issues/3521" target="_blank">#3521</a></p>
+    <p>This test demonstrates how a Modal environment with Toasts could be configured to prevent dismissal of the Modal while toasts are open.</p>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="six columns">
+    <div class="field">
+      <button id="modal-trigger" class="btn-secondary" data-modal="test-modal">
+        <span>Show Modal</span>
+      </button>
+    </div>
+  </div>
+</div>
+
+<div class="hidden" id="test-modal">
+  <div class="row">
+    <div class="twelve columns">
+      <p>After clicking the button below, try closing the Modal with the <b>Escape</b> key</p>
+    </div>
+  </div>
+  <div class="row top-padding">
+    <div class="twelve columns">
+      <div class="field" style="text-align: center;">
+        <button id="make-toasts" class="btn-secondary">
+          <span>Make Toasts</span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script id="test-script">
+  var triggerBtn = $('#modal-trigger');
+  var makeToastsBtn = $('#make-toasts');
+  var modalTemplate = $('#test-modal');
+  var totalToasts = 0;
+
+  triggerBtn.on('click.test', function () {
+    $('body').modal({
+      title: 'Modals with Toast',
+      content: modalTemplate
+    });
+
+    // Prevents the Modal from being closed if any toasts are open
+    var modalAPI = $('body').data('modal');
+    modalAPI.element
+      .on('beforeclose.test', function () {
+        var toasts = $('#toast-container').find('.toast')
+        if (toasts.length) {
+          return false;
+        }
+      })
+      .on('close.test', function () {
+        $(this).off('beforeclose.test');
+      });
+  });
+
+  function makeToast(count) {
+    $('body').toast({
+      title: 'Here \'s a Toast!',
+      message: 'This is toast #' + count
+    });
+  }
+
+  makeToastsBtn.on('click.test', function () {
+    var toastCount = 10;
+    while (toastCount > 0) {
+      makeToast(totalToasts);
+      toastCount--;
+      totalToasts++;
+    }
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v4.29.0
 
+### v4.28.0 Features
+
+- `[Toast]` Added the ability to dismiss toasts via keyboard. ([#3521](https://github.com/infor-design/enterprise/issues/3521))
+
 ### v4.29.0 Fixes
 
 - `[Checkbox]` Fixed an issue where the error icon was inconsistent between subtle and vibrant themes. ([#3575](https://github.com/infor-design/enterprise/issues/3575))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.29.0
 
-### v4.28.0 Features
+### v4.29.0 Features
 
 - `[Toast]` Added the ability to dismiss toasts via keyboard. ([#3521](https://github.com/infor-design/enterprise/issues/3521))
 

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -103,11 +103,22 @@ Toast.prototype = {
       toast.append(progress);
     }
 
+    container.append(toast);
+    toast.addClass((s.audibleOnly ? 'audible' : 'effect-scale'));
+    toast.append(closeBtn);
+
+    // Add draggable
+    self.createDraggable(toast, container);
+
+    // Get the number of toasts
+    const toastsIndex = container.children().length;
+    this.toastsIndex = toastsIndex;
+
     // Build the RenderLoop integration
     const timer = new RenderLoopItem({
       duration: math.convertDelayToFPS(s.timeout),
       timeoutCallback() {
-        self.remove(toast);
+        self.remove(toast, toastsIndex);
       },
       updateCallback(data) {
         percentage = ((data.duration - data.elapsedTime) / maxHideTime) * 100;
@@ -123,18 +134,24 @@ Toast.prototype = {
     });
     renderLoop.register(timer);
 
-    container.append(toast);
-    toast.addClass((s.audibleOnly ? 'audible' : 'effect-scale'));
-    toast.append(closeBtn);
+    // Clears the toast from the container, removing it from renderLoop and tearing down events
+    function clearToast(targetToast) {
+      timer.destroy(true);
+      self.remove(targetToast, toastsIndex);
+    }
 
-    // Add draggable
-    self.createDraggable(toast, container);
-
-    $(document).on('keydown.toast keyup.toast', (e) => {
+    $(document).on(`keydown.toast-${toastsIndex} keyup.toast-${toastsIndex}`, (e) => {
       e = e || window.event;
-      if (e.ctrlKey && e.altKey && e.keyCode === 80) { // [Control + Alt + P] - Pause/Play toggle
+      const key = e.which || e.keyCode;
+
+      if (e.ctrlKey && key === 80) { // [Control + Alt + P] - Pause/Play toggle
         isPausePlay = e.type === 'keydown';
         timer[isPausePlay ? 'pause' : 'resume']();
+      }
+      if (e.type === 'keydown' && key === 27) { // Escape
+        e.stopImmediatePropagation();
+        e.preventDefault();
+        clearToast(toast);
       }
     });
 
@@ -144,8 +161,7 @@ Toast.prototype = {
     });
 
     closeBtn.on('click.toast', () => {
-      timer.destroy();
-      self.remove(toast);
+      clearToast(toast);
     });
   },
 
@@ -383,13 +399,22 @@ Toast.prototype = {
    * Removes event bindings from the instance.
    * @private
    * @param {jQuery[]|HTMLElement} toast the toast message to be removed bindings
+   * @param {number} [id=undefined] a unique number associated with the toast being removed
    * @returns {this} component instance
    */
-  unbind(toast) {
+  unbind(toast, id) {
     const container = toast.closest('.toast-container');
     container.off('dragstart.toast dragend.toast');
     toast.off('mousedown.toast mouseup.toast touchstart.toast touchend.toast');
     toast.find('.btn-close').off('click.toast');
+
+    if (id !== undefined) {
+      $(document).off([
+        `keydown.toast-${id}`,
+        `keyup.toast-${id}`
+      ].join(' '));
+    }
+
     return this;
   },
 
@@ -397,9 +422,10 @@ Toast.prototype = {
    * Remove the Message and Animate
    * @private
    * @param {jQuery[]|HTMLElement} toast the toast message to be removed
+   * @param {number} [id=undefined] a unique number associated with the toast being removed
    * @returns {void}
    */
-  remove(toast) {
+  remove(toast, id) {
     const removeCallback = () => {
       toast.remove();
       const canDestroy = !$(`#toast-container${this.uniqueId} .toast`).length;
@@ -408,7 +434,7 @@ Toast.prototype = {
       }
     };
 
-    this.unbind(toast);
+    this.unbind(toast, id);
 
     if (this.settings.audibleOnly) {
       removeCallback();
@@ -451,8 +477,12 @@ Toast.prototype = {
         this.remove($(toast));
       });
     }
-    $(document).off('keydown.toast keyup.toast mouseup.toast touchend.toast');
+    $(document).off([
+      'mouseup.toast',
+      'touchend.toast'
+    ].join(' '));
     container.remove();
+    delete this.toastsIndex;
     delete this.uniqueId;
     $.removeData(this.element[0], COMPONENT_NAME);
   }

--- a/test/components/toast/toast.e2e-spec.js
+++ b/test/components/toast/toast.e2e-spec.js
@@ -43,6 +43,20 @@ describe('Toast example-index tests', () => {
 
     expect(await element.all(by.css('.toast')).count()).toEqual(0);
   });
+
+  it('Should close after pressing the Escape key', async () => {
+    const buttonEl = await element(by.id('show-toast-message'));
+    await buttonEl.click();
+    await browser.driver.wait(protractor.ExpectedConditions.visibilityOf(element(by.css('.toast'))), config.waitsFor);
+    await browser.driver.sleep(config.sleepShort);
+
+    expect(await element.all(by.css('.toast')).count()).toEqual(1);
+
+    await browser.driver.actions().sendKeys(protractor.Key.ESCAPE).perform();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element.all(by.css('.toast')).count()).toEqual(0);
+  });
 });
 
 describe('Toast example-positions tests', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds keyboard detection to the Toast and allows individual toasts to become dismissed one-by-one by pressing/holding the Escape key.

**Related github/jira issue (required)**:
Closes #3521

**Steps necessary to review your pull request (required)**:
Pull this branch, build, and run the demoapp.  Then:

_Test basic functionality (covered by e2e test):_
- Navigate to http://localhost:4000/components/toast/example-index.html
- Make a bunch of toasts
- Press the `Escape` key.  One by one, the toasts should dismiss.
- Make a lot of toasts.
- Hold the `Escape` key.  One by one, the toasts should quickly be dismissed (based on the user's keyboard response settings).

_Test combination with Modal:_
- Navigate to http://localhost:4000/components/toast/test-modal.html
- Show the Modal
- Click the button inside the modal to make a bunch of toasts
- Press the `Escape` key one at a time.  The Modal should remain open until all the toasts are dismissed, and will be dismissed when `Escape` is pressed one more time.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

----
@jamie-norman
