### PR TITLE
4112 - Make CAP close button work in cases where its subcomponents are open

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### v4.32.0 Fixes
 
+- `[Contextual Action Panel]` Made the close button work in cases where subcomponents are open inside the CAP. ([#4112](https://github.com/infor-design/enterprise/issues/4112))
 - `[Datagrid]` Fixed an issue where the selectedRows array contents continued to multiply each time running `selectAllRows`. ([#4195](https://github.com/infor-design/enterprise/issues/4195))
 - `[Vertical Tabs]` Fixed an issue where the error icon was misaligning. ([#873](https://github.com/infor-design/enterprise-ng/issues/873))
 - `[Dropdown]` Fixed a bug where italic-style highlighting would represent a matched filter term instead of bold-style on a Dropdown List item in some cases. ([#4141](https://github.com/infor-design/enterprise/issues/4141))

--- a/src/components/contextualactionpanel/contextualactionpanel.js
+++ b/src/components/contextualactionpanel/contextualactionpanel.js
@@ -508,16 +508,17 @@ ContextualActionPanel.prototype = {
 
   /**
   * Close the Contextual Action Panel if open and call destroy.
+  * @param {boolean} [doForce = false] if true, forces the modal to close.
   * @returns {void}
   */
-  close(doForce) {
+  close(doForce = false) {
     let destroy;
     if (this.settings.modalSettings.trigger === 'immediate') {
       destroy = true;
     }
 
     if (this.modalAPI) {
-      this.modalAPI.close(destroy, false, true);
+      this.modalAPI.close(destroy, false, doForce);
     }
   },
 

--- a/src/components/contextualactionpanel/contextualactionpanel.js
+++ b/src/components/contextualactionpanel/contextualactionpanel.js
@@ -462,7 +462,7 @@ ContextualActionPanel.prototype = {
   * @returns {void}
   */
   handleToolbarSelected() {
-    this.close();
+    this.close(true);
   },
 
   /**
@@ -510,14 +510,14 @@ ContextualActionPanel.prototype = {
   * Close the Contextual Action Panel if open and call destroy.
   * @returns {void}
   */
-  close() {
+  close(doForce) {
     let destroy;
     if (this.settings.modalSettings.trigger === 'immediate') {
       destroy = true;
     }
 
     if (this.modalAPI) {
-      this.modalAPI.close(destroy);
+      this.modalAPI.close(destroy, false, true);
     }
   },
 

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1283,10 +1283,11 @@ Modal.prototype = {
    * Close the modal.
    * @param {boolean} destroy Call the destroy method.
    * @param {boolean} [noRefresh=false] if true, prevents the ModalManager from refreshing state when the close is complete.
+   * @param {boolean} [force = false] if true, forces the modal closed and ignores open subcomponents/visibility.
    * @returns {boolean} If the dialog was open returns false. If the dialog was closed is true.
    */
-  close(destroy, noRefresh) {
-    if (!this.visible || this.openSubComponents.length) {
+  close(destroy, noRefresh, force = false) {
+    if (!force && (!this.visible || this.openSubComponents.length)) {
       return true;
     }
 

--- a/test/components/contextualactionpanel/contextualactionpanel.e2e-spec.js
+++ b/test/components/contextualactionpanel/contextualactionpanel.e2e-spec.js
@@ -84,6 +84,26 @@ describe('Contextual Action Panel example-index tests', () => {
       expect(await browser.imageComparison.checkElement(panelEl, 'contextual-action-index')).toEqual(0);
     });
   }
+
+  // See Github #4112
+  it('can close the CAP while a subcomponent is open', async () => {
+    // Open the Modal
+    const actionButtonEl = await element(by.css('.btn-secondary'));
+    await actionButtonEl.click();
+    await browser.driver.sleep(config.sleepLonger);
+
+    // Open the "Ship Terms" dropdown
+    const ddEl = await element(by.css('#ship-terms + .dropdown-wrapper > .dropdown'));
+    await ddEl.click();
+    await browser.driver.sleep(config.sleep);
+
+    // Click the modal's "Close" button
+    const closeBtnEl = await element(by.css('.modal .btn[name="close"]'));
+    await closeBtnEl.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('#contextual-action-modal-1')).isDisplayed()).toBeFalsy();
+  });
 });
 
 describe('Contextual Action Panel example-workspace tests', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a small bug in Contextual Action Panels, where it previously wasn't possible to click its Close button if a child component of the CAP was currently open (such as Dropdown, Autocomplete, or any others with an active list subcomponent).  

**Related github/jira issue (required)**:
Closes #4112

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the demoapp.
- Open http://localhost:4000/components/contextualactionpanel/example-index.html
- Open the CAP
- Open the "Ship Terms" dropdown list
- Click the close button without closing the dropdown list.   The CAP should close.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.