### PR TITLE
810 - Fix a bug with validation in lookup

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[Datagrid]` Fixed an issue where using selectRowsAcrossPages setting the selected rows were reseting by filter, to use this feature you may need to set columnIds in the settings to form whats unique for the row. ([#3601](https://github.com/infor-design/enterprise/issues/3601))
 - `[Icons]` Fixed an issue with the amend icon in uplift theme. The meaning was lost on a design change and it has been updated. ([#3613](https://github.com/infor-design/enterprise/issues/3613))
 - `[Locale]` Changed results text to lower case. ([#3974](https://github.com/infor-design/enterprise/issues/3974))
+- `[Lookup]` Fixed a bug that the required validation would not reset from empty in certain cases. ([#810](https://github.com/infor-design/enterprise-ng/issues/810))
 - `[Textarea]` Added tests to show that the textarea count text is translated. ([#3807](https://github.com/infor-design/enterprise/issues/3807))
 - `[Tree]` Fixed an issue where previous text selection was not clearing after clicked to any tree-node. ([#3794](https://github.com/infor-design/enterprise/issues/3794))
 

--- a/src/components/validation/validator.js
+++ b/src/components/validation/validator.js
@@ -204,6 +204,7 @@ Validator.prototype = {
         if (handleEventData &&
             handleEventData.type === e.type &&
             e.handleObj.namespace === 'validate' &&
+            !thisField.is('.lookup') &&
             !thisField.closest('.modal:visible').length) {
           return;
         }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

In some cases the modal that works with lookup would not fire the events in the right sequence to catch all the validation events. This fixes the issue

**Related github/jira issue (required)**:
Fixes infor-design/enterprise-ng#810

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/lookup/example-index.html
- select a value in the first lookup
- clear the value within the field
- open the lookup again and select the same value as before

try other combos like
- select a value in the first lookup
- clear the value within the field
- open the lookup again and select a different value 

and
- select a value in the first lookup
- clear the value within the field
- tab out
- open the lookup again and select a different value 

and
- select a value in the first lookup
- clear the value within the field
- tab out
- open the lookup again and select same value
- tab out

in all cases the validation should be correctly either there when its empty or gone when its not

**Included in this Pull Request**:
- [x] A note to the change log.
