### PR TITLE
3554 - Add support to custom header strings with multiselect

### DIFF
--- a/app/views/components/multiselect/test-header-strings.html
+++ b/app/views/components/multiselect/test-header-strings.html
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="twelve columns">
     <h2>Multiselect - Custom Header Strings</h2>
-    <p>Demonstrate <strong>allTextString</strong> and <strong>selectedTextString</strong> both custom header strings api settings.</p>
+    <p>Demonstrates the <strong>allTextString</strong> and <strong>selectedTextString</strong> settings to customize the headers in multiselect.</p>
   </div>
 </div>
 

--- a/app/views/components/multiselect/test-header-strings.html
+++ b/app/views/components/multiselect/test-header-strings.html
@@ -1,0 +1,39 @@
+<div class="row">
+  <div class="twelve columns">
+    <h2>Multiselect - Custom Header Strings</h2>
+    <p>Demonstrate <strong>allTextString</strong> and <strong>selectedTextString</strong> both custom header strings api settings.</p>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+    <div class="field">
+      <label for="states-multi" class="label">States</label>
+      <select multiple id="states-multi" name="states-multi" class="multiselect" data-options="{allTextString: 'Available to choose', selectedTextString: 'Chosen'}">
+        <option value="AL">Alabama</option>
+        <option value="AK" selected>Alaska</option>
+        <option value="AZ">Arizona</option>
+        <option value="AR">Arkansas</option>
+        <option value="CA">California</option>
+        <option value="CO">Colorado</option>
+      </select>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+    <div class="field">
+      <label for="ajax-test">Ajax Test</label>
+      <select id="ajax-test" name="ajax-test" class="multiselect" data-init="false" multiple></select>
+    </div>
+  </div>
+</div>
+
+<script>
+  $('#ajax-test').multiselect({
+    source: '{{basepath}}api/states?term=',
+    allTextString: 'Available to choose',
+    selectedTextString: 'Chosen'
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[Fonts]` A note that the Source Sans Pro font thats used in the new theme and served at google fonts, now have a fix for the issue that capitalized letters and numbers had different heights. You may need to release any special caching. ([#1789](https://github.com/infor-design/enterprise/issues/1789))
 - `[Locale]` Fixed the es-419 date time value, as it was incorrectly using the medium length date format. ([#3830](https://github.com/infor-design/enterprise/issues/3830))
 - `[Modal]` Fixed the inconsistencies of spacing on required fields. ([#3587](https://github.com/infor-design/enterprise/issues/3587))
+- `[Multiselect]` Added support to api settings to `allTextString` and `selectedTextString` for custom headers. ([#3554](https://github.com/infor-design/enterprise/issues/3554))
 - `[Pie]` Fixed an issue where rounds decimal places for percent values were not working. ([#3599](https://github.com/infor-design/enterprise/issues/3599))
 - `[Pie/Donut]` Fixed an issue where placing legend on bottom was not working for Homepage widget/Cards. ([#3560](https://github.com/infor-design/enterprise/issues/3560))
 - `[Pager]` Reduced the space between buttons. ([#1942](https://github.com/infor-design/enterprise/issues/1942))

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -49,6 +49,8 @@ const reloadSourceStyles = ['none', 'open', 'typeahead'];
 * @param {object} [settings.placementOpts = null]  Gets passed to this control's Place behavior
 * @param {function} [settings.onKeyDown = null]  Allows you to hook into the onKeyDown. If you do you can access the keydown event data. And optionally return false to cancel the keyDown action.
 * @param {object} [settings.tagSettings] if defined, passes along 'clickHandler' and 'dismissHandler' functions to any Tags in the Taglist
+* @param {string} [settings.allTextString]  Custom text string for `All` text header use in MultiSelect.
+* @param {string} [settings.selectedTextString]  Custom text string for `Selected` text header use in MultiSelect.
 */
 const DROPDOWN_DEFAULTS = {
   closeOnSelect: true,
@@ -70,7 +72,9 @@ const DROPDOWN_DEFAULTS = {
   maxWidth: null,
   placementOpts: null,
   onKeyDown: null,
-  tagSettings: {}
+  tagSettings: {},
+  allTextString: null,
+  selectedTextString: null
 };
 
 function Dropdown(element, settings) {
@@ -724,6 +728,7 @@ Dropdown.prototype = {
    */
   updateList(term) {
     const self = this;
+    const s = this.settings;
     const isMobile = self.isMobile();
     const listExists = self.list !== undefined && self.list !== null && self.list.length > 0;
     let listContents = '';
@@ -734,6 +739,15 @@ Dropdown.prototype = {
     const isMultiselect = this.settings.multiple === true;
     let moveSelected = `${this.settings.moveSelected}`;
     const showSelectAll = this.settings.showSelectAll === true;
+    const headerText = {
+      all: Locale.translate('All'),
+      selected: Locale.translate('Selected'),
+      labelText: self.isInlineLabel ? self.inlineLabelText.text() : this.label.text()
+    };
+    headerText.all = (typeof s.allTextString === 'string' && s.allTextString !== '') ?
+      self.settings.allTextString : `${headerText.all} ${headerText.labelText}`;
+    headerText.selected = (typeof s.selectedTextString === 'string' && s.selectedTextString !== '') ?
+      self.settings.selectedTextString : `${headerText.selected} ${headerText.labelText}`;
 
     if (this.element[0].classList.contains('text-align-reverse')) {
       reverseText = ' text-align-reverse';
@@ -866,7 +880,7 @@ Dropdown.prototype = {
 
       // Show a "selected" header if there are selected options
       if (selectedOpts.length > 0) {
-        ulContents += buildLiHeader(`${Locale.translate('Selected')} ${self.isInlineLabel ? self.inlineLabelText.text() : this.label.text()}`);
+        ulContents += buildLiHeader(headerText.selected);
       }
 
       selectedOpts.each(function (i) {
@@ -877,7 +891,7 @@ Dropdown.prototype = {
       // Only show the "all" header beneath the selected options if there
       // are no other optgroups present
       if (!hasOptGroups && opts.length > 0) {
-        ulContents += buildLiHeader(`${Locale.translate('All')} ${self.isInlineLabel ? self.inlineLabelText.text() : this.label.text()}`);
+        ulContents += buildLiHeader(headerText.all);
       }
     }
 

--- a/src/components/multiselect/multiselect.js
+++ b/src/components/multiselect/multiselect.js
@@ -18,7 +18,9 @@ const MULTISELECT_DEFAULTS = {
   showEmptyGroupHeaders: false,
   showSelectAll: false,
   showTags: false,
-  source: undefined
+  source: undefined,
+  allTextString: null,
+  selectedTextString: null
 };
 
 /**
@@ -33,6 +35,8 @@ const MULTISELECT_DEFAULTS = {
  * @param {boolean} [settings.showEmptyGroupHeaders = false]  If true groups with no items will still show the empty group header.
  * @param {boolean} [settings.showSelectAll = false]  Show the select all button and text .
  * @param {function} [settings.source]  The calback for ajax.
+ * @param {string} [settings.allTextString]  Custom text string for `All` text header.
+ * @param {string} [settings.selectedTextString]  Custom text string for `Selected` text header.
  */
 function MultiSelect(element, settings) {
   this.settings = utils.mergeSettings(element, settings, MULTISELECT_DEFAULTS);

--- a/test/components/dropdown/dropdown-updates-events.func-spec.js
+++ b/test/components/dropdown/dropdown-updates-events.func-spec.js
@@ -42,7 +42,9 @@ describe('Dropdown updates, events', () => {
       sourceArguments: {},
       onKeyDown: null,
       showTags: false,
-      tagSettings: {}
+      tagSettings: {},
+      allTextString: null,
+      selectedTextString: null
     };
 
     expect(dropdownObj.settings).toEqual(settings);
@@ -66,7 +68,9 @@ describe('Dropdown updates, events', () => {
       sourceArguments: {},
       onKeyDown: null,
       showTags: false,
-      tagSettings: {}
+      tagSettings: {},
+      allTextString: null,
+      selectedTextString: null
     };
 
     dropdownObj.updated();
@@ -94,7 +98,9 @@ describe('Dropdown updates, events', () => {
       sourceArguments: {},
       onKeyDown: null,
       showTags: false,
-      tagSettings: {}
+      tagSettings: {},
+      allTextString: null,
+      selectedTextString: null
     };
     dropdownObj.updated(settings);
 
@@ -128,7 +134,9 @@ describe('Dropdown updates, events', () => {
       sourceArguments: {},
       onKeyDown: null,
       showTags: false,
-      tagSettings: {}
+      tagSettings: {},
+      allTextString: null,
+      selectedTextString: null
     };
 
     const spyEvent = spyOnEvent('.dropdown', 'has-updated');

--- a/test/components/multiselect/multiselect.e2e-spec.js
+++ b/test/components/multiselect/multiselect.e2e-spec.js
@@ -341,6 +341,31 @@ describe('Multiselect placeholder tests', () => {
   });
 });
 
+describe('Multiselect header strings tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/multiselect/test-header-strings');
+
+    const multiselectEl = await element(by.css('select.multiselect + .dropdown-wrapper div.dropdown'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(multiselectEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should have custom header strings', async () => {
+    const selector = '#dropdown-list .group-label';
+    await clickOnMultiselect();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.className('is-open'))), config.waitsFor);
+
+    expect(await element(by.className('is-open')).isDisplayed()).toBe(true);
+    expect(await element.all(by.css(selector)).get(0).getText()).toBe('Chosen');
+    expect(await element.all(by.css(selector)).get(1).getText()).toBe('Available to choose');
+  });
+});
+
 describe('Multiselect with Tags tests', () => {
   if (utils.isChrome() && utils.isCI()) {
     it('Standard example should not visually regress', async () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added support to api settings to `allTextString` and `selectedTextString` for custom headers with Multiselect.

**Related github/jira issue (required)**:
Closes #3554

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/multiselect/test-header-strings.html
- Open multiselect field titled `States`
- See the header strings selected as `Chosen` and not selected as `Available to choose`

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
