### PR TITLE
4020 - Fix Dropdown backspace special character bug

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@
 - `[Datepicker]` Fixed a bug where two dates may appear selected when moving forward/back in the picker dialog. ([#4018](https://github.com/infor-design/enterprise/issues/4018))
 - `[Datepicker]` Fixed a bug where an error may occur if using the gregorian calendar on ar-SA locale. ([#4130](https://github.com/infor-design/enterprise/issues/4130))
 - `[Dropdown]` Fixed an issue where "phraseStartsWith" does not filter the list after deleting a character. ([#4047](https://github.com/infor-design/enterprise/issues/4047))
+- `[Dropdown]` Fixed a bug when backspacing in windows or fn + delete in Mac OS would render a ascii character in the input field. ([#4020](https://github.com/infor-design/enterprise/issues/4020))
 - `[Editor]` Fixed a number of translation issues in the editor component. ([#4049](https://github.com/infor-design/enterprise/issues/4049))
 - `[Locale]` The Added placeholder for missing Thai `Locale` translation. ([#4041](https://github.com/infor-design/enterprise/issues/4041))
 - `[Locale]` The Added placeholder for incorrect French `SetTime` translation. ([#4045](https://github.com/infor-design/enterprise/issues/4045))

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1091,7 +1091,6 @@ Dropdown.prototype = {
   ignoreKeys(input, e) {
     const charCode = e.which;
 
-    console.log(input[0].element);
     // Needed for browsers that use keypress events to manipulate the window.
     if (e.altKey && (charCode === 38)) {
       e.stopPropagation();
@@ -1134,7 +1133,18 @@ Dropdown.prototype = {
       this.searchKeyMode = false;
     }
 
-    console.log(this.searchInput);
+    const searchInputVal = this.searchInput[0].value;
+    const isIE11 = env.browser.name === 'ie' && env.browser.version === '11';
+    let rectStr;
+    if (!isIE11) {
+      /* eslint-disable */
+      rectStr = String.fromCodePoint(8);
+      /* eslint-enable no-alert, no-console */
+    }
+    if (searchInputVal === '.' || searchInputVal === rectStr) {
+      this.searchInput[0].value = '';
+    }
+
     this.searchInput
       .on(`keydown.${COMPONENT_NAME}`, (e) => {
         const searchInput = $(this);

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1091,6 +1091,7 @@ Dropdown.prototype = {
   ignoreKeys(input, e) {
     const charCode = e.which;
 
+    console.log(input[0].element);
     // Needed for browsers that use keypress events to manipulate the window.
     if (e.altKey && (charCode === 38)) {
       e.stopPropagation();
@@ -1133,6 +1134,7 @@ Dropdown.prototype = {
       this.searchKeyMode = false;
     }
 
+    console.log(this.searchInput);
     this.searchInput
       .on(`keydown.${COMPONENT_NAME}`, (e) => {
         const searchInput = $(this);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes an issue where pressing `backspace` in Windows 10 and `fn + delete` in Mac OS was inserting a special character in the input field. Using `String.fromCodePoint` to check for the special char in windows. Also checking for IE11 as this is not supported, but the bug was actually not occurring in IE11 so I think it's safe.

**Related github/jira issue (required)**:
closes #4020 

**Steps necessary to review your pull request (required)**:
- pull and run branch
- Go to http://localhost:4000/components/datagrid/example-editable.html click in an editable cell in the Action column.
- Select a new value, "Shipped" for example.
- In Windows press `backspace`  / In Mac OS press `fn + delete`
- The cell should now clear and not display a special character.

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
