### PR TITLE
 #3679 Homepage: Edit events should trigger on widgets

### DIFF
--- a/app/views/components/homepage/example-editable.html
+++ b/app/views/components/homepage/example-editable.html
@@ -59,7 +59,11 @@
     }
   });
   $('.homepage')
-    .on('resizecard', function(event, card, data){ console.log("resizecard event: ", [card, data])})
-    .on('reordercard', function(event, card, data){ console.log("reordercard event: ", [card, data])})
-    .on('removecard', function(event, card, data){ console.log("removecard event: ", [card, data])});
+    .on('resizecard', function(event, card, data){ console.log("Homepage: resizecard event: ", [card, data])})
+    .on('reordercard', function(event, card, data){ console.log("Homepage: reordercard event: ", [card, data])})
+    .on('removecard', function(event, card, data){ console.log("Homepage: removecard event: ", [card, data])});
+  $('.widget')
+    .on('resizecard', function(event, card, data){ console.log("Widget: resizecard event: ", [card, data])})
+    .on('reordercard', function(event, card, data){ console.log("Widget: reordercard event: ", [card, data])})
+    .on('removecard', function(event, card, data){ console.log("Widget: removecard event: ", [card, data])});
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Multiselect]` Moved the functionality for displaying the Multiselect List's searchfield underneath/above the pseudo element into a configurable setting. ([#3864](https://github.com/infor-design/enterprise/issues/3864))
 - `[Slider]` Added the ability to set position of the tooltip. ([#3746](https://github.com/infor-design/enterprise/issues/3746))
 - `[Toast]` Added the ability to dismiss toasts via keyboard. ([#3521](https://github.com/infor-design/enterprise/issues/3521))
+- `[Homepage]` Homepage edit events (resize, reorder, remove widgets) now fire on widget elements too ([#3679](https://github.com/infor-design/enterprise/issues/3679))
 
 ### v4.29.0 Fixes
 

--- a/src/components/homepage/homepage.js
+++ b/src/components/homepage/homepage.js
@@ -313,10 +313,10 @@ Homepage.prototype = {
           card.append(homepage.guide);
           homepage.refresh(false);
         })
-        .on('dragend.card', function (event) {
+        .on('dragend.card', function () {
           const card = $(this);
           // Make sure this is not from a resize event, card should have is-dragging class
-          if(card.hasClass('is-dragging')){
+          if (card.hasClass('is-dragging')) {
             const cardOver = $(cards).has('.drop-indicator');
             if (card.index() < cardOver.index()) {
               card.insertAfter(cardOver);

--- a/src/components/homepage/homepage.js
+++ b/src/components/homepage/homepage.js
@@ -172,16 +172,19 @@ Homepage.prototype = {
                 const result = this.settings.onBeforeRemoveCard(card);
                 if (result && result.then && typeof result.then === 'function') { // A promise is returned
                   result.then(() => {
+                    card.triggerHandler('removecard', [card, homepage.state]);
                     card.remove();
                     homepage.refresh(false);
                     homepage.element.triggerHandler('removecard', [card, homepage.state]);
                   });
                 } else if (result) { // Boolean is returned instead of a promise
+                  card.triggerHandler('removecard', [card, homepage.state]);
                   card.remove();
                   homepage.refresh(false);
                   homepage.element.triggerHandler('removecard', [card, homepage.state]);
                 }
               } else {
+                card.triggerHandler('removecard', [card, homepage.state]);
                 card.remove();
                 homepage.refresh(false);
                 homepage.element.triggerHandler('removecard', [card, homepage.state]);
@@ -196,6 +199,7 @@ Homepage.prototype = {
           const eastHandle = $('<div>').addClass('ui-resizable-handle ui-resizable-e')
             .drag({ axis: 'x' })
             .on('dragstart.handle', (dragevent) => {
+              dragevent.stopPropagation();
               dragevent.preventDefault();
               card.addClass('ui-resize-passive');
               card.css({ opacity: 0.9, zIndex: 90 });
@@ -228,12 +232,14 @@ Homepage.prototype = {
                   $('.ui-resizable-handle').remove();
                   card.css({ opacity: 1, width: '' });
                   homepage.refresh(false);
+                  card.triggerHandler('resizecard', [card, homepage.state]);
                   homepage.element.triggerHandler('resizecard', [card, homepage.state]);
                 });
             });
           const southHandle = $('<div>').addClass('ui-resizable-handle ui-resizable-s')
             .drag({ axis: 'y' })
             .on('dragstart.handle', (dragevent) => {
+              dragevent.stopPropagation();
               dragevent.preventDefault();
               card.addClass('ui-resize-passive');
               card.css({ opacity: 0.9, zIndex: 90 });
@@ -262,6 +268,7 @@ Homepage.prototype = {
                   $('.ui-resizable-handle').remove();
                   card.css({ opacity: 1, height: '' });
                   homepage.refresh(false);
+                  card.triggerHandler('resizecard', [card, homepage.state]);
                   homepage.element.triggerHandler('resizecard', [card, homepage.state]);
                 });
             });
@@ -306,18 +313,22 @@ Homepage.prototype = {
           card.append(homepage.guide);
           homepage.refresh(false);
         })
-        .on('dragend.card', function () {
+        .on('dragend.card', function (event) {
           const card = $(this);
-          const cardOver = $(cards).has('.drop-indicator');
-          if (card.index() < cardOver.index()) {
-            card.insertAfter(cardOver);
-          } else {
-            card.insertBefore(cardOver);
+          // Make sure this is not from a resize event, card should have is-dragging class
+          if(card.hasClass('is-dragging')){
+            const cardOver = $(cards).has('.drop-indicator');
+            if (card.index() < cardOver.index()) {
+              card.insertAfter(cardOver);
+            } else {
+              card.insertBefore(cardOver);
+            }
+            card.removeClass('is-dragging');
+            homepage.guide.remove();
+            homepage.refresh(false);
+            card.triggerHandler('reordercard', [card, homepage.state]);
+            homepage.element.triggerHandler('reordercard', [card, homepage.state]);
           }
-          card.removeClass('is-dragging');
-          homepage.guide.remove();
-          homepage.refresh(false);
-          homepage.element.triggerHandler('reordercard', [card, homepage.state]);
         });
     } else {
       cards.attr('draggable', false);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Need to allow handling of events in different ways. It can be more useful for the event to fire on the widget sometimes.

**Related github/jira issue (required)**:
Closes  #3679

**Steps necessary to review your pull request (required)**:
Run the demo app and go to http://localhost:4000/components/homepage/example-editable.html
Resize, reorder, remove widgets.
Expect to see two events in the console. One will fire on the homepage element, and the other on the widget element.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
