### PR TITLE
Enable execution of the Demoapp with persisting settings

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -84,7 +84,8 @@ csp.extend(app);
 
 // Import various custom middleware (order matters!)
 app.use(require('./src/js/middleware/request-logger')(app));
-app.use(require('./src/js/middleware/option-handler')(app, DEFAULT_RESPONSE_OPTS));
+app.use(require('./src/js/middleware/cmd-params-handler')(app, DEFAULT_RESPONSE_OPTS));
+app.use(require('./src/js/middleware/option-handler')(app));
 app.use(require('./src/js/middleware/option-handler-themes')(app));
 app.use(require('./src/js/middleware/option-handler-fonts')());
 app.use(require('./src/js/middleware/basepath-handler')(app));

--- a/app/src/js/middleware/cmd-params-handler.js
+++ b/app/src/js/middleware/cmd-params-handler.js
@@ -1,0 +1,75 @@
+const extend = require('extend');
+
+const commandLineArgs = require('yargs').argv;
+
+const logger = require('../logger');
+const setLayout = require('../set-layout');
+const setImportStyle = require('../set-import-style');
+
+// Command Line/Terminal Paramter Handling - Custom Middleware
+// This module checks possible terminal flags and sets some response options in those cases.
+module.exports = function (app, defaults) {
+  return function cmdParamsHandler(req, res, next) {
+    res.opts = extend({}, defaults);
+
+    // Change Locale (which also changes right-to-left text setting)
+    if (commandLineArgs.locale && commandLineArgs.locale.length > 0) {
+      res.opts.locale = commandLineArgs.locale;
+      logger('info', `Using cmd flags to set locale to "${res.opts.locale}".`);
+    }
+
+    // Global settings to change the layout.
+    if (commandLineArgs.layout && commandLineArgs.layout.length > 0) {
+      setLayout(req, res, `layout-${commandLineArgs.layout}.html`);
+      logger('info', `Using cmd flags to set the page layout to "layout-${commandLineArgs.layout}.html".`);
+    }
+
+    // Set the colorScheme
+    // Fx: http://localhost:4000/controls/modal?colors=9279a6,ffffff
+    if (commandLineArgs.colors && commandLineArgs.colors.length > 0) {
+      res.opts.colors = commandLineArgs.colors;
+      logger('info', `Using cmd flags to set custom color scheme to ${res.opts.colors}`);
+    }
+
+    // Sets a simulated response delay for API Calls
+    if (commandLineArgs.delay && !isNaN(commandLineArgs.delay) && commandLineArgs.delay.length > 0) { //eslint-disable-line
+      res.opts.delay = commandLineArgs.delay;
+    }
+
+    // Uses the minified version of the Soho library instead of the uncompressed version
+    // NOTE: see the `app/src/js/custom-route-options.js` middleware for where this
+    // setting is translated into `window.SohoConfig`.
+    if (commandLineArgs.minify) {
+      setImportStyle(req, res, 'minify');
+      res.opts.minify = true;
+      logger('info', 'Using the minified version of "sohoxi.js" and culture files');
+    }
+
+    // Uses Flex Toolbars in headers
+    if ((commandLineArgs.flextoolbar && commandLineArgs.flextoolbar.length > 0) ||
+      (commandLineArgs.toolbarflex && commandLineArgs.toolbarflex.length > 0)) {
+      commandLineArgs.useFlexToolbar = true;
+      logger('info', 'Using Flex Toolbars inside of page headers');
+    }
+
+    let useLiveReload = false;
+    process.argv.forEach((val) => {
+      if (val === '--livereload') {
+        useLiveReload = true;
+      }
+    });
+
+    // Disable live reload for IE
+    if (commandLineArgs.hostname === '10.0.2.2' && useLiveReload) {
+      res.opts.enableLiveReloadVM = true;
+      res.opts.enableLiveReload = false;
+    }
+
+    if (!useLiveReload) {
+      res.opts.enableLiveReloadVM = false;
+      res.opts.enableLiveReload = false;
+    }
+
+    next();
+  };
+};

--- a/app/src/js/middleware/option-handler.js
+++ b/app/src/js/middleware/option-handler.js
@@ -1,15 +1,12 @@
-const extend = require('extend');
-
 const logger = require('../logger');
 const setLayout = require('../set-layout');
+const setImportStyle = require('../set-import-style');
 
 // Option Handling - Custom Middleware
 // Writes a set of default options the 'req' object.  These options are always eventually passed to the HTML template.
 // In some cases, these options can be modified based on query parameters.  Check the default route for these options.
