### PR TITLE
3909 - Fix spinbox validation

### DIFF
--- a/app/views/components/spinbox/example-range-limits.html
+++ b/app/views/components/spinbox/example-range-limits.html
@@ -6,5 +6,10 @@
       <input id="limited-spinbox" name="limited-spinbox" type="text" class="spinbox" min="-5" max="10" value="0" />
     </div>
 
+    <div class="field">
+      <label for="limited-spinbox-2">Spinbox (init 150, min 100, max 200)</label>
+      <input id="limited-spinbox-2" name="limited-spinbox-2" type="text" class="spinbox"  data-options="{min: 100, max: 200}" value="150" />
+    </div>
+
   </div>
 </div>

--- a/app/views/components/spinbox/example-range-limits.html
+++ b/app/views/components/spinbox/example-range-limits.html
@@ -8,7 +8,7 @@
 
     <div class="field">
       <label for="limited-spinbox-2">Spinbox (init 150, min 100, max 200)</label>
-      <input id="limited-spinbox-2" name="limited-spinbox-2" type="text" class="spinbox"  data-options="{min: 100, max: 200}" value="150" />
+      <input id="limited-spinbox-2" name="limited-spinbox-2" type="text" class="spinbox"  data-options="{min: 100, max: 200}" />
     </div>
 
   </div>

--- a/app/views/components/tree/test-update-node-with-children.html
+++ b/app/views/components/tree/test-update-node-with-children.html
@@ -1,13 +1,13 @@
 <div class="row top-padding">
   <div class="twelve columns">
     <button type="button" id="btn-update-node" class="btn-secondary">updateNode()</button>
+    <button type="button" id="btn-empty-node" class="btn-secondary">emptyNode()</button>
     <button type="button" id="btn-remove-node" class="btn-secondary">removeNode()</button>
   </div>
 </div>
 
 <div class="row top-padding">
   <div class="twelve columns">
-
     <ul id="tree" class="tree" role="tree" aria-label="Asset Types" data-init="false">
       <li><a href="#" id="home">Home</a></li>
       <li><a href="#" id="about">About Us</a></li>
@@ -32,7 +32,7 @@
   var tree = $('#tree').tree().data('tree');
 
   // Update node
