### PR TITLE
ng760 - Prevent Popdown from closing when a nested Modal is opened.

### DIFF
--- a/app/views/components/popdown/test-contains-lookup.html
+++ b/app/views/components/popdown/test-contains-lookup.html
@@ -5,21 +5,21 @@
       <span>Trigger Popdown</span>
     </button>
     <div class="popdown hidden">
-      <div class="widget">
+      <form id="lookup-form" class="widget" action="#" method="post">
         <div class="widget-header">
           <h2 class="widget-title">Look Up Something</h2>
         </div>
-        <div class="widget-content">
+        <div class="widget-content" style="padding: 20px;">
           <div class="field">
             <label for="lookup-input">Lookup</label>
             <input id="lookup-input" class="lookup" data-init="false"/>
           </div>
         </div>
         <div class="widget-footer modal-buttonset">
-          <button id="edit-cart" type="button" class="btn-modal-secondary" style="width: 50%;">Edit Cart</button>
-          <button id="checkout" type="button" class="btn-modal-primary" style="width: 50%;">Checkout</button>
+          <button id="reset" type="reset" class="btn-modal-secondary" style="width: 50%;">Reset</button>
+          <button id="accept" type="submit" class="btn-modal-primary" style="width: 50%;">Accept</button>
         </div>
-      </div>
+      </form>
     </div>
 
   </div>
@@ -69,5 +69,15 @@
         fullWidth: true
       }
     }
+  });
+
+  function closePopdown() {
+    $('#popdown-trigger').data('popdown').close();
+  }
+
+  $('#lookup-form').on('submit.test', function (e) {
+    e.preventDefault();
+    closePopdown();
+    return false;
   });
 </script>

