### PR TITLE
4195 - Fix select all rows with datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v4.32.0 Fixes
 
-- `[Datagrid]` Fixed an issue where select all rows were keep adding to selected array every time method `selectAllRows()` run. ([#4195](https://github.com/infor-design/enterprise/issues/4195))
+- `[Datagrid]` Fixed an issue where the selectedRows array contents continued to multiply each time running `selectAllRows`. ([#4195](https://github.com/infor-design/enterprise/issues/4195))
 - `[Vertical Tabs]` Fixed an issue where the error icon was misaligning. ([#873](https://github.com/infor-design/enterprise-ng/issues/873))
 
 ## v4.31.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### v4.32.0 Fixes
 
+- `[Datagrid]` Fixed an issue where select all rows were keep adding to selected array every time method `selectAllRows()` run. ([#4195](https://github.com/infor-design/enterprise/issues/4195))
 - `[Vertical Tabs]` Fixed an issue where the error icon was misaligning. ([#873](https://github.com/infor-design/enterprise-ng/issues/873))
 
 ## v4.31.0

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7068,7 +7068,7 @@ Datagrid.prototype = {
 
       if (this.filterRowRendered ||
         (this.filterExpr && this.filterExpr[0] && this.filterExpr[0].keywordSearch)) {
-        if (!dataset[i]._isFilteredOut) {
+        if (!dataset[i]._isFilteredOut && !dataset[i]._selected) {
           rows.push(idx);
         }
       } else if (!dataset[i]._selected) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed select all rows were keep adding to selected array every time method `selectAllRows()` run with Datagrid.

**Related github/jira issue (required)**:
Closes #4195

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/test-filter-paging-client-side.html
- Open developer tools
- To select all rows run console: `$('#datagrid').data('datagrid').selectAllRows();`
- Get all selected rows: $('#datagrid').data('datagrid').selectedRows();
- Should do 11-selected items array
- Repeat steps, to select all few times: `$('#datagrid').data('datagrid').selectAllRows();`
- Get again all selected rows: $('#datagrid').data('datagrid').selectedRows();
- Should still keep 11-selected items array

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
