### PR TITLE
4062 - Add fix for checkboxes in an expandable datagrid row

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@
 - `[Datagrid]` Fixed an issue where when using the contentTooltip setting on a datagrid on a modal, the column would expand when hovering rows. ([#3541](https://github.com/infor-design/enterprise/issues/3541))
 - `[Datagrid]` Fixed an issue the arrow on tooltips flowed in the wrong direction. ([#3854](https://github.com/infor-design/enterprise/issues/3854))
 - `[Datagrid]` Fixed an issue where readonly and checkbox cells would show up on the summary row. ([#3862](https://github.com/infor-design/enterprise/issues/3862))
+- `[Datagrid]` Fixed an issue where checkboxes in an expandable area could not be checked. ([#4062](https://github.com/infor-design/enterprise/issues/4062))
 - `[Datepicker]` Fixed an issue where some languages like fr-CA and pt-BR (that are languages in a non default locale), would error when opening the picker. ([#4035](https://github.com/infor-design/enterprise/issues/4035))
 - `[Dropdown]` Changed the keyboard dropdown so it will select the active item when tabbing out. ([#3028](https://github.com/infor-design/enterprise/issues/3028))
 - `[Icons]` Fixed an issue with the amend icon in uplift theme. The meaning was lost on a design change and it has been updated. ([#3613](https://github.com/infor-design/enterprise/issues/3613))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -6010,7 +6010,7 @@ Datagrid.prototype = {
       const target = $(e.target);
       const td = target.closest('td');
 
-      if ($(e.currentTarget).parent().hasClass('.datagrid-row-detail')) {
+      if ($(e.currentTarget).closest('.datagrid-expandable-row').length === 1) {
         return;
       }
 

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -2056,6 +2056,26 @@ describe('Datagrid Header Alignment with Ellipsis and Sorting', () => {
   }
 });
 
+describe('Datagrid Expandable Row with checkboxes', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/test-expandable-row-checkboxes');
+
+    const datagridEl = await element(by.css('#datagrid tr:nth-child(1)'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should be able to check the checkboxes in an expandable area', async () => {
+    await element(by.css('[aria-rowindex="1"] [aria-colindex="1"] button')).click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element.all(by.css('.datagrid-expandable-row.is-expanded .checkbox')).first().isSelected()).toBeTruthy();
+    await element(by.css('.datagrid-expandable-row.is-expanded .inline-checkbox')).click();
+
+    expect(await element.all(by.css('.datagrid-expandable-row.is-expanded .checkbox')).first().isSelected()).toBeFalsy();
+  });
+});
+
 describe('Datagrid Expandable Row with multiselect', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-expandable-row-multiselect');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

An issue regressed where checkboxes in an expandable row could no longer be checked.


**Related github/jira issue (required)**:
Fixes #4062


**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-expandable-row-checkboxes.html#
- expand any row
- click the checkbox (it should toggle and it wasnt before)

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
