### PR TITLE
3939 - Add mask fixes to spinbox

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,6 +57,7 @@
 - `[Tree]` Fixed an issue where data was not in sync for children property. ([#1690](https://github.com/infor-design/enterprise/issues/1690))
 - `[Splitter]` Fixed an issue the drag handle characters render incorrectly. ([#1458](https://github.com/infor-design/enterprise/issues/1458))
 - `[Spinbox]` Fixed an issue where a two or more digit min value would make it difficult to type in the spinbox. To fix this the values will only be validated on blur by default. ([#3909](https://github.com/infor-design/enterprise/issues/3909))
+- `[Spinbox]` Fixed an issue where the number mask did not match the max value of the spinbox. ([#3939](https://github.com/infor-design/enterprise/issues/3939))
 - `[Slider]` Improved the sliding so that decimal values would not trigger the change event. ([#787](https://github.com/infor-design/enterprise-ng/issues/787))
 - `[Slider]` Reduced the number of change events that fire while sliding. ([#788](https://github.com/infor-design/enterprise-ng/issues/788))
 - `[Swaplist]` Fixed an issue where dragging items more than once was not working on Android or iOS devices. ([#1423](https://github.com/infor-design/enterprise/issues/1423))

--- a/src/components/spinbox/spinbox.js
+++ b/src/components/spinbox/spinbox.js
@@ -130,7 +130,7 @@ Spinbox.prototype = {
     }
 
     if (this.element.attr('min')) {
-      this.settings.max = this.element.attr('min');
+      this.settings.min = this.element.attr('min');
     } else if (this.settings.min) {
       this.element.attr('min', this.settings.min);
     }
@@ -197,65 +197,20 @@ Spinbox.prototype = {
     // use them.
     const min = this.element.attr('min');
     let max = this.element.attr('max');
-    let mask = this.element.attr('data-mask');
-    let maskValue = '';
     const attributes = {
       role: 'spinbutton'
     };
-    let i = 0;
 
     // Define a default Max value if none of these attributes exist, to ensure the mask plugin will
     // work correctly.  Cannot define a Min value here because the plugin must be able to invoke
     // itself with a NULL value.
-    if (!min && !max && !mask) {
+    if (!min && !max) {
       max = '9999999';
     }
 
-    // If a mask doesn't exist, but min and max values do exist, create a mask that reflects
-    // those min/max values
-    if ((min || max) && !mask) {
-      let newMask = '';
-      const tempMin = min || '';
-      const tempMax = max || '';
-      const longerVal = tempMin.length > tempMax.length ? tempMin : tempMax;
-      i = 0;
-
-      while (i <= longerVal.length) {
-        newMask += '#';
-        i++;
-      }
-
-      // Add a negative symbol to the mask if it exists within the longer value.
-      if (tempMin.indexOf('-') !== -1 || tempMax.indexOf('-') !== -1) {
-        newMask = `-${newMask.substring(0, (newMask.length - 1))}`;
-      }
-
-      attributes['data-mask'] = newMask;
-      mask = newMask;
-    }
-
-    // If a "data-mask" attribute is already defined, use it to determine missing values
-    // for min/max, if they don't already exist.
-    const maskSize = mask.length;
-
-    i = 0;
-    while (i <= maskSize) {
-      maskValue += '9';
-      i++;
-    }
-
     // If no negative symbol exists in the mask, the minimum value must be zero.
-    if (mask.indexOf('-') === -1) {
-      attributes.min = min || 0;
-      attributes.max = max || maskValue;
-    } else {
-      attributes.min = min || maskValue;
-      attributes.max = max || maskValue.substring(0, (maskValue.length - 1));
-    }
-
-    if (!this.element.attr('data-mask-mode') || this.element.attr('data-mask-mode') !== 'number') {
-      attributes['data-mask-mode'] = 'number';
-    }
+    attributes.min = min || 0;
+    attributes.max = max;
 
     // Destroy the Mask Plugin if it's already been invoked.  We will reinvoke it later
     // on during initialization.  Check to make sure its the actual Mask plugin object,

--- a/test/components/spinbox/spinbox.e2e-spec.js
+++ b/test/components/spinbox/spinbox.e2e-spec.js
@@ -87,4 +87,22 @@ describe('Spinbox Range Tests tests', () => {
 
     expect(await element(by.id('limited-spinbox-2')).getAttribute('value')).toEqual('200');
   });
+
+  it('Should be able to correct over', async () => {
+    await element(by.id('limited-spinbox-2')).clear();
+    await element(by.id('limited-spinbox-2')).sendKeys('999');
+    await element(by.id('limited-spinbox-2')).sendKeys(protractor.Key.TAB);
+    await browser.driver.sleep(config.sleepShort);
+
+    expect(await element(by.id('limited-spinbox-2')).getAttribute('value')).toEqual('200');
+  });
+
+  it('Should be able to correct text', async () => {
+    await element(by.id('limited-spinbox-2')).clear();
+    await element(by.id('limited-spinbox-2')).sendKeys('AA999');
+    await element(by.id('limited-spinbox-2')).sendKeys(protractor.Key.TAB);
+    await browser.driver.sleep(config.sleepShort);
+
+    expect(await element(by.id('limited-spinbox-2')).getAttribute('value')).toEqual('200');
+  });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The spinbox component had remains of old mask options being set that made it not work properly to mask. Removed the older mask options and just have the new mask stuff

**Related github/jira issue (required)**:
Fixes #3939 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/spinbox/example-range-limits.html
mask
- in the first field since the max is ten you can type 2 numbers, if you type over ten it will be corrected on tab since mask doesnt support that
- in the second field since the max is ten you can type 3 numbers, if you type over 200  it will be corrected on tab since mask doesnt support that

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
