### PR TITLE
3871 - Tabs search bar responsive

### DIFF
--- a/app/views/components/tabs-module/example-category-searchfield-go-button-home.html
+++ b/app/views/components/tabs-module/example-category-searchfield-go-button-home.html
@@ -45,10 +45,6 @@
         <div class="tab-panel" id="tab-one">
           <div class="row">
             <div class="twelve columns">
-              <h3>Module Tabs Test: Header + Category Searchfield + Go Button</h3>
-              <p>
-                <a class="hyperlink" href="https://jira.infor.com/browse/SOHO-6711" target="_blank">SOHO-6711</a>
-              </p>
             </div>
           </div>
         </div>

--- a/app/views/components/tabs-module/example-category-searchfield-go-button.html
+++ b/app/views/components/tabs-module/example-category-searchfield-go-button.html
@@ -38,10 +38,6 @@
         <div class="tab-panel" id="tab-one">
           <div class="row">
             <div class="twelve columns">
-              <h3>Module Tabs Test: Header + Category Searchfield + Go Button</h3>
-              <p>
-                <a class="hyperlink" href="https://jira.infor.com/browse/SOHO-6711" target="_blank">SOHO-6711</a>
-              </p>
             </div>
           </div>
         </div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,7 +28,7 @@
 - `[Pie/Donut]` Fixed an issue where placing legend on bottom was not working for Homepage widget/Cards. ([#3560](https://github.com/infor-design/enterprise/issues/3560))
 - `[Pager]` Reduced the space between buttons. ([#1942](https://github.com/infor-design/enterprise/issues/1942))
 - `[Tabs]` Fixed info and alert icons alignment on tabs and inside of modal. ([#2695](https://github.com/infor-design/enterprise/issues/2695))
-- `[Tabs]` Fixes and issue where the search bar background color was going to transparent on smaller breakpoints. ([#3871](https://github.com/infor-design/enterprise/issues/3871))
+- `[Tabs]` Fixes an issue where the search bar background color was going to transparent on smaller breakpoints. ([#3871](https://github.com/infor-design/enterprise/issues/3871))
 - `[Notification]` Fixed an issue where the icons were lagging in the animation. ([#2099](https://github.com/infor-design/enterprise/issues/2099))
 - `[Tree]` Fixed an issue where data was not in sync for children property. ([#1690](https://github.com/infor-design/enterprise/issues/1690))
 - `[Splitter]` Fixed an issue the drag handle characters render incorrectly. ([#1458](https://github.com/infor-design/enterprise/issues/1458))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `[Pie/Donut]` Fixed an issue where placing legend on bottom was not working for Homepage widget/Cards. ([#3560](https://github.com/infor-design/enterprise/issues/3560))
 - `[Pager]` Reduced the space between buttons. ([#1942](https://github.com/infor-design/enterprise/issues/1942))
 - `[Tabs]` Fixed info and alert icons alignment on tabs and inside of modal. ([#2695](https://github.com/infor-design/enterprise/issues/2695))
+- `[Tabs]` Fixes and issue where the search bar background color was going to transparent on smaller breakpoints. ([#3871](https://github.com/infor-design/enterprise/issues/3871))
 - `[Notification]` Fixed an issue where the icons were lagging in the animation. ([#2099](https://github.com/infor-design/enterprise/issues/2099))
 - `[Tree]` Fixed an issue where data was not in sync for children property. ([#1690](https://github.com/infor-design/enterprise/issues/1690))
 - `[Splitter]` Fixed an issue the drag handle characters render incorrectly. ([#1458](https://github.com/infor-design/enterprise/issues/1458))

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -496,8 +496,8 @@ $toolbarsearchfield-category-empty-width: 51px;
     }
 
     .searchfield {
-      background-color: rgba($searchfield-header-bg-color, 0);
-      border-color: rgba($searchfield-header-border-color, 0);
+      background-color: rgba($searchfield-header-bg-color, 0.3);
+      border-bottom-color: rgba($searchfield-header-border-color, 0.7);
       color: $searchfield-header-text-color;
     }
 
@@ -562,6 +562,13 @@ $toolbarsearchfield-category-empty-width: 51px;
             top: 0;
           }
         }
+      }
+    }
+
+    .searchfield-category-button {
+      &.btn {
+        background-color: rgba($searchfield-header-bg-color, 0.5);
+        border-bottom-color: rgba($searchfield-header-border-color, 0.7);
       }
     }
 

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -234,7 +234,7 @@ $toolbarsearchfield-category-empty-width: 51px;
 
     &:not(.non-collapsible) {
       .searchfield {
-        height: 35px; // Unable to use token here. need to use the soho height
+        height: 34px; // Unable to use token here. need to use the soho height
       }
     }
 

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -496,9 +496,17 @@ $toolbarsearchfield-category-empty-width: 51px;
     }
 
     .searchfield {
-      background-color: rgba($searchfield-header-bg-color, 0.3);
-      border-bottom-color: rgba($searchfield-header-border-color, 0.7);
+      background-color: rgba($searchfield-header-bg-color, 0);
+      border-bottom-color: rgba($searchfield-header-border-color, 0);
       color: $searchfield-header-text-color;
+    }
+
+    &.non-collapsible {
+      .searchfield {
+        background-color: rgba($searchfield-header-bg-color, 0.3);
+        border-bottom-color: rgba($searchfield-header-border-color, 0.7);
+        color: $searchfield-header-text-color;
+      }
     }
 
     .go-button {

--- a/src/components/searchfield/_searchfield-uplift.scss
+++ b/src/components/searchfield/_searchfield-uplift.scss
@@ -24,6 +24,12 @@
   .searchfield-category-button {
     height: 38px;
   }
+
+  &.context {
+    > .searchfield {
+      height: 34px;
+    }
+  }
 }
 
 .toolbar-searchfield-wrapper {
@@ -34,7 +40,7 @@
   &:not(.is-open),
   &.non-collapsible {
     .searchfield {
-      height: auto;
+      height: 34px;
       padding-bottom: 6px;
       padding-top: 7px;
     }
@@ -47,12 +53,6 @@
   &:not(.is-open) {
     .icon:not(.close) {
       top: 8px;
-    }
-  }
-
-  &.is-open {
-    .searchfield {
-      padding-bottom: 2px;
     }
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes an issue where the search bar background color was going to transparent on smaller breakpoints.

**Related github/jira issue (required)**:
closes #3871 

**Steps necessary to review your pull request (required)**:
- Pull and build branch
- go to http://localhost:4000/components/tabs-module/example-category-searchfield-go-button-home.html
- make sure the search bar and button maintain there background color on smaller breakpoints.

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
