### PR TITLE
NG#836 - Fix bug in displayed dataset rendering in Blockgrid

### DIFF
--- a/app/views/components/blockgrid/example-paging.html
+++ b/app/views/components/blockgrid/example-paging.html
@@ -10,40 +10,76 @@
     var data = [];
 
     data.push({
-      image: '{{basepath}}/images/8.jpg',
+      image: '{{basepath}}/images/3.jpg',
       title: 'Sheena Taylor',
       subtitle: 'Infor, Developer',
       id: 1
     });
     data.push({
-      image: '{{basepath}}/images/9.jpg',
+      image: '{{basepath}}/images/8.jpg',
       title: 'Jane Taylor',
       subtitle: 'Infor, Developer',
       id: 2
     });
     data.push({
-      image: '{{basepath}}/images/10.jpg',
+      image: '{{basepath}}/images/13.jpg',
       title: 'Sam Smith',
       subtitle: 'Infor, SVP',
       id: 3
     });
     data.push({
-      image: '{{basepath}}/images/11.jpg',
+      image: '{{basepath}}/images/22.jpg',
       title: 'Mary Pane',
       subtitle: 'Infor, Developer',
       id: 4
     });
     data.push({
-      image: '{{basepath}}/images/12.jpg',
+      image: '{{basepath}}/images/3.jpg',
       title: 'Paula Paulson',
       subtitle: 'Infor, Architect',
       id: 5
     });
     data.push({
-      image: '{{basepath}}/images/13.jpg',
+      image: '{{basepath}}/images/8.jpg',
       title: 'Nancy Packer',
       subtitle: 'Infor, Manager',
       id: 6
+    });
+    data.push({
+      image: '{{basepath}}/images/13.jpg',
+      title: 'Danielle Land',
+      subtitle: 'Infor, Developer',
+      id: 7
+    });
+    data.push({
+      image: '{{basepath}}/images/22.jpg',
+      title: 'Donna Horrocks',
+      subtitle: 'Infor, Developer',
+      id: 8
+    });
+    data.push({
+      image: '{{basepath}}/images/3.jpg',
+      title: 'Mary McConnel',
+      subtitle: 'Infor, SVP',
+      id: 9
+    });
+    data.push({
+      image: '{{basepath}}/images/8.jpg',
+      title: 'Julie Ayers',
+      subtitle: 'Infor, Developer',
+      id: 10
+    });
+    data.push({
+      image: '{{basepath}}/images/13.jpg',
+      title: 'Emily Bronte',
+      subtitle: 'Infor, Architect',
+      id: 11
+    });
+    data.push({
+      image: '{{basepath}}/images/22.jpg',
+      title: 'Rita Coyle',
+      subtitle: 'Infor, Manager',
+      id: 12
     });
 
     $('#blockgrid').blockgrid({

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Application Menu]` Fixed a bug where the border top color is wrong in uplift dark and high contrast theme. ([#4042](https://github.com/infor-design/enterprise/issues/4042))
 - `[Application Menu]` Fixed a bug where some buttons did not have labels for the icon buttons in toolbars. Check your application if you use this pattern. ([#4085](https://github.com/infor-design/enterprise/issues/4085))
 - `[Autocomplete]` Fixed an issue where the JavaScript error was thrown for ie11. ([#4148](https://github.com/infor-design/enterprise/issues/4148))
+- `[Blockgrid]` Fixed an issue with paged datasets that would occasionally cause a JS console error. ([ng#836](https://github.com/infor-design/enterprise-ng/issues/836))
 - `[Buttons]` Reverted an inner Css rule change that set 'btn' classes to contains vs starts with. ([#4120](https://github.com/infor-design/enterprise/issues/4120))
 - `[Datagrid]` Fixed an issue where the tooltip for tree grid was not working properly. ([#827](https://github.com/infor-design/enterprise-ng/issues/827))
 - `[Datagrid]` Fixed an issue where the keyword search was not working for server side paging. ([#3977](https://github.com/infor-design/enterprise/issues/3977))

--- a/src/components/blockgrid/blockgrid.js
+++ b/src/components/blockgrid/blockgrid.js
@@ -273,7 +273,7 @@ Blockgrid.prototype = {
         // If the dataset doesn't actually have IDs, set temporary ones for
         // tracking selected/deselected
         if (displayedDataset.length !== this.settings.dataset.length) {
-          for (let j = 0; j < (lastRecordIdx - firstRecordIdx) + 1; j++) {
+          for (let j = 0; j < displayedDataset.length; j++) {
             if (displayedDataset[j].id) {
               break;
             }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
When working on implementing the missing paging features of the Blockgrid API into NG, I ran into an issue where it was possible to try and render dataset items that didn't exist.  This was happening because the calculation of the displayed records on a page were sometimes incorrect in the EP component.  This PR fixes that issue.

**Related github/jira issue (required)**:
infor-design/enterprise-ng#836 (NG issue)
infor-design/enterprise-ng#878 (PR)

**Steps necessary to review your pull request (required)**:
Make sure all existing Blockgrid tests pass (demo of this case is in the NG component).

**Included in this Pull Request**:
- [x] A note to the change log.