### PR TITLE
4031 - Fix filter results for tree grid with datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Buttons]` Reverted an inner Css rule change that set 'btn' classes to contains vs starts with. ([#4120](https://github.com/infor-design/enterprise/issues/4120))
 - `[Datagrid]` Fixed an issue where the tooltip for tree grid was not working properly. ([#827](https://github.com/infor-design/enterprise-ng/issues/827))
 - `[Datagrid]` Fixed an issue where the keyword search was not working for server side paging. ([#3977](https://github.com/infor-design/enterprise/issues/3977))
+- `[Datagrid]` Fixed an issue where the column filter results were inconsistent for tree grid. ([#4031](https://github.com/infor-design/enterprise/issues/4031))
 - `[Datagrid]` Fixed an issue where the data was not exporting to excel when using the groupable setting. ([#4081](https://github.com/infor-design/enterprise/issues/4081))
 - `[Datagrid]` Fixed an issue where if a context menu is opened and then closed with ESC the focus would be reset to the top of the page. ([#4085](https://github.com/infor-design/enterprise/issues/4085))
 - `[Datagrid]` Fixed an issue where the tooltip would not show up if you focus a cell with ellipsis text with the keyboard. ([#4085](https://github.com/infor-design/enterprise/issues/4085))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -2217,49 +2217,66 @@ Datagrid.prototype = {
     };
 
     if (!this.settings.disableClientFilter) {
-      let dataset;
-      let isFiltered;
-      let i;
-      let i2;
-      let len;
-      let dataSetLen;
-
       if (this.settings.treeGrid) {
-        dataset = this.settings.dataset;
-
-        const checkChildNodes = function (nodeData, parentNode) {
-          for (let j = 0; j < nodeData.length; j++) {
-            const childNode = nodeData[j];
-
-            if (isFiltered) {
-              isFiltered = !checkRow(childNode);
+        // Check nodes and set key/value `_isFilteredOut` in given dataset
+        const checkNodes = (dataset) => {
+          let isFiltered = true;
+          for (let i = 0, len = dataset.length; i < len; i++) {
+            const nodeData = dataset[i];
+            let isChildFiltered = true;
+            if (nodeData.children) {
+              isChildFiltered = checkNodes(nodeData.children);
+              if (isChildFiltered) {
+                nodeData._isFilteredOut = !checkRow(nodeData);
+                if (!nodeData._isFilteredOut) {
+                  isFiltered = false;
+                }
+              } else {
+                isFiltered = false;
+              }
+            } else {
+              nodeData._isFilteredOut = !checkRow(nodeData);
+              if (!nodeData._isFilteredOut) {
+                isFiltered = false;
+              }
             }
+          }
+          return isFiltered;
+        };
 
-            childNode._isFilteredOut = !checkRow(childNode);
-
-            if (parentNode && !childNode._isFilteredOut) {
-              parentNode._isFilteredOut = false;
+        // Check empty filter conditions
+        const isFilterEmpty = () => {
+          let isEmpty = true;
+          for (let i = 0, len = conditions.length; i < len; i++) {
+            if (conditions[i].value.toString().trim() !== '') {
+              isEmpty = false;
             }
+          }
+          return isEmpty;
+        };
 
-            if (childNode.children && childNode.children.length) {
-              checkChildNodes(childNode.children, childNode);
+        // Remove all nested key/value `_isFilteredOut` from given dataset
+        const removeFilteredOut = (dataset) => {
+          for (let i = 0, len = dataset.length; i < len; i++) {
+            if (typeof dataset[i]._isFilteredOut !== 'undefined') {
+              delete dataset[i]._isFilteredOut;
+            }
+            if (dataset[i].children) {
+              removeFilteredOut(dataset[i].children);
             }
           }
         };
 
-        for (i = 0, len = dataset.length; i < len; i++) {
-          isFiltered = !checkRow(dataset[i]);
-
-          if (dataset[i].children && dataset[i].children.length) {
-            checkChildNodes(dataset[i].children);
-          }
-
-          dataset[i]._isFilteredOut = isFiltered;
+        if (isFilterEmpty()) {
+          removeFilteredOut(this.settings.dataset);
+        } else {
+          checkNodes(this.settings.dataset);
         }
       } else if (this.settings.groupable) {
-        for (i = 0, len = this.settings.dataset.length; i < len; i++) {
+        let isFiltered;
+        for (let i = 0, len = this.settings.dataset.length; i < len; i++) {
           let isGroupFiltered = true;
-          for (i2 = 0, dataSetLen = this.settings.dataset[i].values.length; i2 < dataSetLen; i2++) {
+          for (let i2 = 0, dataSetLen = this.settings.dataset[i].values.length; i2 < dataSetLen; i2++) {
             isFiltered = !checkRow(this.settings.dataset[i].values[i2]);
             this.settings.dataset[i].values[i2]._isFilteredOut = isFiltered;
 
@@ -2271,7 +2288,8 @@ Datagrid.prototype = {
           this.settings.dataset[i]._isFilteredOut = isGroupFiltered;
         }
       } else {
-        for (i = 0, len = this.settings.dataset.length; i < len; i++) {
+        let isFiltered;
+        for (let i = 0, len = this.settings.dataset.length; i < len; i++) {
           isFiltered = !checkRow(this.settings.dataset[i]);
           this.settings.dataset[i]._isFilteredOut = isFiltered;
         }
@@ -3718,6 +3736,17 @@ Datagrid.prototype = {
     let isHidden = false;
     let skipColumns;
 
+    // Calculate all nested children
+    const calculateChildren = (ds, count = 0) => {
+      count += ds.length;
+      for (let i = 0, l = ds.length; i < l; i++) {
+        if (ds[i].children) {
+          count = calculateChildren(ds[i].children, count);
+        }
+      }
+      return count;
+    };
+
     if (!rowData) {
       return '';
     }
@@ -4126,6 +4155,13 @@ Datagrid.prototype = {
         containerHtml.left += childRowHtml.left;
         containerHtml.center += childRowHtml.center;
         containerHtml.right += childRowHtml.right;
+      }
+    } else if (this.settings.treeGrid && !skipChildren && rowData._isFilteredOut) {
+      if (rowData.children) {
+        const count = calculateChildren(rowData.children);
+        this.recordCount += count + (rowData._isFilteredOut && depth === 1 ? 1 : 0);
+      } else if (depth === 1) {
+        this.recordCount++;
       }
     }
 

--- a/test/components/datagrid/datagrid-tree.func-spec.js
+++ b/test/components/datagrid/datagrid-tree.func-spec.js
@@ -183,6 +183,13 @@ describe('Datagrid Tree', () => { //eslint-disable-line
     datagridObj.clearFilter();
 
     expect(document.body.querySelectorAll('tbody tr:not(.is-hidden)').length).toEqual(19);
+    filter[0].value = 'more';
+    datagridObj.applyFilter(filter);
+
+    expect(document.body.querySelectorAll('tbody tr:not(.is-hidden)').length).toEqual(16);
+    datagridObj.clearFilter();
+
+    expect(document.body.querySelectorAll('tbody tr:not(.is-hidden)').length).toEqual(19);
   });
 
   it('Should be able to set children by allowChildExpandOnMatch:false', () => {
@@ -209,6 +216,13 @@ describe('Datagrid Tree', () => { //eslint-disable-line
     expandBtn = document.querySelector('tr:nth-child(1) .datagrid-expand-btn');
 
     expect(expandBtn.disabled).toBeFalsy();
+    expect(document.body.querySelectorAll('tbody tr:not(.is-hidden)').length).toEqual(19);
+    filter[0].value = 'more';
+    datagridObj.applyFilter(filter);
+
+    expect(document.body.querySelectorAll('tbody tr:not(.is-hidden)').length).toEqual(10);
+    datagridObj.clearFilter();
+
     expect(document.body.querySelectorAll('tbody tr:not(.is-hidden)').length).toEqual(19);
   });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed column filter results were inconsistent for tree grid with Datagrid.

**Related github/jira issue (required)**:
Closes #4031

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app

http://localhost:4000/components/datagrid/test-tree-filter.html
- Apply "Contains" filter on `Task` column with the word `More`
- It should have parent and all child nodes, if not expanded use expand/collapse button
- There should be 10 rows as: 7, 10, 12, 13, 14, 15, 18, 20, 21, 22

If only parent got match then make expand/collapse button to be collapsed, disabled and should not any children nodes added
- Apply "Contains" filter on `Task` column with the word `HMM`
- The expand/collapse button should be collapsed and disabled
- There should be 2 rows as: 1, 6

http://localhost:4000/components/datagrid/test-tree-filter-child-on-match.html
- Use switch "allowChildExpandOnMatch" to toggle the settings
- Keep `allowChildExpandOnMatch: true`
- Apply "Contains" filter on `Task` column with the word `More`
- It should have parent and all child nodes, if not expanded use button `+/-`
- There should be 16 rows as: 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22
- Keep `allowChildExpandOnMatch: false`
- Apply "Contains" filter on `Task` column with the word `More`
- It should have parent and all child nodes, if not expanded use button `+/-`
- There should be 10 rows as: 7, 10, 12, 13, 14, 15, 18, 20, 21, 22

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
