### PR TITLE
ng894/ng895 - Fix columns resize with homepage

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,8 @@
 - `[Datagrid]` Fixed an issue where the selectedRows array contents continued to multiply each time running `selectAllRows`. ([#4195](https://github.com/infor-design/enterprise/issues/4195))
 - `[Datagrid]` Fixed an issue where the dynamic tooltip was not working properly. ([#4260](https://github.com/infor-design/enterprise/issues/4260))
 - `[Dropdown]` Fixed a bug where italic-style highlighting would represent a matched filter term instead of bold-style on a Dropdown List item in some cases. ([#4141](https://github.com/infor-design/enterprise/issues/4141))
+- `[Homepage]` Fixed an issue where the columns were not showing properly after resize by using the maximize button. ([#894](https://github.com/infor-design/enterprise-ng/issues/894))
+- `[Homepage]` Fixed an issue where the columns were not showing properly after resize browser window. ([#895](https://github.com/infor-design/enterprise-ng/issues/895))
 - `[Input]` Fixed a bug where the text input error state border color would be wrong in the vibrant, dark and high contrast. ([#4248](https://github.com/infor-design/enterprise/issues/4248))
 - `[Popupmenu]` Fixed a minor issue with the shortcut text on small breakpoints. ([#3984](https://github.com/infor-design/enterprise/issues/3984))
 - `[Personalize]` Fixed an issue regarding the layout and scroll ability of a page. ([#3330](https://github.com/infor-design/enterprise/issues/3330))

--- a/src/components/homepage/homepage.js
+++ b/src/components/homepage/homepage.js
@@ -89,12 +89,27 @@ Homepage.prototype = {
    */
   init() {
     this.isTransitionsSupports = this.supportsTransitions();
+    this.setColumns();
     this.initHeroWidget();
     this.handleEvents();
     this.initEdit();
 
     // Initial Sizing
     this.resize(this, false);
+  },
+
+  /**
+   * Set max number of columns can be shown.
+   * @private
+   * @returns {void}
+   */
+  setColumns() {
+    let columns = this.settings.columns;
+    const columnsByAttr = parseInt(this.element.attr('data-columns'), 10);
+    if (!isNaN(columnsByAttr) && (columns !== columnsByAttr && columns === HOMEPAGE_DEFAULTS.columns)) {
+      columns = columnsByAttr;
+    }
+    this.columns = columns;
   },
 
   /**
@@ -107,7 +122,7 @@ Homepage.prototype = {
     row = row || 0;
     this.rowsAndCols[row] = [];
 
-    for (let i = 0, l = this.settings.columns; i < l; i++) {
+    for (let i = 0, l = this.columns; i < l; i++) {
       this.rowsAndCols[row][i] = true;// Make all columns available in first row[true]
     }
   },
@@ -501,16 +516,16 @@ Homepage.prototype = {
     }
 
     // Max sized columns brings to top
-    if (this.settings.columns > 1) {
+    if (this.columns > 1) {
       for (let i = 0, j = 0, w = 0, l = this.blocks.length; i < l; i++) {
-        if (this.blocks[i].w >= this.settings.columns && i &&
-          w && (w <= (this.settings.columns / 2))) {
+        if (this.blocks[i].w >= this.columns && i &&
+          w && (w <= (this.columns / 2))) {
           this.arrayIndexMove(this.blocks, i, j);
         }
         w += this.blocks[i].w;
-        if (w >= this.settings.columns) {
+        if (w >= this.columns) {
           w = 0; // reset
-          j = (this.blocks[j].w >= this.settings.columns) ? j + 1 : i; // record to move
+          j = (this.blocks[j].w >= this.columns) ? j + 1 : i; // record to move
         }
       }
     }
@@ -557,29 +572,30 @@ Homepage.prototype = {
     const tablet = (elemWidth >= bpTablet && elemWidth <= bpDesktop);
     const phone = (elemWidth <= bpTablet);
 
-    const maxAttr = this.element.attr('data-columns');
+    // const maxAttr = this.element.attr('data-columns');
     const content = self.element.find('> .content');
-    this.settings.columns = parseInt((maxAttr || this.settings.columns), 10);
+    this.setColumns();
+    // this.settings.columns = parseInt((maxAttr || this.settings.columns), 10);
 
     // Assign columns as breakpoint sizes
-    if (xxl && self.settings.columns === 5) {
-      self.settings.columns = 5;
+    if (xxl && self.columns === 5) {
+      self.columns = 5;
       bp = bpXXL;
     }
-    if (xl && /4|5/g.test(self.settings.columns)) {
-      self.settings.columns = 4;
+    if (xl && /4|5/g.test(self.columns)) {
+      self.columns = 4;
       bp = bpXL;
     }
-    if ((desktop) || ((xxl || xl) && self.settings.columns === 3)) {
-      self.settings.columns = 3;
+    if ((desktop) || ((xxl || xl) && self.columns === 3)) {
+      self.columns = 3;
       bp = bpDesktop;
     }
     if (tablet) {
-      self.settings.columns = 2;
+      self.columns = 2;
       bp = bpTablet;
     }
     if (phone) {
-      self.settings.columns = 1;
+      self.columns = 1;
       bp = bpPhone;
     }
 
@@ -601,16 +617,16 @@ Homepage.prototype = {
       block.elem.removeClass('to-single to-double to-triple to-quad');
 
       // If block more wider than available size, make as available size
-      if (block.w > self.settings.columns) {
-        block.w = self.settings.columns;
+      if (block.w > self.columns) {
+        block.w = self.columns;
 
-        if (self.settings.columns === 1) {
+        if (self.columns === 1) {
           block.elem.addClass('to-single');
-        } else if (self.settings.columns === 2) {
+        } else if (self.columns === 2) {
           block.elem.addClass('to-double');
-        } else if (self.settings.columns === 3) {
+        } else if (self.columns === 3) {
           block.elem.addClass('to-triple');
-        } else if (self.settings.columns === 4) {
+        } else if (self.columns === 4) {
           block.elem.addClass('to-quad');
         }
       }
@@ -620,7 +636,7 @@ Homepage.prototype = {
 
       // Set positions
       const box = self.settings.widgetWidth + self.settings.gutterSize;
-      const totalWidth = box * self.settings.columns;
+      const totalWidth = box * self.columns;
 
       const left = Locale.isRTL() ? totalWidth - ((box * block.w) + (box * available.col)) : box * available.col;// eslint-disable-line
       const top = (self.settings.widgetHeight + self.settings.gutterSize) * available.row;
@@ -665,7 +681,7 @@ Homepage.prototype = {
     * @param {number} columns The number of columns provided by this instance's settings
     * @param {object} metadata A compilation of current state information from the instance.
     */
-    self.element.triggerHandler('resize', [self.settings.columns, self.state]);
+    self.element.triggerHandler('resize', [self.columns, self.state]);
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the columns were not showing properly after resize browser window with Homepage. This issue was produced only in Angular project.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#894
Closes infor-design/enterprise-ng#895

**Steps necessary to review your pull request (required)**:
- Pull and build this branch
- Pull ([NG master](https://github.com/infor-design/enterprise-ng.git))
- If [PR 898](https://github.com/infor-design/enterprise-ng/pull/898) not merged then switch to branch `git checkout 894-homepage-maximize-columns`
- Build NG project
- Copy and replace "dist" folder from `enterprise` to `⁨enterprise-ng⁩/node_modules⁩/ids-enterprise`

issue 894
- Navigate to http://localhost:4200/ids-enterprise-ng-demo/homepage
- Resize the page to make it smaller so that the page uses one column
- Click on the browser's maximize button, to make browser window full width
- There should be two rows (1st: one only three-column-wide, 2nd: two one-column-wide cards)

issue 895
- Edit `src\app\homepage\homepage.demo.html` to set `[columns]="4"` on the homepage component
- Should refresh the build/page
- Navigate to http://localhost:4200/ids-enterprise-ng-demo/homepage
- Resize the page to make it smaller so that the page uses one column
- Click on the browser's maximize button, to make browser window full width
- There should be two rows (1st: three-column-wide + one-column-wide cards, 2nd: only one one-column-wide card)

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
