### PR TITLE
3759 - Add an additional fix for max stack size errors

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Datagrid]` Fixed a bug in some themes, where the multi line cell would not be lined up correctly with a single line of data. ([#2703](https://github.com/infor-design/enterprise/issues/2703))
 - `[Datagrid]` Fixed visibility of sort icons when toggling and when the column is in active. ([#3692](https://github.com/infor-design/enterprise/issues/3692))
 - `[Datagrid]` Fixed a bug where the data passed to resultsText was incorrect in the case of reseting a filter. ([#2177](https://github.com/infor-design/enterprise/issues/2177))
+- `[Datagrid/General]` Fixed an additional bug where when loading the datagrid with a columns object that contain recursive objects the grid would crash in saveColumns. [3759](https://github.com/infor-design/enterprise/issues/3759))
 - `[Dropdown]` Fixed tooltip content gets cut off inside of modal. ([#3106](https://github.com/infor-design/enterprise/issues/3106))
 - `[Fonts]` A note that the Source Sans Pro font thats used in the new theme and served at google fonts, now have a fix for the issue that capitalized letters and numbers had different heights. You may need to release any special caching. ([#1789](https://github.com/infor-design/enterprise/issues/1789))
 - `[Form]` Fix broken links in the form readme file. ([#818](https://github.com/infor-design/website/issues/818))

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1203,30 +1203,7 @@ utils.getScrollbarWidth = function () {
  * @returns {array|object} The copied array or object.
  */
 utils.deepCopy = function (arrayOrObject) {
-  const references = new Map();
-  const copy = (input) => {
-    if (typeof input !== 'object' || input === null) {
-      return input; // Return the value if input is not an object
-    }
-
-    // If an object has already been cloned then return a
-    // reference to that clone to avoid an infinite loop
-    if (references.has(input) === true) {
-      return references.get(input);
-    }
-
-    // Create an array or object to hold the values
-    const output = Array.isArray(input) ? [] : {};
-    references.set(arrayOrObject, input);
-
-    Object.keys(input).forEach((key) => {
-      const value = input[key];
-      // Recursively (deep) copy for nested objects, including arrays
-      output[key] = (typeof value === 'object' && value !== null) ? copy(value) : value;
-    });
-    return output;
-  };
-  return copy(arrayOrObject);
+  return utils.extend(true, {}, arrayOrObject);
 };
 
 /**

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -712,7 +712,6 @@ utils.extend = function extend() {
 
   // Merge the object into the extended object
   const merge = function (obj) {
-    const emptyObj = Array.isArray(obj) ? [] : {};
     for (let prop in obj) { //eslint-disable-line
       if (obj.hasOwnProperty(prop)) { //eslint-disable-line
         // If property is an object, merge properties - in several ways
@@ -720,8 +719,10 @@ utils.extend = function extend() {
           // Needed for now until jQuery is fully dropped
           extended[prop] = $(obj[prop]);
         } else if (deep && Object.prototype.toString.call(obj[prop]) === '[object Object]') {
-          const isPlain = utils.isPlainObject(obj[prop]);
-          extended[prop] = isPlain ? extend(true, emptyObj, extended[prop], obj[prop]) : obj[prop];
+          const newObj = obj[prop];
+          const isPlain = utils.isPlainObject(newObj);
+          const emptyObj = Array.isArray(newObj) ? [] : {};
+          extended[prop] = isPlain ? extend(true, emptyObj, extended[prop], newObj) : newObj;
         } else {
           if (Array.isArray(obj[prop])) { //eslint-disable-line
             extended[prop] = utils.mergeByPosition(extended[prop], obj[prop]);
@@ -1203,7 +1204,7 @@ utils.getScrollbarWidth = function () {
  * @returns {array|object} The copied array or object.
  */
 utils.deepCopy = function (arrayOrObject) {
-  return utils.extend(true, {}, arrayOrObject);
+  return utils.extend(true, Array.isArray(arrayOrObject) ? [] : {}, arrayOrObject);
 };
 
 /**

--- a/test/components/utils/extend.func-spec.js
+++ b/test/components/utils/extend.func-spec.js
@@ -120,4 +120,11 @@ describe('Extend Tests', () => {
 
     expect(newObj2.test).toEqual(1);
   });
+
+  it('can extend arrays of objects', () => {
+    const newArray1 = utils.extend(true, [], [{ test1: '1', test2: '1' }, { test1: '2', test2: '2' }]);
+
+    expect(newArray1[0]).toEqual({ test1: '1', test2: '1' });
+    expect(newArray1[1]).toEqual({ test1: '2', test2: '2' });
+  });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Sunsystems data contains recursive objects. This was fixed on 3759 but we found an additional bug when saveColumns is used the deepCopy is still blowing up. To fix this refactored deepCopy to use the new enhanced extend function

**Related github/jira issue (required)**:
Fixes #3759 

**Steps necessary to review your pull request (required)**:
- smoke test datagrid this may effect save columns.
- retest http://localhost:4000/components/datagrid/test-save-settings-manual.html
- retest http://localhost:4000/components/datagrid/test-save-settings.html
- on those two try hiding and resizing columns and reloading the page - it should persist all that

**Included in this Pull Request**:
- [x] A note to the change log.

@nbeare-infor cc @rvaja-infor