### PR TITLE
2831 - Allow Application Menus to be closed when their inner toolbar buttons are clicked

### DIFF
--- a/app/views/includes/applicationmenu-personalized-role-switcher.html
+++ b/app/views/includes/applicationmenu-personalized-role-switcher.html
@@ -42,31 +42,31 @@
       <div class="application-menu-toolbar">
         <div class="flex-toolbar">
           <div class="toolbar-section buttonset">
-            <button class="btn-icon" title="Download My Profile">
+            <button id="toolbar-btn-download" class="btn-icon" title="Download My Profile">
               <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
                 <use href="#icon-download"></use>
               </svg>
               <span class="audible">Download</span>
             </button>
-            <button class="btn-icon" title="Print My Profile">
+            <button id="toolbar-btn-print" class="btn-icon" title="Print My Profile">
               <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
                 <use href="#icon-print"></use>
               </svg>
               <span class="audible">Print</span>
             </button>
-            <button class="btn-icon" title="Show Purchasing Info">
+            <button id="toolbar-btn-purchasing" class="btn-icon" title="Show Purchasing Info">
               <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
                 <use href="#icon-purchasing"></use>
               </svg>
               <span class="audible">Purchasing</span>
             </button>
-            <button class="btn-icon" title="Show Notification Info">
+            <button id="toolbar-btn-notification" class="btn-icon" title="Show Notification Info">
               <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
                 <use href="#icon-notification"></use>
               </svg>
               <span class="audible">Notification</span>
             </button>
