### PR TITLE
4124 - Add fix for shifting button by making a preference [v4.30]

### DIFF
--- a/app/views/components/modal/test-external-components.html
+++ b/app/views/components/modal/test-external-components.html
@@ -40,11 +40,11 @@
 
 					<div class="field">
 						<button id="popover-trigger" class="btn-secondary" type="button">
-			        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-			          <use href="#icon-upload"></use>
-			        </svg>
-			        <span>Click To Show Popover</span>
-			      </button>
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use href="#icon-upload"></use>
+              </svg>
+              <span>Click To Show Popover</span>
+              </button>
 					</div>
 
 					<div class="field">
@@ -53,15 +53,15 @@
 					</div>
 				</div>
 				<div class="six columns">
-					<div class="field">
-			      <label for="searchfield">Search</label>
-			      <input id="searchfield" class="searchfield" placeholder="Type a search term" data-options="{ clearable: true, source: '{{basepath}}api/states?term='  }"/>
-			    </div>
+          <div class="field">
+            <label for="searchfield">Search</label>
+            <input id="searchfield" class="searchfield" placeholder="Type a search term" data-options="{ clearable: true, source: '{{basepath}}api/states?term='  }"/>
+          </div>
 
 					<div class="field">
-			      <label for="colorpicker">Colorpicker</label>
-			      <input class="colorpicker" id="colorpicker" type="text" />
-			    </div>
+            <label for="colorpicker">Colorpicker</label>
+            <input class="colorpicker" id="colorpicker" type="text" />
+          </div>
 
 					<div class="field">
 						<label for="datepicker" class="label">Datepicker</label>
@@ -69,9 +69,9 @@
 					</div>
 
 					<div class="field">
-			      <label for="timepicker" class="label">Timepicker</label>
-			      <input id="timepicker" class="timepicker" type="text"/>
-			    </div>
+            <label for="timepicker" class="label">Timepicker</label>
+            <input id="timepicker" class="timepicker" type="text"/>
+          </div>
 				</div>
 			</div>
 		</div>
@@ -117,7 +117,8 @@
 			y: 10
 		},
 		title: 'ABC Engine Company',
-		trigger: 'click'
+		trigger: 'click',
+    attachToBody: false
 	};
 
 	$('#popover-trigger').popover(POPOVER_OPTIONS);

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -43,6 +43,7 @@ const TOOLTIP_TRIGGER_METHODS = ['hover', 'immediate', 'click', 'focus'];
  * @param {boolean} [settings.initializeContent] Init the content in the tooltip.
  * @param {string} [settings.headerClass] If set this color will be used on the header (if a popover).
  * @param {string} [settings.delay] The delay before showing the tooltip
+ * @param {string} [settings.attachToBody] The if true (default) the popup is added to the body. In some cases like popups with tab stops you may want to append the element next to the item.
  */
 
 const TOOLTIP_DEFAULTS = {
@@ -65,7 +66,8 @@ const TOOLTIP_DEFAULTS = {
   initializeContent: true,
   headerClass: null,
   delay: 500,
-  onHidden: null
+  onHidden: null,
+  attachToBody: true
 };
 
 function Tooltip(element, settings) {
@@ -805,7 +807,7 @@ Tooltip.prototype = {
     // If the tooltip/popover is located inside a Modal, contain it within the modal, but
     // place its markup directly after its target element.
     const modalParent = this.element.closest('.modal');
-    if (modalParent.length) {
+    if (!this.settings.attachToBody) {
       attachAfterTriggerElem = true;
       targetContainer = modalParent;
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Changed around a fix for https://github.com/infor-design/enterprise/commit/4e2217ba2799311ad4fccea137f9c9e6eebed259#diff-0732597cd96cb9d201490dfa8fe61b4b as it introduced a stacking context issue. That caused popovers like datepicker to get cut off and tooltips to shift content.

Now to get the tabing behavior, developers have to set attachToBody: false on the popovers on modals in order to solve for that issue.

**Related github/jira issue (required)**:
Fixes #4124


**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/modal/example-close-btn.html
- hover the close button til you get the tooltip
- hit close
- try again -> button should not shift
- retest steps on https://github.com/infor-design/enterprise/pull/4023
