### PR TITLE
2806 - Add example page for server side keyword search with lookup

### DIFF
--- a/app/views/components/lookup/test-paging-server-side-keyword-search.html
+++ b/app/views/components/lookup/test-paging-server-side-keyword-search.html
@@ -1,0 +1,61 @@
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="field">
+      <label for="product-lookup" class="label">Products</label>
+      <input id="product-lookup" name="product-lookup" data-init="false" class="lookup" type="text"/>
+    </div>
+
+  </div>
+</div>
+
+<script id="test-script">
+  var columns = [];
+
+  // Define Columns for the Grid.
+  columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink});
+
+  // Init and get the api for the grid
+  $('#product-lookup').lookup({
+    field: 'productName',
+    options: {
+      columns: columns,
+      disableClientFilter: true,
+      disableClientSort: true,
+      columnReorder: true,
+      paging: true,
+      pagesize: 10,
+      pagesizes: [5, 10, 25, 50],
+      selectable: 'single',
+      toolbar: {
+        results: true,
+        keywordFilter: true,
+        actions: false
+      },
+      source: function (req, response) {
+        console.log('lookup source', req);
+        var url = '{{basepath}}api/compressors?pageNum='+ req.activePage +'&pageSize='+ req.pagesize;
+
+        if (req.sortField) {
+          url += '&sortField=' + req.sortField + '&sortAsc=' + req.sortAsc;
+        }
+
+        if (req.filterExpr && req.filterExpr[0]) {
+          url += '&filterValue=' + req.filterExpr[0].value;
+          url += '&filterOp=' + req.filterExpr[0].operator;
+          if (req.filterExpr[0].columnId) {
+            url += '&filterColumn=' + req.filterExpr[0].columnId;
+          } else if (req.filterExpr[0].column === 'all') {
+            url += '&filterColumn=' + columns[0].id;
+          }
+        }
+
+        //Get Page Based on info in Req, return results into response;
+        $.getJSON(url, function(res) {
+          req.total = res.total;
+          response(res.data, req);
+        });
+      }
+    }
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@
 - `[Locale]` Changed results text to lower case. ([#3974](https://github.com/infor-design/enterprise/issues/3974))
 - `[Locale]` Fixed abbreviated chinese month translations. ([#4034](https://github.com/infor-design/enterprise/issues/4034))
 - `[Lookup]` Fixed an issue in the min width examples that showed up in Safari only. ([#3949](https://github.com/infor-design/enterprise/issues/3949))
+- `[Lookup]` Added example page for server side keyword search. ([#2806](https://github.com/infor-design/enterprise/issues/2806))
 - `[Lookup]` Fixed a bug that the required validation would not reset from empty in certain cases. ([#810](https://github.com/infor-design/enterprise-ng/issues/810))
 - `[Lookup]` Fixed an issue in the min width examples that showed up in Safari only. ([#3949](https://github.com/infor-design/enterprise/issues/3949))
 - `[Popover]` Corrected the tabindex order of Popover elements when the Popover is contained within a Modal. ([#3644](https://github.com/infor-design/enterprise/issues/3644))


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added example page for server side keyword search with Lookup.

**Related github/jira issue (required)**:
Closes #2806

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/lookup/test-paging-server-side-keyword-search.html
- Open lookup modal
- See top title results count should be `1000`
- Search for `1` now results should change to `271`
- Change search to `0` now results should change to `181`
- Clear search to show all rows
- See results count should back to be `1000`

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
