### PR TITLE
3915/4026 - Fixed an issue and add option for add new child with tree

### DIFF
--- a/app/views/components/tree/test-add-node.html
+++ b/app/views/components/tree/test-add-node.html
@@ -1,3 +1,21 @@
+<div class="row">
+  <div class="twelve columns">
+    <h2>Tree - Add Node</h2>
+    <p>&bull; Select any tree node and click button below to see in action.<br>
+      &bull; Add to (Top/Bottom) will change type to folder, if parent node not already as folder type.</p>
+    <div class="field">
+      <button id="btn-add" class="btn-secondary btn-menu">
+        <span>Add Node</span>
+      </button>
+      <ul id="popupmenu-add" class="popupmenu">
+        <li><a href="#" data-action="before">Before</a></li>
+        <li><a href="#" data-action="after">After</a></li>
+        <li><a href="#" data-action="top">Top</a></li>
+        <li><a href="#" data-action="bottom">Bottom</a></li>
+      </ul>
+    </div>
+  </div>
+</div>
 <div class="row top-padding">
   <div class="twelve columns">
 
@@ -12,7 +30,7 @@
           <li class="is-open">
               <a href="#" id="leadership">Leadership</a>
               <ul class="is-open">
-                <li class="is-selected">
+                <li>
                   <a href="#" id="managers" class="icon-tree-image">Managers</a>
                 </li>
                 <li>
@@ -78,5 +96,58 @@
   //Wrong escape markup
   api.addNode({text: '<h1>New Item 3</h1>', id: 'new7'});
   api.updateNode({node: $('#new3'), text: '<h1>Changed Item 2</h1>'});
+
+  // ===================================================
+  var tempId = 0;
+
+  function capitalizeFirstLetter(str) {
+    return str[0].toUpperCase() + str.slice(1);
+  }
+
+  function getNodeData(option, parentId) {
+    var id = 'addnew-'+ option + tempId;
+    var text = 'New at '+ capitalizeFirstLetter(option) +' ('+ tempId +')';
+    var nodeData = parentId ?
+      { id: id, text: text, parent: parentId } :
+      { id: id, text: text };
+    tempId++;
+    return nodeData;
+  }
+
+  $('#btn-add').on('selected', function(e, anchor) {
+    if (api) {
+      var action = anchor.attr('data-action');
+      var selected = api.getSelectedNodes();
+      var selectedId = selected && selected[0] && selected[0].data ? selected[0].data.id : null;
+      var nodeData;
+
+      switch(action) {
+        case 'bottom':
+          nodeData = getNodeData(action, selectedId);
+          api.addNode(nodeData, 'bottom');
+          break;
+        case 'top':
+          nodeData = getNodeData(action, selectedId);
+          api.addNode(nodeData, 'top');
+          break;
+        case 'before':
+          nodeData = getNodeData(action);
+          if (selectedId) {
+            api.addNode(nodeData, ('#'+ selectedId), 'before');
+          } else {
+            api.addNode(nodeData, 'top'); // top of tree root
+          }
+          break;
+        case 'after':
+          nodeData = getNodeData(action);
+          if (selectedId) {
+            api.addNode(nodeData, ('#'+ selectedId), 'after');
+          } else {
+            api.addNode(nodeData, 'bottom'); // bottom of tree root
+          }
+          break;
+      }
+    }
+  });
 
 </script>

--- a/app/views/components/tree/test-remove-all-children-and-update.html
+++ b/app/views/components/tree/test-remove-all-children-and-update.html
@@ -1,0 +1,52 @@
+<div class="row top-padding">
+  <div class="twelve columns">
+    <h2>Tree - Remove all children & update</h2>
+    <p>&bull; After pressing button below will remove all children from `Leadership`.<br>
+    &bull; As the node no longer has any children, it will show as a leaf node.</p>
+    <button type="button" id="btn-remove-update-node" class="btn-secondary">Remove all children &amp; update</button>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+    <ul id="tree" class="tree" role="tree" aria-label="Asset Types" data-init="false">
+      <li><a href="#" id="home">Home</a></li>
+      <li><a href="#" id="about">About Us</a></li>
+      <li class="is-open">
+        <a href="#" id="public">Public Folders</a>
+        <ul class="is-open root">
+          <li class="is-open">
+              <a href="#" id="leadership">Leadership</a>
+              <ul class="is-open">
+                <li><a href="#" id="new1">New Item 1</a></li>
+                <li><a href="#" id="new2">New Item 2</a></li>
+              </ul>
+          </li>
+          <li class="is-open">
+            <a href="#" id="hr">HR</a>
+        </li>
+        </ul>
+      </li>
+    </ul>
+
+  </div>
+</div>
+
+<script>
+  var tree = $('#tree').tree().data('tree');
+
+  // Remove node
+  $('#btn-remove-update-node').on('click', function () {
+    tree.removeNode({id: 'new1'});
+    tree.removeNode({id: 'new2'});
+    const node = tree.findById('leadership');
+
+    // children: null|[] - To show as leaf node, has to pass children property and value can be `null` or `[] -an empty array`.
+    node.children = null;
+
+    tree.updateNode(node);
+    $(this).disable(); // let it trigger onetime only
+    console.log('Node Removed');
+  });
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v4.31.0
 
+### v4.31.0 Features
+
+- `[Tree]` Added option to add new child node on top or bottom. ([#3915](https://github.com/infor-design/enterprise/issues/3915))
+
 ### v4.31.0 Fixes
 
 - `[Application Menu]` Fixed a bug where the border top color is wrong in uplift dark and high contrast theme. ([#4042](https://github.com/infor-design/enterprise/issues/4042))
@@ -12,6 +16,7 @@
 - `[Locale]` The Added placeholder for incorrect French `SetTime` translation. ([#4045](https://github.com/infor-design/enterprise/issues/4045))
 - `[Modal]` Reverted nested modal behavior to being visually stacked, instead of one-at-a-time. Made it possible to show one-at-a-time via `hideUnderneath` setting. ([#3910](https://github.com/infor-design/enterprise/issues/3910))
 - `[Tooltip]` Fixed a bug where the title doesn't display when the title starts with '#'. ([#2512](https://github.com/infor-design/enterprise/issues/2512))
+- `[Tree]` Fixed an issue where the tree node still shows folder icon after all children and `children` property deleted. ([#4026](https://github.com/infor-design/enterprise/issues/4026))
 
 ## v4.30.0
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
1) Added option to add new child node on top or bottom with Tree.
2) Fixed an issue where the tree node still shows folder icon after all children and `children` property deleted.

**Related github/jira issue (required)**:
Closes #3915
Closes #4026

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/tree/test-add-node.html
- Select any tree node
- Click on button `Add Node`
- Choose the position to add new node
- If selected node not folder type and chosen position is `Top` or `Bottom`, it will change selected node type to folder
- If there is no-selected node it will add top/bottom to tree root

Remove all children and update
- Navigate to: http://localhost:4000/components/tree/test-remove-all-children-and-update.html
- See node `Leadership` should have two children
- Press button `Remove all children & update`
- See node `Leadership` now, should remove all it's children
- And should show as a leaf node 
**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
