### PR TITLE
3856 - Fix example page for filter and pager with datagrid

### DIFF
--- a/app/views/components/datagrid/example-paging.html
+++ b/app/views/components/datagrid/example-paging.html
@@ -26,6 +26,7 @@
       //Init and get the api for the grid
       grid = $('#datagrid').datagrid({
         allowSelectAcrossPages: true,
+        columnIds: ['productName', 'activity', 'productId'],
         columns: columns,
         selectable: 'multiple',
         paging: true,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Contextual Action Panel]` Fixed an issue where the searchfield should be collapsible on mobile view. ([#918](https://github.com/infor-design/enterprise/issues/918))
 - `[Datagrid]` Fixed an issue where the table doesn't filled the datagrid wrapper inside of modal. ([#3897](https://github.com/infor-design/enterprise/issues/3897))
 - `[Datagrid]` Fix a bug with columns with buttons, they had an unneeded animation that caused states to be delayed when painting. ([#3808](https://github.com/infor-design/enterprise/issues/3808))
+- `[Datagrid]` Fixed an issue where example page for filter and pager was not working properly. ([#3856](https://github.com/infor-design/enterprise/issues/3856))
 - `[Datagrid]` Fix a bug with cellNavigation false, the focus state was still visible. ([#3937](https://github.com/infor-design/enterprise/issues/3937))
 - `[Datagrid]` Fix a bug with cellNavigation false, the focus state was incorrect on stretched rows in IE. ([#1644](https://github.com/infor-design/enterprise/issues/1644))
 - `[Datagrid]` Fixed an issue where an extra border is shown in grid list mode and RTL. ([#3895](https://github.com/infor-design/enterprise/issues/3895))


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed example page for filter and pager was not working properly with Datagrid.

**Related github/jira issue (required)**:
Closes #3856

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/example-paging.html
- Filter `3` on `Product Id`
- Select the filter row with id `3` while filtering
- Now clear the filter to show all the records
- Selected row should remain selected

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
