### PR TITLE
Fixed hierarchy selection issue when nested inside of tabs.

### DIFF
--- a/app/views/components/hierarchy/test-vertical-tabs.html
+++ b/app/views/components/hierarchy/test-vertical-tabs.html
@@ -1,0 +1,71 @@
+<div class="page-container no-scroll">
+  <div class="page-container no-scroll">
+    <div id="tabs-vertical" class="vertical tab-container scrollable" data-options="{ &quot;lazyLoad&quot;: false }">
+      <div class="tab-list-container">
+        <div class="tab-focus-indicator is-selected" role="presentation" style="x: 0px; y: 80px; width: 249px; height: 36px; top: 20px; right: 249px; bottom: 116px; left: 0px;"></div>
+        <ul class="tab-list" role="tablist" aria-multiselectable="false">
+          <li class="tab is-selected" role="presentation">
+            <a href="#outbound-links-page-1" role="tab" aria-expanded="true" aria-selected="true" tabindex="0">Test 1</a>
+          </li>
+          <li class="tab" role="presentation">
+            <a href="#outbound-links-page-2" role="tab" aria-expanded="false" aria-selected="false" tabindex="1">Test 2</a>
+          </li>
+        </ul>
+      </div>
+
+      <div class="tab-panel-container">
+        <div id="outbound-links-page-1" class="tab-panel can-show is-visible" role="tabpanel">
+          <section id="maincontent" class="page-container scrollable" role="main">
+                <div class="twelve columns">
+                  <figure class="hierarchy" id="hierarchy"></figure>
+                </div>
+
+                <script>
+                  const options = {
+                    templateId: 'hierarchyChartTemplate',
+                    dataset: [],
+                    layout: 'stacked'
+                  };
+
+                  // Initial load
+                  $.getJSON('{{basepath}}api/hc-john-randolph', function(data) {
+                    options.dataset = [data];
+                    $('#hierarchy').hierarchy(options);
+                  });
+
+                  $('#hierarchy').on('selected', function(event, eventInfo) {
+                    const hierarchyControl = $('#hierarchy').data('hierarchy');
+                    console.log(event, eventInfo);
+
+                    if (eventInfo.data.childrenUrl) {
+                      $.getJSON('{{basepath}}api/' + eventInfo.data.childrenUrl, function(newData) {
+                        reload(eventInfo, hierarchyControl, newData);
+                      });
+                    }
+                  });
+
+                  function reload(eventInfo, hierarchyControl, newData) {
+                    eventInfo.data.children = newData;
+                    options.dataset = [eventInfo.data.children];
+                    hierarchyControl.reload(options);
+                  }
+                </script>
+
+
+                {{={{{ }}}=}}
+                <script type="text/html" id="hierarchyChartTemplate">
+                  <div class="leaf" id="{{id}}">
+                    <div class="detail">
+                      <p class="heading">{{id}}</p>
+                    </div>
+                  </div>
+                </script>
+              </section>
+        </div>
+        <div id="outbound-links-page-2" class="tab-panel" role="tabpanel">
+          <p>Page 2</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,7 @@
 - `[Dropdown]` Fixed an issue where the search field does not stay in the initial position. ([#2659](https://github.com/infor-design/enterprise/issues/2659))
 - `[Editor]` Fixed missing tooltips. ([#issues](https://github.com/infor-design/enterprise/issues/issues))
 - `[Field Options]` Fixed an issue where the focus style was not aligning. ([#3628](https://github.com/infor-design/enterprise/issues/3628))
+- `[Hierarchy]` Fixed an issue selection causes tab selection to be removed. ([#3597](https://github.com/infor-design/enterprise/issues/3597))
 - `[Icons]` Fixed an issue with the amend icon in uplift theme. The meaning was lost on a design change and it has been updated. ([#3613](https://github.com/infor-design/enterprise/issues/3613))
 - `[Locale]` Changed results text to lower case. ([#3974](https://github.com/infor-design/enterprise/issues/3974))
 - `[Locale]` Fixed abbreviated chinese month translations. ([#4034](https://github.com/infor-design/enterprise/issues/4034))

--- a/src/components/hierarchy/hierarchy.js
+++ b/src/components/hierarchy/hierarchy.js
@@ -223,7 +223,7 @@ Hierarchy.prototype = {
         return;
       }
 
-      $('.is-selected').removeClass('is-selected');
+      $('.leaf.is-selected').removeClass('is-selected');
       $(`#${nodeId}`).addClass('is-selected');
 
       // Is collapse event
@@ -290,7 +290,7 @@ Hierarchy.prototype = {
    */
   selectLeaf(nodeId) {
     const leaf = $(`#${nodeId}`);
-    $('.is-selected').removeClass('is-selected');
+    $('.leaf.is-selected').removeClass('is-selected');
     leaf.addClass('is-selected');
 
     const eventInfo = {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Hierarchy selection causes tab selection to be removed. This happens because both tabs control and hierarchy control have the same class name for selection state.

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise/issues/3597

**Steps necessary to review your pull request (required)**:
1. Pull PR
2. Launch ids-enterprise project
3. Navigate to  http://localhost:4000/components/hierarchy/test-vertical-tabs.html
4. Verify that selection of tabs is no longer lost when expanding a hierarchy leaf

![hierarchy-inside-vertical-tabs-selection](https://user-images.githubusercontent.com/1056684/85900553-a43b2000-b7c5-11ea-87f0-0f399e67a35f.gif)


<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
