### PR TITLE
3106 - Fix tooltip gets cut off on modal

### DIFF
--- a/app/views/components/dropdown/test-truncated-text-on-modal.html
+++ b/app/views/components/dropdown/test-truncated-text-on-modal.html
@@ -1,0 +1,81 @@
+<div class="row">
+  <div class="twelve columns">
+    <button id="test-1" class="btn-secondary" type="button" data-modal="modal-1">Add Context</button>
+    <div class="modal" id="modal-1">
+      <div class="modal-content">
+
+        <div class="modal-header">
+          <h1 class="modal-title">Add Context</h1>
+        </div>
+
+        <div class="modal-body">
+
+          <div class="field">
+            <label for="context-type" class="required">Type</label>
+            <select class="dropdown" id="context-type" name="type" aria-required="true" data-validate="required">
+              <option value="">-- Select Type ---</option>
+              <option value="1">longer test option that shows a tooltip Context 01</option>
+              <option value="2">Context 02</option>
+              <option value="3">Context 03</option>
+              <option value="4">Context 04</option>
+              <option value="5">Context 05</option>
+            </select>
+          </div>
+
+          <div class="field">
+            <label for="context-name" class="required">Name</label>
+            <input type="text" id="context-name" name="context-name" aria-required="true" data-validate="required"
+              placeholder="Example: Name One">
+          </div>
+
+          <div class="field">
+            <label for="context-desc" class="required">Description</label>
+            <textarea id="context-desc" data-validate="required" name="context-desc"
+              placeholder="Example: A description goes here"></textarea>
+          </div>
+
+          <div class="field">
+            <label for="context-desc1" class="required">Description</label>
+            <textarea id="context-desc1" data-validate="required" name="context-desc1"
+              placeholder="Example: A description goes here"></textarea>
+          </div>
+
+          <div class="field">
+            <label for="context-desc2" class="required">Description</label>
+            <textarea id="context-desc2" data-validate="required" name="context-desc2"
+              placeholder="Example: A description goes here"></textarea>
+          </div>
+
+          <div class="field">
+            <label for="context-desc3" class="required">Description</label>
+            <textarea id="context-desc3" data-validate="required" name="context-desc3"
+              placeholder="Example: A description goes here"></textarea>
+          </div>
+
+          <div class="modal-buttonset">
+            <button type="button" class="btn-modal">Cancel</button>
+            <button type="button" id="submit" class="btn-modal-primary">Submit</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+
+<script>
+  var test1 = $('#test-1');
+
+  test1.on('click', function () {
+
+    $('body').modal({
+        content: $('#modal-1')
+      })
+      .on('afterclose', function () {
+        test1.focus();
+      });
+
+  });
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[Datagrid]` Fixed a bug in some themes, where the multi line cell would not be lined up correctly with a single line of data. ([#2703](https://github.com/infor-design/enterprise/issues/2703))
 - `[Datagrid]` Fixed visibility of sort icons when toggling and when the column is in active. ([#3692](https://github.com/infor-design/enterprise/issues/3692))
 - `[Datagrid]` Fixed a bug where the data passed to resultsText was incorrect in the case of reseting a filter. ([#2177](https://github.com/infor-design/enterprise/issues/2177))
+- `[Dropdown]` Fixed tooltip content gets cut off inside of modal. ([#3106](https://github.com/infor-design/enterprise/issues/3106))
 - `[Fonts]` A note that the Source Sans Pro font thats used in the new theme and served at google fonts, now have a fix for the issue that capitalized letters and numbers had different heights. You may need to release any special caching. ([#1789](https://github.com/infor-design/enterprise/issues/1789))
 - `[Form]` Fix broken links in the form readme file. ([#818](https://github.com/infor-design/website/issues/818))
 - `[Locale]` Fixed the es-419 date time value, as it was incorrectly using the medium length date format. ([#3830](https://github.com/infor-design/enterprise/issues/3830))

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -654,6 +654,17 @@ div.multiselect {
   }
 }
 
+// Fix tooltip gets overlap by another element
+.modal {
+  .dropdown-wrapper {
+    .dropdown {
+      .tooltip {
+        position: fixed;
+      }
+    }
+  }
+}
+
 .modal-engaged .dropdown-search {
   background-color: $modal-bg-color;
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The reported bugs were being fixed already. Found another one where the tooltip content gets cut off. This fix will only isolate on dropdown inside of modal.

**Related github/jira issue (required)**:
Closes
- https://github.com/infor-design/enterprise/issues/3106
- #3185

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Navigate to http://localhost:4000/components/dropdown/test-truncated-text-on-modal.html
- Click `Add Context` button
- Select the long text on dropdown
- Hover on it
- Tooltip should pop up without any problem
- Test this also on uplift theme

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
