### PR TITLE
4047 - Fix dropdown phraseStartsWith filter

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[Datagrid]` Fixed an issue where the tooltip for tree grid was not working properly. ([#827](https://github.com/infor-design/enterprise-ng/issues/827))
 - `[Datepicker]` Fixed a number of translation issues in the datepicker component. ([#4046](https://github.com/infor-design/enterprise/issues/4046))
 - `[Datepicker]` Fixed a bug where two dates may appear selected when moving forward/back in the picker dialog. ([#4018](https://github.com/infor-design/enterprise/issues/4018))
+- `[Dropdown]` Fixed an issue where "phraseStartsWith" does not filter the list after deleting a character. ([#4047](https://github.com/infor-design/enterprise/issues/4047))
 - `[Editor]` Fixed a number of translation issues in the editor component. ([#4049](https://github.com/infor-design/enterprise/issues/4049))
 - `[Locale]` The Added placeholder for missing Thai `Locale` translation. ([#4041](https://github.com/infor-design/enterprise/issues/4041))
 - `[Locale]` The Added placeholder for incorrect French `SetTime` translation. ([#4045](https://github.com/infor-design/enterprise/issues/4045))

--- a/src/components/listfilter/listfilter.js
+++ b/src/components/listfilter/listfilter.js
@@ -185,7 +185,7 @@ ListFilter.prototype = {
     function searchItemIterator(item) {
       let text = getSearchableContent(item);
       if (!self.settings.caseSensitive) {
-        text = text.toLowerCase();
+        text = text.toLowerCase().trim();
       }
 
       let match = false;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes an issue where "phraseStartsWith" does not filter the list after deleting a character. The incoming text had a bunch of extra spaces in it which was causing the index of the character to be off.

**Related github/jira issue (required)**:
closes #4047 

**Steps necessary to review your pull request (required)**:
- Pull and run branch
- Go to http://localhost:4000/components/dropdown/test-filter-types.html
- In the PhraseStartsWith Filter text input and type "a"
- Dropdown list shows Alabama, Alaska ...
- Type another "a" ("aa" in the text input)
- List should be empty
- Delete second "a" leaving one "a" in the input
- List should filter again correctly

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
