### PR TITLE
3873 - Make Hierarchy "More Actions" menus open via click [v4.28.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -63,6 +63,7 @@
 - `[Fieldset]` Fixed fieldset text data overlapping in compact mode on mobile view. ([#3627](https://github.com/infor-design/enterprise/issues/3627))
 - `[General]` Added a number of small accessibility fixes base on older testing feedback. ([#1539](https://github.com/infor-design/enterprise/issues/1539))
 - `[Hierarchy]` Added support for separators in the actions menu on a hierarchy leaf. ([#3636](https://github.com/infor-design/enterprise/issues/3636))
+- `[Hierarchy]` Fixed an issue where clicking the "More Actions" menu trigger wouldn't open the menu anymore. ([#3873](https://github.com/infor-design/enterprise/issues/3873))
 - `[Lookup]` Fixed an issue where `keywordFilter: true` and `filterable: true` used together cause the lookup modal to break. ([#3772](https://github.com/infor-design/enterprise/issues/3772))
 - `[Masthead]` Fixed layout and color issues in uplift theme. ([#3526](https://github.com/infor-design/enterprise/issues/3526))
 - `[Modal]` Fixed modal title to a two line with ellipsis when it's too long. ([#3479](https://github.com/infor-design/enterprise/issues/3479))

--- a/src/components/hierarchy/hierarchy.js
+++ b/src/components/hierarchy/hierarchy.js
@@ -330,7 +330,10 @@ Hierarchy.prototype = {
     nodeData.menu.actions = updatedActions;
     popupMenu.append(this.getActionMenuItems(nodeData));
 
+    // Setup flag to prevent double-open
+    popupMenuControl.keydownThenClick = true;
     popupMenuControl.open();
+
     popupMenuControl.handleAfterPlace(null, {
       element: popupMenu.parent(),
       parent: $(leaf).find('.btn-actions'),

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -13,6 +13,9 @@ import '../place/place.jquery';
 // Component Name
 const COMPONENT_NAME = 'popupmenu';
 
+// Popupmenu Trigger Types
+const triggerTypes = ['click', 'rightClick', 'immediate', 'manual'];
+
 /**
  * Responsive Popup Menu Control aka Context Menu when doing a right click action.
  * @class PopupMenu
@@ -43,7 +46,7 @@ const COMPONENT_NAME = 'popupmenu';
 
 const POPUPMENU_DEFAULTS = {
   menu: null,
-  trigger: 'click',
+  trigger: triggerTypes[0],
   autoFocus: true,
   mouseFocus: true,
   attachToBody: true,


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR makes a quick fix to the Hierarchy component that allows More Actions menus on leaves to be opened via clicking again.  This had been broken after some recent work in #3761 and #3783

**Related github/jira issue (required)**:
Closes #3873

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the demoapp
- Open http://localhost:4000/components/hierarchy/example-context-menu-with-details.html?theme=uplift&variant=light
- Click the More Actions "..." menu on the leaf labeled "Kaylee Edwards".  The Popupmenu should open and there should be no JS errors.

**Included in this Pull Request**:
- [x] A note to the change log.

**Additional Context**
- Raised an additional issue for checking this out more comprehensively in the May sprint: #3881 

----
@krishollenbeck 