### PR TITLE
827 - Fix the tooltip for tree grid with datagrid

### DIFF
--- a/app/views/components/datagrid/test-tree-tooltip.html
+++ b/app/views/components/datagrid/test-tree-tooltip.html
@@ -10,7 +10,7 @@
   $('body').one('initialized', function () {
     var columns = [];
     var dynamicFunction = function(row, cell, value, column, dataset, api) {
-      return 'Ordered at '+ dataset.time + ' This is cell: ' + cell;
+      return 'Ordered at '+ dataset.time + ' This is row: ' + row + ' and cell: ' + cell;
     };
 
     //Define Columns for the Grid.

--- a/app/views/components/datagrid/test-tree-tooltip.html
+++ b/app/views/components/datagrid/test-tree-tooltip.html
@@ -14,7 +14,7 @@
     };
 
     //Define Columns for the Grid.
-    columns.push({ id: 'taskName', name: 'Task', field: 'taskName', expanded: 'expanded', formatter: Formatters.Tree, width: 250});
+    columns.push({ id: 'taskName', name: 'Task', field: 'taskName', expanded: 'expanded', formatter: Formatters.Tree, width: 170});
     columns.push({ id: 'id', name: 'Id', field: 'id', width: 25,  formatter: Formatters.Hyperlink, tooltip: 'This is a product', headerTooltip: 'This is the header'});
     columns.push({ id: 'desc', name: 'Description', field: 'desc', width: 200});
     columns.push({ id: 'time', name: 'Time', field: 'time', width: 60, tooltip: dynamicFunction});

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v4.31.0 Fixes
 
-- `[Datagrid]` Fixed an issue where the tooltip for tree grid was not working properly. ([#827](https://github.com/infor-design/enterprise/issues/827))
+- `[Datagrid]` Fixed an issue where the tooltip for tree grid was not working properly. ([#827](https://github.com/infor-design/enterprise-ng/issues/827))
 
 ## v4.30.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### v4.31.0 Fixes
 
+- `[Datagrid]` Fixed an issue where the tooltip for tree grid was not working properly. ([#827](https://github.com/infor-design/enterprise/issues/827))
+
 ## v4.30.0
 
 ### v4.30.0 Announcements

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -4433,3 +4433,41 @@ describe('Datagrid with select rows across pages tests', () => {
     expect(await element(by.css(row2)).getAttribute('class')).toMatch('is-selected');
   });
 });
+
+describe('Datagrid treegrid Tooltip tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/test-tree-tooltip?layout=nofrills');
+
+    const datagridEl = await element(by.css('#datagrid tbody tr:nth-child(1)'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should show tooltip get data with callback', async () => {
+    await browser.actions().mouseMove(element(by.css('tbody tr[aria-rowindex="10"] td[aria-colindex="4"]'))).perform();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.css('.grid-tooltip'))), config.waitsFor);
+    const tooltip = await element(by.css('.grid-tooltip'));
+
+    expect(await tooltip.getAttribute('class')).not.toContain('is-hidden');
+    expect(await tooltip.getText()).toEqual('Ordered at 7:04 AM This is cell: 3');
+  });
+
+  it('Should show tooltip on text cut off for indented area', async () => {
+    await browser.actions().mouseMove(element(by.css('tbody tr[aria-rowindex="10"] td[aria-colindex="1"]'))).perform();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.css('.grid-tooltip'))), config.waitsFor);
+    const tooltip = await element(by.css('.grid-tooltip'));
+
+    expect(await tooltip.getAttribute('class')).not.toContain('is-hidden');
+    expect(await tooltip.getText()).toEqual('Follow up action with Residental New York');
+    await browser.actions().mouseMove(element(by.css('tbody tr[aria-rowindex="11"] td[aria-colindex="1"]'))).perform();
+    await browser.driver.sleep(config.waitsFor);
+
+    expect(await tooltip.getAttribute('class')).toContain('is-hidden');
+  });
+});

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -4454,7 +4454,7 @@ describe('Datagrid treegrid Tooltip tests', () => {
     const tooltip = await element(by.css('.grid-tooltip'));
 
     expect(await tooltip.getAttribute('class')).not.toContain('is-hidden');
-    expect(await tooltip.getText()).toEqual('Ordered at 7:04 AM This is cell: 3');
+    expect(await tooltip.getText()).toEqual('Ordered at 7:04 AM This is row: 9 and cell: 3');
   });
 
   it('Should show tooltip on text cut off for indented area', async () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the tooltip for tree grid was not working properly with Datagrid.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#827

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/test-tree-tooltip.html
- Hover on any cell (specially row with child nodes) in `Time` column
- See the tooltip content should related to cell value

There was js error showing, so check should not show anymore
- Navigate to: http://localhost:4000/components/datagrid/test-tree-tooltip.html
- Open developer tools
- Hover on any parent cell with +/- button in `Task` column
- See console should not be any error

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
