### PR TITLE
3628 - Fix focus style alignment with field options

### DIFF
--- a/app/views/components/field-options/example-fieldset.html
+++ b/app/views/components/field-options/example-fieldset.html
@@ -96,7 +96,7 @@
 
               <div class="field">
                 <span class="label">Estimated Delivery</span>
-                <span class="data field-options">June 21, 2015 <i> (4 days)</i></span>
+                <span class="data field-options">June 21, 2015 (4 days)</span>
 
                 <button class="btn-actions btn-menu" type="button">
                   <span class="audible">Actions for Item Description</span>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@
 - `[Datepicker]` Fixed an issue where change did not fire when rangeselecting the same day. ([#4075](https://github.com/infor-design/enterprise/issues/4075))
 - `[Datepicker]` Fixed an issue where change did not fire when selecting today after having a cleared value in the field. ([#853](https://github.com/infor-design/enterprise-ng/issues/853))
 - `[Dropdown]` Changed the keyboard dropdown so it will select the active item when tabbing out. ([#3028](https://github.com/infor-design/enterprise/issues/3028))
+- `[Field Options]` Fixed an issue where the focus style was not aligning. ([#3628](https://github.com/infor-design/enterprise/issues/3628))
 - `[Icons]` Fixed an issue with the amend icon in uplift theme. The meaning was lost on a design change and it has been updated. ([#3613](https://github.com/infor-design/enterprise/issues/3613))
 - `[Locale]` Changed results text to lower case. ([#3974](https://github.com/infor-design/enterprise/issues/3974))
 - `[Locale]` Fixed abbreviated chinese month translations. ([#4034](https://github.com/infor-design/enterprise/issues/4034))

--- a/src/components/field-options/_field-options-uplift.scss
+++ b/src/components/field-options/_field-options-uplift.scss
@@ -115,6 +115,21 @@
   }
 }
 
+.summary-form {
+  .data.field-options {
+    line-height: 20px;
+    margin-bottom: -10px;
+
+    &.is-singleline {
+      margin-bottom: -7px;
+    }
+
+    ~ .btn-actions {
+      left: -11px;
+    }
+  }
+}
+
 .compound-field .field.is-fieldoptions:first-child input[type='text'] ~ .btn-actions:not(.is-checkbox) {
   left: -12px;
 }

--- a/src/components/field-options/_field-options.scss
+++ b/src/components/field-options/_field-options.scss
@@ -441,12 +441,20 @@
     border: solid 1px transparent;
     display: inline-block;
     height: auto;
-    line-height: 2rem;
+    line-height: 16px;
+    margin-bottom: -4px;
     margin-left: -5px;
     max-width: 100%;
     outline: 0;
     padding: 0 5px;
     width: calc(100% - 46px);
+
+    &.is-singleline {
+      margin-bottom: -5px;
+      margin-top: -9px;
+      padding-bottom: 9px;
+      padding-top: 6px;
+    }
 
     &:focus,
     &:active {

--- a/src/components/field-options/_field-options.scss
+++ b/src/components/field-options/_field-options.scss
@@ -440,6 +440,8 @@
   .data.field-options {
     border: solid 1px transparent;
     display: inline-block;
+    height: auto;
+    line-height: 2rem;
     margin-left: -5px;
     max-width: 100%;
     outline: 0;

--- a/src/components/field-options/field-options.js
+++ b/src/components/field-options/field-options.js
@@ -163,14 +163,7 @@ FieldOptions.prototype = {
       let returns;
 
       if (isFieldset) {
-        const lineHeight = parseInt(this.element.css('line-height'), 10);
-        if (height > lineHeight) {
-          this.element.css({ 'margin-bottom': '', 'padding-bottom': '' });
-          returns = ((height - lineHeight) / 2) * -1;
-        } else {
-          this.element.css({ 'margin-bottom': '8px', 'padding-bottom': '12px' });
-          returns = 6;
-        }
+        returns = (((height - this.trigger.height()) - 1) / 2) * -1;
       } else if (isRadio) {
         returns = ((height - this.trigger.height()) / 2) * -1;
       }

--- a/src/components/field-options/field-options.js
+++ b/src/components/field-options/field-options.js
@@ -163,7 +163,16 @@ FieldOptions.prototype = {
       let returns;
 
       if (isFieldset) {
-        returns = (((height - this.trigger.height()) - 1) / 2) * -1;
+        const lineHeight = parseInt(this.element.css('line-height'), 10);
+        if (height > lineHeight) {
+          this.element.removeClass('is-singleline');
+          returns = (((this.element.outerHeight() - this.trigger.height()) / 2) + 0) * -1;
+          const diff = (lineHeight - 16);
+          returns += diff ? (diff / 2) : 0;
+        } else {
+          this.element.addClass('is-singleline');
+          returns = 1.5;
+        }
       } else if (isRadio) {
         returns = ((height - this.trigger.height()) / 2) * -1;
       }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the focus style was not aligning with Field Options.

**Related github/jira issue (required)**:
Closes #3628

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/field-options/example-fieldset.html
- Click on any filed single line like `Building Suppliers`
- Or Multy line as `4209 Industrial Avenue, Los Angeles, California 90001 USA`
- Filed options button `three dotes` should align properly

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
