### PR TITLE
3628 - Fix focus alignment with field options

### DIFF
--- a/src/components/field-options/_field-options-uplift.scss
+++ b/src/components/field-options/_field-options-uplift.scss
@@ -126,6 +126,8 @@
 
     ~ .btn-actions {
       left: -11px;
+      line-height: 20px;
+      width: 3.7rem !important;
     }
   }
 }

--- a/src/components/field-options/field-options.js
+++ b/src/components/field-options/field-options.js
@@ -171,7 +171,7 @@ FieldOptions.prototype = {
           returns += diff ? (diff / 2) : 0;
         } else {
           this.element.addClass('is-singleline');
-          returns = 1.5;
+          returns = 2;
         }
       } else if (isRadio) {
         returns = ((height - this.trigger.height()) / 2) * -1;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the styles for focus was not aligning with Field Options.

**Related github/jira issue (required)**:
Closes #3628

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/field-options/example-fieldset.html?theme=uplift&variant=light&colors=0066D4
- Click on any filed single line like `June 21, 2015 (4 days)`
- Or Multi line as `4209 Industrial Avenue, Los Angeles, California 90001 USA`
- Filed options button `three dotes` should align properly


<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
