### PR TITLE
3609 - Add the setting for empty message small height with datagrid

### DIFF
--- a/app/views/components/datagrid/test-empty-message-small.html
+++ b/app/views/components/datagrid/test-empty-message-small.html
@@ -1,0 +1,37 @@
+<div class="full-height full-width">
+  <div id="datagrid">
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    var data = [];
+    var columns = [];
+
+    // Define Columns for the Grid.
+    columns.push({ id: 'id', name: 'Id', field: 'id', formatter: Formatters.Readonly, filterType: 'text' });
+    columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Readonly, filterType: 'text' });
+    columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink, filterType: 'text' });
+    columns.push({ id: 'activity', name: 'Activity', field: 'activity', filterType: 'text' });
+    columns.push({ id: 'quantity', name: 'Qty', field: 'quantity', align: 'right', filterType: 'integer' });
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'MM/dd/yyyy', filterType: 'text' });
+    columns.push({ id: 'inStock', name: 'In Stock', field: 'inStock', formatter: Formatters.Checkbox, align: 'center', filterType: 'checkbox' });
+    columns.push({ id: 'status', name: 'Status', field: 'status', formatter: Formatters.Alert });
+    columns.push({ id: 'price',  name: 'Price', field: 'price', formatter: Formatters.Decimal, filterType: 'decimal' });
+
+    // Init and get the api for the grid
+    $('#datagrid').datagrid({
+      columns: columns,
+      dataset: data,
+      filterable: true,
+      selectable: 'single',
+      editable: true,
+      frozenColumns: {
+        left: ['productId', 'productName']
+      },
+      emptyMessage: { title: 'No data available', height: 'small' },
+      toolbar: { title: 'Filterable Datagrid', filterRow: true, results: true, dateFilter: false ,keywordFilter: false, actions: true, views: false, rowHeight: true, collapsibleFilter: false }
+    });
+
+ });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Datagrid]` Added a `spacerColumn` setting, with this setting the last column fills any empty space instead of stretching everything out. ([#4032](https://github.com/infor-design/enterprise/issues/4032))
 - `[Datagrid]` Added a `columnSizing` setting which impacts how the column widths are auto calculated. Options are: `both` (default), `data` or `header` (including filter). ([#4017](https://github.com/infor-design/enterprise/issues/4017))
+- `[Datagrid]` Added the setting for empty message small height. ([#3609](https://github.com/infor-design/enterprise/issues/3609))
 - `[Datepicker]` Added the ability to use +/- to increment the day in the calendar. This is in addition to arrow key functionality. This works in the field or when the calendar is open. ([#4001](https://github.com/infor-design/enterprise/issues/4001))
 - `[Tree]` Added option to add new child node on top or bottom. ([#3915](https://github.com/infor-design/enterprise/issues/3915))
 

--- a/src/components/datagrid/_datagrid-uplift.scss
+++ b/src/components/datagrid/_datagrid-uplift.scss
@@ -293,3 +293,24 @@
   left: 1px !important;
   top: 6px;
 }
+
+// EmptyMessage
+.datagrid-container.has-empty-message.is-empty {
+  &.empty-message-height-small {
+    .empty-message {
+      top: calc(50% + 33px) !important;
+    }
+
+    &.medium-rowheight .empty-message {
+      top: calc(50% + 31px) !important;
+    }
+
+    &.small-rowheight .empty-message {
+      top: calc(50% + 28px) !important;
+    }
+
+    &.extra-small-rowheight .empty-message {
+      top: calc(50% + 26px) !important;
+    }
+  }
+}

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -84,6 +84,47 @@ $datagrid-small-row-height: 25px;
     .datagrid-wrapper {
       min-height: 300px;
     }
+
+    &.empty-message-height-small {
+      height: 95px;
+
+      &.medium-rowheight {
+        height: 88px;
+
+        .empty-message {
+          top: calc(50% + 30px) !important;
+        }
+      }
+
+      &.small-rowheight {
+        height: 81px;
+
+        .empty-message {
+          top: calc(50% + 27px) !important;
+        }
+      }
+
+      &.extra-small-rowheight {
+        height: 75px;
+
+        .empty-message {
+          top: calc(50% + 25px) !important;
+        }
+      }
+
+      .datagrid-wrapper {
+        min-height: auto;
+      }
+
+      .empty-message {
+        min-height: auto;
+        padding-bottom: 0;
+
+        .empty-title {
+          padding-bottom: 0;
+        }
+      }
+    }
   }
 
   &.has-horizontal-scroll {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -127,10 +127,12 @@ const COMPONENT_NAME = 'datagrid';
  * @param {object}   [settings.emptyMessage.title='No Data Available']
  * @param {object}   [settings.emptyMessage.info='']
  * @param {object}   [settings.emptyMessage.icon='icon-empty-no-data']
+ * @param {object}   [settings.emptyMessage.height=null]
  * An empty message will be displayed when there is no rows in the grid. This accepts an object of the form
  * emptyMessage: {title: 'No Data Available', info: 'Make a selection on the list above to see results',
- * icon: 'icon-empty-no-data', button: {text: 'Button Text', click: <function>}} set this to null for no message
+ * icon: 'icon-empty-no-data', button: {text: 'Button Text', click: <function>}, height: null|'small'} set this to null for no message
  * or will default to 'No Data Found with an icon.'
+ * height: The empty message container height. If set to 'small' will show only title and all other will not be render (like: icon, button, info)
  * @param {boolean} [settings.allowChildExpandOnMatch=false] Used with filter
  * if true:
  * and if only parent has a match then add all children nodes too
@@ -224,7 +226,7 @@ const DATAGRID_DEFAULTS = {
   onExpandChildren: null, // Callback fires when expanding children with treeGrid
   onCollapseChildren: null, // Callback fires when collapseing children with treeGrid
   onKeyDown: null,
-  emptyMessage: { title: (Locale ? Locale.translate('NoData') : 'No Data Available'), info: '', icon: 'icon-empty-no-data' },
+  emptyMessage: { title: (Locale ? Locale.translate('NoData') : 'No Data Available'), info: '', icon: 'icon-empty-no-data', height: null },
   searchExpandableRow: true,
   allowChildExpandOnMatch: false
 };
@@ -5833,6 +5835,7 @@ Datagrid.prototype = {
   * @param {object} emptyMessage The update empty message config object.
   */
   setEmptyMessage(emptyMessage) {
+    this.element[emptyMessage.height === 'small' ? 'addClass' : 'removeClass']('empty-message-height-small');
     if (!this.emptyMessage) {
       this.emptyMessageContainer = $('<div class="empty-message-container"><div></div></div>');
       this.element.append(this.emptyMessageContainer).addClass('has-empty-message');

--- a/src/components/emptymessage/_emptymessage.scss
+++ b/src/components/emptymessage/_emptymessage.scss
@@ -18,6 +18,16 @@
   }
 }
 
+.empty-message-height-small {
+  .empty-message {
+    .empty-icon,
+    .empty-info,
+    .empty-actions {
+      display: none !important;
+    }
+  }
+}
+
 .icon-empty-state {
   color: $theme-color-brand-primary-base;
   display: inline-block;

--- a/src/components/emptymessage/emptymessage.js
+++ b/src/components/emptymessage/emptymessage.js
@@ -15,6 +15,7 @@ const COMPONENT_NAME = 'emptymessage';
 * @param {string} [settings.info = null] Longer paragraph text to show
 * @param {string} [settings.icon = null] The name of the icon to use. See {@link https://design.infor.com/code/ids-enterprise/latest/demo/icons/example-empty-widgets?font=source-sans} for options.
 * @param {boolean} [settings.button = null] The button settings to use (click, isPrimary, cssClass ect)
+* @param {string} [settings.height = null]  The container height. If set to 'small' will show only title and all other will not be render (like: icon, button, info)
 * @param {string} [settings.color = 'graphite']  Defaults to 'graphite' but can also be azure. Later may be expanded to all personalization colors.
 */
 const EMPTYMESSAGE_DEFAULTS = {
@@ -22,6 +23,7 @@ const EMPTYMESSAGE_DEFAULTS = {
   info: null,
   icon: null,
   button: null,
+  height: null, // null|'small'
   color: 'graphite' // or azure for now until personalization works
 };
 
@@ -49,12 +51,13 @@ EmptyMessage.prototype = {
 
   build() {
     const opts = this.settings;
+    const isHeightSmall = opts.height === 'small';
 
     if (opts?.button?.isPrimary) {
       this.settings.color = 'azure';
     }
 
-    if (opts.icon) {
+    if (opts.icon && !isHeightSmall) {
       $(`<div class="empty-icon">
           <svg class="icon-empty-state is-${this.settings.color}" focusable="false" aria-hidden="true" role="presentation">
             <use href="#${opts.icon}"></use>
