### PR TITLE
3794 - Fix previous text selection with tree

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Icons]` Fixed an issue with the amend icon in uplift theme. The meaning was lost on a design change and it has been updated. ([#3613](https://github.com/infor-design/enterprise/issues/3613))
 - `[Locale]` Changed results text to lower case. ([#3974](https://github.com/infor-design/enterprise/issues/3974))
 - `[Textarea]` Added tests to show that the textarea count text is translated. ([#3807](https://github.com/infor-design/enterprise/issues/3807))
+- `[Tree]` Fixed an issue where previous text selection was not clearing after clicked to any tree-node. ([#3794](https://github.com/infor-design/enterprise/issues/3794))
 
 ## v4.29.0
 

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -592,7 +592,7 @@ ListView.prototype = {
    * @returns {void}
    */
   selectItemsBetweenIndexes(indexes) {
-    this.clearSelection();
+    utils.clearSelection(); // Clear all currently selected list items.
     indexes.sort((a, b) => a - b);
     for (let i = indexes[0]; i <= indexes[1]; i++) {
       const item = $('li, tbody tr', this.element).eq(i);
@@ -617,19 +617,6 @@ ListView.prototype = {
       if (!item.is('.is-disabled') && item.is('.is-selected')) {
         this.select(item);
       }
-    }
-  },
-
-  /**
-  * Clear all currently selected list items.
-  * @private
-  * @returns {void}
-  */
-  clearSelection() {
-    if (window.getSelection) {
-      window.getSelection().removeAllRanges();
-    } else if (document.selection) {
-      document.selection.empty();
     }
   },
 

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -880,6 +880,7 @@ Tree.prototype = {
     this.element.on('click.tree', 'a:not(.is-clone)', function (e) {
       const target = $(this);
       const parent = this.parentNode;
+      self.clearTextSelection();
       if (!target[0].classList.contains('is-disabled') && !target[0].classList.contains('is-loading')) {
         if (self.isMultiselect) {
           if (DOM.hasClass(e.target, 'icon') && parent.classList.contains('folder')) {
@@ -2372,6 +2373,19 @@ Tree.prototype = {
         node.addClass(node.data('oldData').iconClass);
       }
       node.data('oldData', null);
+    }
+  },
+
+  /**
+   * Deselect all selected text.
+   * @private
+   * @returns {void}
+   */
+  clearTextSelection() {
+    if (window.getSelection) {
+      window.getSelection().removeAllRanges();
+    } else if (document.selection) {
+      document.selection.empty();
     }
   },
 

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -880,7 +880,7 @@ Tree.prototype = {
     this.element.on('click.tree', 'a:not(.is-clone)', function (e) {
       const target = $(this);
       const parent = this.parentNode;
-      self.clearTextSelection();
+      utils.clearSelection(); // Deselect all selected text.
       if (!target[0].classList.contains('is-disabled') && !target[0].classList.contains('is-loading')) {
         if (self.isMultiselect) {
           if (DOM.hasClass(e.target, 'icon') && parent.classList.contains('folder')) {
@@ -2373,19 +2373,6 @@ Tree.prototype = {
         node.addClass(node.data('oldData').iconClass);
       }
       node.data('oldData', null);
-    }
-  },
-
-  /**
-   * Deselect all selected text.
-   * @private
-   * @returns {void}
-   */
-  clearTextSelection() {
-    if (window.getSelection) {
-      window.getSelection().removeAllRanges();
-    } else if (document.selection) {
-      document.selection.empty();
     }
   },
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1232,6 +1232,7 @@ utils.getSiblingsHeight = function getSiblingsHeight(el) {
   const siblings = DOM.getSiblings(el);
   return siblings.map(sibling => sibling.offsetHeight).reduce((a, h) => a + h, 0);
 };
+
 /**
  * Get parent available height for given element.
  * @privateel
@@ -1240,6 +1241,19 @@ utils.getSiblingsHeight = function getSiblingsHeight(el) {
  */
 utils.getParentAvailableHeight = function getParentAvailableHeight(el) {
   return el.parentNode.offsetHeight - utils.getSiblingsHeight(el);
+};
+
+/**
+ * Clear all currently selected.
+ * @privateel
+ * @returns {void}
+ */
+utils.clearSelection = function clearSelection() {
+  if (window.getSelection) {
+    window.getSelection().removeAllRanges();
+  } else if (document.selection) {
+    document.selection.empty();
+  }
 };
 
 export { utils, math };


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed previous text selection was not clearing after clicked to any tree-node with Tree.

**Related github/jira issue (required)**:
Closes #3794

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/tree/example-ajax.html
- Right click on a node
- Node text should have blue selection
- If context menu opened click somewhere else, or press `esc` key to close context menu
- Node text should still have blue selection
- Now without clicking anywhere else, click on another node
- The blue selection for previous node should go away

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
