### PR TITLE
4160 - Locale and datepicker bugs with ar-SA (umalqura) [v4.30.x]

### DIFF
--- a/app/views/components/locale/test-set-value.html
+++ b/app/views/components/locale/test-set-value.html
@@ -30,7 +30,7 @@
         <input class="input-sm" id="input-date-field-MMdd" readonly/>
       </div>
       <div class="field">
-        <label for="date-field-MMdd" class="label">MMMMdd Field</label>
+        <label for="date-field-MMdd" class="label">MMdd Field</label>
         <input id="date-field-MMdd" class="datepicker" type="text">
       </div>
       <div class="field">
@@ -45,7 +45,7 @@
         <input class="input-sm" id="input-date-field-yyyyMM" readonly/>
       </div>
       <div class="field">
-        <label for="date-field-yyyyMM" class="label">yyyyMMMM Field</label>
+        <label for="date-field-yyyyMM" class="label">yyyyMM Field</label>
         <input id="date-field-yyyyMM" class="datepicker" type="text">
       </div>
       <div class="field">
@@ -81,6 +81,21 @@
       <div class="field">
         <label for="output-date-field-timestamp">Transformed Database Value (en-US)</label>
         <input class="input-md" id="output-date-field-timestamp" readonly/>
+      </div>
+    </div>
+
+    <div class="two columns">
+      <div class="field">
+        <label for="input-date-field-time">Beginning Database Value (en-US)</label>
+        <input class="input-sm" id="input-date-field-time" readonly/>
+      </div>
+      <div class="field">
+        <label for="date-field-time" class="label">time Field</label>
+        <input id="date-field-time" class="timepicker" type="text">
+      </div>
+      <div class="field">
+        <label for="output-date-field-time">Transformed Database Value (en-US)</label>
+        <input class="input-sm" id="output-date-field-time" readonly/>
       </div>
     </div>
   </div>
@@ -147,59 +162,33 @@
             showTime: true,
             useCurrentTime: true
           }
+        },
+        time: {
+          dataPattern:      'HHmmss',
+          displayPattern:   Soho.Locale.calendar().dateFormat.timestamp,
+          dbValue:          '104530',
+          fieldId:          'date-field-time',
+          options: {
+            mode: 'standard',
+            timeFormat: Soho.Locale.calendar().dateFormat.timestamp
+          }
         }
       };
 
-      // AFTER
-      // transformation of date value from database format (en-US) to current locale for display
-      var modelKeys = Object.keys(model)
-      .forEach( (key) => {
-        var modelItem = model[key];
-
-        var datepicker = $('#' + modelItem.fieldId).datepicker(modelItem.options);
-        $('#input-' + modelItem.fieldId).val(modelItem.dbValue);
-
-        var fromPattern = modelItem.dataPattern;
-        var toPattern = modelItem.displayPattern;
-
-        var parseDateOptions = {
-          // pattern: toPattern,
-          dateFormat: fromPattern,
-          locale: 'en-US',
-          calendarName: 'gregorian'
-        };
-        var date = Soho.Locale.parseDate(modelItem.dbValue, parseDateOptions, false);
-
-        // dateTimeDisplayRule
-        var formatDateOptions = {
-          pattern: toPattern,
-          fromGregorian: (Soho.Locale.calendar().name === 'islamic-umalqura') ? true : undefined,
-          // locale: 'en-US',
-          // calendarName: 'gregorian'
-        };
-        var value = Soho.Locale.formatDate(date, formatDateOptions);
-
-        datepicker.data('datepicker').setValue(value);
-        // datepicker.data('datepicker').setValue(date);
-
-        console.log([modelItem.fieldId + ' value transformed', modelItem.dbValue, value]);
-      });
-
-      $('.datepicker').on('change', function (e, args) {
+      $('.datepicker, .timepicker').on('change', function (e, args) {
         var key = e.currentTarget.id.substr(e.currentTarget.id.lastIndexOf('-')+1);
         var modelItem = model[key];
 
         // transformation of date value in current locale format to database format (en-US)
-        var elemValue = $('#' + modelItem.fieldId).data('datepicker').element.val();
+        var elemValue = (key === 'time')
+          ? $('#' + modelItem.fieldId).data('timepicker').element.val()
+          : $('#' + modelItem.fieldId).data('datepicker').element.val();
 
         var fromPattern = modelItem.displayPattern;
         var toPattern = modelItem.dataPattern;
 
         var parseDateOptions = {
-          // pattern: toPattern,
-          dateFormat: fromPattern,
-          // locale: 'en-US',
-          // calendarName: 'gregorian'
+          dateFormat: fromPattern
         };
         var date = Soho.Locale.parseDate(elemValue, parseDateOptions, false);
 
@@ -216,6 +205,93 @@
 
         console.log([modelItem.fieldId + '.onchange value transformed', elemValue, value]);
 
+      });
+      // BEFORE 4.30
+      // transformation of date value from database format (en-US) to current locale for display
+      // var modelKeys = Object.keys(model)
+      // .forEach( (key) => {
+      //   var modelItem = model[key];
+      //
+      //   var datepicker = $('#' + modelItem.fieldId).datepicker(modelItem.options);
+      //   $('#input-' + modelItem.fieldId).val(modelItem.dbValue);
+      //
+      //   var fromPattern = modelItem.dataPattern;
+      //   var toPattern = modelItem.displayPattern;
+      //
+      //   var date = Soho.Locale.parseDate(modelItem.dbValue, fromPattern, false);
+      //
+      //   var formatDateOptions = {
+      //     pattern: toPattern,
+      //     // fromGregorian: true   // comment to fix en-US issue
+      //   };
+      //   var value = Soho.Locale.formatDate(date, formatDateOptions);
+      //
+      //   datepicker.data('datepicker').setValue(value);
+      //
+      //   console.log([modelItem.fieldId + ' value transformed', modelItem.dbValue, value]);
+      // });
+      //
+      // $('.datepicker').on('change', function (e, args) {
+      //   // transformation of date value in current locale format to database format (en-US)
+      //   var key = e.currentTarget.id.substr(e.currentTarget.id.lastIndexOf('-')+1);
+      //   var modelItem = model[key];
+      //
+      //   var elemValue = $('#' + modelItem.fieldId).data('datepicker').element.val();
+      //
+      //   var fromPattern = modelItem.displayPattern;
+      //   var toPattern = modelItem.dataPattern;
+      //
+      //   var date = Soho.Locale.parseDate(elemValue, fromPattern, false);
+      //
+      //   var formatDateOptions = {
+      //     pattern: toPattern,
+      //     // toGregorian: true   // comment to fix en-US issue
+      //   };
+      //   var value = Soho.Locale.formatDate(date, formatDateOptions);
+      //
+      //   $('#output-' + modelItem.fieldId).val(value);
+      //
+      //   console.log([modelItem.fieldId + '.onchange value transformed', elemValue, value]);
+      // });
+
+      // -----------------------------------
+
+      // AFTER
+      // transformation of date value from database format (en-US) to current locale for display
+      var modelKeys = Object.keys(model)
+      .forEach( (key) => {
+        var modelItem = model[key];
+        var control = (key === 'time')
+          ? $('#' + modelItem.fieldId).timepicker(modelItem.options)
+          : $('#' + modelItem.fieldId).datepicker(modelItem.options);
+
+        $('#input-' + modelItem.fieldId).val(modelItem.dbValue);
+
+        var fromPattern = modelItem.dataPattern;
+        var toPattern = modelItem.displayPattern;
+
+        var parseDateOptions = {
+          dateFormat: fromPattern,
+          locale: 'en-US',
+          calendarName: 'gregorian'
+        };
+        var date = Soho.Locale.parseDate(modelItem.dbValue, parseDateOptions, false);
+
+        // dateTimeDisplayRule
+        var formatDateOptions = {
+          pattern: toPattern,
+          fromGregorian: (Soho.Locale.calendar().name === 'islamic-umalqura') ? true : undefined
+        };
+        var value = Soho.Locale.formatDate(date, formatDateOptions);
+
+        if (key === 'time') {
+          control.data('timepicker').element.val(value);
+        } else {
+          control.data('datepicker').setValue(value);
+        }
+
+        control.trigger('change');
+        console.log([modelItem.fieldId + ' value transformed', modelItem.dbValue, value]);
       });
     });
 

