### PR TITLE
3609 - Fix icon and height for empty message small height with datagrid

### DIFF
--- a/src/components/datagrid/_datagrid-uplift.scss
+++ b/src/components/datagrid/_datagrid-uplift.scss
@@ -296,6 +296,10 @@
 
 // EmptyMessage
 .datagrid-container.has-empty-message.is-empty {
+  .empty-title {
+    font-size: 1.8rem !important;
+  }
+
   &.empty-message-height-small {
     .empty-message {
       top: calc(50% + 33px) !important;
@@ -307,18 +311,10 @@
 
     &.small-rowheight .empty-message {
       top: calc(50% + 28px) !important;
-
-      .empty-title {
-        font-size: 1.8rem;
-      }
     }
 
     &.extra-small-rowheight .empty-message {
       top: calc(50% + 26px) !important;
-
-      .empty-title {
-        font-size: 1.8rem;
-      }
     }
   }
 }

--- a/src/components/datagrid/_datagrid-uplift.scss
+++ b/src/components/datagrid/_datagrid-uplift.scss
@@ -307,10 +307,18 @@
 
     &.small-rowheight .empty-message {
       top: calc(50% + 28px) !important;
+
+      .empty-title {
+        font-size: 1.8rem;
+      }
     }
 
     &.extra-small-rowheight .empty-message {
       top: calc(50% + 26px) !important;
+
+      .empty-title {
+        font-size: 1.8rem;
+      }
     }
   }
 }

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -121,6 +121,9 @@ $datagrid-small-row-height: 25px;
         padding-bottom: 0;
 
         .empty-title {
+          font-size: $theme-size-font-px-16;
+          -webkit-font-smoothing: antialiased;
+          font-weight: 400;
           padding-bottom: 0;
         }
       }

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -86,10 +86,10 @@ $datagrid-small-row-height: 25px;
     }
 
     &.empty-message-height-small {
-      height: 95px;
+      height: 130px;
 
       &.medium-rowheight {
-        height: 88px;
+        height: 123px;
 
         .empty-message {
           top: calc(50% + 30px) !important;
@@ -97,7 +97,7 @@ $datagrid-small-row-height: 25px;
       }
 
       &.small-rowheight {
-        height: 81px;
+        height: 116px;
 
         .empty-message {
           top: calc(50% + 27px) !important;
@@ -105,7 +105,7 @@ $datagrid-small-row-height: 25px;
       }
 
       &.extra-small-rowheight {
-        height: 75px;
+        height: 110px;
 
         .empty-message {
           top: calc(50% + 25px) !important;
@@ -4805,6 +4805,15 @@ html[dir='rtl'] {
 
     th {
       z-index: auto;
+
+      &.l-center-text .datagrid-filter-wrapper {
+        .btn-filter.btn-filter-checkbox {
+          &.btn-filter-checkbox {
+            left: auto !important;
+            margin-left: calc(50% - 5px);
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fix icon and height for empty message small height with Datagrid.

**Related github/jira issue (required)**:
Closes #3609

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/test-empty-message-small.html
- See icon in header `In Stock` should be aligned
- See the empty message
- Should be small height
- Only title text should showing (no icon, button etc.)
- Check for all themes and row height sizes