-module.exports = function (app, defaults) {
+module.exports = function () {
   return function optionHandler(req, res, next) {
-    res.opts = extend({}, defaults);
-
     // Change Locale (which also changes right-to-left text setting)
     if (req.query.locale && req.query.locale.length > 0) {
       res.opts.locale = req.query.locale;
@@ -37,6 +34,7 @@ module.exports = function (app, defaults) {
     // NOTE: see the `app/src/js/custom-route-options.js` middleware for where this
     // setting is translated into `window.SohoConfig`.
     if (req.query.minify && req.query.minify.length > 0) {
+      setImportStyle(req, res, 'minify');
       res.opts.minify = true;
       logger('info', 'Using the minified version of "sohoxi.js" and culture files');
     }

--- a/app/src/js/set-import-style.js
+++ b/app/src/js/set-import-style.js
@@ -1,0 +1,13 @@
+// Import styles
+const importStyles = ['default', 'min', 'esm'];
+
+// Wrapper function for setting the import style of the IDS library
+// If the style isn't included
+module.exports = function setImportStyle(req, res, style) {
+  if (!importStyles.includes(style)) {
+    return;
+  }
+  if (style !== 'default') {
+    res.opts.importStyle = style;
+  }
+};

--- a/app/views/includes/head.html
+++ b/app/views/includes/head.html
@@ -22,16 +22,30 @@
   {{#SohoConfig}}
   <script>
     window.SohoConfig = JSON.parse('{{{SohoConfig}}}');
+    window.IDSConfig = window.SohoConfig;
   </script>
   {{/SohoConfig}}
 
-  {{#minify}}
-  <script src="{{basepath}}js/sohoxi.min.js"></script>
-  {{/minify}}
-  {{^minify}}
-  <script src="{{basepath}}js/sohoxi.js"></script>
-  {{/minify}}
-  <script src="{{basepath}}js/sohoxi-migrate-4.4.0.js"></script>
+  {{#importStyle}}
+    {{#esModule}}
+    <script id="ids-module" type="module">
+      (async () => {
+        const moduleSpecifier = '{{basepath}}js/sohoxi.esm.js';
+        const Soho = await import(moduleSpecifier);
+
+        window.Soho = Soho;
+      })();
+    </script>
+    {{/esModule}}
+    {{^esModule}}
+      <script src="{{basepath}}js/sohoxi.{{importStyle}}.js"></script>
+      <script src="{{basepath}}js/sohoxi-migrate-4.4.0.js"></script>
+    {{/esModule}}
+  {{/importStyle}}
+  {{^importStyle}}
+    <script src="{{basepath}}js/sohoxi.js"></script>
+    <script src="{{basepath}}js/sohoxi-migrate-4.4.0.js"></script>
+  {{/importStyle}}
 
   <!-- Supplying the culture in the head is supported
   <script src="{{basepath}}js/sohoxi.js?v=MTIuMC4wLjAuMQ"></script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### v4.30.0 Features
 
 - `[Datagrid]` Added a setting disableRowDeselection that if enabled does not allow selected rows to be toggled to deselected. ([#3791](https://github.com/infor-design/enterprise/issues/3791))
+- `[Demoapp]` Added the ability to set runtime flags for persisting settings that were previously only possible to set via URL query parameters. ([n/a])
 
 ### v4.30.0 Fixes
 

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -148,12 +148,28 @@ Optional: We use [`nvm`](https://github.com/creationix/nvm) in development so th
 
 See the `scripts` object in [package.json](../package.json) for a full list of commands.
 
-#### Debugging the Demo Server
+#### Debugging the Demo Application
+
+Debugging the Demo App can be done in the usual manner for Node applications, with the `--inspect` or `--inspect-brk` flags:
 
 - Add a break point in the demo app code
-- Run `node --inspect app/server.js --verbose` to start the app in debug mode
+- Run `node --inspect-brk app/server.js --verbose` to start the app in debug mode
 - Open chrome and navigate to `chrome://inspect` and press run target
 - Open the page in question and the debugger should popup up
+
+It's also possible to start the demoapp with flags that control certain options, such as locale, color scheme, etc.  Unless these flags are individually overriden via URL query parameters, they will take effect on all pages until the demoapp is restarted.
+
+For example, if you wanted to test overall changes to the demoapp in the Spanish locale with an alternate color scheme, you could start the demoapp with the following flags:
+
+```sh
+node app/server.js --verbose --locale=es-ES --colors=#941e1e
+```
+
+Appending these same parameters to the URL is a way to temporarily test them against a single page:
+
+```
+http://localhost:4000/components/mask/test-number-mask-gauntlet?locale=es-ES&colors=#941e1e
+```
 
 #### Editor Plugins
 

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -167,7 +167,7 @@ node app/server.js --verbose --locale=es-ES --colors=#941e1e
 
 Appending these same parameters to the URL is a way to temporarily test them against a single page:
 
-```
+```html
 http://localhost:4000/components/mask/test-number-mask-gauntlet?locale=es-ES&colors=#941e1e
 ```
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds middleware to the Demoapp that makes matching terminal flags available for the same settings that we normally use for testing via URL query params.  It's now possible to run the demoapp with parameters such as:

```sh
node app/server.js --verbose --locale=es-ES colors=#941e1e
```

**Related github/jira issue (required)**:
N/A

**Steps necessary to review your pull request (required)**:
- Pull this branch and build the library if necessary
- Run the demoapp manually with `node app/server.js --verbose --locale=es-ES colors=#941e1e` (or test other combinations of the settings found [here](https://github.com/infor-design/enterprise/compare/add-demoapp-cmd-flags?expand=1#diff-3c3a0c18d3331c0e92869c1a5c893cf0R16-R71))
- Navigate to any page (I tested with the [Number Mask Gauntlet](http://localhost:4000/components/mask/test-number-mask-gauntlet)).  The flags set in the terminal should cause those settings to permanently work on all pages, unless specifically overriden by a URL query paramter (or in the case of page layouts, layouts that are specifically set by the demoapp in some cases).

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
