### PR TITLE
MISC - Fix tab and datagrid QA bugs [v4.29.x] 

### DIFF
--- a/app/views/components/datepicker/example-custom-format.html
+++ b/app/views/components/datepicker/example-custom-format.html
@@ -24,7 +24,7 @@
 
     <div class="field">
       <label for="date-field-4" class="label">Uses Custom Override</label>
-      <input id="date-field-4" data-options="{'dateFormat': 'dd/MM/yyyy'}" class="datepicker" name="date-field-4" type="text"/>
+      <input id="date-field-4" data-options="{'dateFormat': 'dd/M/yyyy'}" class="datepicker" name="date-field-4" type="text"/>
     </div>
 
     <div class="field">

--- a/app/views/components/datepicker/example-custom-format.html
+++ b/app/views/components/datepicker/example-custom-format.html
@@ -24,7 +24,7 @@
 
     <div class="field">
       <label for="date-field-4" class="label">Uses Custom Override</label>
-      <input id="date-field-4" data-options="{'dateFormat': 'dd/M/yyyy'}" class="datepicker" name="date-field-4" type="text"/>
+      <input id="date-field-4" data-options="{'dateFormat': 'dd/MM/yyyy'}" class="datepicker" name="date-field-4" type="text"/>
     </div>
 
     <div class="field">

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1974,8 +1974,13 @@ $datagrid-short-row-height: 25px;
     }
 
     .hyperlink {
+      color: $hyperlink-color;
       display: inline-block;
       font-size: $theme-size-font-base;
+
+      &:hover {
+        color: $hyperlink-hover-color;
+      }
 
       &:focus {
         outline: none;

--- a/src/components/locale/readme.md
+++ b/src/components/locale/readme.md
@@ -248,7 +248,7 @@ The following options are supported:
 
 ## Date and Time Format Patterns
 
-A date format can be constructed by adding the needed date and time parts. For example `yyyy-MM-DD HH:mm`. In formatting dates and numbers we use a variation on the CLDR formats http://cldr.unicode.org/translation/date-time-1/date-time The following parts can be used:
+A date format can be constructed by adding the needed date and time parts. For example `yyyy-MM-DD HH:mm`. In formatting dates and numbers we use a subset off the <a href="http://cldr.unicode.org/translation/date-time-1/date-time" target="_blank">CLDR formats</a>. The following formats can be used:
 
 - `dd` - Shows the date portion padded with zeros
 - `d` - Shows the date portion un-padded

--- a/src/components/locale/readme.md
+++ b/src/components/locale/readme.md
@@ -248,7 +248,7 @@ The following options are supported:
 
 ## Date and Time Format Patterns
 
-A date format can be constructed by adding the needed date and time parts. For example `yyyy-MM-DD HH:mm`. The following parts can be used.
+A date format can be constructed by adding the needed date and time parts. For example `yyyy-MM-DD HH:mm`. In formatting dates and numbers we use a variation on the CLDR formats http://cldr.unicode.org/translation/date-time-1/date-time The following parts can be used:
 
 - `dd` - Shows the date portion padded with zeros
 - `d` - Shows the date portion un-padded
@@ -267,7 +267,7 @@ A date format can be constructed by adding the needed date and time parts. For e
 - `MMMM` - Shows the month in wide format (For example August)
 - `MMM` - Shows the month in abbreviated format (For example Aug, Mar, Sept)
 - `MM` - Shows the month in numeric format padded
-- `MM` - Shows the month in numeric format unpadded
+- `M` - Shows the month in numeric format unpadded
 - `EEEE` - Shows the date of the week in wide format (Monday, Tuesday ect)
 
 ## Timezones

--- a/src/components/tabs/_tabs-uplift.scss
+++ b/src/components/tabs/_tabs-uplift.scss
@@ -40,7 +40,9 @@
 }
 
 .tab-container.horizontal > .tab-list-container .tab .icon-error {
+  right: 3px;
   top: 16px;
+  width: 15px;
 }
 
 .tab-container.horizontal .add-tab-button {

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -488,7 +488,7 @@
         color: $error-icon-fill;
         height: 14px;
         position: absolute;
-        right: -2px;
+        right: 1px;
         top: 13px;
         width: 18px;
       }

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -3434,11 +3434,6 @@ Tabs.prototype = {
 
     const self = this;
     const target = li;
-    const scrollingTablist = this.tablistContainer;
-    const isRTL = Locale.isRTL();
-    let tablistScrollWidth;
-    let tablistScrollLeft;
-    let anchorStyle;
 
     this.animatedBar.removeClass('no-transition');
 
@@ -3446,33 +3441,11 @@ Tabs.prototype = {
       this.animatedBar.removeClass('visible');
       return;
     }
-
-    const targetStyle = window.getComputedStyle(target[0], null);
-    let paddingRight = parseInt(targetStyle.getPropertyValue('padding-right'), 10) || 0;
-    const width = parseInt(targetStyle.getPropertyValue('width'), 10) || 0;
-
-    if (target.is('.tab')) {
-      anchorStyle = window.getComputedStyle(target.children('a')[0]);
-      paddingRight += parseInt(anchorStyle.getPropertyValue('padding-right'), 10) || 0;
-    }
-
-    const left = isRTL ?
-      (paddingRight + target.position().left + target.outerWidth(true)) : (target.position().left);
-
     clearTimeout(self.animationTimeout);
     this.animatedBar.addClass('visible');
 
     function animationTimeout(cb) {
-      const style = self.animatedBar[0].style;
-      tablistScrollLeft = scrollingTablist[0].scrollLeft;
-      tablistScrollWidth = scrollingTablist[0].scrollWidth;
-
-      if (isRTL) {
-        style.right = `${tablistScrollWidth + paddingRight - (left + tablistScrollLeft)}px`;
-      } else {
-        style.left = `${left + tablistScrollLeft}px`;
-      }
-      style.width = `${width}px`;
+      self.sizeBar(target);
 
       if (cb && typeof cb === 'function') {
         cb();
@@ -3480,6 +3453,40 @@ Tabs.prototype = {
     }
 
     animationTimeout(callback);
+  },
+
+  /**
+   * Recalculate the sizes on the animated bar
+   * @param {jQuery} target The target tab element
+   * @private
+   * @returns {void}
+   */
+  sizeBar(target) {
+    target = target || this.element.find('.tab.is-selected');
+    const style = this.animatedBar[0].style;
+    const scrollingTablist = this.tablistContainer;
+    const tablistScrollLeft = scrollingTablist[0].scrollLeft;
+    const tablistScrollWidth = scrollingTablist[0].scrollWidth;
+
+    const targetStyle = window.getComputedStyle(target[0], null);
+    let paddingRight = parseInt(targetStyle.getPropertyValue('padding-right'), 10) || 0;
+    const width = parseInt(targetStyle.getPropertyValue('width'), 10) || 0;
+
+    if (target.is('.tab')) {
+      const anchorStyle = window.getComputedStyle(target.children('a')[0]);
+      paddingRight += parseInt(anchorStyle.getPropertyValue('padding-right'), 10) || 0;
+    }
+
+    const left = Locale.isRTL() ?
+      (paddingRight + target.position().left + target.outerWidth(true)) : (target.position().left);
+
+    if (Locale.isRTL()) {
+      style.right = `${tablistScrollWidth + paddingRight - (left + tablistScrollLeft)}px`;
+    } else {
+      style.left = `${left + tablistScrollLeft}px`;
+    }
+    style.width = `${width}px`;
+    this.focusState[0].style.width = `${width}px`;
   },
 
   /**

--- a/src/components/validation/validator.js
+++ b/src/components/validation/validator.js
@@ -497,6 +497,11 @@ Validator.prototype = {
       if (!($(`.icon-${type}`, iconContainer).length)) {
         iconContainer.addClass(`is-${type}`).append(errorIcon);
       }
+
+      const tabsAPI = parentContainer.data('tabs');
+      if (tabsAPI) {
+        tabsAPI.sizeBar();
+      }
     } else {
       // Remove icon
       iconContainer = iconContainer.add(menuitem);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed two QA issues as detailed in the steps below.

**Related github/jira issue (required)**:
Fixes #3960
Fixes #3935

**Steps necessary to review your pull request (required)**:
**Issue 3960**
- go to http://localhost:4000/components/datagrid/example-tooltips.html?theme=uplift&variant=dark&colors=50535a
- the link should be visible as before and should stay visible during hover
- try all themes

**Issue 3935**
- go to http://localhost:4000/components//tabs/example-enable-disable-individual-tabs-with-keydown.html?theme=soho&variant=light&colors=0066D4
- go to the last tab and then shifttab out of the input to both show an error in the tab and focuss it
- the focus state should not cut off the error icon
- try in soho theme as well

