### PR TITLE
NA - Add fixes to speed up accordion

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -652,7 +652,7 @@
 .accordion-pane {
   @include transition(padding 300ms cubic-bezier(0.17, 0.04, 0.03, 0.94));
 
-  display: block;
+  display: none;
   overflow: hidden;
   padding: 0;
 
@@ -662,6 +662,7 @@
 
   // Visible accordion panes force a border to show up on the next accordion header for visual separation
   &.is-expanded {
+    display: block;
     padding: 0;
 
     + .accordion-header,

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -744,7 +744,7 @@ Accordion.prototype = {
       return;
     }
 
-    return header.children('a').attr('aria-expanded') === 'true';
+    return header.children('a').attr('aria-expanded') === 'true' || header.hasClass('is-expanded');
   },
 
   /**

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -942,9 +942,6 @@ Accordion.prototype = {
       expander.children('.audible').text(Locale.translate('Expand'));
     }
 
-    header.add(pane).removeClass('is-expanded');
-    a.attr('aria-expanded', 'false');
-
     if (closeChildren) {
       pane.closeChildren();
     }
@@ -972,6 +969,8 @@ Accordion.prototype = {
       }
       pane.triggerHandler('aftercollapse', [a]);
       self.element.trigger('aftercollapse', [a]);
+      header.add(pane).removeClass('is-expanded');
+      a.attr('aria-expanded', 'false');
       dfd.resolve();
     }
 

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -485,7 +485,6 @@ Calendar.prototype = {
     }
 
     $('.accordion-pane.no-transition', this.element).removeClass('no-transition');
-    $(this.eventDetailsContainer).find('.is-expanded').removeClass('is-expanded');
   },
 
   /**

--- a/test/components/calendar/calendar.e2e-spec.js
+++ b/test/components/calendar/calendar.e2e-spec.js
@@ -373,7 +373,7 @@ describe('Calendar allow one pane tests', () => {
   it('Should only allow one pane open at a time', async () => {
     await utils.checkForErrors();
 
-    expect(await element.all(by.css('.calendar-event-details .accordion-pane.is-expanded')).count()).toEqual(0);
+    expect(await element.all(by.css('.calendar-event-details .accordion-pane.is-expanded')).count()).toEqual(1);
 
     const buttonEl = await element(by.css('.calendar-event-details > div:nth-child(5) button'));
     await buttonEl.click();

--- a/test/components/calendar/calendar.e2e-spec.js
+++ b/test/components/calendar/calendar.e2e-spec.js
@@ -380,6 +380,7 @@ describe('Calendar allow one pane tests', () => {
 
     await browser.driver
       .wait(protractor.ExpectedConditions.visibilityOf(await element(by.css('.calendar-event-details > div:nth-child(6).is-expanded'))), config.waitsFor);
+    await browser.driver.sleep(1000);
 
     expect(await element.all(by.css('.calendar-event-details .accordion-pane.is-expanded')).count()).toEqual(1);
   });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
When dealing with a huge list of accordions plus a couple of expensive methods forcing reflow as mentioned here: https://gist.github.com/paulirish/5d52fb081b3570c81e3a, the whole application performance suffers. Anything you do is unbearably slow even just ticking a checkbox.

The proposed style changes here is not going to affect how the accordion would look. Doing the `display:none` when the panel is not expanded just helps the browser deal with the force reflows more easily.

**Related github/jira issue (required)**:
I am unable to create a reproducible example in this repo since the problem only occurs when using the library in an angular project where those methods mentioned above are called during component modifications done in AfterViewChecks. 

What I can show is how it affects the performance in landmark:
![accordion-reflow](https://user-images.githubusercontent.com/11013464/84643145-037c7300-af30-11ea-8fb0-f874f9807bc0.gif)
This gif above shows the comparison with and without the proposed changes and how it affects the animations like expanding the menus and ticking the checkboxes.

**Steps necessary to review your pull request (required)**:
http://localhost:4000/components/applicationmenu
http://localhost:4000/components/calendar
and
http://localhost:4000/components/accordion
