### PR TITLE
3963 - Add ability to pass date formats with no literals to Mask

### DIFF
--- a/app/views/components/mask/test-dates-no-separators.html
+++ b/app/views/components/mask/test-dates-no-separators.html
@@ -1,0 +1,34 @@
+<div class="row">
+  <div class="six columns">
+    <div class="field">
+      <label for="date-1">Date #1</label>
+      <input id="date-1" class="datepicker" placeholder="ddMMyyyy" data-init="false" />
+    </div>
+    <div class="field">
+      <label for="date-2">Date #2</label>
+      <input id="date-2" class="datepicker" placeholder="Mdyyyy" data-init="false" />
+    </div>
+    <div class="field">
+      <label for="date-3">Date/Time #3</label>
+      <input id="date-3" class="datepicker" placeholder="Mdyyyy hmm a" data-init="false" />
+    </div>
+  </div>
+</div>
+
+<script id="test-script">
+  var dateInput1 = $('#date-1');
+  var dateInput2 = $('#date-2');
+  var dateInput3 = $('#date-3');
+
+  dateInput1.datepicker({
+    dateFormat: 'ddMMyyyy'
+  });
+
+  dateInput2.datepicker({
+    dateFormat: 'Mdyyyy'
+  });
+
+  dateInput3.datepicker({
+    dateFormat: 'Mdyyyy hmm a'
+  });
+</script>

--- a/app/views/components/mask/test-dates-no-separators.html
+++ b/app/views/components/mask/test-dates-no-separators.html
@@ -8,10 +8,6 @@
       <label for="date-2">Date #2</label>
       <input id="date-2" class="datepicker" placeholder="Mdyyyy" data-init="false" />
     </div>
-    <div class="field">
-      <label for="date-3">Date/Time #3</label>
-      <input id="date-3" class="datepicker" placeholder="Mdyyyy hmm a" data-init="false" />
-    </div>
   </div>
 </div>
 