--- a/app/views/components/locale/test-set-value.html
+++ b/app/views/components/locale/test-set-value.html
@@ -1,172 +1,224 @@
+<div class="page-container scrollable" id="maincontent" role="main">
   <div class="row">
-   <div class="two columns">
-     <div class="field">
-       <label for="locale-field">Current Locale</label>
-       <input class="input-mm" id="locale-field" readonly="true"/>
-     </div>
-   </div>
+    <div class="two columns">
+      <div class="field">
+        <label for="locale-field">Current Locale</label>
+        <input class="input-mm" id="locale-field" readonly/>
+      </div>
+    </div>
   </div>
 
-<div class="row">
-      <div class="two columns">
-        <div class="field">
-          <label for="input-date-field-yyyyMMdd">Beginning Database Value (en-US)</label>
-          <input class="input-sm" id="input-date-field-yyyyMMdd" readonly="true"/>
-        </div>
-         <div class="field">
-            <label for="date-field-yyyyMMdd" class="label">Date Field</label>
-            <input id="date-field-yyyyMMdd" class="datepicker" type="text"/>
-         </div>
-        <div class="field">
-          <label for="output-date-field-yyyyMMdd">Transformed Database Value (en-US)</label>
-          <input class="input-sm" id="output-date-field-yyyyMMdd" readonly="true"/>
-        </div>
+  <div class="row">
+    <div class="two columns">
+      <div class="field">
+        <label for="input-date-field-yyyyMMdd">Beginning Database Value (en-US)</label>
+        <input class="input-sm" id="input-date-field-yyyyMMdd" readonly/>
       </div>
+      <div class="field">
+        <label for="date-field-yyyyMMdd" class="label">Date Field</label>
+        <input id="date-field-yyyyMMdd" class="datepicker" type="text">
+      </div>
+      <div class="field">
+        <label for="output-date-field-yyyyMMdd">Transformed Database Value (en-US)</label>
+        <input class="input-sm" id="output-date-field-yyyyMMdd" readonly/>
+      </div>
+    </div>
 
-     <div class="two columns">
-       <div class="field">
-         <label for="input-date-field-MMdd">Beginning Database Value (en-US)</label>
-         <input class="input-sm" id="input-date-field-MMdd" readonly="true"/>
-       </div>
-       <div class="field">
-         <label for="date-field-MMdd" class="label">MMMMdd Field</label>
-         <input id="date-field-MMdd" class="datepicker" type="text"/>
-       </div>
-       <div class="field">
-         <label for="output-date-field-MMdd">Transformed Database Value (en-US)</label>
-         <input class="input-sm" id="output-date-field-MMdd" readonly="true"/>
-       </div>
-     </div>
+    <div class="two columns">
+      <div class="field">
+        <label for="input-date-field-MMdd">Beginning Database Value (en-US)</label>
+        <input class="input-sm" id="input-date-field-MMdd" readonly/>
+      </div>
+      <div class="field">
+        <label for="date-field-MMdd" class="label">MMMMdd Field</label>
+        <input id="date-field-MMdd" class="datepicker" type="text">
+      </div>
+      <div class="field">
+        <label for="output-date-field-MMdd">Transformed Database Value (en-US)</label>
+        <input class="input-sm" id="output-date-field-MMdd" readonly/>
+      </div>
+    </div>
 
     <div class="two columns">
       <div class="field">
         <label for="input-date-field-yyyyMM">Beginning Database Value (en-US)</label>
