### PR TITLE
3731 - Fix hyperlink and keyword search with datagrid

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5802,7 +5802,7 @@ Datagrid.prototype = {
     let row = this.settings.treeGrid ? this.actualRowIndex(rowElem) : this.dataRowIndex(rowElem);
     let isTrigger = true;
 
-    if (target.is('a')) {
+    if (target.is('a') || target.closest('a').length) {
       stopPropagation = false;
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed hyperlinks were not working after keyword search with Datagrid.

**Related github/jira issue (required)**:
Closes #3731

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to http://localhost:4000/components/datagrid/example-keyword-search.html
- Click on any cell in column `Product Name`
- Link should open in next tab
- Do keyword search for `I Love Compressors`
- In searched result click in column `Product Name`
- Link should open in next tab
- Clear keyword search
- - Click again on any cell in column `Product Name`
- Link should open in next tab

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
