### PR TITLE
3855/3731 - Fix keyword search with datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### v4.29.0 Fixes
 
 - `[Checkbox]` Fixed an issue where the error icon was inconsistent between subtle and vibrant themes. ([#3575](https://github.com/infor-design/enterprise/issues/3575))
+- `[Datagrid]` Fixed an issue where keyword search results were breaking the html markup for icons and badges. ([#3855](https://github.com/infor-design/enterprise/issues/3855))
+- `[Datagrid]` Fixed an issue where keyword search results were breaking the html markup for hyperlink. ([#3731](https://github.com/infor-design/enterprise/issues/3731))
 - `[Datagrid]` Fixed an issue where contents filtertype was not working on example page. ([#2887](https://github.com/infor-design/enterprise/issues/2887))
 - `[Datagrid]` Fixed a bug in some themes, where the multi line cell would not be lined up correctly with a single line of data. ([#2703](https://github.com/infor-design/enterprise/issues/2703))
 - `[Datagrid]` Fixed visibility of sort icons when toggling and when the column is in active. ([#3692](https://github.com/infor-design/enterprise/issues/3692))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -6615,10 +6615,6 @@ Datagrid.prototype = {
         }
       });
 
-      thisSearch.off('blur.datagrid').on('blur.datagrid', () => {
-        self.keywordSearch(thisSearch.val());
-      });
-
       xIcon.off('click.datagrid').on('click.datagrid', () => {
         self.keywordSearch(thisSearch.val());
       });
@@ -11383,7 +11379,7 @@ Datagrid.prototype = {
       const searchfield = toolbar.find('.searchfield');
       const searchfieldApi = searchfield.data('searchfield');
       const xIcon = searchfield.parent().find('.close.icon');
-      searchfield.off('keypress.datagrid blur.datagrid');
+      searchfield.off('keypress.datagrid');
       xIcon.off('click.datagrid');
       if (searchfieldApi && typeof searchfieldApi.destroy === 'function') {
         searchfieldApi.destroy();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed keyword search results were breaking the html markup for icons, badges and hyperlink with Datagrid.

**Related github/jira issue (required)**:
Closes #3855
Closes #3731

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app

3855
- Navigate to: http://localhost:4000/components/datagrid/example-singleselect.html
- Open the search filter and type `error`
- See error icons and error badges should show

3731
- Navigate to: http://localhost:4000/components/datagrid/example-keyword-search.html
- Open the search filter and type `air`
- See error hyperlinks should remain links

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
