### PR TITLE
3629 - Fix keyword search with datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[Datagrid]` Fixed an issue where blank tooltip was showing when use Alert Formatter and no text. ([#2852](https://github.com/infor-design/enterprise/issues/2852))
 - `[Datagrid]` Fixed an issue where keyword search results were breaking the html markup for icons and badges. ([#3855](https://github.com/infor-design/enterprise/issues/3855))
 - `[Datagrid]` Fixed an issue where keyword search results were breaking the html markup for hyperlink. ([#3731](https://github.com/infor-design/enterprise/issues/3731))
+- `[Datagrid]` Fixed an issue where keyword search results were not showing for paging, if searched from other than 1st page it came blank table. ([#3629](https://github.com/infor-design/enterprise/issues/3629))
 - `[Datagrid]` Fixed an issue where contents filtertype was not working on example page. ([#2887](https://github.com/infor-design/enterprise/issues/2887))
 - `[Datagrid]` Fixed a bug in some themes, where the multi line cell would not be lined up correctly with a single line of data. ([#2703](https://github.com/infor-design/enterprise/issues/2703))
 - `[Datagrid]` Fixed visibility of sort icons when toggling and when the column is in active. ([#3692](https://github.com/infor-design/enterprise/issues/3692))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -6698,7 +6698,7 @@ Datagrid.prototype = {
     this.filterKeywordSearch();
     this.clearCache();
     this.renderRows();
-    this.setSearchActivePage({ trigger: 'searched' });
+    this.setSearchActivePage({ trigger: 'searched', type: 'filtered' });
 
     if (!(this.settings.paging && this.settings.source)) {
       this.highlightSearchRows(term);

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -6842,7 +6842,7 @@ Datagrid.prototype = {
             [].slice.call(cell.querySelectorAll('*')).forEach((node) => {
               [].slice.call(node.childNodes).forEach((childNode) => {
                 const parent = childNode.parentElement;
-                if (childNode.nodeType === 3 &&
+                if (childNode.nodeType === 3 && parent.tagName.toLowerCase() !== 'i' &&
                   xssUtils.unescapeHTML(parent.innerHTML) === childNode.textContent) {
                   const contents = childNode.textContent;
                   const exp = new RegExp(`(${stringUtils.escapeRegExp(term)})`, 'gi');

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -1930,6 +1930,7 @@ describe('Datagrid editor dropdown source tests', () => {
     const datagridEl = await element(by.css('#datagrid tbody tr:nth-child(1)'));
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+    await browser.driver.sleep(config.sleep);
   });
 
   it('Should datagrid exists', async () => {
@@ -3392,6 +3393,7 @@ describe('Datagrid save user settings', () => {
     const datagridEl = await element(by.css('#datagrid tbody tr:nth-child(4)'));
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+    await browser.driver.sleep(config.sleep);
   });
 
   afterEach(async () => {
@@ -4145,6 +4147,7 @@ describe('Datagrid hide pager on one page tests', () => {
     const datagridEl = await element(by.css('#datagrid .datagrid-wrapper tbody tr:nth-child(4)'));
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+    await browser.driver.sleep(config.sleep);
   });
 
   it('Should not have errors', async () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed keyword search results were not showing for paging, if searched from other than 1st page it came blank table with Datagrid.

**Related github/jira issue (required)**:
Closes #3629

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/example-paging-client-side.html
- Click `Next Page` icon button to go to next page
- Type `Compressor 0` in the keyword input box
- Press `Enter` to search
- Grid should show one result

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
