### PR TITLE
2852 - Fix blank tooltip with datagrid

### DIFF
--- a/app/views/components/datagrid/test-alerts.html
+++ b/app/views/components/datagrid/test-alerts.html
@@ -39,6 +39,7 @@
       $('#datagrid').datagrid({
         columns: columns,
         dataset: data,
+        enableTooltips: true,
         selectable: 'single',
         cellNavigation: false,
         clickToSelect: true,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### v4.29.0 Fixes
 
 - `[Checkbox]` Fixed an issue where the error icon was inconsistent between subtle and vibrant themes. ([#3575](https://github.com/infor-design/enterprise/issues/3575))
+- `[Datagrid]` Fixed an issue where blank tooltip was showing when use Alert Formatter and no text. ([#2852](https://github.com/infor-design/enterprise/issues/2852))
 - `[Datagrid]` Fixed an issue where contents filtertype was not working on example page. ([#2887](https://github.com/infor-design/enterprise/issues/2887))
 - `[Datagrid]` Fixed a bug in some themes, where the multi line cell would not be lined up correctly with a single line of data. ([#2703](https://github.com/infor-design/enterprise/issues/2703))
 - `[Datagrid]` Fixed visibility of sort icons when toggling and when the column is in active. ([#3692](https://github.com/infor-design/enterprise/issues/3692))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -11109,7 +11109,7 @@ Datagrid.prototype = {
           }
         } else {
           // Default use wrapper content
-          tooltip.content = xssUtils.stripHTML(tooltip.wrapper.textContent);
+          tooltip.content = xssUtils.stripHTML(tooltip.wrapper.textContent).trim();
         }
       }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed blank tooltip was showing when use Alert Formatter and no text with Datagrid.

**Related github/jira issue (required)**:
Closes #2852

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/test-alerts.html
- Resize the column `Alert Choose Header` width till icons partial hidden
- Hover over any icon in that column
- Tooltip should not show

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
