### PR TITLE
3970 / 3969 - Add more spinbox fixes [v4.29.x]

### DIFF
--- a/app/views/components/spinbox/example-sizes.html
+++ b/app/views/components/spinbox/example-sizes.html
@@ -38,7 +38,7 @@
 
     <div class="field">
       <label class="required" for="xs-spinbox-example">Extra-Small Spinbox</label>
-      <input type="text" id="xs-spinbox-example" class="spinbox input-xs" name="xs-spinbox-example" aria-required="true" data-validate="required">
+      <input type="text" id="xs-spinbox-example" class="spinbox input-xs" name="xs-spinbox-example" data-options="{min: 0, max: 9}" aria-required="true" data-validate="required">
     </div>
 
   </div>

--- a/src/components/spinbox/_spinbox.scss
+++ b/src/components/spinbox/_spinbox.scss
@@ -169,6 +169,7 @@ input::-webkit-inner-spin-button {
   width: 75px;
 
   input {
+    padding: 5px;
     width: calc(100% - 50px) !important;
   }
 

--- a/src/components/spinbox/spinbox.js
+++ b/src/components/spinbox/spinbox.js
@@ -232,6 +232,7 @@ Spinbox.prototype = {
       process: 'number',
       patternOptions: {
         allowDecimal: false,
+        allowThousandsSeparator: false,
         allowNegative: Math.min(this.settings.min, this.settings.max) < 0,
         decimalLimit: 0,
         integerLimit: String(this.settings.max).length


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adds a couple more small spinbox fixes.

**Related github/jira issue (required)**:
Fixes #3970
Fixes #3969

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/spinbox/example-sizes.html
- in "Small Spinbox" type 999999 -> no thousands seperator should appear
- in "Extra-Small Spinbox" type 0-9 -> the single digit should now show
- try these both in uplift and soho theme
