### PR TITLE
2670 - Fix scroll bar for card action with line chart

### DIFF
--- a/src/components/line/line.js
+++ b/src/components/line/line.js
@@ -244,7 +244,7 @@ Line.prototype = {
     // let height = parent.height() - margin.top - margin.bottom - 30; // legend
 
     if (isCardAction) {
-      height -= 40;
+      height -= 42;
     }
 
     self.svg = d3.select(this.element[0]).append('svg')


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed scroll bar for card action with line chart.

**Related github/jira issue (required)**:
Fixes #2670

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/line/example-axis-ticks.html?theme=uplift&variant=light&colors=0066D4
- See the chart should fit properly and no scroll bar in widget