### PR TITLE
1904 - Added a row number column formatter

### DIFF
--- a/app/views/components/datagrid/example-row-numbers.html
+++ b/app/views/components/datagrid/example-row-numbers.html
@@ -1,0 +1,39 @@
+<div class="full-height full-width">
+    <div id="datagrid" class="datagrid">
+    </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    var grid,
+      columns = [],
+      data = [];
+
+    var url = '{{basepath}}api/compressors?pageNum=1&pageSize=100';
+    $.getJSON(url, function(res) {
+      data = res.data;
+
+      // Define Columns for the Grid.
+      columns.push({ id: 'rowNumbers', name: '', field: '', formatter: Formatters.RowNumber, sortable: false, align: 'center', reorderable: false });
+      columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Text, filterType: 'text' });
+      columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink, filterType: 'text' });
+      columns.push({ id: 'activity', name: 'Activity', field: 'activity'});
+      columns.push({ id: 'quantity', hidden: true, name: 'Quantity', field: 'quantity'});
+      columns.push({ id: 'price', align: 'right', name: 'Actual Price', field: 'price', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'currency', currencySign: '$'}});
+      columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+      columns.push({ id: 'status', name: 'Status', field: 'status', formatter: Formatters.Text});
+      columns.push({ id: 'action', name: 'Action Item', field: 'action'});
+
+      // Init and get the api for the grid
+      $('#datagrid').datagrid({
+        columns: columns,
+        columnReorder: true,
+        dataset: data,
+        paging: true,
+        filterable: false,
+        pagesize: 20,
+        toolbar: {title: 'Compressors', actions: true, rowHeight: true, results: true, filterRow: true }
+      });
+    });
+ });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.32.0
 
-### v4.31.0 Features
+### v4.32.0 Features
 
 - `[Datagrid]` Add a new `RowNumber` formatter that will show a row number column that remains the same no matter how the grid is sorted. ([#1904](https://github.com/infor-design/enterprise/issues/1904))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## v4.32.0
 
+### v4.31.0 Features
+
+- `[Datagrid]` Add a new `RowNumber` formatter that will show a row number column that remains the same no matter how the grid is sorted. ([#1904](https://github.com/infor-design/enterprise/issues/1904))
+
 ### v4.32.0 Fixes
 
+- `[Dropdown]` Fixed a bug where italic-style highlighting would represent a matched filter term instead of bold-style on a Dropdown List item in some cases. ([#4141](https://github.com/infor-design/enterprise/issues/4141))
 - `[Datagrid]` Fixed an issue where the selectedRows array contents continued to multiply each time running `selectAllRows`. ([#4195](https://github.com/infor-design/enterprise/issues/4195))
 - `[Vertical Tabs]` Fixed an issue where the error icon was misaligning. ([#873](https://github.com/infor-design/enterprise-ng/issues/873))
-- `[Dropdown]` Fixed a bug where italic-style highlighting would represent a matched filter term instead of bold-style on a Dropdown List item in some cases. ([#4141](https://github.com/infor-design/enterprise/issues/4141))
 
 ## v4.31.0
 

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -81,6 +81,10 @@ const formatters = {
     return `<span class="is-readonly">${((value === null || value === undefined) ? '' : value)}</span>`;
   },
 
+  RowNumber(row) {
+    return `<span class="is-readonly">${row + 1}</span>`;
+  },
+
   Date(row, cell, value, col, isReturnValue) {
     let formatted = ((value === null || value === undefined) ? '' : value);
     let value2;

--- a/src/components/datagrid/readme.md
+++ b/src/components/datagrid/readme.md
@@ -179,6 +179,7 @@ $('#datagrid').datagrid({
 |`Spinbox` | Formats the cell as text for use with a Spinbox editor. Also supports the `inlineEditor` option as well for list grids.|
 |`Favorite` | Formats the cell with a favorite star. The star's value (checked or unchecked) is populated like the checkbox column with a boolean or truthy value in the data. The `isChecked` function or boolean can be used to more dynamically check set state.|
 |`TargetedAchievement` | Formats the cell with the a targeted achievement chart. The row value will be divided by 100 to form a percent and the chart will show the percent value. See the <a href="https://design.infor.com/code/ids-enterprise/latest/demo/datagrid/test-targeted-achievement.html?font=source-sans" target="_blank">targeted achievement example</a>|
+|`RowNumber` | Formats the cell with a row number column that is shown 1 to n no matter the sort order. See the <a href="https://design.infor.com/code/ids-enterprise/latest/demo/datagrid/example-row-numbers?font=source-sans" target="_blank">row numbers example</a>|
 
 ## Creating Custom Formatters
 

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -1621,6 +1621,38 @@ describe('Datagrid Row Row Reorder', () => {
   }
 });
 
+describe('Datagrid Row Numbers', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/example-row-numbers?layout=nofrills');
+
+    const datagridEl = await element(by.css('#datagrid tbody tr:nth-child(1)'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should number rows', async () => {
+    expect(await element(by.css('#datagrid tr:nth-child(1) td:nth-child(1)')).getText()).toBe('1');
+    expect(await element(by.css('#datagrid tr:nth-child(1) td:nth-child(2)')).getText()).toBe('214220');
+    expect(await element(by.css('#datagrid tr:nth-child(20) td:nth-child(1)')).getText()).toBe('20');
+    expect(await element(by.css('#datagrid tr:nth-child(20) td:nth-child(2)')).getText()).toBe('214239');
+  });
+
+  it('Should number rows on sort', async () => {
+    await element(by.css('#datagrid .datagrid-header th:nth-child(2)')).click();
+    await browser.driver.sleep(350);
+    await element(by.css('#datagrid .datagrid-header th:nth-child(2)')).click();
+
+    expect(await element(by.css('#datagrid tr:nth-child(1) td:nth-child(1)')).getText()).toBe('1');
+    expect(await element(by.css('#datagrid tr:nth-child(1) td:nth-child(2)')).getText()).toBe('214319');
+    expect(await element(by.css('#datagrid tr:nth-child(20) td:nth-child(1)')).getText()).toBe('20');
+    expect(await element(by.css('#datagrid tr:nth-child(20) td:nth-child(2)')).getText()).toBe('214300');
+  });
+});
+
 describe('Datagrid Date default values', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-accept-default-date-value?layout=nofrills');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Added a new built in formatter to format a number column.

**Related github/jira issue (required)**:
Fixes #1904

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-row-numbers
- should bea new readonly column showing the row number down across all pages
- sort any column, row number will stay the same
- enable the filter column in the .. menu
- filter on something -> row number will show for that number as if it was unfiltered

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
