### PR TITLE
2154 - Fix header alignment for rtl and ie11 with application menu

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### v4.31.0 Fixes
 
+- `[Application Menu]` Fixed an issue where the Header was unable to hide for RTL and ie11. ([#2154](https://github.com/infor-design/enterprise/issues/2154))
 - `[Application Menu]` Fixed a bug where the border top color is wrong in uplift dark and high contrast theme. ([#4042](https://github.com/infor-design/enterprise/issues/4042))
 - `[Application Menu]` Fixed a bug where some buttons did not have labels for the icon buttons in toolbars. Check your application if you use this pattern. ([#4085](https://github.com/infor-design/enterprise/issues/4085))
 - `[Autocomplete]` Fixed an issue where the JavaScript error was thrown for ie11. ([#4148](https://github.com/infor-design/enterprise/issues/4148))

--- a/src/components/applicationmenu/_applicationmenu.scss
+++ b/src/components/applicationmenu/_applicationmenu.scss
@@ -560,6 +560,13 @@ html[dir='rtl'] {
 
   }
 
+  &.ie11 {
+    .application-menu {
+      + .page-container {
+        right: auto;
+      }
+    }
+  }
 }
 
 // On large + extra-large breakpoints, the .page-content element will shift to the left while the menu is open


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the Header was unable to hide for RTL and ie11 with Application Menu.

**Related github/jira issue (required)**:
Closes #2154

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Use win10 ie11 (Desktop or Tablet view)
- Navigate to: http://localhost:4000/components/header/example-index?locale=he-IL
- Click on the hamburger icon
- See application menu should not overlap the hamburger icon

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
