### PR TITLE
3986 - Fix toast message doesn't dismissed when pressing ESC

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,7 @@
 - `[Popupmenu]` Fixed a bug that the aria items are in the wrong place. Its now using [this guide](https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html). ([#4085](https://github.com/infor-design/enterprise/issues/4085))
 - `[Popupmenu]` Fixed a bug where the heading doesn't display properly with multi-select menu. ([#3926](https://github.com/infor-design/enterprise/issues/3926))
 - `[Searchfield]` Fixed an issue where some of the searchfield examples did not have focus states. ([#1060](https://github.com/infor-design/enterprise/issues/1060))
+- `[Toast]` Fixed a bug where the toast message doesn't close when pressing escape, and when it has multiple trigger elements and uses unique id's. ([#3986](https://github.com/infor-design/enterprise/issues/3986))
 - `[Tooltip]` Fixed a bug where the title doesn't display when the title starts with '#'. ([#2512](https://github.com/infor-design/enterprise/issues/2512))
 - `[Tooltip]` Fixed an issue where the tooltip would not show up if you focus a button with the keyboard. ([#4085](https://github.com/infor-design/enterprise/issues/4085))
 - `[Tree]` Fixed an issue where the tree node still shows folder icon after all children and `children` property deleted. ([#4026](https://github.com/infor-design/enterprise/issues/4026))

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -111,8 +111,14 @@ Toast.prototype = {
     self.createDraggable(toast, container);
 
     // Get the number of toasts
-    const toastsIndex = container.children().length;
+    let toastsIndex = container.children().length;
     this.toastsIndex = toastsIndex;
+
+    // Get the number of unique toast container
+    const toastUniqueContainer = this.element.find('.toast-container');
+    for (let i = 0, len = toastUniqueContainer.children(); i < len.length; i++) {
+      toastsIndex = len.length;
+    }
 
     // Build the RenderLoop integration
     const timer = new RenderLoopItem({


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes a bug where the toast message doesn't dismissed when pressing ESC.

Having unique id's creates multiple containers. Because of that, we need to connect all of the toast elements on a single instance for the escape dismissal to work. If there are multiple unique containers, it creates its own indexes.


**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/3986

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Navigate to http://localhost:4000/components/toast/example-draggable.html
- Click `Show Toast Message 1` multiple times
- Drag this container to another place
- Click also `Show Toast Message 2` multiple times
- Press ESC to dismiss all the toast messages simultaneously
- It should dismissed all the toast messages (Including those on Message 2 button)

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
