### PR TITLE
4149 - Fix am and pm for timepicker editor with datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `[Datagrid]` The selection checkbox cell had aria-selected on it which was incorrect. ([#4085](https://github.com/infor-design/enterprise/issues/4085))
 - `[Datagrid]` Fixed an issue where the client side selection was not working. ([#4138](https://github.com/infor-design/enterprise/issues/4138))
 - `[Datagrid]` Changed invalid css fill-available property. ([#4133](https://github.com/infor-design/enterprise/issues/4133))
+- `[Datagrid]` Fixed an issue where the time picker editor was switching between AM and PM when set to 12:00. ([#4149](https://github.com/infor-design/enterprise/issues/4149))
 - `[Datepicker]` Fixed a number of translation issues in the datepicker component. ([#4046](https://github.com/infor-design/enterprise/issues/4046))
 - `[Datepicker]` Fixed a bug that the datepicker would focus the field when closing the month and year pane. ([#4085](https://github.com/infor-design/enterprise/issues/4085))
 - `[Datepicker]` Fixed a bug where two dates may appear selected when moving forward/back in the picker dialog. ([#4018](https://github.com/infor-design/enterprise/issues/4018))

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -126,10 +126,14 @@ const formatters = {
       if (time === null) {
         return null;
       }
+      const getValue = v => (!isNaN(parseInt(v, 10)) ? parseInt(v, 10) : 0);
       const d = new Date();
-      d.setHours(parseInt(time[1], 10) + (time[4] ? 12 : 0));
-      d.setMinutes(parseInt(time[2], 10) || 0);
-      d.setSeconds(parseInt(time[3], 10) || 0);
+      let hours = getValue(time[1]);
+      hours -= (hours === 12 ? 12 : 0);
+      hours += (time[4] ? 12 : 0);
+      d.setHours(hours);
+      d.setMinutes(getValue(time[2]));
+      d.setSeconds(getValue(time[3]));
       return d;
     };
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the time picker editor was switching between AM and PM when set to 12:00 with Datagrid.

**Related github/jira issue (required)**:
Closes #4149

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/example-filter.html
- Enter either 12 AM or 12 PM on any cell in column `Time`
- Tab out from it, and see it should not switches between AM/PM

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
