### PR TITLE
3839 - Fix custom builds for Locale on Windows [v4.28.x]

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -142,8 +142,8 @@ const filePaths = {
 // File Paths that are stripped/ignored.
 // Generally these are copied with another task, such as `npx grunt copy:main`.
 const ignoredFilePaths = [
-  'components/locale/cultures',
-  'components/locale/info'
+  path.join('components', 'locale', 'cultures'),
+  path.join('components', 'locale', 'info')
 ];
 
 // These search terms are used when scanning existing index files to determine


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a previous change to Custom Builds to use Node's `path.join()` for excluded file globbing paths.  This was preventing Locale builds from properly excluding culture files on any non-Unix-based file systems.

**Related github/jira issue (required)**:
- Closes #3839 
- Related to #3841 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the app
- Run a custom build dry run of Locale with npm run build -- --components=locale --dry-run.
- Open your project folder and find temp/components.txt. Open this in a text editor and make sure only locale.js is present. No culture or info paths should exist here.
- In your terminal run npm run build -- --components=locale. It should complete without errors and generate a file in dist/js/sohoxi.js that only includes the required core files and Locale.js

---
@awbuboltz