--- a/app/views/components/popdown/test-trigger-lookup.html
+++ b/app/views/components/popdown/test-trigger-lookup.html
@@ -1,0 +1,73 @@
+<div class="row">
+  <div class="six columns">
+
+    <button id="popdown-trigger" class="btn-secondary" data-popdown="true">
+      <span>Trigger Popdown</span>
+    </button>
+    <div class="popdown hidden">
+      <div class="widget">
+        <div class="widget-header">
+          <h2 class="widget-title">Look Up Something</h2>
+        </div>
+        <div class="widget-content">
+          <div class="field">
+            <label for="lookup-input">Lookup</label>
+            <input id="lookup-input" class="lookup" data-init="false"/>
+          </div>
+        </div>
+        <div class="widget-footer modal-buttonset">
+          <button id="edit-cart" type="button" class="btn-modal-secondary" style="width: 50%;">Edit Cart</button>
+          <button id="checkout" type="button" class="btn-modal-primary" style="width: 50%;">Checkout</button>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<script id="test-script">
+  var grid,
+    columns = [],
+    data = [];
+
+  // Some Sample Data
+  data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+  data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+  data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+  data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+  data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+  data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+  data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+
+  //Define Columns for the Grid.
+  columns.push({ id: 'productId', name: 'Product Id', field: 'productId'});
+  columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink});
+  columns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity'});
+  columns.push({ id: 'quantity', filterType: 'text', name: 'Quantity', field: 'quantity'});
+  columns.push({ id: 'price', name: 'Price', field: 'price', formatter: Formatters.Decimal});
+
+  //Init and get the api for the grid
+  $('#lookup-input').lookup({
+    field: 'productId',
+    autoApply: true,
+    autoFocus: false,
+    options: {
+      columns: columns,
+      dataset: data,
+      selectable: 'single',
+      rowNavigation: true,
+      toolbar: {
+        results: true,
+        keywordFilter: true,
+        advancedFilter: false,
+        actions: false,
+        selectable: 'single',
+        filterable: true,
+        views: true,
+        rowHeight: false,
+        collapsibleFilter: false,
+        fullWidth: true
+      }
+    }
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[Lookup]` Added a clear (x icon) button and apply button inside of modal so there are now two options to clear the field. ([#2507](https://github.com/infor-design/enterprise/issues/2507))
 - `[Lookup]` Fixed a bug where validation did not work if the lookup is non-editable (select only). ([#3950](https://github.com/infor-design/enterprise/issues/3950))
 - `[Multiselect]` Moved the functionality for displaying the Multiselect List's searchfield underneath/above the pseudo element into a configurable setting. ([#3864](https://github.com/infor-design/enterprise/issues/3864))
+- `[Popdown]` Fixed some integration problems with nested Lookups that were causing closing to happen prematurely. ([ng#760](https://github.com/infor-design/enterprise-ng/issues/760))
 - `[Slider]` Added the ability to set position of the tooltip. ([#3746](https://github.com/infor-design/enterprise/issues/3746))
 - `[Toast]` Added the ability to dismiss toasts via keyboard. ([#3521](https://github.com/infor-design/enterprise/issues/3521))
 - `[Homepage]` Homepage edit events (resize, reorder, remove widgets) now fire on widget elements too ([#3679](https://github.com/infor-design/enterprise/issues/3679))

--- a/src/components/lookup/lookup.js
+++ b/src/components/lookup/lookup.js
@@ -73,7 +73,8 @@ Lookup.prototype = {
     const active = document.activeElement;
     const inputIsActive = this.element.is(active);
     const wrapperHasActive = this.element.parent('.lookup-wrapper')[0].contains(active);
-    return (inputIsActive || wrapperHasActive);
+    const lookupModalHasActive = this.modal?.element[0].contains(active);
+    return (inputIsActive || wrapperHasActive || lookupModalHasActive);
   },
 
   /**

--- a/src/components/popdown/_popdown.scss
+++ b/src/components/popdown/_popdown.scss
@@ -14,14 +14,12 @@
   background-color: $popupmenu-bg-color;
   border: 1px solid $popupmenu-border-color;
   border-radius: 4px;
-  //box-shadow: 0 2px 5px 0 rgba(0, 0, 0, .2);
   left: -9999px;
   opacity: 0;
   position: absolute;
   top: 0;
   white-space: normal;
   width: 300px;
-  z-index: 1010;
 
   h2 {
     color: $font-color-extrahighcontrast;

--- a/test/components/popdown/popdown.e2e-spec.js
+++ b/test/components/popdown/popdown.e2e-spec.js
@@ -123,3 +123,35 @@ describe('Popdown first last tab Tests', () => {
     expect(await focusedId()).toEqual('date-field-normal');
   });
 });
+
+describe('Popdown/Lookup integration Tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/popdown/test-contains-lookup.html?layout=nofrills');
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should remain open when an inner Lookup component is opened', async () => {
+    // Open the Popdown
+    await element(by.id('popdown-trigger')).click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('.popdown'))), config.waitsFor);
+
+    // Open the Lookup
+    await element(by.css('.lookup-wrapper > .trigger')).click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('.lookup-modal'))), config.waitsFor);
+
+    // Test that the Popdown remained open
+    expect(await element(by.css('.popdown')).isDisplayed()).toBeTruthy();
+
+    // Choose an option from the Lookup
+    await element(by.css('#lookup-datagrid > div.datagrid-wrapper > table > tbody > tr:nth-child(1) > td:nth-child(2) > div > a')).click();
+    await browser.driver.sleep(config.sleep);
+
+    // Test that the Popdown remained open
+    expect(await element(by.css('.popdown')).isDisplayed()).toBeTruthy();
+  });
+});

--- a/test/components/popdown/popdown.e2e-spec.js
+++ b/test/components/popdown/popdown.e2e-spec.js
@@ -75,7 +75,7 @@ describe('Popdown first last tab Tests', () => {
     await element(by.css('#date-field-normal')).sendKeys(protractor.Key.TAB);
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('.popdown'))), config.waitsFor);
-    await browser.driver.sleep(config.sleep);
+    await browser.driver.sleep(config.sleepLonger);
 
     // Popdown should open and first input should be focused.
     expect(await element(by.css('.popdown')).isDisplayed()).toBeTruthy();
@@ -85,14 +85,14 @@ describe('Popdown first last tab Tests', () => {
 
     // Tab on first input
     await element(by.css('#first-name')).sendKeys(protractor.Key.TAB);
-    await browser.driver.sleep(config.sleep);
+    await browser.driver.sleep(config.sleepLonger);
 
     // Last input should be focused in popdown.
     expect(await focusedId()).toEqual('last-name');
 
     // Tab on last input in popdown
     await element(by.css('#last-name')).sendKeys(protractor.Key.TAB);
-    await browser.driver.sleep(config.sleep);
+    await browser.driver.sleep(config.sleepLonger);
 
     // Popdown should close and next input (another-field) should be focused.
     expect(await element(by.css('.popdown')).isDisplayed()).toBeFalsy();
@@ -103,7 +103,7 @@ describe('Popdown first last tab Tests', () => {
     // Shift + Tab on this next to popdown input (another-field)
     await element(by.css('#another-field'))
       .sendKeys(protractor.Key.chord(protractor.Key.SHIFT, protractor.Key.TAB));
-    await browser.driver.sleep(config.sleep);
+    await browser.driver.sleep(config.sleepLonger);
 
     // Popdown should open again and first input should be focused.
     expect(await element(by.css('.popdown')).isDisplayed()).toBeTruthy();
@@ -114,7 +114,7 @@ describe('Popdown first last tab Tests', () => {
     // Shift + Tab on first input in popdown
     await element(by.css('#first-name'))
       .sendKeys(protractor.Key.chord(protractor.Key.SHIFT, protractor.Key.TAB));
-    await browser.driver.sleep(config.sleep);
+    await browser.driver.sleep(config.sleepLonger);
 
     // Popdown should close and previous input (date field) should be focused.
     expect(await element(by.css('.popdown')).isDisplayed()).toBeFalsy();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds improved checks for "open" subcomponents within a Popdown content area, to prevent the Popdown from closing prematurely while interacting with these subcomponents.  Previously, when trying to work with Lookups specifically, clicking the lookup trigger or anywhere within an open Lookup component that was originally opened from a Popdown component would cause the Popdown to close unexpectedly.  This is now fixed.

**Related github/jira issue (required)**:
infor-design/enterprise-ng#760

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the demoapp.
- Open http://localhost:4000/components/popdown/test-contains-lookup.html
- Click the Popdown trigger button to open it
- Click the Lookup trigger inside the Popdown. When the Lookup opens, the Popdown should still be open.
- Choose any option from the Lookup to select and close.  The Popdown should remain open and the selected item from the Lookup should be visible.

Can also test this issue against the new test case added to NG in infor-design/enterprise-ng#824.  There's also a new e2e test for this case.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
