### PR TITLE
3692 - Fix sort icons visibility when column is in active

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Checkbox]` Fixed an issue where the error icon was inconsistent between subtle and vibrant themes. ([#3575](https://github.com/infor-design/enterprise/issues/3575))
 - `[Datagrid]` Fixed a bug in some themes, where the multi line cell would not be lined up correctly with a single line of data. ([#2703](https://github.com/infor-design/enterprise/issues/2703))
+- `[Datagrid]` Fixed visibility of sort icons when toggling and when the column is in active. ([#3692](https://github.com/infor-design/enterprise/issues/3692))
 - `[Datagrid]` Fixed a bug where the data passed to resultsText was incorrect in the case of reseting a filter. ([#2177](https://github.com/infor-design/enterprise/issues/2177))
 - `[Fonts]` A note that the Source Sans Pro font thats used in the new theme and served at google fonts, now have a fix for the issue that capitalized letters and numbers had different heights. You may need to release any special caching. ([#1789](https://github.com/infor-design/enterprise/issues/1789))
 - `[Locale]` Fixed the es-419 date time value, as it was incorrectly using the medium length date format. ([#3830](https://github.com/infor-design/enterprise/issues/3830))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -476,6 +476,28 @@ $datagrid-short-row-height: 25px;
     }
   }
 
+  &.has-draggable-columns {
+    th.is-active.is-sorted-asc {
+      .sort-indicator {
+        .sort-desc {
+          .icon {
+            color: $datagrid-list-draggable-sorted-icon-color;
+          }
+        }
+      }
+    }
+
+    th.is-active.is-sorted-desc {
+      .sort-indicator {
+        .sort-asc {
+          .icon {
+            color: $datagrid-list-draggable-sorted-icon-color;
+          }
+        }
+      }
+    }
+  }
+
   &.has-inline-editor {
     td {
       &:focus,

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -366,6 +366,26 @@ $datagrid-short-row-height: 25px;
           border: 1px solid $datagrid-list-header-checkbox-border-color;
         }
       }
+
+      &.is-active.is-sorted-asc {
+        .sort-indicator {
+          .sort-desc {
+            .icon {
+              color: $datagrid-list-alt-sorted-icon-color;
+            }
+          }
+        }
+      }
+
+      &.is-active.is-sorted-desc {
+        .sort-indicator {
+          .sort-asc {
+            .icon {
+              color: $datagrid-list-alt-sorted-icon-color;
+            }
+          }
+        }
+      }
     }
 
     td {

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -651,6 +651,7 @@ $datagrid-list-header-color: $theme-color-palette-graphite-60;
 $datagrid-list-header-hover-color: $theme-color-palette-graphite-20;
 $datagrid-list-row-hover-color: transparent;
 $datagrid-list-sort-icon-color: $theme-color-brand-secondary-base;
+$datagrid-list-alt-sorted-icon-color: $theme-color-palette-graphite-40;
 $datagrid-list-sort-icon-hover-color: $theme-color-palette-graphite-50;
 $datagrid-header-focus-bg-color: $datagrid-header-bg-color;
 $datagrid-header-focus-border-color: $theme-color-palette-white;

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -652,6 +652,7 @@ $datagrid-list-header-hover-color: $theme-color-palette-graphite-20;
 $datagrid-list-row-hover-color: transparent;
 $datagrid-list-sort-icon-color: $theme-color-brand-secondary-base;
 $datagrid-list-alt-sorted-icon-color: $theme-color-palette-graphite-40;
+$datagrid-list-draggable-sorted-icon-color: $theme-color-palette-slate-40;
 $datagrid-list-sort-icon-hover-color: $theme-color-palette-graphite-50;
 $datagrid-header-focus-bg-color: $datagrid-header-bg-color;
 $datagrid-header-focus-border-color: $theme-color-palette-white;

--- a/src/themes/theme-soho-contrast.scss
+++ b/src/themes/theme-soho-contrast.scss
@@ -535,6 +535,7 @@ $datagrid-header-hover-color: $theme-color-palette-graphite-100;
 $datagrid-header-active-color: $theme-color-palette-graphite-80;
 $datagrid-header-checkbox-border-color: $theme-color-palette-graphite-50;
 $datagrid-sort-icon-color: $theme-color-brand-secondary-alt;
+$datagrid-list-alt-sorted-icon-color: $theme-color-palette-graphite-40;
 $datagrid-sort-icon-sorted-color: $theme-color-palette-white;
 $datagrid-required-icon-color: $theme-color-palette-white;
 
@@ -564,7 +565,8 @@ $datagrid-list-header-border-color: transparent;
 $datagrid-list-header-color: $theme-color-palette-graphite-100;
 $datagrid-list-header-hover-color: $theme-color-brand-secondary-alt;
 $datagrid-list-row-hover-color: transparent;
-$datagrid-list-sort-icon-color: $theme-color-brand-secondary-alt;
+$datagrid-list-sort-icon-color: $theme-color-palette-graphite-50;
+$datagrid-list-alt-sorted-icon-color: $theme-color-palette-graphite-50;
 $datagrid-list-sort-icon-hover-color: $theme-color-palette-graphite-60;
 $datagrid-header-focus-bg-color: $theme-color-palette-graphite-80;
 $datagrid-header-focus-border-color: $theme-color-palette-white;

--- a/src/themes/theme-soho-contrast.scss
+++ b/src/themes/theme-soho-contrast.scss
@@ -567,6 +567,7 @@ $datagrid-list-header-hover-color: $theme-color-brand-secondary-alt;
 $datagrid-list-row-hover-color: transparent;
 $datagrid-list-sort-icon-color: $theme-color-palette-graphite-50;
 $datagrid-list-alt-sorted-icon-color: $theme-color-palette-graphite-50;
+$datagrid-list-draggable-sorted-icon-color: $theme-color-palette-graphite-50;
 $datagrid-list-sort-icon-hover-color: $theme-color-palette-graphite-60;
 $datagrid-header-focus-bg-color: $theme-color-palette-graphite-80;
 $datagrid-header-focus-border-color: $theme-color-palette-white;

--- a/src/themes/theme-soho-dark.scss
+++ b/src/themes/theme-soho-dark.scss
@@ -521,6 +521,7 @@ $datagrid-header-active-color: $theme-color-palette-slate-40;
 $datagrid-header-checkbox-border-color: $theme-color-palette-slate-90;
 $datagrid-sort-icon-color: $theme-color-palette-slate-40;
 $datagrid-list-alt-sorted-icon-color: $theme-color-palette-slate-40;
+$datagrid-list-draggable-sorted-icon-color: $theme-color-palette-slate-50;
 $datagrid-sort-icon-sorted-color: $theme-color-palette-slate-100;
 $datagrid-required-icon-color: $theme-color-palette-slate-100;
 

--- a/src/themes/theme-soho-dark.scss
+++ b/src/themes/theme-soho-dark.scss
@@ -520,6 +520,7 @@ $datagrid-header-hover-color: $theme-color-palette-slate-20;
 $datagrid-header-active-color: $theme-color-palette-slate-40;
 $datagrid-header-checkbox-border-color: $theme-color-palette-slate-90;
 $datagrid-sort-icon-color: $theme-color-palette-slate-40;
+$datagrid-list-alt-sorted-icon-color: $theme-color-palette-slate-40;
 $datagrid-sort-icon-sorted-color: $theme-color-palette-slate-100;
 $datagrid-required-icon-color: $theme-color-palette-slate-100;
 

--- a/src/themes/theme-uplift-contrast.scss
+++ b/src/themes/theme-uplift-contrast.scss
@@ -540,6 +540,7 @@ $datagrid-header-hover-color: $theme-color-palette-graphite-100;
 $datagrid-header-active-color: $theme-color-palette-graphite-80;
 $datagrid-header-checkbox-border-color: $theme-color-palette-graphite-50;
 $datagrid-sort-icon-color: $theme-color-palette-graphite-40;
+$datagrid-list-alt-sorted-icon-color: $theme-color-palette-graphite-50;
 $datagrid-sort-icon-sorted-color: $theme-color-palette-white;
 $datagrid-required-icon-color: $theme-color-palette-white;
 

--- a/src/themes/theme-uplift-contrast.scss
+++ b/src/themes/theme-uplift-contrast.scss
@@ -541,6 +541,7 @@ $datagrid-header-active-color: $theme-color-palette-graphite-80;
 $datagrid-header-checkbox-border-color: $theme-color-palette-graphite-50;
 $datagrid-sort-icon-color: $theme-color-palette-graphite-40;
 $datagrid-list-alt-sorted-icon-color: $theme-color-palette-graphite-50;
+$datagrid-list-draggable-sorted-icon-color: $theme-color-palette-graphite-50;
 $datagrid-sort-icon-sorted-color: $theme-color-palette-white;
 $datagrid-required-icon-color: $theme-color-palette-white;
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes the visibility of sort icons when toggling and when the column is in active.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/3692

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app

1.)
- Navigate to http://localhost:4000/components/datagrid/example-expandable-row-one-only.html
- Select any first item in column to activate it
- Click sort filter
- Icon should be visible
- Test this on different variants and themes

2.)
- Navigate to http://localhost:4000/components/datagrid/example-export-from-button.html?theme=soho&variant=dark
- Select any first item in column to activate it
- Click sort filter
- Icon should be visible
- Test this also on light and contrast to verify other variants

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