-        <input class="input-sm" id="input-date-field-yyyyMM" readonly="true"/>
+        <input class="input-sm" id="input-date-field-yyyyMM" readonly/>
       </div>
       <div class="field">
         <label for="date-field-yyyyMM" class="label">yyyyMMMM Field</label>
-        <input id="date-field-yyyyMM" class="datepicker" type="text"/>
+        <input id="date-field-yyyyMM" class="datepicker" type="text">
       </div>
       <div class="field">
         <label for="output-date-field-yyyyMM">Transformed Database Value (en-US)</label>
-        <input class="input-sm" id="output-date-field-yyyyMM" readonly="true"/>
+        <input class="input-sm" id="output-date-field-yyyyMM" readonly/>
       </div>
     </div>
 
     <div class="two columns">
       <div class="field">
         <label for="input-date-field-yyyy">Beginning Database Value (en-US)</label>
-        <input class="input-sm" id="input-date-field-yyyy" readonly="true"/>
+        <input class="input-sm" id="input-date-field-yyyy" readonly/>
       </div>
       <div class="field">
         <label for="date-field-yyyy" class="label">yyyy Field</label>
-        <input id="date-field-yyyy" class="datepicker" type="text"/>
+        <input id="date-field-yyyy" class="datepicker" type="text">
       </div>
       <div class="field">
         <label for="output-date-field-yyyy">Transformed Database Value (en-US)</label>
-        <input class="input-sm" id="output-date-field-yyyy" readonly="true"/>
+        <input class="input-sm" id="output-date-field-yyyy" readonly/>
       </div>
     </div>
-</div>
 
