### PR TITLE
3898 - Allow Modal Manager to close About dialogs from its Modal stack via keyboard

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### v4.29.0 Fixes
 
+- `[About]` Fixed a bug where About dialogs disappeared when being closed by the Modal Manager API. ([#3898](https://github.com/infor-design/enterprise/issues/3898))
 - `[General]` We Updated a lot of development dependencies. Most important things to note are: we now support node 12 for development and this is recommended, from tests 13 will also work. Node 14 will not work. We updated jQuery to 3.5.1 as a client side dependency and d3 to 5.16.0. If copying files from the `dist` folder note that the d3 file is called d3.v5.js. ([#1690](https://github.com/infor-design/enterprise/issues/1690))
 - `[Checkbox]` Fixed an issue where the error icon was inconsistent between subtle and vibrant themes. ([#3575](https://github.com/infor-design/enterprise/issues/3575))
 - `[Datagrid]` Fixed an issue where blank tooltip was showing when use Alert Formatter and no text. ([#2852](https://github.com/infor-design/enterprise/issues/2852))

--- a/src/components/about/about.js
+++ b/src/components/about/about.js
@@ -228,16 +228,19 @@ About.prototype = {
 
   /**
    * Teardown and remove any added markup and events.
+   * @param {boolean} [noModalDestroy=false] if true, skips the routine for destroying the modal (presumably because this is called from another method that destroys the modal manually)
    * @returns {void}
    */
-  destroy() {
+  destroy(noModalDestroy) {
     this.buttons.off();
     this.element.off('open.about');
 
-    const modalApi = this.modal.data('modal');
-    if (modalApi) {
-      modalApi.element.off('beforeopen.about');
-      modalApi.destroy();
+    if (noModalDestroy !== true) {
+      const modalApi = this.modal.data('modal');
+      if (modalApi) {
+        modalApi.element.off('beforeopen.about');
+        modalApi.destroy();
+      }
     }
 
     if (this.element.length > 0) {

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -106,6 +106,19 @@ Modal.prototype = {
 
   /**
    * @private
+   */
+  get aboutAPI() {
+    let api;
+    if (this.trigger && this.trigger.length) {
+      api = this.trigger.data('about');
+    } else if (this.mainContent && this.mainContent.length && this.mainContent.is('body')) {
+      api = this.mainContent.data('about');
+    }
+    return api;
+  },
+
+  /**
+   * @private
    * @returns {boolean} whether or not the Modal is a Contextual Action Panel (CAP)
    */
   get isCAP() {
@@ -1410,6 +1423,9 @@ Modal.prototype = {
       // Properly teardown contexual action panels
       if (self.isCAP && self.capAPI) {
         self.capAPI.destroy();
+      }
+      if (self.aboutAPI) {
+        self.aboutAPI.destroy(true);
       }
 
       // If a buttonset exists, remove events and destroy completely.

--- a/test/components/about/about.e2e-spec.js
+++ b/test/components/about/about.e2e-spec.js
@@ -34,6 +34,29 @@ describe('About index tests', () => {
       expect(await browser.imageComparison.checkElement(searchfieldSection, 'about-open')).toEqual(0);
     });
   }
+
+  it('should destroy and reinvoke properly', async () => {
+    // Open the About dialog
+    await element(by.id('about-trigger')).click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('about-modal'))), config.waitsFor);
+
+    expect(await element(by.id('about-modal')).isDisplayed()).toBeTruthy();
+
+    // Press the ESCAPE key to close the About Dialog (via modal manager)
+    await browser.driver.actions().sendKeys(protractor.Key.ESCAPE).perform();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.invisibilityOf(await element(by.id('about-modal'))), config.waitsFor);
+
+    expect(await element(by.id('about-modal')).isDisplayed()).toBeFalsy();
+
+    // Reopen the About Dialog (creates a new instance)
+    await element(by.id('about-trigger')).click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('about-modal'))), config.waitsFor);
+
+    expect(await element(by.id('about-modal')).isDisplayed()).toBeTruthy();
+  });
 });
 
 describe('About translation tests', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a regression that was preventing About dialogs from being closed properly via keyboard, creating a situation where they couldn't be displayed more than once.

**Related github/jira issue (required)**:
Closes #3898

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the demoapp
- Open http://localhost:4000/components/about/example-index.html
- Click the "Show About Screen" button.  The About dialog should appear.
- Press the Escape key.  This closes the About dialog using the Modal Manager stack and its events.
- Click the "Show About Screen" button again.  The About dialog should be displayed with no console errors.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

----
@SofiK