### PR TITLE
3767/4055 - Multiselect padding followup fix

### DIFF
--- a/src/components/dropdown/_dropdown-uplift.scss
+++ b/src/components/dropdown/_dropdown-uplift.scss
@@ -322,7 +322,18 @@ html.is-firefox:not([dir='rtl']) {
     }
 
     &.has-tags {
-      padding: 1px 30px 1px 10px;
+      padding: 0;
+    }
+
+    .tag-list {
+      padding: 4px 30px 6px 10px;
+
+      &.empty {
+        &::after {
+          content: ' ';
+          display: inline-block;
+        }
+      }
     }
   }
 

--- a/src/components/dropdown/_dropdown-uplift.scss
+++ b/src/components/dropdown/_dropdown-uplift.scss
@@ -25,7 +25,7 @@ div.multiselect {
   }
 
   &.has-tags {
-    padding: 2px 30px 3px 10px;
+    padding: 0;
 
     + .icon {
       height: 30px;
@@ -33,7 +33,7 @@ div.multiselect {
   }
 
   .tag-list {
-    padding: 1px 4px 4px;
+    padding: 2px 30px 4px 10px;
 
     &.empty {
       padding: 16px 0 15px;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
I noticed in this screenshot from @janahintal that the padding on Uplift theme was off in the Multiselect with tags. This PR patches that in all browsers.

![image](https://user-images.githubusercontent.com/45757016/85011881-c238cd00-b194-11ea-84b5-35302c732fd0.png)

**Related github/jira issue (required)**:
Closes #3767
Closes #4055 

**Steps necessary to review your pull request (required)**:
- Pull the branch, build, and run the app
- Open http://localhost:4000/components/multiselect/test-select-all-tags.html?theme=uplift&variant=light
- Open the Multiselect and select all
- Try and scroll the Tag List.  It should be flush with the left/right edges of the pseudo-element.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
