### PR TITLE
4042 - Fix wrong border top color in application menu

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### v4.31.0 Fixes
 
+- `[Application Menu]` Fixed a bug where the border top color is wrong in uplift dark and high contrast theme. ([#4042](https://github.com/infor-design/enterprise/issues/4042))
+
 ## v4.30.0
 
 ### v4.30.0 Announcements

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -565,7 +565,6 @@
   // Selected color scheme
   &.is-focused:not(.hide-focus) {
     border-color: $accordion-focused-border-color;
-    border-top-color: $accordion-focused-border-color !important;
     box-shadow: $focus-box-shadow;
   }
 

--- a/src/components/calendar/_calendar.scss
+++ b/src/components/calendar/_calendar.scss
@@ -33,6 +33,14 @@
         top: 0;
       }
     }
+
+    .accordion-header {
+      &.is-focused {
+        &:not(.hide-focus) {
+          border-top-color: $accordion-focused-border-color;
+        }
+      }
+    }
   }
 
   .calendar-event-legend {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes a bug where the border top color is wrong in uplift dark and high contrast theme.

Noticed that this line causes the issue
https://github.com/infor-design/enterprise/blob/master/src/components/accordion/_accordion.scss#L568

Moving this to its specific component (calendar) so it will not affect the entire accordion that was being used in other components.

I found out that line of css code was part of this fix https://github.com/infor-design/enterprise/commit/7b4420f19a5a97f5ed98604033e3f25f5ed8ccb4

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/4042

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Navigate to http://localhost:4000/components/applicationmenu/example-index.html
- Change to `Vibrant` theme and `Dark` Variant
- Click the icon menu to open the application menu
- Click to the other menu items
- The border color should be consistent `(The issue has a color top border blue)` 
- Test also the `High Contrast` Variant

Test also the calendar accordion to make sure that the related fix on https://github.com/infor-design/enterprise/commit/7b4420f19a5a97f5ed98604033e3f25f5ed8ccb4 will work too

- Navigate to http://localhost:4000/components/calendar/test-specific-month.html
- Click the `Upcoming` accordion
- It should highlight and has a consistent border color

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
