### PR TITLE
4197 - Add fix for clicking nested rows

### DIFF
--- a/app/views/components/datagrid/example-nested-grids.html
+++ b/app/views/components/datagrid/example-nested-grids.html
@@ -37,13 +37,20 @@
           var datagridHtml = $('<div class="datagrid"></div>');
           args.detail.find('.datagrid-row-detail-padding').append(datagridHtml);
 
+          var clickHandler = function (e, args) {
+            $('body').toast({
+              title: 'Nested Datagrid Row <span style="font-weight: bold;">#' + args[0].item.id + '</span> Clicked!',
+              message: 'The row #' + args[0].row + ' cell # ' + args[0].cell + ' was clicked'
+            });
+          };
+
           var subColumns = [];
           subColumns.push({ id: 'id', name: 'Part Id', field: 'id', width: 200});
           subColumns.push({ id: 'partName', name: 'Part Name',field: 'partName', formatter: Formatters.Hyperlink});
           subColumns.push({ id: 'price', name: 'Price', field: 'price'});
           subColumns.push({ id: 'amount', name: 'Amount', field: 'amount'});
           subColumns.push({ id: 'quantity', name: 'Quantity', field: 'quantity'});
-          subColumns.push({ id: 'action', name: 'Active', sortable: false, width: 80, formatter: Formatters.Button, icon: 'delete', tooltip: 'Delete', click: function (e, args) {console.log(args[0].cell, args[0].row, args[0].item.id);}});
+          subColumns.push({ id: 'action', name: 'Active', sortable: false, width: 80, formatter: Formatters.Button, icon: 'delete', tooltip: 'Delete', click: clickHandler });
 
           var subData = [];
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[Buttons]` Reverted an inner Css rule change that set 'btn' classes to contains vs starts with. ([#4120](https://github.com/infor-design/enterprise/issues/4120))
 - `[Datagrid]` Fixed an issue where the tooltip for tree grid was not working properly. ([#827](https://github.com/infor-design/enterprise-ng/issues/827))
 - `[Datagrid]` Fixed an issue where the keyword search was not working for server side paging. ([#3977](https://github.com/infor-design/enterprise/issues/3977))
+- `[Datagrid]` Fixed a bug that nested datagrid columns could not be clicked. ([#4197](https://github.com/infor-design/enterprise/issues/4197))
 - `[Datagrid]` Fixed an issue where the 'value' and 'oldValue' on cell change event were showing escaped. ([#4028](https://github.com/infor-design/enterprise/issues/4028))
 - `[Datagrid]` Fixed an issue where the keyword search was not working for group headers. ([#4068](https://github.com/infor-design/enterprise/issues/4068))
 - `[Datagrid]` Fixed an issue where the column filter results were inconsistent for tree grid. ([#4031](https://github.com/infor-design/enterprise/issues/4031))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -6037,7 +6037,8 @@ Datagrid.prototype = {
       const target = $(e.target);
       const td = target.closest('td');
 
-      if ($(e.currentTarget).closest('.datagrid-expandable-row').length === 1) {
+      if ($(e.currentTarget).closest('.datagrid-expandable-row').length === 1 &&
+        $(e.currentTarget).attr('role') !== 'gridcell') {
         return;
       }
 

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -1193,6 +1193,41 @@ describe('Datagrid multiselect tests', () => {
   }
 });
 
+describe('Datagrid Nested Datagrid tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/example-nested-grids?layout=nofrills');
+
+    const datagridEl = await element(by.css('#datagrid tbody tr:nth-child(1)'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should expand and be clickable', async () => {
+    await element(by.css('[aria-rowindex="1"] [aria-colindex="1"] button')).click();
+    await browser.driver.sleep(config.sleep);
+
+    await element.all(by.css('.row-btn')).first().click();
+
+    await browser.driver.sleep(config.sleepShort);
+
+    expect(await element(by.css('.toast-message')).getText()).toEqual('The row #0 cell # 5 was clicked');
+  });
+
+  if (utils.isChrome() && utils.isCI()) {
+    it('Should not visual regress', async () => {
+      const containerEl = await element(by.className('container'));
+      await element(by.css('[aria-rowindex="1"] [aria-colindex="1"] button')).click();
+      await browser.driver.sleep(config.sleep);
+
+      expect(await browser.imageComparison.checkElement(containerEl, 'datagrid-nested')).toEqual(0);
+    });
+  }
+});
+
 describe('Datagrid paging tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/example-paging');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Clicking nested rows regressed. This is a fix for this.

**Related github/jira issue (required)**:
Fixes #4197 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-nested-grids.html
- expand a row
- click the delete button on any nested row
- toast should show

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.