### PR TITLE
3978 - Add design system release for new icons

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@
 - `[Custom Builds]` The build script can now produce an ES Module version of the components that can be imported by your application. ([#3771](https://github.com/infor-design/enterprise/issues/3771))
 - `[Datagrid]` Added a setting disableRowDeselection that if enabled does not allow selected rows to be toggled to deselected. ([#3791](https://github.com/infor-design/enterprise/issues/3791))
 - `[Demoapp]` Added the ability to set runtime flags for persisting settings that were previously only possible to set via URL query parameters. ([n/a])
+- `[Demoapp]` Added the ability to set runtime flags for persisting settings that were previously only possible to set via URL query parameters. ([n/a])
+- `[Icons]` Changed the tree node icon to be more meaningful in uplift theme. Added a print-preview icon. This replaces the update-preview icon which has confusing meaning but was not removed.
 - `[Searchfield]` Added the ability to clear the searchfield by calling a public clear() function. ([#3810](https://github.com/infor-design/enterprise/issues/3810))
 - `[Tree]` Added a setting to support to expanding/collapsing when clicking only the icon portion of the tree node. ([#3730](https://github.com/infor-design/enterprise/issues/3730))
 - `[Tree]` Added the ability to have separate icon button for expand/collapse and children count. ([#3847](https://github.com/infor-design/enterprise/issues/3847))

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "handlebars-registrar": "^1.5.2",
     "html-loader": "^1.1.0",
     "ids-css": "^1.5.0",
-    "ids-identity": "2.9.10",
+    "ids-identity": "2.9.11",
     "jasmine-core": "^3.5.0",
     "jasmine-jquery": "^2.1.1",
     "jasmine-spec-reporter": "^5.0.2",


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Merged two new icons `print-preview` and `tree-node` in an updated design system

**Related github/jira issue (required)**:
Fixes #3978 

**Steps necessary to review your pull request (required)**:
- make sure to do `npm i` to get the latest ids identity
- go to http://localhost:4000/components/icons/example-index.html
- check out the print-preview icon 
- check it in uplift too
- go to http://localhost:4000/components/tree/example-index.html?theme=uplift&variant=light&colors=0066D4
- tree icon should not look like radio button any more

**Included in this Pull Request**:
- [x] A note to the change log.