### PR TITLE
NG#860 - Add ResizeObserver to Tabs list/panels for resize handling detection

### DIFF
--- a/app/views/components/tabs/test-container-resize-homepages.html
+++ b/app/views/components/tabs/test-container-resize-homepages.html
@@ -1,19 +1,12 @@
 <div class="row">
   <div class="six columns">
-
-    <!-- Fill out all the information about this test page below, in plain English -->
-    <h2>Tabs Test: Resizable Tab Containers</h2>
-
-    <p>A <a class="hyperlink" href="http://jira.infor.com/browse/HFC-3707" target="_blank">bug was reported</a> where the Tabs Control would not re-evaluate its number of overflowed tabs when an element containing the Tab Container was resized.  This test attempts to demonstrate that this functionality works as intended.</p>
-
-    <p>Use the slider control below to adjust the width of the Tab Container.  If it's working properly, the spillover menu should always show the correct number of invisible tabs.</p>
-
-    <p></p>
-
+    <h2>Tabs Test: Resizable Tab Containers (Homepages)</h2>
+    <p>Github Issue: <a class="hyperlink" href="https://github.com/infor-design/enterprise-ng/issues/860" target="_blank">NG#860</a>.</p>
+    <p>Use the Slider below to resize the component.  When releasing the drag handle, the state of the Tabs List (overflowed items) should update as expected.</p>
   </div>
 </div>
 
-<div class="row">
+<div class="row top-padding">
   <div class="six columns">
 
     <div class="field">
@@ -25,9 +18,8 @@
 </div>
 
 <div class="row">
-  <div class="twelve columns">
+  <div id="resize-container" class="twelve columns">
 
-    <!-- Tabs Container -->
     <div id="sizeable-tabs" class="tab-container">
       <ul class="tab-list">
         <li class="tab is-selected"><a href="#first-tab">First Tab</a></li>
@@ -102,15 +94,16 @@
 
 <script>
   $('body').on('initialized', function() {
-    var tabset = $('#sizeable-tabs'),
-      slider = $('#container-width');
+    var container = $('#resize-container');
+    var slider = $('#container-width');
+    var tabsAPI = $('#sizeable-tabs').data('tabs');
 
     // Change the width of the tabset whenever the slider is adjusted.
     slider.on('change.test', function() {
       var api = $(this).data('slider'),
         val = api.value();
 
-      tabset.css('width', val[0] + '%');
+      container.css('width', val[0] + '%');
 
       // On IE, need to trigger the resize event manually
       if (Soho.env.isIE10 || Soho.env.isIE11) {

--- a/app/views/components/tabs/test-container-resize-with-toolbar.html
+++ b/app/views/components/tabs/test-container-resize-with-toolbar.html
@@ -171,7 +171,11 @@
         val = api.value();
 
       tabset.css('width', val[0] + '%');
-      $('body').triggerHandler('resize');
+
+      // On IE, need to trigger the resize event manually
+      if (Soho.env.isIE10 || Soho.env.isIE11) {
+        $('body').triggerHandler('resize');
+      }
     });
   });
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[Dropdown]` Fixed a bug where italic-style highlighting would represent a matched filter term instead of bold-style on a Dropdown List item in some cases. ([#4141](https://github.com/infor-design/enterprise/issues/4141))
 - `[Datagrid]` Fixed an issue where the selectedRows array contents continued to multiply each time running `selectAllRows`. ([#4195](https://github.com/infor-design/enterprise/issues/4195))
 - `[Searchfield]` Added a shadow to the focus state of searchfields with category buttons. ([#4181](https://github.com/infor-design/enterprise-ng/issues/4181))
+- `[Tabs]` Added detection for width/height/style changes on a Tabs component, which now triggers a resize event. ([ng#860](https://github.com/infor-design/enterprise-ng/issues/860))
 - `[Vertical Tabs]` Fixed an issue where the error icon was misaligning. ([#873](https://github.com/infor-design/enterprise-ng/issues/873))
 
 ## v4.31.0

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -23,7 +23,7 @@ module.exports = {
 
   rules: {
     // Browser compatibility
-    'compat/compat': 'error',
+    'compat/compat': 'warn',
 
     // ensure JSDoc comments are valid
     // https://eslint.org/docs/rules/valid-jsdoc

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -433,6 +433,19 @@ Tabs.prototype = {
       this.renderEdgeFading();
     }
 
+    // Setup a resize observer on both the tab panel container and the tab list container (if applicable)
+    // to auto-refresh the state of the Tabs on resize.  ResizeObserver doesn't work in IE.
+    if (typeof ResizeObserver !== 'undefined') {
+      this.ro = new ResizeObserver(() => {
+        $('body').triggerHandler('resize');
+      });
+
+      this.ro.observe(this.element[0]);
+      if (this.containerElement) {
+        this.ro.observe(this.containerElement[0]);
+      }
+    }
+
     return this;
   },
 
@@ -1461,7 +1474,7 @@ Tabs.prototype = {
   },
 
   /**
-   * @private
+   * Resets the visual state of the Tab List and Tab Panel Container to match current width/height and responsive.
    * @param {boolean} ignoreResponsiveCheck if true, doesn't run `this.checkResponsive()`
    * @returns {void}
    */
@@ -3925,6 +3938,11 @@ Tabs.prototype = {
       .removeAttr('aria-expanded')
       .removeAttr('aria-selected')
       .removeAttr('tabindex');
+
+    if (this.ro) {
+      this.ro.disconnect();
+      delete this.ro;
+    }
 
     if (this.settings.moduleTabsTooltips || this.settings.multiTabsTooltips) {
       this.anchors.each(function () {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds internal detection for resizing of a Tabs panel/list container.  In browsers that support it, the Tabs component now sets up a [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) that will respond by automatically triggering the IDS global `resize` event on the body tag.

In older browsers such as IE11, it's still necessary to trigger the `resize` event manually.  This PR also exposes Tabs' `handleResize()` method as public API for this purpose.

There's also a new test page added that specifically recreates the resize conditions from @anhallbe's test in the NG repo.

**Related github/jira issue (required)**:
Related to infor-design/enterprise-ng#860
Depended on by infor-design/enterprise-ng#886

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the demoapp.
- Open http://localhost:4000/components/tabs/test-container-resize-homepages.html
- Drag the slider handle to change the size of the `.columns` element that wraps the tabs.  When the size of the container shrinks below the width of the tab list, the "More Tabs" button should appear.  When it grows beyond the width of the tab list, the button should disappear.

All existing functional/e2e tests for Tabs should pass (some tests that called the `handleResize` API already existed)

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.