### PR TITLE
4213 - Fix render rows for dynamically update with tree datagrid [v4.31.x]

### DIFF
--- a/app/views/components/datagrid/test-tree-update-data.html
+++ b/app/views/components/datagrid/test-tree-update-data.html
@@ -1,0 +1,101 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script id="test-script">
+  $('body').one('initialized', function () {
+
+    var columns = [];
+    var initData = [{
+      id: 1,
+      demoDataId: 0,
+      depth: 1,
+      expanded: false,
+      name: 'A',
+      children: []
+    }];
+
+    var mockChildDataSets = {
+      0: [
+        {
+          id: 2,
+          demoDataId: 1,
+          depth: 2,
+          expanded: false,
+          name: 'AA',
+          children: []
+        },
+        {
+          id: 3,
+          demoDataId: 2,
+          depth: 2,
+          expanded: false,
+          name: 'BB',
+          children: []
+        }
+      ],
+      1: [
+        {
+          id: 4,
+          depth: 3,
+          expanded: false,
+          name: 'AAA'
+        },
+        {
+          id: 5,
+          depth: 3,
+          expanded: false,
+          name: 'BBB'
+        }
+      ],
+      2: [
+        {
+          id: 6,
+          depth: 3,
+          expanded: false,
+          name: 'AAA'
+        },
+        {
+          id: 7,
+          depth: 3,
+          expanded: false,
+          name: 'BBB'
+        }
+      ]
+    }
+
+    // Define Columns for the Grid.
+    columns.push({ id: 'name', name: 'Name', field: 'name', formatter: Formatters.Tree });
+    columns.push({ id: 'id', name: 'Id', field: 'id' });
+
+    // Initialize the Grid
+    $('#datagrid').datagrid({
+      columns: columns,
+      dataset: initData,
+      treeGrid: true,
+      toolbar: {title: 'Test Updating Data using updateDataSet()', results: true, personalize: true}
+    })
+    // Bind on Expand Row
+    .on('expandrow', function (e, args) {
+      initData.map(function callback(v) {
+        if (v.children && v.children.length > 0) {
+          v.children.map(callback);
+        }
+
+        if (v.id === args.rowData.id) {
+          v.children = mockChildDataSets[args.rowData.demoDataId];
+        }
+      });
+      // Mock ajax call
+      setTimeout(function() {
+        var grid = $('#datagrid').data('datagrid');
+        grid.updateDataset(initData)
+      });
+    });
+
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `[Blockgrid]` Fixed a bug where first/last pager buttons would show and be disabled by default (buttons are now hidden by default). ([ng#836](https://github.com/infor-design/enterprise-ng/issues/836))
 - `[Buttons]` Reverted an inner Css rule change that set 'btn' classes to contains vs starts with. ([#4120](https://github.com/infor-design/enterprise/issues/4120))
 - `[Datagrid]` Fixed an issue when hiding columns after loading a datagrid up with grouped headers and frozen columns. ([#4218](https://github.com/infor-design/enterprise/issues/4218))
+- `[Datagrid]` Fixed an issue where the rows were not render properly when use method `updateDataset()` for treegrid. ([#4213](https://github.com/infor-design/enterprise/issues/4213))
 - `[Datagrid]` Fixed an issue where the tooltip for tree grid was not working properly. ([#827](https://github.com/infor-design/enterprise-ng/issues/827))
 - `[Datagrid]` Fixed an issue where the keyword search was not working for server side paging. ([#3977](https://github.com/infor-design/enterprise/issues/3977))
 - `[Datagrid]` Fixed a bug that nested datagrid columns could not be clicked. ([#4197](https://github.com/infor-design/enterprise/issues/4197))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3014,12 +3014,15 @@ Datagrid.prototype = {
     }
     const self = this;
     let idx = 0;
-    const iterate = function (node, depth) {
+    const iterate = function (node, depth, parent = []) {
       idx++;
-      self.settings.treeDepth.push({ idx, depth, node });
-      const children = node.children || [];
-      for (let i = 0, len = children.length; i < len; i++) {
-        iterate(children[i], depth + 1);
+      self.settings.treeDepth.push({ idx, depth, parents: parent.slice(), node });
+      const len = node.children?.length;
+      if (len) {
+        parent.push(idx - 1);
+        for (let i = 0; i < len; i++) {
+          iterate(node.children[i], depth + 1, parent.slice());
+        }
       }
     };
 
@@ -3811,34 +3814,19 @@ Datagrid.prototype = {
 
     // Determine if the tree rows should be hidden or not
     if (self.settings.treeDepth && self.settings.treeDepth.length) {
-      for (let i = 0; i < self.settings.treeDepth.length; i++) {
-        const treeDepthItem = self.settings.treeDepth[i];
-
-        if (dataRowIdx === (treeDepthItem.idx - 1)) {
-          let parentNode = null;
-          let currentDepth = 0;
-          for (let i2 = i; i2 >= 0; i2--) {
-            currentDepth = self.settings.treeDepth[i2].depth < currentDepth ||
-            currentDepth === 0 ? self.settings.treeDepth[i2].depth : currentDepth;
-            if (currentDepth < treeDepthItem.depth) {
-              parentNode = self.settings.treeDepth[i2];
-
-              if (currentDepth === 1 ||
-                parentNode.node.expanded !== undefined && !parentNode.node.expanded) {
-                break;
-              }
+      if (rowData._isFilteredOut) {
+        isHidden = true;
+      } else {
+        const nodeData = self.settings.treeDepth[dataRowIdx];
+        if (nodeData && nodeData.depth > 1 && nodeData.parents?.length) {
+          for (let i = 0, l = nodeData.parents.length; i < l; i++) {
+            const parentIdx = nodeData.parents[i];
+            const parent = self.settings.treeDepth[parentIdx];
+            if (parent.node && parent.node.expanded !== undefined && !parent.node.expanded) {
+              isHidden = true;
+              break;
             }
           }
-
-          if (parentNode && parentNode.node.expanded !== undefined && !parentNode.node.expanded) {
-            isHidden = true;
-          } else {
-            isHidden = rowData._isFilteredOut;
-          }
-
-          depth = treeDepthItem.depth;
-
-          break;
         }
       }
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed rows were not render properly when use method `updateDataset()` for treegrid with Datagrid.

**Related github/jira issue (required)**:
Closes #4213

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/test-tree-update-data.html
- Expand all rows
- Should show 7-rows `Id` as: 1, 2, 4, 5, 3, 6, 7

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
