### PR TITLE
853 - Add fixes for datepicker change event

### DIFF
--- a/app/views/components/datepicker/test-change-event.html
+++ b/app/views/components/datepicker/test-change-event.html
@@ -17,6 +17,7 @@
   $('#date-field-1, #date-field-2').on('change', function () {
       $('body').toast({
       title: 'Change Event Fired',
+      timeout: 20000,
       message: 'Value is now: '+ $(this).val() +''
     });
   });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,8 @@
 - `[Datagrid]` Fixed an issue the arrow on tooltips flowed in the wrong direction. ([#3854](https://github.com/infor-design/enterprise/issues/3854))
 - `[Datagrid]` Fixed an issue where readonly and checkbox cells would show up on the summary row. ([#3862](https://github.com/infor-design/enterprise/issues/3862))
 - `[Datepicker]` Fixed an issue where some languages like fr-CA and pt-BR (that are languages in a non default locale), would error when opening the picker. ([#4035](https://github.com/infor-design/enterprise/issues/4035))
+- `[Datepicker]` Fixed an issue where change did not fire when rangeselecting the same day. ([#4075](https://github.com/infor-design/enterprise/issues/4075))
+- `[Datepicker]` Fixed an issue where change did not fire when selecting today after having a cleared value in the field. ([#853](https://github.com/infor-design/enterprise-ng/issues/853))
 - `[Dropdown]` Changed the keyboard dropdown so it will select the active item when tabbing out. ([#3028](https://github.com/infor-design/enterprise/issues/3028))
 - `[Icons]` Fixed an issue with the amend icon in uplift theme. The meaning was lost on a design change and it has been updated. ([#3613](https://github.com/infor-design/enterprise/issues/3613))
 - `[Locale]` Changed results text to lower case. ([#3974](https://github.com/infor-design/enterprise/issues/3974))

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -854,6 +854,7 @@ DatePicker.prototype = {
 
         const cell = $(this);
         cell.addClass(`is-selected${(s.range.useRange ? ' range' : '')}`).attr('aria-selected', 'true');
+        self.lastValue = '';
         self.insertSelectedDate(cell);
 
         if (s.range.useRange) {
@@ -1694,6 +1695,7 @@ DatePicker.prototype = {
    */
   setToday(keepFocus) {
     const s = this.settings;
+    this.lastValue = null;
     this.currentDate = new Date();
 
     if (!this.settings.useCurrentTime) {

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -854,7 +854,7 @@ DatePicker.prototype = {
 
         const cell = $(this);
         cell.addClass(`is-selected${(s.range.useRange ? ' range' : '')}`).attr('aria-selected', 'true');
-        self.lastValue = '';
+        self.lastValue = null;
         self.insertSelectedDate(cell);
 
         if (s.range.useRange) {

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -749,6 +749,22 @@ describe('Datepicker Change Event Tests', () => {
 
     expect(await element.all(by.css('#toast-container')).count()).toEqual(1);
   });
+
+  it('Should trigger after clearing the value', async () => {
+    await element(by.css('#date-field-1 + .icon')).click();
+    await element(by.css('.hyperlink.today')).click();
+
+    expect(await element.all(by.css('#toast-container')).count()).toEqual(1);
+
+    await element(by.css('#date-field-1')).click();
+    await element(by.css('#date-field-1')).clear();
+    await element(by.css('#date-field-1')).sendKeys(protractor.Key.TAB);
+
+    await element(by.css('#date-field-1 + .icon')).click();
+    await element(by.css('.hyperlink.today')).click();
+
+    expect(await element.all(by.css('#toast-container')).count()).toEqual(1);
+  });
 });
 
 describe('Datepicker Destroy Mask Tests', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

In a couple cases the change event didnt fire right.

**Related github/jira issue (required)**:
Fixes infor-design/enterprisee-ng#853
Fixes #4075

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datepicker/test-change-event.html
- open the picker and click today -> toast will fire
- blank out the field -> toast will fire
- open the picker and click today again -> toast will fire (this wasnt working before)
- go to http://localhost:4000/components/datepicker/example-range.html
- in the "Range - No Initial value" field open the picker
- click June 3
- click June 3rd again
- check the console and there should be two events one with one value and one with the same day range

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