-            <button class="btn-icon" title="Show Inventory Info">
+            <button id="toolbar-btn-inventory" class="btn-icon" title="Show Inventory Info">
               <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
                 <use href="#icon-inventory"></use>
               </svg>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### v4.29.0 Fixes
 
 - `[General]` We Updated a lot of development dependencies. Most important things to note are: we now support node 12 for development and this is recommended, from tests 13 will also work. Node 14 will not work. We updated jQuery to 3.5.1 as a client side dependency and d3 to 5.16.0. If copying files from the `dist` folder note that the d3 file is called d3.v5.js. ([#1690](https://github.com/infor-design/enterprise/issues/1690))
+- `[Application Menu]` - Made it possible for App Menu Toolbars to dismiss the menu when the `dismissOnClickMobile` setting is true. ([#2831](https://github.com/infor-design/enterprise/issues/2831))
 - `[Checkbox]` Fixed an issue where the error icon was inconsistent between subtle and vibrant themes. ([#3575](https://github.com/infor-design/enterprise/issues/3575))
 - `[Datagrid]` Fixed an issue where blank tooltip was showing when use Alert Formatter and no text. ([#2852](https://github.com/infor-design/enterprise/issues/2852))
 - `[Datagrid]` Fixed an issue where keyword search results were breaking the html markup for icons and badges. ([#3855](https://github.com/infor-design/enterprise/issues/3855))

--- a/src/components/applicationmenu/applicationmenu.js
+++ b/src/components/applicationmenu/applicationmenu.js
@@ -707,6 +707,8 @@ ApplicationMenu.prototype = {
       'aftercollapse.applicationmenu'
     ].join(' '));
 
+    this.element.find('.application-menu-toolbar').off(`click.${COMPONENT_NAME}`);
+
     if (this.accordionAPI && typeof this.accordionAPI.destroy === 'function') {
       if (this.isFiltered) {
         this.accordionAPI.collapse();
@@ -852,6 +854,15 @@ ApplicationMenu.prototype = {
         delete this.keyboardChangedFocus;
       });
     }
+
+    // If application menu toolbars exist, clicking buttons on the toolbars
+    // should cause the menu to close in some conditions.
+    this.element.find('.application-menu-toolbar').on(`click.${COMPONENT_NAME}`, 'button', (e) => {
+      if (e.defaultPrevented) {
+        return;
+      }
+      this.handleDismissOnClick();
+    });
 
     $(document).on('open-applicationmenu', () => {
       self.openMenu(undefined, true);

--- a/test/components/applicationmenu/applicationmenu.e2e-spec.js
+++ b/test/components/applicationmenu/applicationmenu.e2e-spec.js
@@ -230,6 +230,27 @@ describe('Application Menu personalize roles switcher tests', () => {
     expect(await element(by.id('application-menu')).getAttribute('class')).not.toContain('is-open');
     await browser.driver.manage().window().setSize(windowSize.width, windowSize.height);
   });
+
+  it('should dismiss the appliction menu when clicking on one of the menu\'s toolbar buttons', async () => {
+    // NOTE: This only happens on mobile, and when `AppliationMenu.settings.dismissOnClickMobile: true;`
+    const windowSize = await browser.driver.manage().window().getSize();
+
+    // Simulate iPhone X device size.
+    // Shrinking the screen causes the menu to be dismissed.
+    await browser.driver.manage().window().setSize(375, 812);
+    await browser.driver.sleep(config.sleep);
+
+    // Reactivate App Menu
+    await element(by.css('#hamburger-button')).click();
+    await browser.driver.sleep(config.sleep);
+
+    // Click the first button in the Application Menu toolbar
+    await element(by.css('#toolbar-btn-download')).click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.id('application-menu')).getAttribute('class')).not.toContain('is-open');
+    await browser.driver.manage().window().setSize(windowSize.width, windowSize.height);
+  });
 });
 
 describe('Application Menu role switcher tests', () => {

--- a/test/components/applicationmenu/applicationmenu.e2e-spec.js
+++ b/test/components/applicationmenu/applicationmenu.e2e-spec.js
@@ -211,7 +211,7 @@ describe('Application Menu personalize roles switcher tests', () => {
   }
 
   it('should dismiss the application menu when clicking on a popupmenu trigger', async () => {
-    // NOTE: This only happens on mobile, and when `AppliationMenu.settings.dismissOnClickMobile: true;`
+    // NOTE: This only happens on mobile, and when `ApplicationMenu.settings.dismissOnClickMobile: true;`
     const windowSize = await browser.driver.manage().window().getSize();
 
     // Simulate iPhone X device size.
@@ -232,7 +232,7 @@ describe('Application Menu personalize roles switcher tests', () => {
   });
 
   it('should dismiss the appliction menu when clicking on one of the menu\'s toolbar buttons', async () => {
-    // NOTE: This only happens on mobile, and when `AppliationMenu.settings.dismissOnClickMobile: true;`
+    // NOTE: This only happens on mobile, and when `ApplicationMenu.settings.dismissOnClickMobile: true;`
     const windowSize = await browser.driver.manage().window().getSize();
 
     // Simulate iPhone X device size.

--- a/test/components/applicationmenu/applicationmenu.e2e-spec.js
+++ b/test/components/applicationmenu/applicationmenu.e2e-spec.js
@@ -231,22 +231,22 @@ describe('Application Menu personalize roles switcher tests', () => {
     await browser.driver.manage().window().setSize(windowSize.width, windowSize.height);
   });
 
-  it('should dismiss the appliction menu when clicking on one of the menu\'s toolbar buttons', async () => {
+  fit('should dismiss the application menu when clicking on one of the menu\'s toolbar buttons', async () => {
     // NOTE: This only happens on mobile, and when `ApplicationMenu.settings.dismissOnClickMobile: true;`
     const windowSize = await browser.driver.manage().window().getSize();
 
     // Simulate iPhone X device size.
     // Shrinking the screen causes the menu to be dismissed.
     await browser.driver.manage().window().setSize(375, 812);
-    await browser.driver.sleep(config.sleep);
+    await browser.driver.sleep(config.sleepLonger);
 
     // Reactivate App Menu
     await element(by.css('#hamburger-button')).click();
-    await browser.driver.sleep(config.sleep);
+    await browser.driver.sleep(config.sleepLonger);
 
     // Click the first button in the Application Menu toolbar
     await element(by.css('#toolbar-btn-download')).click();
-    await browser.driver.sleep(config.sleep);
+    await browser.driver.sleep(config.sleepLonger);
 
     expect(await element(by.id('application-menu')).getAttribute('class')).not.toContain('is-open');
     await browser.driver.manage().window().setSize(windowSize.width, windowSize.height);

--- a/test/components/applicationmenu/applicationmenu.e2e-spec.js
+++ b/test/components/applicationmenu/applicationmenu.e2e-spec.js
@@ -231,7 +231,7 @@ describe('Application Menu personalize roles switcher tests', () => {
     await browser.driver.manage().window().setSize(windowSize.width, windowSize.height);
   });
 
-  fit('should dismiss the application menu when clicking on one of the menu\'s toolbar buttons', async () => {
+  it('should dismiss the application menu when clicking on one of the menu\'s toolbar buttons', async () => {
     // NOTE: This only happens on mobile, and when `ApplicationMenu.settings.dismissOnClickMobile: true;`
     const windowSize = await browser.driver.manage().window().getSize();
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes an issue in Application Menus where clicking an App Menu Toolbar button on a menu configured with `dismissOnClickMobile` would not properly dismiss the application menu.  

**Related github/jira issue (required)**:
Closes #2831

**Steps necessary to review your pull request (required)**:
- Go to http://localhost:4000/components/applicationmenu/example-personalized-role-switcher.html
- Open Developer Tools - Toggle Device toolbar to iPhone
- Open the Application Menu
- Click on the any of the application menu's toolbar button, it should dismiss the menu.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

----
@vonnyw 