### PR TITLE
Broken contributing.md link and personalize readme typo fix

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -67,7 +67,7 @@ If you'd like to submit a pull request you'll need to do the following:
     - Occasionally there will be a need to contribute to a version branch (i.e. `4.9.x`) in which case you want to branch off of one of those.
     - If you are unsure, just ask someone on the team so you don't have to redo your branch.
 1. Remember to make an **e2e or functional test** for your case.
-1. Remember to add a **note to the [Change Log](docs/CHANGELOG.md)**.
+1. Remember to add a **note to the [Change Log](CHANGELOG.md)**.
 1. **Commit your changes locally.**  Try to follow the standards for your commit message outlined below.
     - Try to follow
         - [Github's commit message standards](https://github.com/erlang/otp/wiki/Writing-good-commit-messagesMore)

--- a/src/components/personalize/readme.md
+++ b/src/components/personalize/readme.md
@@ -25,7 +25,7 @@ The Vibrant Dark and Vibrant Contrast are still considered beta at this time as 
 To use each theme you need to:
 
 1. Import the correct style stylesheet which would be one of `theme-soho-contrast.css`, `theme-soho-dark.css`, `theme-soho-light.css`, `theme-uplift-contrast.css`, `theme-uplift-dark.css`, `theme-uplift-light.css` . The files `light-theme.css`, `high-contrast-theme.css` and `dark-theme.css` are there for backwards compatibility and will later be removed. We will later rename these to the new names Subtle and Vibrant.
-2. Add the correct SVG Block Element to the top of the page document (`theme-uplift-svg.html` or `theme-uplift-svg.html`). The file `svg.html` is there for backwards compatibility and will later be removed.
+2. Add the correct SVG Block Element to the top of the page document (`theme-soho-svg.html` or `theme-uplift-svg.html`). The file `svg.html` is there for backwards compatibility and will later be removed.
 
 It's also possible to get information about the themes from the theme api For info on that see the [theme api]( ./theme)
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fix broken change log link in CONTRIBUTING.md and correct typo in the personalize readme

**Steps necessary to review your pull request (required)**:
Click the "Change Log" link on enterprise/blob/master/docs/CONTRIBUTING.md and ensure it goes to the change log

Verify that step 2 in the themes section of personalize/readme.md says `theme-soho-svg.html` or `theme-uplift-svg.html` (it has uplift listed twice)


<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
