### PR TITLE
NG#836 - Fix pager button display bug on Blockgrid [v4.31.x]

### DIFF
--- a/app/views/components/blockgrid/example-paging.html
+++ b/app/views/components/blockgrid/example-paging.html
@@ -86,8 +86,10 @@
       dataset: data,
       selectable: 'multiple',
       paging: true,
-      pagesize: 3,
-      pagesizes: [3, 10, 25, 50, 75]
+      pagerSettings: {
+        pagesize: 3,
+        pagesizes: [3, 10, 25, 50, 75]
+      }
     }).on('selected', function (e, args) {
       console.log(args);
     }).on('unselected', function (e, args) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Application Menu]` Fixed a bug where some buttons did not have labels for the icon buttons in toolbars. Check your application if you use this pattern. ([#4085](https://github.com/infor-design/enterprise/issues/4085))
 - `[Autocomplete]` Fixed an issue where the JavaScript error was thrown for ie11. ([#4148](https://github.com/infor-design/enterprise/issues/4148))
 - `[Blockgrid]` Fixed an issue with paged datasets that would occasionally cause a JS console error. ([ng#836](https://github.com/infor-design/enterprise-ng/issues/836))
+- `[Blockgrid]` Fixed a bug where first/last pager buttons would show and be disabled by default (buttons are now hidden by default). ([ng#836](https://github.com/infor-design/enterprise-ng/issues/836))
 - `[Buttons]` Reverted an inner Css rule change that set 'btn' classes to contains vs starts with. ([#4120](https://github.com/infor-design/enterprise/issues/4120))
 - `[Datagrid]` Fixed an issue where the tooltip for tree grid was not working properly. ([#827](https://github.com/infor-design/enterprise-ng/issues/827))
 - `[Datagrid]` Fixed an issue where the keyword search was not working for server side paging. ([#3977](https://github.com/infor-design/enterprise/issues/3977))

--- a/src/components/blockgrid/blockgrid.js
+++ b/src/components/blockgrid/blockgrid.js
@@ -32,6 +32,10 @@ const BLOCKGRID_DEFAULTS = {
 
 // Moves/Converts certain settings
 function handleLegacySettings(storedSettings, incomingSettings) {
+  if (!incomingSettings) {
+    return storedSettings;
+  }
+
   // Bypasses deep copy issues with `mergeSettings`
   if (incomingSettings.dataset) {
     storedSettings.dataset = incomingSettings.dataset;

--- a/test/components/blockgrid/blockgrid-api.func-spec.js
+++ b/test/components/blockgrid/blockgrid-api.func-spec.js
@@ -21,8 +21,10 @@ const settings = {
   }],
   selectable: 'single', // false, 'single' or 'multiple' or mixed
   paging: false,
-  pagesize: 25,
-  pagesizes: [10, 25, 50, 75]
+  pagerSettings: {
+    pagesize: 25,
+    pagesizes: [10, 25, 50, 75]
+  }
 };
 
 describe('Blockgrid API', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR makes a change to the Blockgrid Pager's default configuration to hide the first/last pager buttons, per the original design.  This PR also makes all Pager settings configurable when using the Pager within the Blockgrid, by passing a new `pagerSettings` object.  Additionally, some inline documentation from the source code was updated.

**Related github/jira issue (required)**:
- infor-design/enterprise-ng#836
- #4204 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the demoapp
- Open http://localhost:4000/components/blockgrid/example-paging.html?theme=uplift
- Observe the only paging buttons that should be present are the Previous, Next and Page Size Selector buttons.

**Included in this Pull Request**:
- [x] A note to the change log.