### PR TITLE
4261 - Add new fix for entering edit mode in dropdown [v4.31.x]

### DIFF
--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -2454,12 +2454,12 @@ $datagrid-small-row-height: 25px;
         }
       }
 
-      //Drop Down
+      // Drop Down
       .dropdown {
         border: medium none;
         height: inherit;
         line-height: normal;
-        padding: 4px 30px 5px 19px;
+        padding: 4px 30px 5px 16px;
         width: 100%;
 
         &:focus {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -8959,7 +8959,7 @@ Datagrid.prototype = {
     this.editor.focus();
 
     // Make sure the first keydown gets captured and trigger the dropdown
-    if (this.editor?.input.is('.dropdown') && ![9, 13, 32, 37, 38, 39, 40].includes(event.keyCode)) {
+    if (this.editor?.input.is('.dropdown') && event.keyCode && ![9, 13, 32, 37, 38, 39, 40].includes(event.keyCode)) {
       const dropdownApi = this.editor.input.data('dropdown');
       dropdownApi.handleAutoComplete(event);
     }

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -8351,15 +8351,6 @@ Datagrid.prototype = {
       const key = e.which || e.keyCode || e.charCode || 0;
       let handled = false;
 
-      // Make sure the first keydown gets captured and trigger the dropdown
-      setTimeout(() => {
-        self.activeCell.node.find('select.dropdown').each(function () {
-          const dropdown = $(this);
-          const dropdownApi = dropdown.data('dropdown');
-          dropdownApi.handleAutoComplete(e);
-        });
-      });
-
       // F2 - toggles actionableMode "true" and "false"
       // Force to not toggle, if "inlineMode: true"
       if (key === 113 && !this.inlineMode) {
@@ -8966,6 +8957,12 @@ Datagrid.prototype = {
     }
 
     this.editor.focus();
+
+    // Make sure the first keydown gets captured and trigger the dropdown
+    if (this.editor?.input.is('.dropdown') && ![9, 13, 32, 37, 38, 39, 40].includes(event.keyCode)) {
+      const dropdownApi = this.editor.input.data('dropdown');
+      dropdownApi.handleAutoComplete(event);
+    }
 
     /**
     * Fires after a cell goes into edit mode.

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -2239,7 +2239,7 @@ describe('Datagrid editor dropdown source tests', () => {
   });
 });
 
-describe('Datagrid onKeyDown Tests', () => { //eslint-disable-line
+describe('Datagrid onKeyDown Tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-editable-onkeydown?layout=nofrills');
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Updated the fix on https://github.com/infor-design/enterprise/issues/3980 to solve https://github.com/infor-design/enterprise/issues/4261 by..

- making it happen with no timeout
- checking and ignoring certain keys
- calling api same way

**Related github/jira issue (required)**:
Fixes #4261

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-editable.html
- click in the grid and arrow to the Action field
- type a key like a or b and the dropdown should open and filter
- reset 
- click in the grid and arrow to the Action field hit enter -> this will enter edit mode but wont open
- now type a and it should filter
- reset 
- click in the grid and hit F2 to toggle "tabs mode"
- tab to the Action field -> this will enter edit mode but wont open
- now type a and it should filter
- try various tests of tabbing and arrowing and typing see if you can bust it
 
