### PR TITLE
2161 - Fix alignment of chevron icon in Safari

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # What's New with Enterprise
 
+## v4.30.0
+
+### v4.30.0 Announcements
+
+### v4.30.0 Features
+
+### v4.30.0 Fixes
+
+- `[Accordion]` Fixed an issue where the chevron icon is not poperly centered in Safari. ([#2161](https://github.com/infor-design/enterprise/issues/2161))
+
 ## v4.29.0
 
 ### v4.29.0 Announcements

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -1410,6 +1410,17 @@ html[dir='rtl'] {
   }
 }
 
+html {
+  &.is-safari,
+  &.ios {
+    .accordion-header {
+      .btn {
+        top: -2px;
+      }
+    }
+  }
+}
+
 // Fix size of the bullet icon on Android devices
 html.android {
   .accordion-pane {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Makes the chevron icon perfectly centered in Safari browser and iOS devices. 

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/2161

**Steps necessary to review your pull request (required)**:
- Pull this branch, build and run the app
- Open in Safari, http://localhost:4000/components/accordion/example-index.html
- Chevron icon should perfectly centered now
- Test this on iOS devices too, if needed
- Test in Uplift theme

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
