### PR TITLE
4252 - Fix return focus state for context menu with tree

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Tabs]` Added detection for width/height/style changes on a Tabs component, which now triggers a resize event. ([ng#860](https://github.com/infor-design/enterprise-ng/issues/860))
 - `[Tabs]` Fixed a small error by removing a - 1 involved with testing. ([#4093](https://github.com/infor-design/enterprise/issues/4093))
 - `[Toolbar Searchfield]` Fixed a bug where the searchfield doesn't perfectly align together with flex toolbar. [[#4226](https://github.com/infor-design/enterprise/issues/4226)]
+- `[Tree]` Fixed an issue where the return focus state was not working properly after closing the context menu. ([#4252](https://github.com/infor-design/enterprise/issues/4252))
 - `[Vertical Tabs]` Fixed an issue where the error icon was misaligning. ([#873](https://github.com/infor-design/enterprise-ng/issues/873))
 
 ## v4.31.0

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -1132,6 +1132,9 @@ Tree.prototype = {
       if (data.selected) {
         self.selectNode(a, data.focus);
       }
+      if (a.is('.hide-focus')) {
+        a.hideFocus();
+      }
     });
     const dropdowns = [].slice.call(self.element[0].querySelectorAll('select.dropdown'));
     for (let i = 0; i < dropdowns.length; i++) {
@@ -2320,10 +2323,17 @@ Tree.prototype = {
       return;
     }
 
+    // Handle focus state after closing contextmenu
+    function returnFocus(popupmenuApi, args) {
+      if (typeof $(':focus')[0] === 'undefined' && args) {
+        args.triggerElement?.focus();
+      }
+    }
+
     this.element.off('contextmenu.tree').on('contextmenu.tree', 'a', function (e) {
       const node = $(this);
       e.preventDefault();
-      self.popupEl = $(e.currentTarget).popupmenu({ menuId, eventObj: e, trigger: 'immediate', attachToBody: true }).off('selected').on('selected', (event, args) => {
+      self.popupEl = $(e.currentTarget).popupmenu({ menuId, eventObj: e, trigger: 'immediate', attachToBody: true, returnFocus }).off('selected').on('selected', (event, args) => {
         /**
         * Fires when the an attached context menu item is selected.
         *


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the return focus state was not working properly after closing the context menu with Tree.

**Related github/jira issue (required)**:
Closes #4252

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app
Navigate to: http://localhost:4000/components/tree/example-context-menu.html

1st Test
- Tab to focus `Node One` (should show blue focus)

2nd Test
- Click `Node Two` to expand
- Right click `Node 2.1` (context menu should open)
- Press `Escape` key or click a menu item (should show blue focus on Node 2.1)
- Click another node after closing the menu (should focus node with no focus state shown)

3rd Test
- Click `Node Two` to expand
- Right click `Node 2.1` (context menu should open)
- While open click another node
- Clicked node should be focused with no focus state shown and there should be no focus on the previous item

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
