### PR TITLE
2788 - Fix safari calendar bugs

### DIFF
--- a/src/components/calendar/_calendar.scss
+++ b/src/components/calendar/_calendar.scss
@@ -410,7 +410,6 @@
   .modal-buttonset {
     background-color: $modal-bg-color;
     border-top: 0;
-    bottom: 19px;
     height: 45px;
     margin-top: 0;
     padding: 0;

--- a/src/components/monthview/_monthview.scss
+++ b/src/components/monthview/_monthview.scss
@@ -245,6 +245,7 @@
 
     .day-text {
       @include rem(font-size, 1.4rem);
+      @include no-select();
 
       border-radius: 50%;
       color: $datepicker-day-color;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fix a QA issue noted on #2788

**Related github/jira issue (required)**:
Fixes #2788

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/calendar/test-specific-month.html
- click on a day
- note the buttons should be on the bottom now 
- try this in Safari and Chrome...
- also fixed an issue when clicking the day a blue state would show briefly that looked odd