### PR TITLE
3984 - Fixed a minor issue with the shortcut text on small breakpoints.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `[Datagrid]` Fixed an issue where the selectedRows array contents continued to multiply each time running `selectAllRows`. ([#4195](https://github.com/infor-design/enterprise/issues/4195))
 - `[Searchfield]` Added a shadow to the focus state of searchfields with category buttons. ([#4181](https://github.com/infor-design/enterprise-ng/issues/4181))
 - `[Vertical Tabs]` Fixed an issue where the error icon was misaligning. ([#873](https://github.com/infor-design/enterprise-ng/issues/873))
+- `[Popupmenu]` Fixed a minor issue with the shortcut text on small breakpoints. ([#3984](https://github.com/infor-design/enterprise/issues/3984))
 
 ## v4.31.0
 

--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -767,3 +767,14 @@ html[dir='rtl'] {
     }
   }
 }
+
+// Fixing minor issue with shortcut text on small phones
+@media (max-width: $breakpoint-phone) {
+  .popupmenu {
+    .shortcut-text {
+      font-size: 12px;
+      margin-left: $theme-number-spacing-base * 1.5;
+      margin-top: 1px;
+    }
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a minor display issue with the shortcut text on small breakpoints

**Related github/jira issue (required)**:
closes #3984 

**Steps necessary to review your pull request (required)**:
- Pull and run this branch
- Go to http://localhost:4000/components/popupmenu/example-shortcut-text.html?theme=soho&variant=light&colors=2578a9
- Open chrome DevTools and select Iphone 5 / SE
- The shortcut text should no longer wrap to two lines

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
