### PR TITLE
3922 - Make datagrid empty buttons clickable

### DIFF
--- a/app/views/components/datagrid/test-empty-message-button.html
+++ b/app/views/components/datagrid/test-empty-message-button.html
@@ -1,0 +1,47 @@
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid" class="datagrid">
+    </div>
+  </div>
+</div>
+
+<script id="datagrid-script">
+$('body').one('initialized', function () {
+  $.getJSON('{{basepath}}api/datagrid-sample-data', function(res) {
+
+    // Define Columns for the Grid.
+    var columns = [];
+    columns.push({ id: 'productId', hideable: false, name: 'Id', field: 'productId', formatter: Formatters.Text, width: 100});
+    columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink, width: 300, minWidth: 100});
+    columns.push({ id: 'activity', name: 'Activity', field: 'activity'});
+    columns.push({ id: 'hidden', hidden: true, name: 'Hidden', field: 'hidden'});
+    columns.push({ id: 'price', align: 'right', name: 'Actual Price', field: 'price', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'currency', currencySign: '$'}});
+    columns.push({ id: 'percent', align: 'right', name: 'Actual %', field: 'percent', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'percent'}});
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+    columns.push({ id: 'phone', name: 'Phone', field: 'phone', formatter: Formatters.Text});
+
+    // Init and get the api for the grid
+    var emptyMessage = {
+      title: 'No Data Available',
+      icon: 'icon-empty-no-data',
+      color: 'graphite',
+      button: {
+        text: 'Retry',
+        id: 'reload',
+        click: function() {
+          $('body').toast({
+            title: 'Retry button clicked',
+            message: 'Do a reload action'
+          });
+        }}
+    };
+
+    $('#datagrid').datagrid({
+      columns: columns,
+      saveColumns: false,
+      emptyMessage: emptyMessage,
+      toolbar: {title: 'Compressors', results: true, actions: true, rowHeight: true, personalize: true}
+    });
+  });
+});
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Application Menu]` - Made it possible for App Menu Toolbars to dismiss the menu when the `dismissOnClickMobile` setting is true. ([#2831](https://github.com/infor-design/enterprise/issues/2831))
 - `[Checkbox]` Fixed an issue where the error icon was inconsistent between subtle and vibrant themes. ([#3575](https://github.com/infor-design/enterprise/issues/3575))
 - `[Datagrid]` Fixed an issue where blank tooltip was showing when use Alert Formatter and no text. ([#2852](https://github.com/infor-design/enterprise/issues/2852))
+- `[Datagrid]` Fixed a bug where the datagrid had blocked the clicking of buttons in an empty message area. ([#3922](https://github.com/infor-design/enterprise/issues/3922))
 - `[Datagrid]` Fixed an issue where keyword search results were breaking the html markup for icons and badges. ([#3855](https://github.com/infor-design/enterprise/issues/3855))
 - `[Datagrid]` Fixed an issue where keyword search results were breaking the html markup for hyperlink. ([#3731](https://github.com/infor-design/enterprise/issues/3731))
 - `[Datagrid]` Fixed an issue where keyword search results were not showing for paging, if searched from other than 1st page it came blank table. ([#3629](https://github.com/infor-design/enterprise/issues/3629))

--- a/src/components/emptymessage/_emptymessage.scss
+++ b/src/components/emptymessage/_emptymessage.scss
@@ -64,6 +64,10 @@
     top: calc(50% + 20px);
     transform: translate(0, -50%);
     width: inherit;
+
+    button {
+      pointer-events: initial;
+    }
   }
 }
 

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -2150,6 +2150,23 @@ describe('Datagrid Empty Message Tests After Load', () => {
   }
 });
 
+describe('Datagrid Empty Message Button', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/test-empty-message-button?layout=nofrills');
+
+    const button = await element(by.id('reload'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(button), config.waitsFor);
+  });
+
+  it('Should be able to click the relaod button', async () => {
+    await element(by.id('reload')).click();
+    await browser.driver.sleep(config.sleepShort);
+
+    expect(await element(by.css('.toast .toast-title')).getText()).toEqual('Retry button clicked');
+  });
+});
+
 describe('Datagrid Empty Message with two rows', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-empty-message-two-rows?layout=nofrills');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Datagrid empty message areas have a feature to add buttons. But the pointer events were turned off so this did not work. This fixes the issue.

**Related github/jira issue (required)**:
Fixes #3922

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-empty-message-button
- click the button and you should get a toast
- also test http://localhost:4000/components/datagrid/test-empty-card.html
- make sure you can still scroll the container

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