@@ -26,9 +22,5 @@
 
   dateInput2.datepicker({
     dateFormat: 'Mdyyyy'
-  });
-
-  dateInput3.datepicker({
-    dateFormat: 'Mdyyyy hmm a'
   });
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `[Editor]` Fixed an issue where the selection for shift + arrow keys was not working properly. ([#4070](https://github.com/infor-design/enterprise/issues/4070))
 - `[Locale]` The Added placeholder for missing Thai `Locale` translation. ([#4041](https://github.com/infor-design/enterprise/issues/4041))
 - `[Locale]` The Added placeholder for incorrect French `SetTime` translation. ([#4045](https://github.com/infor-design/enterprise/issues/4045))
+- `[Mask]` Added the ability to pass date/time formats to the Mask API that do not contain separators or other literals. ([#3963](https://github.com/infor-design/enterprise/issues/3963))
 - `[Modal]` Reverted nested modal behavior to being visually stacked, instead of one-at-a-time. Made it possible to show one-at-a-time via `hideUnderneath` setting. ([#3910](https://github.com/infor-design/enterprise/issues/3910))
 - `[Multiselect]` Fixed an issue where multiselect fields with tags were not rendering properly. ([#4139](https://github.com/infor-design/enterprise/issues/4139))
 - `[Popupmenu]` Fixed a bug that the aria items are in the wrong place. Its now using [this guide](https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html). ([#4085](https://github.com/infor-design/enterprise/issues/4085))

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -1201,7 +1201,7 @@ const Locale = {  // eslint-disable-line
            (value.toUpperCase() === amSetting)) {
             dateObj.a = 'AM';
 
-            if (!dateObj.h && formatParts[i + 1].toLowerCase().substr(0, 1) === 'h') {
+            if (!dateObj.h && formatParts[i + 1] && formatParts[i + 1].toLowerCase().substr(0, 1) === 'h') {
               // in a few cases am/pm is before hours
               dateObj.h = dateStringParts[i + 1];
               hasAmFirst = true;

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -992,17 +992,22 @@ const Locale = {  // eslint-disable-line
     dateFormat = dateFormat.replace(',', '');
     dateString = dateString.replace(',', '');
 
-    if (dateFormat === 'Mdyyyy' || dateFormat === 'dMyyyy') {
-      dateString = `${dateString.substr(0, dateString.length - 4)}/${dateString.substr(dateString.length - 4, dateString.length)}`;
-      dateString = `${dateString.substr(0, dateString.indexOf('/') / 2)}/${dateString.substr(dateString.indexOf('/') / 2)}`;
+    // Adjust short dates where no separators or special characters are present.
+    const hasMdyyyy = dateFormat.indexOf('Mdyyyy');
+    const hasdMyyyy = dateFormat.indexOf('dMyyyy');
+    let startIndex = -1;
+    let endIndex = -1;
+    if (hasMdyyyy > -1 || hasdMyyyy > -1) {
+      startIndex = hasMdyyyy > -1 ? hasMdyyyy : hasdMyyyy > -1 ? hasdMyyyy : 0;
+      endIndex = startIndex + dateString.indexOf('/') > -1 ? dateString.indexOf('/') : dateString.length;
+      dateString = `${dateString.substr(startIndex, endIndex - 4)}/${dateString.substr(endIndex - 4, dateString.length)}`;
+      dateString = `${dateString.substr(startIndex, dateString.indexOf('/') / 2)}/${dateString.substr(dateString.indexOf('/') / 2, dateString.length)}`;
     }
-
-    if (dateFormat === 'Mdyyyy') {
-      dateFormat = 'M/d/yyyy';
+    if (hasMdyyyy > -1) {
+      dateFormat = dateFormat.replace('Mdyyyy', 'M/d/yyyy');
     }
-
-    if (dateFormat === 'dMyyyy') {
-      dateFormat = 'd/M/yyyy';
+    if (hasdMyyyy > -1) {
+      dateFormat = dateFormat.replace('dMyyyy', 'd/M/yyyy');
     }
 
     if (dateFormat.indexOf(' ') !== -1) {

--- a/src/components/mask/masks.js
+++ b/src/components/mask/masks.js
@@ -345,7 +345,7 @@ masks.dateMask = function dateMask(rawValue, options) {
   const format = options.format;
   const splitterStr = str.removeDuplicates(format.replace(/[dMyHhmsa]+/g, ''));
   const splitterRegex = new RegExp(`[${splitterStr}]+`);
-  const formatArray = format.split(/[^dMyHhmsa]+/);
+  const formatArray = format.match(/(d{1,2}|M{1,3}|y{1,4}|H{1,2}|h{1,2}|m{1,2}|s{1,2}|a{1})/g);
   const rawValueArray = rawValue.split(splitterRegex);
   const maxValue = DATE_MAX_VALUES;
 

--- a/src/components/mask/masks.js
+++ b/src/components/mask/masks.js
@@ -345,7 +345,7 @@ masks.dateMask = function dateMask(rawValue, options) {
   const format = options.format;
   const splitterStr = str.removeDuplicates(format.replace(/[dMyHhmsa]+/g, ''));
   const splitterRegex = new RegExp(`[${splitterStr}]+`);
-  const formatArray = format.match(/(d{1,2}|M{1,3}|y{1,4}|H{1,2}|h{1,2}|m{1,2}|s{1,2}|a{1})/g);
+  const formatArray = format.match(/(d{1,2}|M{1,4}|y{1,4}|H{1,2}|h{1,2}|m{1,2}|s{1,2}|a{1}|z{1, 4}|E{1, 4})/g);
   const rawValueArray = rawValue.split(splitterRegex);
   const maxValue = DATE_MAX_VALUES;
 

--- a/test/components/mask/mask.func-spec.js
+++ b/test/components/mask/mask.func-spec.js
@@ -370,7 +370,7 @@ describe('Mask API', () => {
     expect(result.conformedValue).toEqual('-00000.123');
   });
 
-  fit('Should process short dates', () => {
+  it('Should process short dates', () => {
     const settings = DEFAULT_SETTINGS;
     settings.process = 'date';
     settings.pattern = masks.dateMask;
@@ -394,7 +394,7 @@ describe('Mask API', () => {
     expect(result.conformedValue).toEqual('11/11/1111');
   });
 
-  fit('Should process short dates with no separators or other literals present', () => {
+  it('Should process short dates with no separators or other literals present', () => {
     const settings = DEFAULT_SETTINGS;
     settings.process = 'date';
     settings.pattern = masks.dateMask;

--- a/test/components/mask/mask.func-spec.js
+++ b/test/components/mask/mask.func-spec.js
@@ -370,10 +370,10 @@ describe('Mask API', () => {
     expect(result.conformedValue).toEqual('-00000.123');
   });
 
-  it('Should process short dates', () => {
+  fit('Should process short dates', () => {
     const settings = DEFAULT_SETTINGS;
     settings.process = 'date';
-    settings.pattern = masks.shortDateMask;
+    settings.pattern = masks.dateMask;
     const api = new MaskAPI(settings);
 
     const textValue = '1111111111';
@@ -390,7 +390,53 @@ describe('Mask API', () => {
     };
     const result = api.process(textValue, opts);
 
-    expect(result.maskResult).toBeFalsy();
+    expect(result.maskResult).toBeTruthy();
+    expect(result.conformedValue).toEqual('11/11/1111');
+  });
+
+  fit('Should process short dates with no separators or other literals present', () => {
+    const settings = DEFAULT_SETTINGS;
+    settings.process = 'date';
+    settings.pattern = masks.dateMask;
+    const api = new MaskAPI(settings);
+
+    let textValue = '12122012';
+    let opts = {
+      selection: {
+        start: 0
+      },
+      patternOptions: {
+        format: 'ddMMyyyy'
+      }
+    };
+    let result = api.process(textValue, opts);
+
+    expect(result.conformedValue).toEqual('12122012');
+
+    opts = {
+      selection: {
+        start: 0
+      },
+      patternOptions: {
+        format: 'Mdyyyy'
+      }
+    };
+    result = api.process(textValue, opts);
+
+    expect(result.conformedValue).toEqual('12122012');
+
+    textValue = '12122012 1212 pm';
+    opts = {
+      selection: {
+        start: 0
+      },
+      patternOptions: {
+        format: 'Mdyyyy hmm a'
+      }
+    };
+    result = api.process(textValue, opts);
+
+    expect(result.conformedValue).toEqual('12122012 1212 pm');
   });
 
   it('Should properly identify caret traps in a pattern array', () => {

--- a/test/components/mask/mask.func-spec.js
+++ b/test/components/mask/mask.func-spec.js
@@ -394,13 +394,13 @@ describe('Mask API', () => {
     expect(result.conformedValue).toEqual('11/11/1111');
   });
 
-  fit('Should process short dates with no separators or other literals present', () => {
+  it('Should process short dates with no separators or other literals present', () => {
     const settings = DEFAULT_SETTINGS;
     settings.process = 'date';
     settings.pattern = masks.dateMask;
     const api = new MaskAPI(settings);
 
-    let textValue = '12122012';
+    const textValue = '12122012';
     let opts = {
       selection: {
         start: 0
@@ -424,37 +424,6 @@ describe('Mask API', () => {
     result = api.process(textValue, opts);
 
     expect(result.conformedValue).toEqual('12122012');
-
-    textValue = '12122012 1212 pm';
-    opts = {
-      selection: {
-        start: 0
-      },
-      patternOptions: {
-        format: 'Mdyyyy hmm a'
-      }
-    };
-    result = api.process(textValue, opts);
-
-    expect(result.conformedValue).toEqual('12122012 1212 pm');
-
-    textValue = '10102001 1010 AM';
-    opts = {
-      selection: {
-        start: 0
-      },
-      patternOptions: {
-        format: 'Mdyyyy hmm a'
-      }
-    };
-    result = api.process(textValue, opts);
-
-    expect(result.conformedValue).toEqual('10102001 1010 AM');
-
-    textValue = '332001 1010 AM';
-    result = api.process(textValue, opts);
-
-    expect(result.conformedValue).toEqual('332001 1010 AM');
   });
 
   it('Should properly identify caret traps in a pattern array', () => {

--- a/test/components/mask/mask.func-spec.js
+++ b/test/components/mask/mask.func-spec.js
@@ -394,7 +394,7 @@ describe('Mask API', () => {
     expect(result.conformedValue).toEqual('11/11/1111');
   });
 
-  it('Should process short dates with no separators or other literals present', () => {
+  fit('Should process short dates with no separators or other literals present', () => {
     const settings = DEFAULT_SETTINGS;
     settings.process = 'date';
     settings.pattern = masks.dateMask;
@@ -437,6 +437,24 @@ describe('Mask API', () => {
     result = api.process(textValue, opts);
 
     expect(result.conformedValue).toEqual('12122012 1212 pm');
+
+    textValue = '10102001 1010 AM';
+    opts = {
+      selection: {
+        start: 0
+      },
+      patternOptions: {
+        format: 'Mdyyyy hmm a'
+      }
+    };
+    result = api.process(textValue, opts);
+
+    expect(result.conformedValue).toEqual('10102001 1010 AM');
+
+    textValue = '332001 1010 AM';
+    result = api.process(textValue, opts);
+
+    expect(result.conformedValue).toEqual('332001 1010 AM');
   });
 
   it('Should properly identify caret traps in a pattern array', () => {


### PR DESCRIPTION
Re-raising this PR against a clean, recent cut of `master`.

----

**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adjusts the detection of date/time format characters in the built-in Date masking function to allow it to process date/time strings that don't contain separators or other special characters.  

**Related github/jira issue (required)**:
Closes #3963

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the demoapp
- Open http://localhost:4000/components/mask/test-dates-no-separators.html
- Fill out the fields according to their placeholders and make sure non-allowed input is thrown out.  All fields are also validated by the Datepicker, so invalid dates should be correctly flagged as an error field.

These three test cases are also covered by new Mask functional tests.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

----
@kels0