### PR TITLE
1423 - Fix drag more than once on android or ios with swaplist

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `[Pie]` Fixed an issue where rounds decimal places for percent values were not working. ([#3599](https://github.com/infor-design/enterprise/issues/3599))
 - `[Pie/Donut]` Fixed an issue where placing legend on bottom was not working for Homepage widget/Cards. ([#3560](https://github.com/infor-design/enterprise/issues/3560))
 - `[Pager]` Reduced the space between buttons. ([#1942](https://github.com/infor-design/enterprise/issues/1942))
+- `[Swaplist]` Fixed an issue where dragging items more than once was not working on Android or iOS devices. ([#1423](https://github.com/infor-design/enterprise/issues/1423))
 - `[Tabs]` Fixed info and alert icons alignment on tabs and inside of modal. ([#2695](https://github.com/infor-design/enterprise/issues/2695))
 - `[Notification]` Fixed an issue where the icons were lagging in the animation. ([#2099](https://github.com/infor-design/enterprise/issues/2099))
 - `[Tree]` Fixed an issue where data was not in sync for children property. ([#1690](https://github.com/infor-design/enterprise/issues/1690))

--- a/src/components/swaplist/swaplist.js
+++ b/src/components/swaplist/swaplist.js
@@ -688,17 +688,37 @@ SwapList.prototype = {
       return false;
     };
 
-    for (let i = 0, l = this.selections.items.length; i < l; i++) {
-      const item = this.selections.items[i];
-      for (let dtIndex = 0, l2 = droptargetNodes.length; dtIndex < l2; dtIndex++) {
-        if ($(droptargetNodes[dtIndex]).is(item)) {
-          for (let ownerIndex = 0, l3 = ownerDataList.length; ownerIndex < l3; ownerIndex++) {
-            const ownerItem = ownerDataList[ownerIndex];
-            if (isMoved(ownerItem.node[0], item[0])) {
-              dtDataList.push(ownerItem);
-              ownerDataList.splice(ownerIndex, 1);
-              this.arrayIndexMove(dtDataList, dtDataList.length - 1, dtIndex);
-              break;
+    if (owner.is(droptarget)) {
+      const syncedList = [];
+      for (let i = 0, l = droptargetNodes.length; i < l; i++) {
+        const item = droptargetNodes[i];
+        for (let ownerIndex = 0, l2 = ownerDataList.length; ownerIndex < l2; ownerIndex++) {
+          const ownerItem = ownerDataList[ownerIndex];
+          if (isMoved(ownerItem.node[0], item)) {
+            syncedList.push(ownerItem);
+            break;
+          }
+        }
+      }
+      ownerDataList.splice(0, ownerDataList.length);
+      for (let i = 0, l = syncedList.length; i < l; i++) {
+        ownerDataList.push(syncedList[i]);
+      }
+    } else {
+      for (let i = 0, l = this.selections.items.length; i < l; i++) {
+        const item = this.selections.items[i];
+        let canLoop = true;
+        for (let dtIndex = 0, l2 = droptargetNodes.length; dtIndex < l2 && canLoop; dtIndex++) {
+          if ($(droptargetNodes[dtIndex]).is(item)) {
+            for (let ownerIndex = 0, l3 = ownerDataList.length; ownerIndex < l3; ownerIndex++) {
+              const ownerItem = ownerDataList[ownerIndex];
+              if (isMoved(ownerItem.node[0], item[0])) {
+                dtDataList.push(ownerItem);
+                ownerDataList.splice(ownerIndex, 1);
+                this.arrayIndexMove(dtDataList, dtDataList.length - 1, dtIndex);
+                canLoop = false;
+                break;
+              }
             }
           }
         }
@@ -1198,7 +1218,7 @@ SwapList.prototype = {
 
     // Dragend - implement items being validly dropped into targets
       .on(self.dragEnd, self.dragElements, (e) => {
-        if (!selections.dragged) {
+        if (!selections.dragged || !selections.droptarget) {
           return;
         }
         const related = $(selections.related).closest('li');
@@ -1212,7 +1232,8 @@ SwapList.prototype = {
           val = $(val);
           val.find('mark.highlight').contents().unwrap();
           if (currentSize && !$(selections.related).is('ul')) {
-            const isLess = (related.index() < selections.draggedIndex);
+            const isLess = (related.index() < selections.draggedIndex) &&
+              (selections.owner.is(selections.droptarget));
             const el = isLess ? val : $(selections.items[(selections.items.length - 1) - index]);
             const posinset = related.index() + (isLess ? index + 1 : index + 2);
 

--- a/src/components/swaplist/swaplist.js
+++ b/src/components/swaplist/swaplist.js
@@ -221,8 +221,8 @@ SwapList.prototype = {
     // Dragging time placeholder
     s.numOfSelectionsClass = 'num-of-selections';
     s.itemContentClass = 'swaplist-item-content';
-    s.itemContentTempl = $(`<div><p><span class="${s.numOfSelectionsClass}">###</span> ${
-      Locale ? Locale.translate('ItemsSelected') : ' Items Selected '}</p><div/>`);
+    s.itemContentTempl = $(`<div><p><span class="${s.numOfSelectionsClass}">###</span>
+      <span class="${s.numOfSelectionsClass}-text">&nbsp;</span></p><div/>`);
 
     // Make top buttons disabled if not draggable
     if (!s.draggable.available) {
@@ -1105,6 +1105,7 @@ SwapList.prototype = {
         }
 
         $(`.${settings.numOfSelectionsClass}`, settings.itemContentTempl).html(selections.items.length);
+        $(`.${settings.numOfSelectionsClass}-text`, settings.itemContentTempl).text(Locale.translate('ItemsSelected'));
         self.addDropeffects();
 
         if (!self.isTouch) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed dragging items more than once was not working on Android or iOS devices with Swaplist.

**Related github/jira issue (required)**:
Closes #1423

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Test for Android and iOS device
- Navigate to: http://localhost:4000/components/swaplist/example-index.html
- Select multiple items from one of the lists and drag them over to the next one
- Items will move
- Select moved items again and drag them back to same list
- Try again as many times, drag and drop should work fine

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
