### PR TITLE
2656 - Enable Dropdown/Multiselect AJAX calls to populate selected values

### DIFF
--- a/app/data/states-multiselect.json
+++ b/app/data/states-multiselect.json
@@ -1,0 +1,241 @@
+[
+	{
+		"value": "AL",
+		"label": "Alabama"
+	},
+	{
+		"value": "AK",
+		"label": "Alaska"
+	},
+	{
+		"value": "AS",
+		"label": "American Samoa"
+	},
+	{
+		"value": "AZ",
+		"label": "Arizona"
+	},
+	{
+		"value": "AR",
+		"label": "Arkansas"
+	},
+	{
+		"value": "CA",
+		"label": "California"
+	},
+	{
+		"value": "CO",
+		"label": "Colorado"
+	},
+	{
+		"value": "CT",
+		"label": "Connecticut"
+	},
+	{
+		"value": "DE",
+		"label": "Delaware"
+	},
+	{
+		"value": "DC",
+		"label": "District Of Columbia"
+	},
+	{
+		"value": "FM",
+		"label": "Federated States Of Micronesia"
+	},
+	{
+		"value": "FL",
+		"label": "Florida"
+	},
+	{
+		"value": "GA",
+		"label": "Georgia"
+	},
+	{
+		"value": "GU",
+		"label": "Guam"
+	},
+	{
+		"value": "HI",
+		"label": "Hawaii"
+	},
+	{
+		"value": "ID",
+		"label": "Idaho"
+	},
+	{
+		"value": "IL",
+		"label": "Illinois"
+	},
+	{
+		"value": "IN",
+		"label": "Indiana"
+	},
+	{
+		"value": "IA",
+		"label": "Iowa"
+	},
+	{
+		"value": "KS",
+		"label": "Kansas"
+	},
+	{
+		"value": "KY",
+		"label": "Kentucky"
+	},
+	{
+		"value": "LA",
+		"label": "Louisiana"
+	},
+	{
+		"value": "ME",
+		"label": "Maine"
+	},
+	{
+		"value": "MH",
+		"label": "Marshall Island Teritory"
+	},
+	{
+		"value": "MD",
+		"label": "Maryland"
+	},
+	{
+		"value": "MA",
+		"label": "Massachusetts"
+	},
+	{
+		"value": "MI",
+		"label": "Michigan"
+	},
+	{
+		"value": "MN",
+		"label": "Minnesota"
+	},
+	{
+		"value": "MS",
+		"label": "Mississippi"
+	},
+	{
+		"value": "MO",
+		"label": "Missouri"
+	},
+	{
+		"value": "MT",
+		"label": "Montana"
+	},
+	{
+		"value": "NE",
+		"label": "Nebraska"
+	},
+	{
+		"value": "NV",
+		"label": "Nevada"
+	},
+	{
+		"value": "NH",
+		"label": "New Hampshire"
+	},
+	{
+		"value": "NJ",
+		"label": "New Jersey",
+		"selected": true
+	},
+	{
+		"value": "NM",
+		"label": "New Mexico"
+	},
+	{
+		"value": "NY",
+		"label": "New York",
+		"selected": true
+	},
+	{
+		"value": "NC",
+		"label": "North Carolina"
+	},
+	{
+		"value": "ND",
+		"label": "North Dakota"
+	},
+	{
+		"value": "MP",
+		"label": "Northern Mariana Island Teritory"
+	},
+	{
+		"value": "OH",
+		"label": "Ohio"
+	},
+	{
+		"value": "OK",
+		"label": "Oklahoma"
+	},
+	{
+		"value": "OR",
+		"label": "Oregon"
+	},
+	{
+		"value": "PW",
+		"label": "Palau"
+	},
+	{
+		"value": "PA",
+		"label": "Pennsylvania",
+		"selected": true
+	},
+	{
+		"value": "PR",
+		"label": "Puerto Rico"
+	},
+	{
+		"value": "RI",
+		"label": "Rhode Island Teritory"
+	},
+	{
+		"value": "SC",
+		"label": "South Carolina"
+	},
+	{
+		"value": "SD",
+		"label": "South Dakota"
+	},
+	{
+		"value": "TN",
+		"label": "Tennessee"
+	},
+	{
+		"value": "TX",
+		"label": "Texas"
+	},
+	{
+		"value": "UT",
+		"label": "Utah"
+	},
+	{
+		"value": "VT",
+		"label": "Vermont"
+	},
+	{
+		"value": "VI",
+		"label": "Virgin Island Teritory"
+	},
+	{
+		"value": "VA",
+		"label": "Virginia"
+	},
+	{
+		"value": "WA",
+		"label": "Washington"
+	},
+	{
+		"value": "WV",
+		"label": "West Virginia"
+	},
+	{
+		"value": "WI",
+		"label": "Wisconsin"
+	},
+	{
+		"value": "WY",
+		"label": "Wyoming"
+	}
+]

