### PR TITLE
3644 - Fix focus traps when nesting Popovers within Modals

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[Icons]` Fixed an issue with the amend icon in uplift theme. The meaning was lost on a design change and it has been updated. ([#3613](https://github.com/infor-design/enterprise/issues/3613))
 - `[Locale]` Changed results text to lower case. ([#3974](https://github.com/infor-design/enterprise/issues/3974))
 - `[Lookup]` Fixed a bug that the required validation would not reset from empty in certain cases. ([#810](https://github.com/infor-design/enterprise-ng/issues/810))
+- `[Popover]` Corrected the tabindex order of Popover elements when the Popover is contained within a Modal. ([#3644](https://github.com/infor-design/enterprise/issues/3644))
 - `[Textarea]` Added tests to show that the textarea count text is translated. ([#3807](https://github.com/infor-design/enterprise/issues/3807))
 - `[Tree]` Fixed an issue where previous text selection was not clearing after clicked to any tree-node. ([#3794](https://github.com/infor-design/enterprise/issues/3794))
 

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -788,7 +788,8 @@ Tooltip.prototype = {
   /**
    * Places the tooltip element itself in the correct DOM element.
    * If the current element is inside a scrollable container, the tooltip element
-   *  goes as high as possible in the DOM structure.
+   * goes as high as possible in the DOM structure.
+   * @private
    * @returns {void}
    */
   setTargetContainer() {

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -684,6 +684,7 @@ Tooltip.prototype = {
 
     this.position();
     utils.fixSVGIcons(this.tooltip);
+
     /**
      * Fires on show the tooltip.
      *
@@ -792,6 +793,7 @@ Tooltip.prototype = {
    */
   setTargetContainer() {
     let targetContainer = $('body');
+    let attachAfterTriggerElem = false;
 
     // adjust the tooltip if the element is being scrolled inside a scrollable DIV
     this.scrollparent = this.element.closest('.page-container.scrollable');
@@ -799,12 +801,24 @@ Tooltip.prototype = {
       targetContainer = this.scrollparent;
     }
 
+    // If the tooltip/popover is located inside a Modal, contain it within the modal, but
+    // place its markup directly after its target element.
+    const modalParent = this.element.closest('.modal');
+    if (modalParent.length) {
+      attachAfterTriggerElem = true;
+      targetContainer = modalParent;
+    }
+
+    // If a specific parent element is defined, use that
     if (this.settings.parentElement) {
       targetContainer = this.settings.parentElement;
     }
 
-    // this.tooltip.detach().appendTo(targetContainer);
-    targetContainer[0].appendChild(this.tooltip[0]);
+    if (attachAfterTriggerElem) {
+      this.tooltip.insertAfter(this.element);
+    } else {
+      targetContainer[0].appendChild(this.tooltip[0]);
+    }
   },
 
   /**

--- a/test/components/modal/modal.e2e-spec.js
+++ b/test/components/modal/modal.e2e-spec.js
@@ -454,3 +454,32 @@ describe('Nested Modal keyboard access tests', () => {
     expect(await element(by.css('#ids-modal-root')).getAttribute('aria-hidden')).not.toBe(null);
   });
 });
+
+describe('Modal with external components tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/modal/test-external-components?layout=nofrills');
+    const buttonEl = await element(by.id('add-context'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(buttonEl), config.waitsFor);
+    await buttonEl.click();
+    await browser.driver.sleep(config.sleep);
+  });
+
+  it('should be able to tab into Popover elements from within the Modal', async () => {
+    // Tab to the Popover trigger button
+    await browser.driver.actions().sendKeys(protractor.Key.TAB).perform();
+    await browser.driver.actions().sendKeys(protractor.Key.TAB).perform();
+    await browser.driver.actions().sendKeys(protractor.Key.TAB).perform();
+
+    // Activate the popover
+    await browser.driver.actions().sendKeys(protractor.Key.ENTER).perform();
+    await browser.driver.sleep(config.sleep);
+
+    // Press tab, which should tab into the Popover and focus the close button
+    await browser.driver.actions().sendKeys(protractor.Key.TAB).perform();
+    const focusedElemText = await browser.driver.switchTo().activeElement().getText();
+
+    // Check the text content of the button for accuracy
+    expect(focusedElemText).toEqual('Close');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR changes how Popovers are rendered when nested within Modal components, in order to fix the `tabindex` order of focusable elements.  This fixes an accessibility issue where it was not possible to access the contents of a Popover with the keyboard while nested within a Modal.

**Related github/jira issue (required)**:
Close #3644

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the demoapp
- Open http://localhost:4000/components/modal/test-external-components?layout=nofrills
- Click the "Show Modal" button
- Use the keyboard to tab into the "Click to Show Popover" button
- Press the enter key to activate the Popover
- Press the tab key once more to tab into the Popover contents.  The Popover's `close` button should become focused, not the Textarea below.

This sequence is also covered by a new e2e test 

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.