### PR TITLE
4087 - Datepicker change event getting missed

### DIFF
--- a/app/views/components/datepicker/test-change-event.html
+++ b/app/views/components/datepicker/test-change-event.html
@@ -2,19 +2,30 @@
   <div class="four columns">
     <div class="field">
       <label for="date-field-1" class="label">Date Field 1</label>
-      <input id="date-field-1" class="datepicker" name="date-field" type="text"/>
+      <input id="date-field-1" class="datepicker" name="date-field-1" type="text"/>
     </div>
 
     <div class="field">
       <label for="date-field-2" class="label">Date Field 2</label>
-      <input id="date-field-2" class="datepicker" name="date-field" type="text" value="3/3/2020"/>
+      <input id="date-field-2" class="datepicker" name="date-field-2" type="text" value="3/3/2020"/>
     </div>
+
+    <div class="field">
+      <label for="date-field-3" class="label">Date-Time Picker</label>
+      <input id="date-field-3" data-init="false" class="datepicker datetime" name="date-field-3" type="text" />
+    </div>
+
   </div>
 </div>
 
-
 <script>
-  $('#date-field-1, #date-field-2').on('change', function () {
+  $('body').on('initialized', function () {
+    $('#date-field-3').datepicker({
+      showTime: true
+    });
+  });
+
+  $('#date-field-1, #date-field-2, #date-field-3').on('change', function () {
       $('body').toast({
       title: 'Change Event Fired',
       timeout: 20000,

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -532,7 +532,6 @@ DatePicker.prototype = {
     const self = this;
     const s = this.settings;
     const timeOptions = {};
-    this.lastValue = typeof this.currentDate === 'string' ? this.currentDate : this.currentDate?.getTime();
 
     if ((this.element.is(':disabled') || this.element.attr('readonly')) && this.element.closest('.monthview').length === 0) {
       return;
@@ -1240,11 +1239,7 @@ DatePicker.prototype = {
       }));
     }
 
-    const newValue = typeof this.currentDate === 'string' ? this.currentDate : this.currentDate?.getTime();
-    const isChanged = this.lastValue !== newValue;
-    this.lastValue = newValue;
-
-    if (trigger && isChanged) {
+    if (trigger) {
       if (s.range.useRange) {
         if (!isTime) {
           this.element
@@ -1641,6 +1636,10 @@ DatePicker.prototype = {
       }
       if (parsedDate !== undefined && self.element.val().trim() !== '' && !s.range.useRange) {
         self.setValue(parsedDate);
+
+        if (fieldValueTrimmed !== self.element.val().trim()) {
+          this.element.trigger('change').trigger('input');
+        }
       }
     }
 
@@ -1917,8 +1916,6 @@ DatePicker.prototype = {
 
     // Fix two digit year for main input element
     self.element.on('blur.datepicker', () => {
-      this.lastValue = this.currentDate?.getTime;
-
       if (this.element.val().trim() !== '') {
         this.setValueFromField();
       }

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -708,7 +708,7 @@ describe('Datepicker Legend Tests', () => {
   }
 });
 
-describe('Datepicker Change Event Tests', () => {
+fdescribe('Datepicker Change Event Tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datepicker/test-change-event?layout=nofrills');
   });
@@ -737,6 +737,15 @@ describe('Datepicker Change Event Tests', () => {
     await element(by.css('#date-field-2')).clear();
     await element(by.css('#date-field-2')).sendKeys('5/2/2020');
     await element(by.css('#date-field-2')).sendKeys(protractor.Key.TAB);
+
+    expect(await element.all(by.css('#toast-container')).count()).toEqual(1);
+  });
+
+  it('Should trigger 1 change on clear and then change value', async () => {
+    await element(by.css('#date-field-2')).sendKeys('5/2/2020');
+    await element(by.css('#date-field-2')).clear();
+    await element(by.css('#date-field-1 + .icon')).click();
+    await element(by.css('.hyperlink.today')).click();
 
     expect(await element.all(by.css('#toast-container')).count()).toEqual(1);
   });

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -708,7 +708,7 @@ describe('Datepicker Legend Tests', () => {
   }
 });
 
-fdescribe('Datepicker Change Event Tests', () => {
+describe('Datepicker Change Event Tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datepicker/test-change-event?layout=nofrills');
   });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Essentially reverse the fix for https://github.com/infor-design/enterprise/pull/3593 as it seems to work ok now. And its better to have change fire more than once rather than case it doesn't fire and data gets lost. In most cases we get the right change events but in a couple multistep operations you may now get an extra change event.

But the change event should never NOT fire for a change at least once

**Related github/jira issue (required)**:
Fixes #4087 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datepicker/test-change-event.html
- click first field
- pick a value in the picker
- clear the field
- without leaving pick a new value (will get 3 changes for each step)
- try the steps on 3593 

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
