### PR TITLE
4133 - Add fix for invalid css property [v4.30.x and v.4.31.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[Datagrid]` Fixed an issue where the tooltip would not show up if you focus a cell with ellipsis text with the keyboard. ([#4085](https://github.com/infor-design/enterprise/issues/4085))
 - `[Datagrid]` Made the header checkbox focusable. ([#4085](https://github.com/infor-design/enterprise/issues/4085))
 - `[Datagrid]` The selection checkbox cell had aria-selected on it which was incorrect. ([#4085](https://github.com/infor-design/enterprise/issues/4085))
+- `[Datagrid]` Changed invalid css fill-available property. ([#4133](https://github.com/infor-design/enterprise/issues/4133))
 - `[Datepicker]` Fixed a number of translation issues in the datepicker component. ([#4046](https://github.com/infor-design/enterprise/issues/4046))
 - `[Datepicker]` Fixed a bug that the datepicker would focus the field when closing the month and year pane. ([#4085](https://github.com/infor-design/enterprise/issues/4085))
 - `[Datepicker]` Fixed a bug where two dates may appear selected when moving forward/back in the picker dialog. ([#4018](https://github.com/infor-design/enterprise/issues/4018))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -4561,14 +4561,14 @@ html[dir='rtl'] {
     width: 300px;
     width: -moz-available;
     width: -webkit-fill-available;
-    width: fill-available;
+    width: stretch;
   }
 
   .paginated table {
     width: 466px;
     width: -moz-available;
     width: -webkit-fill-available;
-    width: fill-available;
+    width: stretch;
   }
 }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Changed non vendor prefix fill-available to stretch. As it was causing downstream build issues. Doesn't effect anything since the browsers use the vendor prefix but was giving a ton of warnings in down steam builds.

Will patch this back to 4.30 soon

**Related github/jira issue (required)**:
Fixes #4133

**Steps necessary to review your pull request (required)**:
- retest steps on https://github.com/infor-design/enterprise/pull/4009

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
