### PR TITLE
3766 - Fix dropdown icon position in Safari

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### v4.30.0 Fixes
 
+- `[Application Menu]` Fixed an issue where the dropdown icon is not properly centered in Safari. ([#3766](https://github.com/infor-design/enterprise/issues/3766))
 - `[Accordion]` Fixed an issue where the chevron icon is not properly centered in Safari. ([#2161](https://github.com/infor-design/enterprise/issues/2161))
 - `[Calendar]` Fixed a bug that when setting accordions to allowOnePane it did not work. ([#3773](https://github.com/infor-design/enterprise/issues/3773))
 - `[Calendar]` Fixed a bug where the accordion sections would show a line on hover in high contrast mode. ([#2779](https://github.com/infor-design/enterprise/issues/2779))

--- a/src/components/applicationmenu/_applicationmenu-uplift.scss
+++ b/src/components/applicationmenu/_applicationmenu-uplift.scss
@@ -806,3 +806,15 @@ html[dir='rtl'] {
     }
   }
 }
+
+.is-safari {
+  .application-menu {
+    .accordion-static-panel {
+      .btn-menu {
+        svg {
+          margin-top: -2px;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fix the dropdown icon not properly centered in Safari.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/3766

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Open Safari and go to http://localhost:4000/components/applicationmenu/example-menubutton.html?theme=uplift&variant=light&colors=0066D4
- Dropdown icon should properly aligned with the text beside it.

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