-<script>
-  $('body').on('initialized', function () {
-    $('#locale-field').val(Soho.Locale.currentLocale.name + ', ' + Soho.Locale.calendar().name);
+    <div class="two columns">
+      <div class="field">
+        <label for="input-date-field-timestamp">Beginning Database Value (en-US)</label>
+        <input class="input-md" id="input-date-field-timestamp" readonly/>
+      </div>
+      <div class="field">
+        <label for="date-field-timestamp" class="label">timestamp Field</label>
+        <input id="date-field-timestamp" class="datepicker input-md" type="text">
+      </div>
+      <div class="field">
+        <label for="output-date-field-timestamp">Transformed Database Value (en-US)</label>
+        <input class="input-md" id="output-date-field-timestamp" readonly/>
+      </div>
+    </div>
+  </div>
 
-    var model = {
-      yyyyMMdd: {
-        dataPattern:      'yyyyMMdd',
-        displayPattern:   Soho.Locale.calendar().dateFormat.short,
-        dbValue:          '20200229',
-        fieldId:          'date-field-yyyyMMdd',
-        options: {
-          mode: 'standard',
-          dateFormat: Soho.Locale.calendar().dateFormat.short,
-          showMonthYearPicker: true
+  <script>
+    $('body').on('initialized', function () {
+      $('#locale-field').val(Soho.Locale.currentLocale.name + ', ' + Soho.Locale.calendar().name);
+
+      var model = {
+        yyyyMMdd: {
+          dataPattern:      'yyyyMMdd',
+          displayPattern:   Soho.Locale.calendar().dateFormat.short,
+          dbValue:          '20200229',
+          fieldId:          'date-field-yyyyMMdd',
+          options: {
+            mode: 'standard',
+            dateFormat: Soho.Locale.calendar().dateFormat.short,
+            showMonthYearPicker: true
           }
         },
-      MMdd: {
-        dataPattern:      'MMdd',
-        displayPattern:   Soho.Locale.calendar().dateFormat.month,
-        dbValue:          '0229',
-        fieldId:          'date-field-MMdd',
-        options: {
-          mode: 'standard',
-          dateFormat: Soho.Locale.calendar().dateFormat.month
+        MMdd: {
+          dataPattern:      'MMdd',
+          displayPattern:   Soho.Locale.calendar().dateFormat.month,
+          dbValue:          '0229',
+          fieldId:          'date-field-MMdd',
+          options: {
+            mode: 'standard',
+            dateFormat: Soho.Locale.calendar().dateFormat.month
+          }
+        },
+        yyyyMM: {
+          dataPattern:      'yyyyMM',
+          displayPattern:   Soho.Locale.calendar().dateFormat.year,
+          dbValue:          '202002',
+          fieldId:          'date-field-yyyyMM',
+          options: {
+            mode: 'standard',
+            dateFormat: Soho.Locale.calendar().dateFormat.year,
+            showMonthYearPicker: true,
+            hideDays: true
+          }
+        },
+        yyyy: {
+          dataPattern:      'yyyy',
+          displayPattern:   'yyyy',
+          dbValue:          '2020',
+          fieldId:          'date-field-yyyy',
+          options: {
+            mode: 'standard',
+            dateFormat: 'yyyy',
+            showMonthYearPicker: true,
+            hideDays: true
+          }
+        },
+        timestamp: {
+          dataPattern:      'yyyyMMddHHmmss',
+          displayPattern:   Soho.Locale.calendar().dateFormat.short + ' ' + Soho.Locale.calendar().dateFormat.timestamp,
+          dbValue:          '20200229104530',
+          fieldId:          'date-field-timestamp',
+          options: {
+            mode: 'standard',
+            dateFormat: Soho.Locale.calendar().dateFormat.short + ' ' + Soho.Locale.calendar().dateFormat.timestamp,
+            showMonthYearPicker: true,
+            showTime: true,
+            useCurrentTime: true
+          }
         }
-      },
-      yyyyMM: {
-        dataPattern:      'yyyyMM',
-        displayPattern:   Soho.Locale.calendar().dateFormat.year,
-        dbValue:          '202002',
-        fieldId:          'date-field-yyyyMM',
-        options: {
-          mode: 'standard',
-          dateFormat: Soho.Locale.calendar().dateFormat.year,
-          showMonthYearPicker: true,
-          hideDays: true
-        }
-      },
-      yyyy: {
-        dataPattern:      'yyyy',
-        displayPattern:   'yyyy',
-        dbValue:          '2020',
-        fieldId:          'date-field-yyyy',
-        options: {
-          mode: 'standard',
-          dateFormat: 'yyyy',
-          showMonthYearPicker: true,
-          hideDays: true
-        }
-      },
-    };
-
-    var modelKeys = Object.keys(model)
-    .forEach( (key) => {
-      var modelItem = model[key];
-      var datepicker = $('#' + modelItem.fieldId).datepicker(modelItem.options);
-      $('#input-' + modelItem.fieldId).val(modelItem.dbValue);
-      var fromPattern = modelItem.dataPattern;
-      var toPattern = modelItem.displayPattern;
-      var parseDateOptions = {
-        dateFormat: fromPattern,
-        locale: 'en-US',
-        calendarName: 'gregorian'
       };
-      var date = Soho.Locale.parseDate(modelItem.dbValue, parseDateOptions, false);
-      var formatDateOptions = {
-        pattern: toPattern,
-        fromGregorian: (Soho.Locale.calendar().name === 'islamic-umalqura') ? true : undefined,
-      };
-      var value = Soho.Locale.formatDate(date, formatDateOptions);
-      datepicker.data('datepicker').setValue(value);
 
-      console.log([modelItem.fieldId + ' value transformed', modelItem.dbValue, value]);
+      // AFTER
+      // transformation of date value from database format (en-US) to current locale for display
+      var modelKeys = Object.keys(model)
+      .forEach( (key) => {
+        var modelItem = model[key];
+
+        var datepicker = $('#' + modelItem.fieldId).datepicker(modelItem.options);
+        $('#input-' + modelItem.fieldId).val(modelItem.dbValue);
+
+        var fromPattern = modelItem.dataPattern;
+        var toPattern = modelItem.displayPattern;
+
+        var parseDateOptions = {
+          // pattern: toPattern,
+          dateFormat: fromPattern,
+          locale: 'en-US',
+          calendarName: 'gregorian'
+        };
+        var date = Soho.Locale.parseDate(modelItem.dbValue, parseDateOptions, false);
+
+        // dateTimeDisplayRule
+        var formatDateOptions = {
+          pattern: toPattern,
+          fromGregorian: (Soho.Locale.calendar().name === 'islamic-umalqura') ? true : undefined,
+          // locale: 'en-US',
+          // calendarName: 'gregorian'
+        };
+        var value = Soho.Locale.formatDate(date, formatDateOptions);
+
+        datepicker.data('datepicker').setValue(value);
+        // datepicker.data('datepicker').setValue(date);
+
+        console.log([modelItem.fieldId + ' value transformed', modelItem.dbValue, value]);
+      });
+
+      $('.datepicker').on('change', function (e, args) {
+        var key = e.currentTarget.id.substr(e.currentTarget.id.lastIndexOf('-')+1);
+        var modelItem = model[key];
+
+        // transformation of date value in current locale format to database format (en-US)
+        var elemValue = $('#' + modelItem.fieldId).data('datepicker').element.val();
+
+        var fromPattern = modelItem.displayPattern;
+        var toPattern = modelItem.dataPattern;
+
+        var parseDateOptions = {
+          // pattern: toPattern,
+          dateFormat: fromPattern,
+          // locale: 'en-US',
+          // calendarName: 'gregorian'
+        };
+        var date = Soho.Locale.parseDate(elemValue, parseDateOptions, false);
+
+        // dateTimeDataRule
+        var formatDateOptions = {
+          pattern: toPattern,
+          toGregorian: (Soho.Locale.calendar().name === 'islamic-umalqura') ? true : undefined,
+          locale: 'en-US',
+          calendarName: 'gregorian'
+        };
+        var value = Soho.Locale.formatDate(date, formatDateOptions);
+
+        $('#output-' + modelItem.fieldId).val(value);
+
+        console.log([modelItem.fieldId + '.onchange value transformed', elemValue, value]);
+
+      });
     });
 
-    $('.datepicker').on('change', function (e, args) {
-      var key = e.currentTarget.id.substr(e.currentTarget.id.lastIndexOf('-')+1);
-      var modelItem = model[key];
+  </script>
 
-      // transformation of date value in current locale format to database format (en-US)
-      var elemValue = $('#' + modelItem.fieldId).data('datepicker').element.val();
-      var fromPattern = modelItem.displayPattern;
-      var toPattern = modelItem.dataPattern;
-      var parseDateOptions = {
-        dateFormat: fromPattern
-      };
-
-      var date = Soho.Locale.parseDate(elemValue, parseDateOptions, false);
-      var formatDateOptions = {
-        pattern: toPattern,
-        toGregorian: (Soho.Locale.calendar().name === 'islamic-umalqura') ? true : undefined,
-        locale: 'en-US',
-        calendarName: 'gregorian'
-      };
-
-      var value = Soho.Locale.formatDate(date, formatDateOptions);
-      $('#output-' + modelItem.fieldId).val(value);
-      console.log([modelItem.fieldId + '.onchange value transformed', elemValue, value]);
-    });
-  });
-</script>
+</div>

--- a/app/views/components/locale/test-set-value.html
+++ b/app/views/components/locale/test-set-value.html
@@ -1,0 +1,172 @@
+  <div class="row">
+   <div class="two columns">
+     <div class="field">
+       <label for="locale-field">Current Locale</label>
+       <input class="input-mm" id="locale-field" readonly="true"/>
+     </div>
+   </div>
+  </div>
+
+<div class="row">
+      <div class="two columns">
+        <div class="field">
+          <label for="input-date-field-yyyyMMdd">Beginning Database Value (en-US)</label>
+          <input class="input-sm" id="input-date-field-yyyyMMdd" readonly="true"/>
+        </div>
+         <div class="field">
+            <label for="date-field-yyyyMMdd" class="label">Date Field</label>
+            <input id="date-field-yyyyMMdd" class="datepicker" type="text"/>
+         </div>
+        <div class="field">
+          <label for="output-date-field-yyyyMMdd">Transformed Database Value (en-US)</label>
+          <input class="input-sm" id="output-date-field-yyyyMMdd" readonly="true"/>
+        </div>
+      </div>
+
+     <div class="two columns">
+       <div class="field">
+         <label for="input-date-field-MMdd">Beginning Database Value (en-US)</label>
+         <input class="input-sm" id="input-date-field-MMdd" readonly="true"/>
+       </div>
+       <div class="field">
+         <label for="date-field-MMdd" class="label">MMMMdd Field</label>
+         <input id="date-field-MMdd" class="datepicker" type="text"/>
+       </div>
+       <div class="field">
+         <label for="output-date-field-MMdd">Transformed Database Value (en-US)</label>
+         <input class="input-sm" id="output-date-field-MMdd" readonly="true"/>
+       </div>
+     </div>
+
+    <div class="two columns">
+      <div class="field">
+        <label for="input-date-field-yyyyMM">Beginning Database Value (en-US)</label>
+        <input class="input-sm" id="input-date-field-yyyyMM" readonly="true"/>
+      </div>
+      <div class="field">
+        <label for="date-field-yyyyMM" class="label">yyyyMMMM Field</label>
+        <input id="date-field-yyyyMM" class="datepicker" type="text"/>
+      </div>
+      <div class="field">
+        <label for="output-date-field-yyyyMM">Transformed Database Value (en-US)</label>
+        <input class="input-sm" id="output-date-field-yyyyMM" readonly="true"/>
+      </div>
+    </div>
+
+    <div class="two columns">
+      <div class="field">
+        <label for="input-date-field-yyyy">Beginning Database Value (en-US)</label>
+        <input class="input-sm" id="input-date-field-yyyy" readonly="true"/>
+      </div>
+      <div class="field">
+        <label for="date-field-yyyy" class="label">yyyy Field</label>
+        <input id="date-field-yyyy" class="datepicker" type="text"/>
+      </div>
+      <div class="field">
+        <label for="output-date-field-yyyy">Transformed Database Value (en-US)</label>
+        <input class="input-sm" id="output-date-field-yyyy" readonly="true"/>
+      </div>
+    </div>
+</div>
+
+<script>
+  $('body').on('initialized', function () {
+    $('#locale-field').val(Soho.Locale.currentLocale.name + ', ' + Soho.Locale.calendar().name);
+
+    var model = {
+      yyyyMMdd: {
+        dataPattern:      'yyyyMMdd',
+        displayPattern:   Soho.Locale.calendar().dateFormat.short,
+        dbValue:          '20200229',
+        fieldId:          'date-field-yyyyMMdd',
+        options: {
+          mode: 'standard',
+          dateFormat: Soho.Locale.calendar().dateFormat.short,
+          showMonthYearPicker: true
+          }
+        },
+      MMdd: {
+        dataPattern:      'MMdd',
+        displayPattern:   Soho.Locale.calendar().dateFormat.month,
+        dbValue:          '0229',
+        fieldId:          'date-field-MMdd',
+        options: {
+          mode: 'standard',
+          dateFormat: Soho.Locale.calendar().dateFormat.month
+        }
+      },
+      yyyyMM: {
+        dataPattern:      'yyyyMM',
+        displayPattern:   Soho.Locale.calendar().dateFormat.year,
+        dbValue:          '202002',
+        fieldId:          'date-field-yyyyMM',
+        options: {
+          mode: 'standard',
+          dateFormat: Soho.Locale.calendar().dateFormat.year,
+          showMonthYearPicker: true,
+          hideDays: true
+        }
+      },
+      yyyy: {
+        dataPattern:      'yyyy',
+        displayPattern:   'yyyy',
+        dbValue:          '2020',
+        fieldId:          'date-field-yyyy',
+        options: {
+          mode: 'standard',
+          dateFormat: 'yyyy',
+          showMonthYearPicker: true,
+          hideDays: true
+        }
+      },
+    };
+
+    var modelKeys = Object.keys(model)
+    .forEach( (key) => {
+      var modelItem = model[key];
+      var datepicker = $('#' + modelItem.fieldId).datepicker(modelItem.options);
+      $('#input-' + modelItem.fieldId).val(modelItem.dbValue);
+      var fromPattern = modelItem.dataPattern;
+      var toPattern = modelItem.displayPattern;
+      var parseDateOptions = {
+        dateFormat: fromPattern,
+        locale: 'en-US',
+        calendarName: 'gregorian'
+      };
+      var date = Soho.Locale.parseDate(modelItem.dbValue, parseDateOptions, false);
+      var formatDateOptions = {
+        pattern: toPattern,
+        fromGregorian: (Soho.Locale.calendar().name === 'islamic-umalqura') ? true : undefined,
+      };
+      var value = Soho.Locale.formatDate(date, formatDateOptions);
+      datepicker.data('datepicker').setValue(value);
+
+      console.log([modelItem.fieldId + ' value transformed', modelItem.dbValue, value]);
+    });
+
+    $('.datepicker').on('change', function (e, args) {
+      var key = e.currentTarget.id.substr(e.currentTarget.id.lastIndexOf('-')+1);
+      var modelItem = model[key];
+
+      // transformation of date value in current locale format to database format (en-US)
+      var elemValue = $('#' + modelItem.fieldId).data('datepicker').element.val();
+      var fromPattern = modelItem.displayPattern;
+      var toPattern = modelItem.dataPattern;
+      var parseDateOptions = {
+        dateFormat: fromPattern
+      };
+
+      var date = Soho.Locale.parseDate(elemValue, parseDateOptions, false);
+      var formatDateOptions = {
+        pattern: toPattern,
+        toGregorian: (Soho.Locale.calendar().name === 'islamic-umalqura') ? true : undefined,
+        locale: 'en-US',
+        calendarName: 'gregorian'
+      };
+
+      var value = Soho.Locale.formatDate(date, formatDateOptions);
+      $('#output-' + modelItem.fieldId).val(value);
+      console.log([modelItem.fieldId + '.onchange value transformed', elemValue, value]);
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,10 +4,13 @@
 
 ### v4.30.1 Fixes
 
+- `[Datepicker]` Fixed the datepicker in ar-SA setting timestamps would null the times in some situations. ([#4160](https://github.com/infor-design/enterprise/issues/4160))
 - `[Datagrid]` The last row border was removed but this was incorrect, reverted this. ([#4140](https://github.com/infor-design/enterprise/issues/4140))
 - `[Datagrid]` Fixed an alignment issue in datagrid filter that caused some fields to be misaligned. ([#4151](https://github.com/infor-design/enterprise/issues/4151))
 - `[Datagrid]` Fixed an alignment issue with column colspan. In some situations it was not rendering correctly causing some cells to be misaligned. ([#4109](https://github.com/infor-design/enterprise/issues/4109))
 - `[Datagrid]` Changed invalid css fill-available property. ([#4133](https://github.com/infor-design/enterprise/issues/4133))
+- `[Locale]` Fixed a bug with MMMM dd format in ar-SA. ([#4160](https://github.com/infor-design/enterprise/issues/4160))
+- `[Locale]` Changed the arguments names for better symmetry fromGregorian == toUmalqura and toGregorian === options.fromUmalqura. ([#4160](https://github.com/infor-design/enterprise/issues4160))
 
 ## v4.30.0
 

--- a/src/components/datepicker/_datepicker.scss
+++ b/src/components/datepicker/_datepicker.scss
@@ -94,6 +94,10 @@
 .monthview-popup.popover {
   max-width: inherit;
 
+  .monthview .monthview-table {
+    max-width: 330px;
+  }
+
   // Week picker adjustments
   &.is-range-week {
     .monthview td .day-text {

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -1603,7 +1603,7 @@ DatePicker.prototype = {
 
     // Check and fix two digit year for main input element
     const dateFormat = self.pattern;
-    const isStrict = !(dateFormat === 'MMMM d' || dateFormat === 'd MMMM' || dateFormat === 'yyyy' ||
+    const isStrict = !(dateFormat.indexOf('MMMM') > -1 || dateFormat.indexOf('MMM') > -1 || dateFormat === 'yyyy' ||
       dateFormat === 'MMMM' || dateFormat === 'MMM' || dateFormat === 'MM');
     const fieldValueTrimmed = self.element.val().trim();
 

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -1786,7 +1786,7 @@ DatePicker.prototype = {
     if (date instanceof Array) {
       date[3] = hours ? parseInt(hours, 10) : date[3];
       date[4] = minutes ? parseInt(minutes, 10) : date[4];
-      date[5] = seconds ? parseInt(seconds, 10) : date[4];
+      date[5] = seconds ? parseInt(seconds, 10) : date[5];
     } else {
       date = new Date(date);
       date.setHours(hours, minutes, seconds);

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -1207,7 +1207,7 @@ DatePicker.prototype = {
   /**
    * Set the Formatted value in the input
    * @private
-   * @param {object} date The date to set in date format.
+   * @param {object|string} date The date to set in date format or a valid datestring
    * @param {boolean} trigger If true will trigger the change event.
    * @param {boolean} isTime will pass to set range.
    * @returns {void}

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -1784,9 +1784,9 @@ DatePicker.prototype = {
       !periodValue) && parseInt(hours, 10) === 12) ? 0 : hours;
 
     if (date instanceof Array) {
-      date[3] = hours;
-      date[4] = minutes;
-      date[5] = seconds;
+      date[3] = hours ? parseInt(hours, 10) : date[3];
+      date[4] = minutes ? parseInt(minutes, 10) : date[4];
+      date[5] = seconds ? parseInt(seconds, 10) : date[4];
     } else {
       date = new Date(date);
       date.setHours(hours, minutes, seconds);

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -1253,6 +1253,11 @@ const Locale = {  // eslint-disable-line
       if (dateObj.isUndefindedYear) {
         const isFeb29 = parseInt(dateObj.day, 10) === 29 && parseInt(dateObj.month, 10) === 1;
         dateObj.year = isFeb29 ? closestLeap() : (new Date()).getFullYear();
+
+        if (thisLocaleCalendar.name === 'islamic-umalqura') {
+          const umDate = this.gregorianToUmalqura(new Date(dateObj.year, 0, 1));
+          dateObj.year = umDate[0];
+        }
       } else {
         delete dateObj.year;
       }

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -596,13 +596,13 @@ const Locale = {  // eslint-disable-line
     const seconds = (value instanceof Array ? value[5] : value.getSeconds());
     const millis = (value instanceof Array ? value[6] : value.getMilliseconds());
 
-    if (options.fromGregorian) {
+    if (options.fromGregorian || options.toUmalqura) {
       const islamicParts = this.gregorianToUmalqura(value);
       day = islamicParts[2];
       month = islamicParts[1];
       year = islamicParts[0];
     }
-    if (options.toGregorian) {
+    if (options.toGregorian || options.fromUmalqura) {
       const gregorianDate = this.umalquraToGregorian(year, month, day);
       day = gregorianDate.getDate();
       month = gregorianDate.getMonth();
@@ -1010,8 +1010,9 @@ const Locale = {  // eslint-disable-line
       dateString = dateString.replace(regex, '/');
     }
 
-    // Extra Check incase month has spaces
-    if (dateFormat.indexOf('MMMM') > -1 && Locale.isRTL() && dateFormat) {
+    // Extra Check in case month has spaces
+    if (dateFormat.indexOf('MMMM') > -1 && Locale.isRTL() && dateFormat &&
+      dateFormat !== 'MMMM/dd' && dateFormat !== 'dd/MMMM') {
       const lastIdx = dateString.lastIndexOf('/');
       dateString = dateString.substr(0, lastIdx - 1).replace('/', ' ') + dateString.substr(lastIdx);
     }

--- a/test/components/locale/locale.e2e-spec.js
+++ b/test/components/locale/locale.e2e-spec.js
@@ -29,23 +29,37 @@ describe('Locale Format Date Tests', () => {
 describe('Locale Set Value Tests', () => {
   it('Should format dates in en-US', async () => {
     await utils.setPage('/components/locale/test-set-value?layout=nofrills');
-    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('date-field-yyyy'))), config.waitsFor);
+    await browser.driver.wait(protractor.ExpectedConditions.visibilityOf(element(by.id('output-date-field-time'))), config.waitsFor);
 
     expect(await element(by.id('date-field-yyyyMMdd')).getAttribute('value')).toEqual('2/29/2020');
     expect(await element(by.id('date-field-MMdd')).getAttribute('value')).toEqual('February 29');
     expect(await element(by.id('date-field-yyyyMM')).getAttribute('value')).toEqual('February 2020');
     expect(await element(by.id('date-field-yyyy')).getAttribute('value')).toEqual('2020');
     expect(await element(by.id('date-field-timestamp')).getAttribute('value')).toEqual('2/29/2020 10:45:30 AM');
+
+    expect(await element(by.id('output-date-field-yyyyMMdd')).getAttribute('value')).toEqual('20200229');
+    expect(await element(by.id('output-date-field-MMdd')).getAttribute('value')).toEqual('0229');
+    expect(await element(by.id('output-date-field-yyyyMM')).getAttribute('value')).toEqual('202002');
+    expect(await element(by.id('output-date-field-yyyy')).getAttribute('value')).toEqual('2020');
+    expect(await element(by.id('output-date-field-timestamp')).getAttribute('value')).toEqual('20200229104530');
+    expect(await element(by.id('output-date-field-time')).getAttribute('value')).toEqual('104530');
   });
 
   it('Should format dates in ar-SA', async () => {
     await utils.setPage('/components/locale/test-set-value?layout=nofrills&locale=ar-SA');
-    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('date-field-yyyy'))), config.waitsFor);
+    await browser.driver.wait(protractor.ExpectedConditions.visibilityOf(element(by.id('output-date-field-time'))), config.waitsFor);
 
     expect(await element(by.id('date-field-yyyyMMdd')).getAttribute('value')).toEqual('1441/07/05');
     expect(await element(by.id('date-field-MMdd')).getAttribute('value')).toEqual('05 رجب');
     expect(await element(by.id('date-field-yyyyMM')).getAttribute('value')).toEqual('جمادى الآخرة 1441');
     expect(await element(by.id('date-field-yyyy')).getAttribute('value')).toEqual('1441');
     expect(await element(by.id('date-field-timestamp')).getAttribute('value')).toEqual('1441/07/05 10:45:30 ص');
+
+    expect(await element(by.id('output-date-field-yyyyMMdd')).getAttribute('value')).toEqual('20200229');
+    expect(await element(by.id('output-date-field-MMdd')).getAttribute('value')).toEqual('0229');
+    expect(await element(by.id('output-date-field-yyyyMM')).getAttribute('value')).toEqual('202001');
+    expect(await element(by.id('output-date-field-yyyy')).getAttribute('value')).toEqual('2020');
+    expect(await element(by.id('output-date-field-timestamp')).getAttribute('value')).toEqual('20200229104530');
+    expect(await element(by.id('output-date-field-time')).getAttribute('value')).toEqual('104530');
   });
 });

--- a/test/components/locale/locale.e2e-spec.js
+++ b/test/components/locale/locale.e2e-spec.js
@@ -25,3 +25,25 @@ describe('Locale Format Date Tests', () => {
     expect(await element(by.id('date-field4')).getAttribute('value')).toEqual('05/12/2019');
   });
 });
+
+describe('Locale Set Value Tests', () => {
+  it('Should format dates in en-US', async () => {
+    await utils.setPage('/components/locale/test-set-value?layout=nofrills');
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('date-field-yyyy'))), config.waitsFor);
+
+    expect(await element(by.id('date-field-yyyyMMdd')).getAttribute('value')).toEqual('2/29/2020');
+    expect(await element(by.id('date-field-MMdd')).getAttribute('value')).toEqual('February 29');
+    expect(await element(by.id('date-field-yyyyMM')).getAttribute('value')).toEqual('February 2020');
+    expect(await element(by.id('date-field-yyyy')).getAttribute('value')).toEqual('2020');
+  });
+
+  it('Should format dates in ar-SA', async () => {
+    await utils.setPage('/components/locale/test-set-value?layout=nofrills&locale=ar-SA');
+    await browser.driver.wait(protractor.ExpectedConditions.presenceOf(element(by.id('date-field-yyyy'))), config.waitsFor);
+
+    expect(await element(by.id('date-field-yyyyMMdd')).getAttribute('value')).toEqual('1441/07/05');
+    expect(await element(by.id('date-field-MMdd')).getAttribute('value')).toEqual('05 رجب');
+    expect(await element(by.id('date-field-yyyyMM')).getAttribute('value')).toEqual('جمادى الآخرة 1441');
+    expect(await element(by.id('date-field-yyyy')).getAttribute('value')).toEqual('1441');
+  });
+});

--- a/test/components/locale/locale.e2e-spec.js
+++ b/test/components/locale/locale.e2e-spec.js
@@ -35,6 +35,7 @@ describe('Locale Set Value Tests', () => {
     expect(await element(by.id('date-field-MMdd')).getAttribute('value')).toEqual('February 29');
     expect(await element(by.id('date-field-yyyyMM')).getAttribute('value')).toEqual('February 2020');
     expect(await element(by.id('date-field-yyyy')).getAttribute('value')).toEqual('2020');
+    expect(await element(by.id('date-field-timestamp')).getAttribute('value')).toEqual('2/29/2020 10:45:30 AM');
   });
 
   it('Should format dates in ar-SA', async () => {
@@ -45,5 +46,6 @@ describe('Locale Set Value Tests', () => {
     expect(await element(by.id('date-field-MMdd')).getAttribute('value')).toEqual('05 رجب');
     expect(await element(by.id('date-field-yyyyMM')).getAttribute('value')).toEqual('جمادى الآخرة 1441');
     expect(await element(by.id('date-field-yyyy')).getAttribute('value')).toEqual('1441');
+    expect(await element(by.id('date-field-timestamp')).getAttribute('value')).toEqual('1441/07/05 10:45:30 ص');
   });
 });

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -1284,7 +1284,7 @@ describe('Locale API', () => {
 
     const testDate2 = Soho.Locale.formatDate([1441, 6, 5, 0, 0, 0, 0], formatDateOptions);
 
-    expect(testDate2).toEqual('0915');
+    expect(testDate2).toEqual('0229');
 
     const testDate3 = Locale.formatDate('May 01', {
       pattern: 'MMMM dd',

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -1264,6 +1264,25 @@ describe('Locale API', () => {
     expect(time).toEqual(new Date(2010, 11, 1, 0, 0, 0).getTime());
   });
 
+  it('Should properly parseDate on ddMM format to the current same format', () => {
+    Locale.set('ar-SA');
+    const testDate = Locale.parseDate('05 رجب', {
+      pattern: 'dd MMMM',
+      locale: 'ar-SA'
+    });
+
+    expect(testDate[0]).toEqual(2020);
+    expect(testDate[1]).toEqual(6);
+    expect(testDate[2]).toEqual(5);
+
+    const testDate2 = Locale.formatDate('May 01', {
+      pattern: 'MMMM dd',
+      locale: 'en-US'
+    });
+
+    expect(testDate2).toEqual('May 01');
+  });
+
   it('Should handle numbers passed to parseNumber', () => {
     Locale.set('en-US');
 

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -1271,16 +1271,27 @@ describe('Locale API', () => {
       locale: 'ar-SA'
     });
 
-    expect(testDate[0]).toEqual(2020);
+    expect(testDate[0]).toEqual(1441);
     expect(testDate[1]).toEqual(6);
     expect(testDate[2]).toEqual(5);
 
-    const testDate2 = Locale.formatDate('May 01', {
+    const formatDateOptions = {
+      pattern: 'MMdd',
+      toGregorian: true,
+      locale: 'en-US',
+      calendarName: 'gregorian'
+    };
+
+    const testDate2 = Soho.Locale.formatDate([1441, 6, 5, 0, 0, 0, 0], formatDateOptions);
+
+    expect(testDate2).toEqual('0915');
+
+    const testDate3 = Locale.formatDate('May 01', {
       pattern: 'MMMM dd',
       locale: 'en-US'
     });
 
-    expect(testDate2).toEqual('May 01');
+    expect(testDate3).toEqual('May 01');
   });
 
   it('Should handle numbers passed to parseNumber', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Added several fixes uncovered on a new test page. See steps and is covered by tests.

**Related github/jira issue (required)**:
Fixes #4160 

**Steps necessary to review your pull request (required)**:
**Main issue**
- go to http://localhost:4000/components/locale/test-set-value.html
- each field should fill in with an arbitrary date (selecting a new date will fill the bottom set of fields)
- go to http://localhost:4000/components/locale/test-set-value.html?locale=ar-SA
- each field should fill in with an arbitrary date (selecting a new date will fill the bottom set of fields)
- the problem was the MMdd Field wasnt working and neither was yyyyMM Field

**Supplemental issue**
- on http://localhost:4000/components/locale/test-set-value.html?locale=ar-SA
- open the picker on the timestamp example and click today
- reopen again and pick one week up (19th)
- the times were turning to null (this should not happen now)

Don't worry if longer dates are partly cut off.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
