### PR TITLE
414 - Polyfill jQuery `mousewheel`/`touchstart` events to be passive

### DIFF
--- a/src/components/arrange/arrange.js
+++ b/src/components/arrange/arrange.js
@@ -210,169 +210,168 @@ Arrange.prototype = {
           this.dragDrop();// ie9
         }
         return this.isIe;
-      })
-      .end()
+      });
 
-      .each(function () {
-        $(this)
+    this.items.each(function () {
+      $(this)
         // Drag start --------------------------------------------------------------------------
-          .on(self.dragStart, function (e) {
-            if (self.handle && !isHandle) {
-              if (self.isTouch) {
-                return;
-              }
-              return false;// eslint-disable-line
+        .on(self.dragStart, function (e) {
+          if (self.handle && !isHandle) {
+            if (self.isTouch) {
+              return;
             }
-            isHandle = false;
-            self.dragging = $(this);
+            return false;// eslint-disable-line
+          }
+          isHandle = false;
+          self.dragging = $(this);
 
-            index = self.dragging.addClass('arrange-dragging').index();
+          index = self.dragging.addClass('arrange-dragging').index();
+          const idx = s.isVisualItems ?
+            self.getVisualIndex(self.dragging) : index;
+
+          $.extend(status, { start: self.dragging, startIndex: idx });
+
+          /**
+          * Fires before moving an element allowing you to access the ui to
+           customize the draggable item.
+          *
+          * @event beforearrange
+          * @memberof Arrange
+          * @property {object} event - The jquery event object
+          * @property {object} status - Status for this item
+          */
+          const result = self.element.triggerHandler('beforearrange', status);
+          if ((typeof result === 'boolean' && !result) || (typeof result === 'string' && result.toLowerCase() === 'false')) {
+            self.dragging = null;
+            return;
+          }
+
+          if (self.isTouch) {
+            const rect = self.dragging[0].getBoundingClientRect();
+            const touch = e.originalEvent.changedTouches[0];
+
+            // Save offset
+            self.offset = {
+              x: touch.pageX - rect.left,
+              y: touch.pageY - rect.top
+            };
+            self.placeholderTouch = self.dragging
+              .clone().addClass('is-touch').attr('id', 'arrange-placeholder-touch')
+              .insertBefore(self.dragging);
+
+            self.dragTouchElement(e, self.placeholderTouch);
+          } else {
+            const dt = e.originalEvent.dataTransfer;
+            dt.effectAllowed = 'move';
+            dt.setData('Text', 'dummy');
+          }
+        })
+
+        // Drag end ----------------------------------------------------------
+        .on(self.dragEnd, () => {
+          if (!self.dragging) {
+            return;
+          }
+
+          if (self.isTouch) {
+            self.dragging.css('opacity', 1);
+            self.placeholderTouch.remove();
+          }
+
+          self.placeholders.filter(':visible').after(self.dragging);
+          self.dragging.removeClass('arrange-dragging').show();
+          self.placeholders.detach();
+
+          if (index !== self.dragging.index()) {
             const idx = s.isVisualItems ?
-              self.getVisualIndex(self.dragging) : index;
-
-            $.extend(status, { start: self.dragging, startIndex: idx });
+              self.getVisualIndex(self.dragging) : self.dragging.index();
+            $.extend(status, { end: self.dragging, endIndex: idx });
 
             /**
-            * Fires before moving an element allowing you to access the ui to
-             customize the draggable item.
+            * Fires after moving an element allowing you do any follow up updating.
             *
-            * @event beforearrange
+            * @event arrangeupdate
             * @memberof Arrange
             * @property {object} event - The jquery event object
             * @property {object} status - Status for this item
             */
-            const result = self.element.triggerHandler('beforearrange', status);
-            if ((typeof result === 'boolean' && !result) || (typeof result === 'string' && result.toLowerCase() === 'false')) {
-              self.dragging = null;
-              return;
-            }
+            self.element.triggerHandler('arrangeupdate', status);
+          }
+          self.dragging = null;
+          self.placeholderTouch = null;
+        })
 
-            if (self.isTouch) {
-              const rect = self.dragging[0].getBoundingClientRect();
-              const touch = e.originalEvent.changedTouches[0];
+        // While dragging ----------------------------------------------------
+        .on(self.dragWhileDragging, function (e) {
+          if (!self.dragging) {
+            return;
+          }
+          let overItem = this;
+          let overIndex;
+          e.preventDefault();
 
-              // Save offset
-              self.offset = {
-                x: touch.pageX - rect.left,
-                y: touch.pageY - rect.top
-              };
-              self.placeholderTouch = self.dragging
-                .clone().addClass('is-touch').attr('id', 'arrange-placeholder-touch')
-                .insertBefore(self.dragging);
-
-              self.dragTouchElement(e, self.placeholderTouch);
-            } else {
-              const dt = e.originalEvent.dataTransfer;
-              dt.effectAllowed = 'move';
-              dt.setData('Text', 'dummy');
-            }
-          })
-
-          // Drag end ----------------------------------------------------------
-          .on(self.dragEnd, () => {
-            if (!self.dragging) {
-              return;
-            }
-
-            if (self.isTouch) {
-              self.dragging.css('opacity', 1);
-              self.placeholderTouch.remove();
-            }
-
-            self.placeholders.filter(':visible').after(self.dragging);
-            self.dragging.removeClass('arrange-dragging').show();
-            self.placeholders.detach();
-
-            if (index !== self.dragging.index()) {
-              const idx = s.isVisualItems ?
-                self.getVisualIndex(self.dragging) : self.dragging.index();
-              $.extend(status, { end: self.dragging, endIndex: idx });
-
-              /**
-              * Fires after moving an element allowing you do any follow up updating.
-              *
-              * @event arrangeupdate
-              * @memberof Arrange
-              * @property {object} event - The jquery event object
-              * @property {object} status - Status for this item
-              */
-              self.element.triggerHandler('arrangeupdate', status);
-            }
-            self.dragging = null;
-            self.placeholderTouch = null;
-          })
-
-          // While dragging ----------------------------------------------------
-          .on(self.dragWhileDragging, function (e) {
-            if (!self.dragging) {
-              return;
-            }
-            let overItem = this;
-            let overIndex;
-            e.preventDefault();
-
-            /**
-            * Fires after finishing an arrange action.
-            *
-            * @event dragend
-            * @memberof ApplicationMenu
-            * @param {object} event - The jquery event object
-            */
-            if (e.type === 'drop') {
-              e.stopPropagation();
-              self.dragging.trigger('dragend.arrange');
-              return false;// eslint-disable-line
-            }
-
-            if (self.isTouch) {
-              const touch = e.originalEvent.touches[0];
-              overItem = self.getElementByTouchInList(items, touch.pageX, touch.pageY) || overItem;
-            }
-            overItem = $(overItem);
-
-            if (!self.isTouch) {
-              e.originalEvent.dataTransfer.dropEffect = 'move';
-            }
-
-            if (items.is(overItem) && placeholder.index() !== overItem.index()) {
-              if (self.isTouch) {
-                self.dragging.css('opacity', 0);
-              } else {
-                self.dragging.hide();
-              }
-
-              let idx;
-              if (placeholder.index() < (overItem.index())) {
-                placeholder.insertAfter(overItem);
-                overIndex = overItem.index();
-                idx = s.isVisualItems ?
-                  self.getVisualIndex(overItem) : overIndex;
-              } else {
-                placeholder.insertBefore(overItem);
-                overIndex = placeholder.index();
-                idx = s.isVisualItems ?
-                  self.getVisualIndex(placeholder) : overIndex;
-              }
-
-              $.extend(status, { over: overItem, overIndex: idx });
-              self.element.triggerHandler('draggingarrange', status);
-
-              // Fix: IE-11 on windows-10 svg was disappering
-              utils.fixSVGIcons(overItem);
-
-              self.placeholders.not(placeholder).detach();
-            } else if (!self.placeholders.is(this)) {
-              self.placeholders.detach();
-              self.element.append(placeholder);
-            }
-
-            if (self.isTouch) {
-              self.dragTouchElement(e, self.placeholderTouch);
-              return;
-            }
+          /**
+          * Fires after finishing an arrange action.
+          *
+          * @event dragend
+          * @memberof ApplicationMenu
+          * @param {object} event - The jquery event object
+          */
+          if (e.type === 'drop') {
+            e.stopPropagation();
+            self.dragging.trigger('dragend.arrange');
             return false;// eslint-disable-line
-          });//-----------------------------------------------------------------
-      });// end each items
+          }
+
+          if (self.isTouch) {
+            const touch = e.originalEvent.touches[0];
+            overItem = self.getElementByTouchInList(items, touch.pageX, touch.pageY) || overItem;
+          }
+          overItem = $(overItem);
+
+          if (!self.isTouch) {
+            e.originalEvent.dataTransfer.dropEffect = 'move';
+          }
+
+          if (items.is(overItem) && placeholder.index() !== overItem.index()) {
+            if (self.isTouch) {
+              self.dragging.css('opacity', 0);
+            } else {
+              self.dragging.hide();
+            }
+
+            let idx;
+            if (placeholder.index() < (overItem.index())) {
+              placeholder.insertAfter(overItem);
+              overIndex = overItem.index();
+              idx = s.isVisualItems ?
+                self.getVisualIndex(overItem) : overIndex;
+            } else {
+              placeholder.insertBefore(overItem);
+              overIndex = placeholder.index();
+              idx = s.isVisualItems ?
+                self.getVisualIndex(placeholder) : overIndex;
+            }
+
+            $.extend(status, { over: overItem, overIndex: idx });
+            self.element.triggerHandler('draggingarrange', status);
+
+            // Fix: IE-11 on windows-10 svg was disappering
+            utils.fixSVGIcons(overItem);
+
+            self.placeholders.not(placeholder).detach();
+          } else if (!self.placeholders.is(this)) {
+            self.placeholders.detach();
+            self.element.append(placeholder);
+          }
+
+          if (self.isTouch) {
+            self.dragTouchElement(e, self.placeholderTouch);
+            return;
+          }
+          return false;// eslint-disable-line
+        });//-----------------------------------------------------------------
+    });// end each items
   }
 
 };

