### PR TITLE
3749 - Fix row reorder and paging data sync with datagrid

### DIFF
--- a/app/views/components/datagrid/test-row-reorder-paging.html
+++ b/app/views/components/datagrid/test-row-reorder-paging.html
@@ -1,0 +1,37 @@
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+
+<script id="test-script">
+  $('body').one('initialized', function () {
+    var columns = [];
+
+    // Define columns for the grid
+    columns.push({ id: 'rowReorder', name: '', field: 'id', align: 'center', sortable: false, formatter: Formatters.RowReorder });
+    columns.push({ id: 'id', name: 'Id', field: 'id', formatter: Formatters.Text, sortable: false });
+    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink });
+    columns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', sortable: false });
+    columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', sortable: false });
+    columns.push({ id: 'price', name: 'Price', field: 'price', formatter: Formatters.Decimal, sortable: false });
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy', sortable: false });
+
+    // Get some data via ajax
+    var url = '{{basepath}}api/compressors?pageNum=1&pageSize=1000';
+    $.getJSON(url, function(res) {
+
+      // Initialize the grid
+      $('#datagrid').datagrid({
+        columns: columns,
+        dataset: res.data,
+        paging: true,
+        pagesize: 5,
+        rowReorder: true,
+        toolbar: { title: 'Compressors', actions: true, personalize: true, results: true }
+      });
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Datagrid]` Fix a bug with columns with buttons, they had an unneeded animation that caused states to be delayed when painting. ([#3808](https://github.com/infor-design/enterprise/issues/3808))
 - `[Datagrid]` Fixed an issue where an extra border is shown in grid list mode and RTL. ([#3895](https://github.com/infor-design/enterprise/issues/3895))
 - `[Datagrid]` Fix a bug with columns with buttons, they had an unneeded animation that caused states to be delayed when painting. ([#3808](https://github.com/infor-design/enterprise/issues/3808))
+- `[Datagrid]` Fixed an issue where data was not in sync for row reorder and paging. ([#3749](https://github.com/infor-design/enterprise/issues/3749))
 - `[Datagrid]` Fixed an issue where using selectRowsAcrossPages setting the selected rows were reseting by filter, to use this feature you may need to set columnIds in the settings to form whats unique for the row. ([#3601](https://github.com/infor-design/enterprise/issues/3601))
 - `[Icons]` Fixed an issue with the amend icon in uplift theme. The meaning was lost on a design change and it has been updated. ([#3613](https://github.com/infor-design/enterprise/issues/3613))
 - `[Locale]` Changed results text to lower case. ([#3974](https://github.com/infor-design/enterprise/issues/3974))

--- a/src/components/arrange/arrange.js
+++ b/src/components/arrange/arrange.js
@@ -212,7 +212,7 @@ Arrange.prototype = {
         return this.isIe;
       });
 
-    this.items.each(function () {
+    this.items.add(placeholder).each(function () {
       $(this)
         // Drag start --------------------------------------------------------------------------
         .on(self.dragStart, function (e) {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -2864,33 +2864,30 @@ Datagrid.prototype = {
     const endRow = this.tableBody.find('tr').eq(endIndex);
 
     // Move the elem in the data set
-    const startRowIdx = this.settings.dataset.splice(startIndex, 1)[0];
-    this.settings.dataset.splice(endIndex, 0, startRowIdx);
+    const dataRowIndex = { start: this.dataRowIndex(status ? status.start : endRow) };
+    dataRowIndex.end = dataRowIndex.start + (endIndex - startIndex);
+    this.arrayIndexMove(this.settings.dataset, dataRowIndex.start, dataRowIndex.end);
 
-    // move in the ui
-    if (!status && moveDown) {
-      startRow.insertAfter(endRow);
-    }
-
-    if (!status && !moveDown) {
-      startRow.insertBefore(endRow);
-    }
-
-    // If using expandable rows move the expandable row with it
-    if ((this.settings.rowTemplate || this.settings.expandableRow) && moveDown) {
-      this.tableBody.find('tr').eq(startIndex * 2).insertAfter(status.end);
-      status.end.next().next().insertAfter(status.over);
-    }
-
-    if ((this.settings.rowTemplate || this.settings.expandableRow) && !moveDown) {
-      this.tableBody.find('tr').eq(startIndex * 2).next().insertAfter(status.end);
+    if (status) {
+      // If using expandable rows move the expandable row with it
+      if (this.settings.rowTemplate || this.settings.expandableRow) {
+        if (moveDown) {
+          this.tableBody.find('tr').eq(startIndex * 2).insertAfter(status.end);
+          status.end.next().next().insertAfter(status.over);
+        } else {
+          this.tableBody.find('tr').eq(startIndex * 2).next().insertAfter(status.end);
+        }
+      }
+    } else {
+      // Move in the ui
+      startRow[moveDown ? 'insertAfter' : 'insertBefore'](endRow);
     }
 
     // Resequence the rows
     const allRows = this.tableBody.find('tr:not(.datagrid-expandable-row)');
     for (let i = 0; i < allRows.length; i++) {
       allRows[i].setAttribute('data-index', i);
-      allRows[i].setAttribute('aria-rowindex', i + 1);
+      allRows[i].setAttribute('aria-rowindex', this.pagingRowIndex(i + 1));
     }
 
     /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed data was not in sync for row reorder and paging with Datagrid, also found arrange was broken after drag end the dragged item was returning to its initial place so this PR will fix arrange issue too.

**Related github/jira issue (required)**:
Closes #3794

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/test-row-reorder-paging.html
- Use first column tree dots icon handle to drag rows
- Drag any row to change the order
- See after drag-end dragged item should stay where it droped
- Do the same on different pages, then revisit the pages
- See the rows should stay as you had changed the order

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
