### PR TITLE
3791 - Add a fix to avoid deselecting selected rows

### DIFF
--- a/app/views/components/datagrid/example-singleselect.html
+++ b/app/views/components/datagrid/example-singleselect.html
@@ -39,6 +39,7 @@
         dataset: data,
         selectable: 'single',
         cellNavigation: false,
+        disableRowDeselection: true,
         clickToSelect: true,
         toolbar: {title: 'Data Grid Header Title', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: true,  collapsibleFilter: true}
       }).on('selected', function (e, args) {

--- a/app/views/components/datagrid/test-tree-select-siblings.html
+++ b/app/views/components/datagrid/test-tree-select-siblings.html
@@ -25,6 +25,7 @@
         columns: columns,
         dataset: data,
         selectable: 'siblings',
+        disableRowDeselection: true,
         rowHeight: 'short',
         treeGrid: true,
         toolbar: {title: 'Tasks (Hierarchical)', results: true, actions: true, rowHeight: true, personalize: true, rowHeight: true}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### v4.30.0 Features
 
+- `[Datagrid]` Added a setting disableRowDeselection that if enabled does not allow selected rows to be toggled to deselected. ([#3791](https://github.com/infor-design/enterprise/issues/3791))
+
 ### v4.30.0 Fixes
 
 - `[Accordion]` Fixed an issue where the chevron icon is not poperly centered in Safari. ([#2161](https://github.com/infor-design/enterprise/issues/2161))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -106,7 +106,8 @@ const COMPONENT_NAME = 'datagrid';
  * @param {boolean}  [settings.showSelectAllCheckBox=true] Allow to hide the checkbox header (true to show, false to hide)
  * @param {boolean}  [settings.allowOneExpandedRow=true] Controls if you cna expand more than one expandable row.
  * @param {boolean}  [settings.enableTooltips=false] Process tooltip logic at a cost of performance
- * @param {boolean}  [settings.disableRowDeactivation=false] if a row is activated the user should not be able to deactivate it by clicking on the activated row
+ * @param {boolean}  [settings.disableRowDeactivation=false] if a row is activated the user will not be able to deactivate it by clicking on the activated row
+ * @param {boolean}  [settings.disableRowDeselection=false] if a row is selected the user will not be able to deselect it by clicking on the selected row again
  * @param {boolean}  [settings.sizeColumnsEqually=false] If true make all the columns equal width
  * @param {boolean}  [settings.expandableRow=false] If true we append an expandable row area without the rowTemplate feature being needed.
  * @param {boolean}  [settings.exportConvertNegative=false] If set to true export data with trailing negative signs moved in front.
@@ -206,6 +207,7 @@ const DATAGRID_DEFAULTS = {
   allowOneExpandedRow: true, // Only allows one expandable row at a time
   enableTooltips: false, // Process tooltip logic at a cost of performance
   disableRowDeactivation: false,
+  disableRowDeselection: false,
   sizeColumnsEqually: false, // If true make all the columns equal width
   expandableRow: false, // Supply an empty expandable row template
   exportConvertNegative: false, // Export data with trailing negative signs moved in front
@@ -7670,14 +7672,16 @@ Datagrid.prototype = {
       return;
     }
 
-    if (isSingle && row.hasClass('is-selected')) {
+    if (isSingle && row.hasClass('is-selected') && !this.settings.disableRowDeselection) {
       this.unselectRow(rowIndex);
       this.displayCounts();
       return this._selectedRows; // eslint-disable-line
     }
 
     if (row.hasClass('is-selected')) {
-      this.unselectRow(rowIndex);
+      if (!this.settings.disableRowDeselection) {
+        this.unselectRow(rowIndex);
+      }
     } else {
       this.selectRow(rowIndex);
     }

--- a/test/components/datagrid/datagrid-settings.func-spec.js
+++ b/test/components/datagrid/datagrid-settings.func-spec.js
@@ -102,6 +102,7 @@ describe('Datagrid Settings', () => { //eslint-disable-line
       allowOneExpandedRow: true,
       enableTooltips: false,
       disableRowDeactivation: false,
+      disableRowDeselection: false,
       sizeColumnsEqually: false,
       expandableRow: false,
       exportConvertNegative: false,

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -1643,7 +1643,7 @@ describe('Datagrid single select tests', () => {
     await element(by.css('#datagrid .datagrid-wrapper tbody tr:nth-child(2) td:nth-child(1)')).click();
 
     expect(await element(by.css('#datagrid .datagrid-wrapper tbody tr:nth-child(1)')).getAttribute('class')).not.toMatch('is-selected');
-    expect(await element(by.css('#datagrid .datagrid-wrapper tbody tr:nth-child(2)')).getAttribute('class')).not.toMatch('is-selected');
+    expect(await element(by.css('#datagrid .datagrid-wrapper tbody tr:nth-child(2)')).getAttribute('class')).toMatch('is-selected');
   });
 
   it('Should work with sort', async () => {
@@ -3817,7 +3817,7 @@ describe('Datagrid tree do not select children tests', () => {
   });
 });
 
-describe('Datagrid tree do not select siblings tests', () => {
+describe('Datagrid tree select siblings tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-tree-select-siblings');
 
@@ -3835,9 +3835,19 @@ describe('Datagrid tree do not select siblings tests', () => {
 
     expect(await element.all(by.css('tr.is-selected')).count()).toEqual(5);
 
+    await element(by.css('#datagrid .datagrid-wrapper tbody tr:nth-child(8) td:nth-child(1)')).click();
+
+    expect(await element.all(by.css('tr.is-selected')).count()).toEqual(3);
+  });
+
+  it('Should not de-select siblings', async () => {
     await element(by.css('#datagrid .datagrid-wrapper tbody tr:nth-child(1) td:nth-child(1)')).click();
 
-    expect(await element.all(by.css('tr.is-selected')).count()).toEqual(0);
+    expect(await element.all(by.css('tr.is-selected')).count()).toEqual(5);
+
+    await element(by.css('#datagrid .datagrid-wrapper tbody tr:nth-child(1) td:nth-child(1)')).click();
+
+    expect(await element.all(by.css('tr.is-selected')).count()).toEqual(5);
 
     await element(by.css('#datagrid .datagrid-wrapper tbody tr:nth-child(8) td:nth-child(1)')).click();
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The poster requested that we add a setting so that rows can not be deselected (rows must always be selected so its not valid to have rows unselected). To do this i added a new setting.

**Related github/jira issue (required)**:
Fixes #3791 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-singleselect
- click row two -> it will select
- click row two again -> it will not deselect
- click row three -> it will select, deselecting the previous selection
- go to http://localhost:4000/components/datagrid/test-tree-select-siblings.html
- click row one -> it will select
- click row one again -> it will not deselect
- click row eight -> it will select, deselecting the previous selection

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
