### PR TITLE
4181 - Adjust the Searchfield focus state

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### v4.32.0 Fixes
 
 - `[Datagrid]` Fixed an issue where the selectedRows array contents continued to multiply each time running `selectAllRows`. ([#4195](https://github.com/infor-design/enterprise/issues/4195))
-- `[Searchfield]` Added a shadow to searchfields with catergory buttons. ([#4181](https://github.com/infor-design/enterprise-ng/issues/4181))
+- `[Searchfield]` Added a shadow to the focus state of searchfields with category buttons. ([#4181](https://github.com/infor-design/enterprise-ng/issues/4181))
 - `[Vertical Tabs]` Fixed an issue where the error icon was misaligning. ([#873](https://github.com/infor-design/enterprise-ng/issues/873))
 
 ## v4.31.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### v4.32.0 Fixes
 
 - `[Datagrid]` Fixed an issue where the selectedRows array contents continued to multiply each time running `selectAllRows`. ([#4195](https://github.com/infor-design/enterprise/issues/4195))
+- `[Searchfield]` Added a shadow to searchfields with catergory buttons. ([#4181](https://github.com/infor-design/enterprise-ng/issues/4181))
 - `[Vertical Tabs]` Fixed an issue where the error icon was misaligning. ([#873](https://github.com/infor-design/enterprise-ng/issues/873))
 
 ## v4.31.0

--- a/src/components/lookup/_lookup.scss
+++ b/src/components/lookup/_lookup.scss
@@ -82,6 +82,10 @@
 
         .searchfield {
           border-color: transparent transparent rgba($searchfield-border-color, 1);
+
+          &:focus {
+            border-color: transparent transparent rgba($searchfield-border-color, 1);
+          }
         }
       }
     }

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -138,7 +138,7 @@ $toolbarsearchfield-category-empty-width: 51px;
       border: 1px solid transparent;
 
       &:not(.hide-focus) {
-        box-shadow: none;
+        box-shadow: none !important;
         color: $button-color-secondary-initial-font;
 
         &::after {
@@ -299,19 +299,23 @@ $toolbarsearchfield-category-empty-width: 51px;
       }
 
       &.toolbar-searchfield-wrapper {
-        box-shadow: $focus-box-shadow-bottom;
+        box-shadow: $focus-box-shadow-input;
 
         &.has-categories {
-          box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
-
           .searchfield {
-            border-left-color: rgba($input-color-focus-border, 1);
+            border-bottom-color: rgba($searchfield-border-color, 1);
+
+            &:focus {
+              border-color: rgba($input-color-focus-border, 1);
+            }
           }
         }
       }
 
       .searchfield {
-        border-color: rgba($input-color-focus-border, 1);
+        &:focus {
+          border-color: rgba($input-color-focus-border, 1);
+        }
       }
 
       .btn {
@@ -398,12 +402,6 @@ $toolbarsearchfield-category-empty-width: 51px;
       .searchfield {
         border-left-color: transparent;
       }
-    }
-  }
-
-  &.has-go-button {
-    .searchfield {
-      width: auto !important;
     }
   }
 

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -300,6 +300,14 @@ $toolbarsearchfield-category-empty-width: 51px;
 
       &.toolbar-searchfield-wrapper {
         box-shadow: $focus-box-shadow-bottom;
+
+        &.has-categories {
+          box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
+
+          .searchfield {
+            border-left-color: rgba($input-color-focus-border, 1);
+          }
+        }
       }
 
       .searchfield {

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -291,6 +291,10 @@ $toolbarsearchfield-category-empty-width: 51px;
   &.has-focus {
     .searchfield {
       border-color: transparent;
+
+      &:focus {
+        border-color: rgba($input-color-focus-border, 1);
+      }
     }
 
     &.active {
@@ -309,12 +313,6 @@ $toolbarsearchfield-category-empty-width: 51px;
               border-color: rgba($input-color-focus-border, 1);
             }
           }
-        }
-      }
-
-      .searchfield {
-        &:focus {
-          border-color: rgba($input-color-focus-border, 1);
         }
       }
 

--- a/src/components/searchfield/_searchfield-uplift.scss
+++ b/src/components/searchfield/_searchfield-uplift.scss
@@ -23,6 +23,10 @@
 
   .searchfield-category-button {
     height: 38px;
+
+    svg {
+      margin-top: -5px;
+    }
   }
 
   &.context {

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -45,6 +45,7 @@ $focus-box-shadow-spinbox-up: 3px 0 3px 0 $focus-box-shadow-color,
   0 -3px 3px 0 $focus-box-shadow-color;
 
 $focus-box-shadow-bottom: 0 4px 2px -2px $focus-box-shadow-color;
+$focus-box-shadow-input: 0 0 8px $focus-box-shadow-color;
 
 // Base Colors
 $inverse-color: $theme-color-palette-white;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adds an adjustment to the box shadow for Searchfields with category buttons (focus state)

**Related github/jira issue (required)**:
closes #4181 

**Steps necessary to review your pull request (required)**:
- Pull and run branch
- Go to http://localhost:4000/components/toolbarsearchfield/example-alternate-style-with-categories.html?theme=soho&variant=light&colors=0066D4
- Make sure when the Searchfield opens it matches design in #4181 
- Check for breaking changes in other examples http://localhost:4000/components/toolbarsearchfield

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
