### PR TITLE
3599 - Fix rounds decimal percent values with pie chart

### DIFF
--- a/app/views/components/pie/test-label-currency.html
+++ b/app/views/components/pie/test-label-currency.html
@@ -51,8 +51,12 @@ $('body').on('initialized', function () {
       show: 'label'
     },
     lines: {
-      show: 'percent', // value, label or percent or custom function
-      formatter: '.2',// Currency
+      show: 'value', // value, label or percent or custom function
+      formatter: '$,.2f',// Currency
+    },
+    tooltip: {
+      show: 'label (percent)',
+      formatter: ',.0%'
     }
   });
 

--- a/app/views/components/pie/test-percent-decimal-places.html
+++ b/app/views/components/pie/test-percent-decimal-places.html
@@ -1,0 +1,60 @@
+
+<div class="row">
+  <div class="two-thirds column">
+      <div class="widget">
+        <div class="widget-header">
+          <h2 class="widget-title">Pie Chart Title</h2>
+        </div>
+        <div class="widget-content">
+          <div id="pie-chart-example" class="chart-container">
+          </div>
+        </div>
+      </div>
+  </div>
+</div>
+
+{{={{{ }}}=}}
+
+<script>
+$('body').on('initialized', function () {
+
+var pieData = [{
+    data: [{
+      name: 'Component A',
+      value: 4,
+      tooltip: 'Component A <b>{{percent}}</b>'
+    }, {
+      name: 'Component B',
+      value: 0,
+      tooltip: 'Component B <b>{{percent}}</b>'
+    }, {
+      name: 'Component C',
+      value: 5,
+      tooltip: 'Component C <b>{{percent}}</b>'
+    }, {
+      name: 'Component D',
+      value: 5,
+      tooltip: 'Component D <b>{{percent}}</b>'
+    }, {
+      name: 'Component E',
+      value: 11.6,
+      tooltip: 'Component E <b>{{percent}}</b>'
+    }, {
+      name: 'Component F',
+      value: 12.6,
+      tooltip: 'Component F <b>{{percent}}</b>'
+    }]
+  }];
+
+  $('#pie-chart-example').chart({
+    type: 'pie',
+    dataset: pieData,
+    showLegend: false,
+    lines: {
+      show: 'percent',
+      formatter: ',.2%'
+    }
+  });
+
+});
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[Fonts]` A note that the Source Sans Pro font thats used in the new theme and served at google fonts, now have a fix for the issue that capitalized letters and numbers had different heights. You may need to release any special caching. ([#1789](https://github.com/infor-design/enterprise/issues/1789))
 - `[Locale]` Fixed the es-419 date time value, as it was incorrectly using the medium length date format. ([#3830](https://github.com/infor-design/enterprise/issues/3830))
 - `[Modal]` Fixed the inconsistencies of spacing on required fields. ([#3587](https://github.com/infor-design/enterprise/issues/3587))
+- `[Pie]` Fixed an issue where rounds decimal places for percent values were not working. ([#3599](https://github.com/infor-design/enterprise/issues/3599))
 - `[Pie/Donut]` Fixed an issue where placing legend on bottom was not working for Homepage widget/Cards. ([#3560](https://github.com/infor-design/enterprise/issues/3560))
 - `[Pager]` Reduced the space between buttons. ([#1942](https://github.com/infor-design/enterprise/issues/1942))
 - `[Notification]` Fixed an issue where the icons were lagging in the animation. ([#2099](https://github.com/infor-design/enterprise/issues/2099))

--- a/src/components/charts/charts.js
+++ b/src/components/charts/charts.js
@@ -31,6 +31,7 @@ charts.tooltipSize = function tooltipSize(content) {
  */
 charts.formatToSettings = function formatToSettings(data, settings) {
   const d = data.data ? data.data : data;
+  const percentValue = (settings.formatter && settings.formatter !== '.0f' ? d3.format(settings.formatter)(d.percent) : `${isNaN(d.percentRound) ? 0 : d.percentRound}%`);
 
   if (settings.show === 'value') {
     return settings.formatter ? d3.format(settings.formatter)(d.value) : d.value;
@@ -41,7 +42,7 @@ charts.formatToSettings = function formatToSettings(data, settings) {
   }
 
   if (settings.show === 'label (percent)') {
-    return `${d.name} (${isNaN(d.percentRound) ? 0 : d.percentRound}%)`;
+    return `${d.name} (${percentValue})`;
   }
 
   if (settings.show === 'label (value)') {
@@ -49,7 +50,7 @@ charts.formatToSettings = function formatToSettings(data, settings) {
   }
 
   if (settings.show === 'percent') {
-    return `${isNaN(d.percentRound) ? 0 : d.percentRound}%`;
+    return percentValue;
   }
 
   if (typeof settings.show === 'function') {

--- a/src/components/pie/pie.js
+++ b/src/components/pie/pie.js
@@ -352,6 +352,19 @@ Pie.prototype = {
     const slice = self.svg.select('.slices').selectAll('path.slice')
       .data(self.pie(data), self.key);
 
+    const formatters = {
+      str: null,
+      isTooltip: self.settings.tooltip?.formatter &&
+        self.settings.tooltip.formatter !== PIE_DEFAULTS.tooltip.formatter,
+      isLines: self.settings.lines?.formatter &&
+        self.settings.lines.formatter !== PIE_DEFAULTS.lines.formatter
+    };
+    if (formatters.isTooltip) {
+      formatters.str = self.settings.tooltip.formatter;
+    } else if (formatters.isLines) {
+      formatters.str = self.settings.lines.formatter;
+    }
+
     const getOffset = (node) => {
       const body = document.body;
       let rect;
@@ -469,10 +482,15 @@ Pie.prototype = {
         };
 
         const value = charts.formatToSettings(d, self.settings.tooltip);
-        content = d.data.tooltip || value;
-        content = content.replace('{{percent}}', `${d.data.percentRound}%`);
+        const formatted = {
+          value: formatters.str && !formatters.isTooltip ?
+            d3.format(formatters.str)(d.value) : value,
+          percent: formatters.str ? d3.format(formatters.str)(d.data.percent) : `${isNaN(d.data.percentRound) ? 0 : d.data.percentRound}%`
+        };
+        content = d.data.tooltip || formatted.value;
+        content = content.replace('{{percent}}', `${formatted.percent}`);
         content = content.replace('{{value}}', d.value);
-        content = content.replace('%percent%', `${d.data.percentRound}%`);
+        content = content.replace('%percent%', `${formatted.percent}`);
         content = content.replace('%value%', d.value);
 
         if (content.indexOf('<b>') === -1) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed rounds decimal places for percent values were not working with Pie.

**Related github/jira issue (required)**:
Closes #3599

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Test on both Android and iOS device
- Navigate to: http://localhost:4000/components/pie/test-percent-decimal-places.html
- See the values should be rounds two decimal places

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
