### PR TITLE
3872 - Modify test page to demonstrate working Module Tabs Tooltips

### DIFF
--- a/app/views/components/tabs-module/example-add-tab-button.html
+++ b/app/views/components/tabs-module/example-add-tab-button.html
@@ -7,7 +7,7 @@
   <div class="page-container no-scroll">
 
     <!-- Module Tabs -->
-    <section id="module-tabs-example" class="tab-container module-tabs" data-options="{ addTabButton: true, containerElement: '#module-tabs-container', 'changeTabOnHashChange': true }">
+    <section id="module-tabs-example" class="tab-container module-tabs" data-options="{ addTabButton: true, containerElement: '#module-tabs-container', 'changeTabOnHashChange': true, 'moduleTabsTooltips': true }">
       <div class="tab-list-container">
         <ul class="tab-list">
           <li class="tab is-selected"><a href="#module-tabs-controls">New Tab Builder</a></li>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
After doing some testing on #3872, it appears the Module Tabs Tooltips are working as expected, but the sample that was being tested did not enable the setting that creates tooltips, as it's an opt-in feature.  This PR simply enables this setting on the example page in question.

**Related github/jira issue (required)**:
Closes #3872

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the demoapp
- Open http://localhost:4000/components/tabs-module/example-add-tab-button.html
- In the first tab (which should be active), uncheck "Fill With Garbage" and create a very long title for the name of the tab.  No content is necessary.
- Click "Create New Tab".  
- See the new tab in the Module Tabs Toolbar area.  It should be cut off with an `...` ellipsis.  When you use the mouse to hover the tab, it should display a tooltip with the full contents of the Title.
