### PR TITLE
4130 - Add fix for gregorian locale on ar-SA

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[Datepicker]` Fixed a number of translation issues in the datepicker component. ([#4046](https://github.com/infor-design/enterprise/issues/4046))
 - `[Datepicker]` Fixed a bug that the datepicker would focus the field when closing the month and year pane. ([#4085](https://github.com/infor-design/enterprise/issues/4085))
 - `[Datepicker]` Fixed a bug where two dates may appear selected when moving forward/back in the picker dialog. ([#4018](https://github.com/infor-design/enterprise/issues/4018))
+- `[Datepicker]` Fixed a bug where an error may occur if using the gregorian calendar on ar-SA locale. ([#4130](https://github.com/infor-design/enterprise/issues/4130))
 - `[Dropdown]` Fixed an issue where "phraseStartsWith" does not filter the list after deleting a character. ([#4047](https://github.com/infor-design/enterprise/issues/4047))
 - `[Editor]` Fixed a number of translation issues in the editor component. ([#4049](https://github.com/infor-design/enterprise/issues/4049))
 - `[Locale]` The Added placeholder for missing Thai `Locale` translation. ([#4041](https://github.com/infor-design/enterprise/issues/4041))

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -927,6 +927,7 @@ const Locale = {  // eslint-disable-line
     let dateFormat = options;
     let locale = this.currentLocale.name;
     let thisLocaleCalendar = this.calendar();
+
     if (typeof options === 'object') {
       locale = options.locale || locale;
       dateFormat = options.dateFormat || this.calendar(locale).dateFormat[dateFormat.date];
@@ -937,7 +938,7 @@ const Locale = {  // eslint-disable-line
     }
 
     if (typeof options === 'object' && options.calendarName && options.locale) {
-      thisLocaleCalendar = this.calendar(options.locale, options.calendarName);
+      thisLocaleCalendar = this.calendar(options.locale, options.language, options.calendarName);
     }
 
     if (!dateFormat) {

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -1505,6 +1505,22 @@ describe('Datepicker Gregorian SA Tests', () => {
     await utils.setPage('/components/datepicker/test-ar-sa-gregorian');
   });
 
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should be able to select a day and tab out', async () => {
+    const datepickerEl = await element(by.id('islamic-date'));
+    await datepickerEl.sendKeys('15/07/2020');
+    await element(by.css('#islamic-date + .icon')).click();
+    const focusTD = await element(by.css('#monthview-popup td.is-selected'));
+    await focusTD.sendKeys(protractor.Key.ARROW_LEFT);
+    await focusTD.sendKeys(protractor.Key.ENTER);
+
+    expect(await datepickerEl.getAttribute('value')).toEqual('14/07/2020');
+    await utils.checkForErrors();
+  });
+
   it('Should render gregorian on ar-SA time', async () => {
     const datepickerEl = await element(by.id('islamic-date'));
     await datepickerEl.sendKeys(protractor.Key.ARROW_DOWN);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

If using a secondary / non default calendar (ie gregorian on ar-SA). The calendar would error when tabbing out of he field.

**Related github/jira issue (required)**:
Fixes #4130

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datepicker/test-ar-sa-gregorian.html
- open the picker and select a value
- tab out of the field
- check the console for errors (should be none)

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.