@@ -70,11 +73,11 @@ EmptyMessage.prototype = {
       $(`<div class="empty-title">${opts.title}</div>`).appendTo(this.element);
     }
 
-    if (opts.info) {
+    if (opts.info && !isHeightSmall) {
       $(`<div class="empty-info">${opts.info}</div>`).appendTo(this.element);
     }
 
-    if (opts.button) {
+    if (opts.button && !isHeightSmall) {
       const buttonMarkup = `<div class="empty-actions">
           <button type="button" class="${opts.button.isPrimary ? 'btn-primary' : 'btn-secondary'} ${opts.button.cssClass} hide-focus" id="${opts.button.id}">
             <span>${opts.button.text}</span>

--- a/test/components/datagrid/datagrid-settings.func-spec.js
+++ b/test/components/datagrid/datagrid-settings.func-spec.js
@@ -117,7 +117,7 @@ describe('Datagrid Settings', () => { //eslint-disable-line
       onExpandChildren: null,
       onCollapseChildren: null,
       onKeyDown: null,
-      emptyMessage: { title: (Locale ? Locale.translate('NoData') : 'No Data Available'), info: '', icon: 'icon-empty-no-data' },
+      emptyMessage: { title: (Locale ? Locale.translate('NoData') : 'No Data Available'), info: '', icon: 'icon-empty-no-data', height: null },
       searchExpandableRow: true,
       allowChildExpandOnMatch: false
     };


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added the setting for empty message small height with Datagrid.

**Related github/jira issue (required)**:
Closes #3609

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/test-empty-message-small.html
- See the empty message
- Should be small height
- Only title text should showing (no icon, button etc.)
- Check for all themes and row height sizes

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