--- a/app/views/components/multiselect/example-ajax.html
+++ b/app/views/components/multiselect/example-ajax.html
@@ -17,7 +17,9 @@
 
     <div class="field">
       <label for="ajax-test">Ajax Test</label>
-      <select id="ajax-test" name="ajax-test" class="multiselect" data-init="false" multiple></select>
+      <select id="ajax-test" name="ajax-test" class="multiselect" data-init="false" multiple>
+        <option selected value="FL">Florida</option>
+      </select>
     </div>
 
   </div>
@@ -68,7 +70,7 @@
 
     cachedTerm = term;
 
-    var apiRoute = '{{basepath}}api/states';
+    var apiRoute = '{{basepath}}api/states-multiselect';
     if (term && typeof term === 'string' && term.length) {
       apiRoute += '?term=' + term;
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,7 +23,7 @@
 - `[Form]` Fix broken links in the form readme file. ([#818](https://github.com/infor-design/website/issues/818))
 - `[Locale]` Fixed the es-419 date time value, as it was incorrectly using the medium length date format. ([#3830](https://github.com/infor-design/enterprise/issues/3830))
 - `[Modal]` Fixed the inconsistencies of spacing on required fields. ([#3587](https://github.com/infor-design/enterprise/issues/3587))
-- `[Multiselect]` Added ability to detect selected items from incoming data via `callSource()`. ((#2656)[https://github.com/infor-design/enterprise/issues/2656])
+- `[Multiselect]` Added ability to detect selected items from incoming data via `callSource()`. ([#2656](https://github.com/infor-design/enterprise/issues/2656))
 - `[Multiselect]` Added support to api settings to `allTextString` and `selectedTextString` for custom headers. ([#3554](https://github.com/infor-design/enterprise/issues/3554))
 - `[Pie]` Fixed an issue where rounds decimal places for percent values were not working. ([#3599](https://github.com/infor-design/enterprise/issues/3599))
 - `[Pie/Donut]` Fixed an issue where placing legend on bottom was not working for Homepage widget/Cards. ([#3560](https://github.com/infor-design/enterprise/issues/3560))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `[Form]` Fix broken links in the form readme file. ([#818](https://github.com/infor-design/website/issues/818))
 - `[Locale]` Fixed the es-419 date time value, as it was incorrectly using the medium length date format. ([#3830](https://github.com/infor-design/enterprise/issues/3830))
 - `[Modal]` Fixed the inconsistencies of spacing on required fields. ([#3587](https://github.com/infor-design/enterprise/issues/3587))
+- `[Multiselect]` Added ability to detect selected items from incoming data via `callSource()`. ((#2656)[https://github.com/infor-design/enterprise/issues/2656])
 - `[Multiselect]` Added support to api settings to `allTextString` and `selectedTextString` for custom headers. ([#3554](https://github.com/infor-design/enterprise/issues/3554))
 - `[Pie]` Fixed an issue where rounds decimal places for percent values were not working. ([#3599](https://github.com/infor-design/enterprise/issues/3599))
 - `[Pie/Donut]` Fixed an issue where placing legend on bottom was not working for Homepage widget/Cards. ([#3560](https://github.com/infor-design/enterprise/issues/3560))

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -2897,17 +2897,19 @@ Dropdown.prototype = {
           textContent = option.label;
         }
 
+        // Detect whether or not the `<option>` should be selected
         const selectedValues = self.selectedValues;
         const hasSelectedValues = selectedValues.indexOf(val) > -1;
         if (self.settings.multiple) {
           val.forEach((value) => {
             if (value === option.value) {
               option.selected = true;
-              selected = ' selected';
             }
           });
         } else if (option.value === val || hasSelectedValues) {
           option.selected = true;
+        }
+        if (option.selected) {
           selected = ' selected';
         }
 

--- a/test/components/multiselect/multiselect-api.func-spec.js
+++ b/test/components/multiselect/multiselect-api.func-spec.js
@@ -3,6 +3,7 @@ import { cleanup } from '../../helpers/func-utils';
 
 const multiSelectHTML = require('../../../app/views/components/multiselect/_samples-standard.html');
 const svg = require('../../../src/components/icons/svg.html');
+const statesMultiselectData = require('../../../app/data/states-multiselect.json');
 
 let multiSelectEl;
 let multiSelectObj;
@@ -37,5 +38,64 @@ describe('MultiSelect API', () => {
 
   it('Should enable multiselect', () => {
     multiSelectObj.enable();
+  });
+});
+
+describe('Multiselect API (ajax)', () => {
+  const multiSelectSingleItemHTML = `
+    <div class="field">
+      <label for="multi-standard" class="label">Multiselect</label>
+      <select multiple id="multi-standard" name="multi-standard" data-maxselected="10" class="multiselect">
+        <option selected value="FL">Florida</option>
+      </div>
+    </div>
+  `;
+
+  // Pulls this in directly from the demoapp's datasource.
+  // "NJ", "NY", and "PA" are all selected.
+  const source = function (response) {
+    response(statesMultiselectData);
+  };
+
+  beforeEach(() => {
+    multiSelectEl = null;
+    multiSelectObj = null;
+    document.body.insertAdjacentHTML('afterbegin', multiSelectSingleItemHTML);
+    document.body.insertAdjacentHTML('afterbegin', svg);
+    multiSelectEl = document.body.querySelector('.multiselect');
+  });
+
+  afterEach(() => {
+    multiSelectObj.destroy();
+    cleanup([
+      '.multiselect',
+      '.dropdown',
+      '.svg-icons',
+      '#dropdown-list',
+      '.field',
+      '.row',
+      'select'
+    ]);
+  });
+
+  it('can set selected items from a datasource', (done) => {
+    multiSelectObj = new MultiSelect(multiSelectEl, {
+      source
+    });
+    const predefinedOpt = multiSelectEl.querySelector('option');
+
+    // Detect the pre-defined selected option
+    expect(predefinedOpt).toBeDefined();
+    expect(predefinedOpt.value).toEqual('FL');
+    expect(multiSelectObj.dropdown.selectedValues.includes(predefinedOpt.value)).toBeTruthy();
+
+    multiSelectObj.dropdown.open();
+
+    setTimeout(() => {
+      // Should include the predefined selected value AND the selected values from the backend
+      expect(multiSelectObj.dropdown.selectedValues.length).toEqual(4);
+      expect(multiSelectObj.dropdown.selectedValues.includes(predefinedOpt.value)).toBeTruthy();
+      done();
+    }, 650);
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR makes a change to how the Dropdown/Multiselect components detect selected values from incoming JSON via a `source` setting, fixing an issue where it was not possible to set selected values from a backend.

**Related github/jira issue (required)**:
Closes #2656 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the demoapp
- Open http://localhost:4000/components/multiselect/example-ajax
- See that the Multiselect has one pre-populated value (Florida, "FL")
- Click the Multiselect to open it.
- When the list renders, see that three more states have been added to the list of selected values (NJ, NY, and PA), and the original pre-populated value is still selected (FL)
- If the "Search Caching" option on this page remains "Enabled", if you deselect any of the values that would be selected on the backend (NJ, NY, or PA), they should remain deselected when further opening/closing the list.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
