### PR TITLE
1423 - Update handle on touch devices with swaplist

### DIFF
--- a/src/components/swaplist/swaplist.js
+++ b/src/components/swaplist/swaplist.js
@@ -438,8 +438,8 @@ SwapList.prototype = {
     if (this.isDragAndDropSupports) {
       // Use Handle if available
       this.handle = ul.first().attr('data-swap-handle');
-      this.handle = $(this.handle, ul).length > 0 ? this.handle : null;
-      // this.handle = (!this.isTouch && $(this.handle, ul).length > 0) ? this.handle : null;
+      // this.handle = $(this.handle, ul).length > 0 ? this.handle : null;
+      this.handle = (!this.isTouch && $(this.handle, ul).length > 0) ? this.handle : null;
       $(this.handle, ul).addClass('draggable')
         .off('mousedown.swaplist touchstart.swaplist')
         .on('mousedown.swaplist touchstart.swaplist', () => {

--- a/src/components/swaplist/swaplist.js
+++ b/src/components/swaplist/swaplist.js
@@ -438,7 +438,6 @@ SwapList.prototype = {
     if (this.isDragAndDropSupports) {
       // Use Handle if available
       this.handle = ul.first().attr('data-swap-handle');
-      // this.handle = $(this.handle, ul).length > 0 ? this.handle : null;
       this.handle = (!this.isTouch && $(this.handle, ul).length > 0) ? this.handle : null;
       $(this.handle, ul).addClass('draggable')
         .off('mousedown.swaplist touchstart.swaplist')


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Updated to use whole `LI` item instead of tree dot icon `handle` on touch devices with swaplist

**Related github/jira issue (required)**:
1423

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Use iOS device
- Navigate to: http://localhost:4000/components/swaplist/example-index.html
- Select multiple items from one of the lists
- Use whole LI item and drag them over to the next one
- Items will move
- Select moved items again and drag them back to same list
- Try again as many times, drag and drop should work fine