-  $('#btn-update-node').one('click', function () {
+  $('#btn-update-node').on('click', function () {
     tree.updateNode({
       id: 'leadership',
       text: 'Just Updated',
@@ -53,11 +53,21 @@
   });
 
   // Remove node
-  $('#btn-remove-node').one('click', function () {
+  $('#btn-remove-node').on('click', function () {
     var toRemoveId = tree.findById('line-mgr') ? 'line-mgr' : 'new2';
     tree.removeNode({id: toRemoveId});
     $(this).disable(); // let it trigger onetime only
     console.log('Node Removed');
   });
+
+  // Revert to Root Node
+   $('#btn-empty-node').on('click', function () {
+      tree.updateNode({
+        id: 'leadership',
+        text: 'Leadership',
+        icon: 'icon-tree-node',
+        children: []
+      });
+   });
 
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,7 @@
 - `[Notification]` Fixed an issue where the icons were lagging in the animation. ([#2099](https://github.com/infor-design/enterprise/issues/2099))
 - `[Tree]` Fixed an issue where data was not in sync for children property. ([#1690](https://github.com/infor-design/enterprise/issues/1690))
 - `[Splitter]` Fixed an issue the drag handle characters render incorrectly. ([#1458](https://github.com/infor-design/enterprise/issues/1458))
+- `[Spinbox]` Fixed an issue where a two or more digit min value would make it difficult to type in the spinbox. To fix this the values will only be validated on blur by default. ([#3909](https://github.com/infor-design/enterprise/issues/3909))
 - `[Swaplist]` Fixed an issue where dragging items more than once was not working on Android or iOS devices. ([#1423](https://github.com/infor-design/enterprise/issues/1423))
 
 ## v4.28.0

--- a/src/components/spinbox/readme.md
+++ b/src/components/spinbox/readme.md
@@ -20,11 +20,11 @@ demo:
 
 ## Behavior Guidelines
 
-Using the arrows, the user can move through the range of values. Depending on the exact use case, users can also type one of the supported values directly in the field.
+Using the up and down arrow keys, the user can move through the range of values. Depending on the exact settings, users can also type one of the supported values directly in the field.
 
 ## Code Example
 
-A spinbox is created from a standard `type="text"` `<input>` field by adding `class="spinbox"`. The initializer will initialize this control using the following attributes:
+A spinbox is created from a standard `type="text"` `<input>` field by adding `class="spinbox"`. The `type="number"` input can not be used as the browser will take over controlling the field if you use this. The initializer will initialize this control using the following attributes:
 
 - `min` - Determines the lowest value this can be set to
 - `max` - Determines the highest value this can be set to
@@ -39,14 +39,6 @@ Touch and mobile keyboard are supported.
   <input id="stepped-spinbox" name="stepped-spinbox" type="text" class="spinbox" min="-99" max="99" value="0" step="3"/>
 </div>
 ```
-
-## Implementation Tips
-
-- Localization for right to left languages may wish to reverse the left and right arrows.
-
-## Accessibility
-
-- Focus should remain on the edit field
 
 ## Testability
 
@@ -66,7 +58,7 @@ The spinbox takes the same states as any trigger field. See the Text Box for mor
 
 ## Responsive Guidelines
 
-- Its size is always less than mobile (150px) small size. From guidelines apply
+- Its size is always less than mobile (150px) small size. General form guidelines apply.
 
 ## Upgrading from 3.X
 

--- a/test/components/spinbox/spinbox-settings.func-spec.js
+++ b/test/components/spinbox/spinbox-settings.func-spec.js
@@ -32,11 +32,11 @@ describe('Spinbox settings', () => {
     spinboxEl.removeAttribute('data-options');
     spinboxApi.destroy();
     const settings = {
-      autocorrectOnBlur: false,
+      autocorrectOnBlur: true,
       min: 0,
       max: 10,
       step: null,
-      validateOnInput: true
+      maskOptions: null
     };
 
     settings.min = 0; // example initializes with data-options
@@ -47,11 +47,11 @@ describe('Spinbox settings', () => {
 
   it('Should update set settings via data', () => {
     const settings = {
-      autocorrectOnBlur: false,
+      autocorrectOnBlur: true,
       min: 10,
       max: 20,
       step: null,
-      validateOnInput: true
+      maskOptions: null
     };
 
     spinboxApi.updated();
@@ -63,11 +63,11 @@ describe('Spinbox settings', () => {
 
   it('Should update set settings via parameter', () => {
     const settings = {
-      autocorrectOnBlur: false,
+      autocorrectOnBlur: true,
       min: 10,
       max: 20,
       step: null,
-      validateOnInput: true
+      maskOptions: null
     };
     spinboxApi.updated(settings);
     spinboxApi.settings.min = 10;
@@ -78,11 +78,11 @@ describe('Spinbox settings', () => {
 
   it('Should update settings via data-options', () => {
     const settings = {
-      autocorrectOnBlur: false,
+      autocorrectOnBlur: true,
       min: 0,
       max: 10,
       step: null,
-      validateOnInput: true
+      maskOptions: null
     };
 
     expect(spinboxApi.settings).toEqual(settings);

--- a/test/components/spinbox/spinbox.e2e-spec.js
+++ b/test/components/spinbox/spinbox.e2e-spec.js
@@ -53,3 +53,20 @@ describe('Spinbox example-index tests', () => {
     expect(await spinboxEl.getAttribute('value')).toEqual('1');
   });
 });
+
+describe('Spinbox Range Tests tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/spinbox/example-range-limits');
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.id('limited-spinbox-2'))), config.waitsFor);
+  });
+
+  it('Should be able to type in range 100 to 200', async () => {
+    await element(by.id('limited-spinbox-2')).clear();
+    await element(by.id('limited-spinbox-2')).sendKeys('111');
+    await element(by.id('limited-spinbox-2')).sendKeys(protractor.Key.TAB);
+    await browser.driver.sleep(config.sleepShort);
+
+    expect(await element(by.id('limited-spinbox-2')).getAttribute('value')).toEqual('111');
+  });
+});

--- a/test/components/spinbox/spinbox.e2e-spec.js
+++ b/test/components/spinbox/spinbox.e2e-spec.js
@@ -69,4 +69,22 @@ describe('Spinbox Range Tests tests', () => {
 
     expect(await element(by.id('limited-spinbox-2')).getAttribute('value')).toEqual('111');
   });
+
+  it('Should be able to correct down', async () => {
+    await element(by.id('limited-spinbox-2')).clear();
+    await element(by.id('limited-spinbox-2')).sendKeys('50');
+    await element(by.id('limited-spinbox-2')).sendKeys(protractor.Key.TAB);
+    await browser.driver.sleep(config.sleepShort);
+
+    expect(await element(by.id('limited-spinbox-2')).getAttribute('value')).toEqual('100');
+  });
+
+  it('Should be able to correct up', async () => {
+    await element(by.id('limited-spinbox-2')).clear();
+    await element(by.id('limited-spinbox-2')).sendKeys('250');
+    await element(by.id('limited-spinbox-2')).sendKeys(protractor.Key.TAB);
+    await browser.driver.sleep(config.sleepShort);
+
+    expect(await element(by.id('limited-spinbox-2')).getAttribute('value')).toEqual('200');
+  });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

If the min value in spinbox is something other than a single digit number the routine didnt work to validate the value typing inline. So in order to fix this made processOnBlur the default and removed the old logic.

Also fixed some docs and added a support example in tree.

**Related github/jira issue (required)**:
Fixes #3909 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/spinbox/example-range-limits.html
- in the second input try to change the value to 111 -> should be possible to get any value to stay in there between 100 and 200
- try and type less or greater values like 50 or 250 -> the value will stay but when you leave the field it will correct to the max
- test the page out more in both fields


**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