--- a/src/polyfills/jquery-passive-events.js
+++ b/src/polyfills/jquery-passive-events.js
@@ -11,6 +11,13 @@ jQuery.event.special.touchstart = {
     });
   }
 };
+jQuery.event.special.touchmove = {
+  setup(_, ns, handle) {
+    this.addEventListener('touchmove', handle, {
+      passive: true
+    });
+  }
+};
 jQuery.event.special.mousewheel = {
   setup(_, ns, handle) {
     this.addEventListener('mousewheel', handle, {

--- a/src/polyfills/jquery-passive-events.js
+++ b/src/polyfills/jquery-passive-events.js
@@ -1,0 +1,20 @@
+/**
+ * Polyfills passive event support in jQuery
+ * This eliminates a ton of console warnings when doing scrolling.
+ * - https://github.com/jquery/jquery/issues/2871
+ * - https://github.com/infor-design/enterprise/issues/414
+ */
+jQuery.event.special.touchstart = {
+  setup(_, ns, handle) {
+    this.addEventListener('touchstart', handle, {
+      passive: true
+    });
+  }
+};
+jQuery.event.special.mousewheel = {
+  setup(_, ns, handle) {
+    this.addEventListener('mousewheel', handle, {
+      passive: true
+    });
+  }
+};

--- a/src/polyfills/polyfills.js
+++ b/src/polyfills/polyfills.js
@@ -1,2 +1,4 @@
 import './element-matches';
 import './element-remove';
+
+import './jquery-passive-events';


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR attempts to get rid of many console warnings that will be displayed by our internal usage of `touchstart` and `mousewheel` jQuery events.  This is done be polyfilling jQuery's handling of these event types and overriding them to add `passive: true` to their arguments, per the [recommendation by a jQuery core team member here](https://github.com/jquery/jquery/issues/2871#issuecomment-497963776)

**Related github/jira issue (required)**:
Closes #414

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the demoapp.
- Open kitchen sink page (http://localhost:4000) with a dev tools console present
- Scroll up and down in the page body.  No console warnings should be present related to requiring passive events.

**TODO:** Need to fully test any touchstart events on mobile, as well as do a general smoke test of everything to make sure all behavior is working as intended.  We should not remove the WIP label until this is conducted.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.