### PR TITLE
783 - Allow ID to be passed to accordion collapse and expand

### DIFF
--- a/app/views/components/accordion/test-expand-collapse-by-id.html
+++ b/app/views/components/accordion/test-expand-collapse-by-id.html
@@ -1,8 +1,7 @@
-
 <div class="row">
   <div class="six columns">
 
-    <div class="accordion" data-demo-set-links="true" data-options="{'allowOnePane': false}">
+    <div class="accordion" id="accordion-example" data-options="{'allowOnePane': false}">
       <div class="accordion-header" id="header-one">
         <a href="#"><span>Warehouse Location</span></a>
       </div>
@@ -64,3 +63,11 @@
 
   </div>
 </div>
+
+<script>
+  $('body').on('initialized', function() {
+    $('#accordion-example').data('accordion').expand('header-four');
+    $('#accordion-example').data('accordion').collapse('header-four');
+    $('#accordion-example').data('accordion').expand('header-three');
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### v4.29.0 Features
 
+- `[Accordion]` Added the ability to call collapse and expand with a header ID. ([#783](https://github.com/infor-design/enterprise-ng/issues/783))
 - `[Lookup]` Added a tooltip functionality when the data is overflowed. ([#3703](https://github.com/infor-design/enterprise/issues/3703))
 - `[Lookup]` Added a clear (x icon) button to clear the field. ([#740](https://github.com/infor-design/enterprise/issues/740))
 - `[Lookup]` Added a clear (x icon) button and apply button inside of modal so there are now two options to clear the field. ([#2507](https://github.com/infor-design/enterprise/issues/2507))

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -751,13 +751,16 @@ Accordion.prototype = {
 
   /**
   * Expand the given Panel on the Accordion.
-  * @param {object} header The jquery header element.
+  * @param {object|string} header The jquery header element or the id of a header DOM element
   * @param {boolean} dontCollapseHeaders if defined, will not collapse any open accordion headers
   *  (generally used while filtering)
   * @returns {$.Deferred} resolved on the completion of an Accordion pane's
   *  collapse animation (or immediately, if animation is disabled).
   */
   expand(header, dontCollapseHeaders) {
+    if (typeof header === 'string') {
+      header = this.element.find(`#${header}`).first();
+    }
     if (!header || !header.length) {
       return;
     }
@@ -887,12 +890,15 @@ Accordion.prototype = {
 
   /**
   * Collapse the given Panel on the Accordion.
-  * @param {object} header The jquery header element.
+  * @param {object|string} header The jquery header element or the id of a header DOM element
   * @param {boolean} closeChildren If true closeChildren elements that may be on the page. Skip for performance.
   * @returns {$.Deferred} resolved on the completion of an Accordion pane's
   *  collapse animation (or immediately, if animation is disabled).
   */
   collapse(header, closeChildren = true) {
+    if (typeof header === 'string') {
+      header = this.element.find(`#${header}`).first();
+    }
     if (!header || !header.length) {
       return;
     }

--- a/test/components/accordion/accordion-api.func-spec.js
+++ b/test/components/accordion/accordion-api.func-spec.js
@@ -113,6 +113,32 @@ describe('Accordion API', () => {
       }, 300);
     }, 300);
   });
+
+  it('can expand by ID', (done) => {
+    expect(accordionObj.isExpanded(accordionObj.headers[0])).toBeFalsy();
+    expect(accordionObj.isExpanded(accordionObj.headers[1])).toBeFalsy();
+    expect(accordionObj.isExpanded(accordionObj.headers[2])).toBeFalsy();
+    expect(accordionObj.isExpanded(accordionObj.headers[3])).toBeFalsy();
+
+    accordionObj.expand('header-two');
+
+    setTimeout(() => {
+      expect(accordionObj.isExpanded(accordionObj.headers[0])).toBeFalsy();
+      expect(accordionObj.isExpanded(accordionObj.headers[1])).toBeTruthy();
+      expect(accordionObj.isExpanded(accordionObj.headers[2])).toBeFalsy();
+      expect(accordionObj.isExpanded(accordionObj.headers[3])).toBeFalsy();
+
+      accordionObj.collapse('header-two');
+
+      setTimeout(() => {
+        expect(accordionObj.isExpanded(accordionObj.headers[0])).toBeFalsy();
+        expect(accordionObj.isExpanded(accordionObj.headers[1])).toBeFalsy();
+        expect(accordionObj.isExpanded(accordionObj.headers[2])).toBeFalsy();
+        expect(accordionObj.isExpanded(accordionObj.headers[3])).toBeFalsy();
+        done();
+      }, 300);
+    }, 300);
+  });
 });
 
 describe('Accordion API (settings)', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Changed the accordion collapse and expand api to let it take an ID and look for the header that way. Will add the NG settings for all of 4.29 later 

**Related github/jira issue (required)**:
Fixes infor-design/ids-enterprise#783

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/accordion/test-expand-collapse-by-id.html
- in the end the third accordion should be expanded (the API code in the example is expanding and collapsing the last one so it ends closed) then expands the third
- covered by a new functional test

**Included in this Pull Request**:
- [x] A functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
