### PR TITLE
3808 - Remove an unneeded animation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise
 
+## v4.30.0
+
+### v4.30.0 Announcements
+
+- `[Datagrid]` Fix a bug with columns with buttons, they had an unneeded animation that caused states to be delayed when painting. ([#3808](https://github.com/infor-design/enterprise/issues/3808))
+
 ## v4.29.0
 
 ### v4.29.0 Announcements

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1772,6 +1772,8 @@ $datagrid-short-row-height: 25px;
 
   //Table Body
   td {
+    @include transition(none);
+
     background-color: $datagrid-cell-bg-color;
     border-bottom: 1px solid $datagrid-cell-border-color;
     border-right: 1px solid $datagrid-cell-border-color;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The animation transition for buttons was being applied on datagrid rows that had class ~.btn

**Related github/jira issue (required)**:
Fixes #3803 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-actions-reload.html
- bring the mouse down the first actions column slowly and watch the hover state
- all cells should now change color at the same time

**Included in this Pull Request**:
- [x] A note to the change log.
