### PR TITLE
Fix build link and lint errors on fresh node_modules

### DIFF
--- a/docs/PUBLISH.md
+++ b/docs/PUBLISH.md
@@ -77,7 +77,7 @@ git config --global credential.helper wincred
     - You may get warnings about the release you are trying to do, will not line up with the previous tag. This is usually nothing, but spend a minute or two to think through it.
 
 1. Set the master branch to the next minor dev version. For example if we made branch `4.23.x`, then the `master` package.json version should now be changed to `4.24.0-dev`
-1. Check that the build is running after for the deploy on the [Jenkins Server](http://jenkins.design.infor.com:8080/job/soho4-swarm-deploy/)
+1. Check that the build is running after for the deploy on the [Jenkins Server](http://jenkins.design.infor.com:8080/job/soho-kubernetes-deploy/)
 1. Watch Ms Teams for a posted release and notify QA for beta and minor
 
 For a final release, finish with:

--- a/scripts/jenkins-deploy.sh
+++ b/scripts/jenkins-deploy.sh
@@ -2,7 +2,7 @@
 
 JENKINS_USER="Jenkins"
 JENKINS_DOMAIN="jenkins.design.infor.com:8080"
-JENKINS_JOB="soho4-swarm-deploy"
+JENKINS_JOB="soho-kubernetes-deploy"
 JENKINS_URL="http://$JENKINS_USER:$JENKINS_API_TOKEN@$JENKINS_DOMAIN"
 
 BUILD_FROM="master"

--- a/src/components/column/column.js
+++ b/src/components/column/column.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-nested-ternary, prefer-arrow-callback */
+/* eslint-disable no-nested-ternary, prefer-arrow-callback, no-unused-vars */
 
 // Other Shared Imports
 import * as debug from '../../utils/debug';

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 const { browserStackErrorReporter } = requireHelper('browserstack-error-reporter');
 const config = requireHelper('e2e-config');
 const utils = requireHelper('e2e-utils');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

A ~ update of eslint has some lint errors. Fixing these. Also the build name on jenkins was renamed.

**Steps necessary to review your pull request (required)**:
- rm -rf node_modules
- npm i
- npm run build
-  npm run eslint:error-only
