### PR TITLE
4230 - Fix minute and second interval for timepicker with datepicker

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[Contextual Action Panel]` Made the close button work in cases where subcomponents are open inside the CAP. ([#4112](https://github.com/infor-design/enterprise/issues/4112))
 - `[Datagrid]` Fixed an issue where the selectedRows array contents continued to multiply each time running `selectAllRows`. ([#4195](https://github.com/infor-design/enterprise/issues/4195))
 - `[Datagrid]` Fixed an issue where the dynamic tooltip was not working properly. ([#4260](https://github.com/infor-design/enterprise/issues/4260))
+- `[Datepicker]` Fixed an issue where the minute and second interval for timepicker was not working properly when use along useCurrentTime setting. ([#4230](https://github.com/infor-design/enterprise/issues/4230))
 - `[Dropdown]` Fixed a bug where italic-style highlighting would represent a matched filter term instead of bold-style on a Dropdown List item in some cases. ([#4141](https://github.com/infor-design/enterprise/issues/4141))
 - `[Input]` Fixed a bug where the text input error state border color would be wrong in the vibrant, dark and high contrast. ([#4248](https://github.com/infor-design/enterprise/issues/4248))
 - `[Popupmenu]` Fixed a minor issue with the shortcut text on small breakpoints. ([#3984](https://github.com/infor-design/enterprise/issues/3984))

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -597,17 +597,23 @@ DatePicker.prototype = {
       } else {
         timeOptions.timeFormat = s.timeFormat;
       }
-      if (s.minuteInterval !== undefined) {
-        timeOptions.minuteInterval = s.minuteInterval;
-      }
-      if (s.secondInterval !== undefined) {
-        timeOptions.secondInterval = s.minuteInterval;
+      if (s.useCurrentTime) {
+        timeOptions.minuteInterval = 1;
+        timeOptions.secondInterval = 1;
+        timeOptions.roundToInterval = false;
+      } else {
+        if (s.minuteInterval !== undefined) {
+          timeOptions.minuteInterval = s.minuteInterval;
+        }
+        if (s.secondInterval !== undefined) {
+          timeOptions.secondInterval = s.secondInterval;
+        }
+        if (s.roundToInterval !== undefined) {
+          timeOptions.roundToInterval = s.roundToInterval;
+        }
       }
       if (s.mode !== undefined) {
         timeOptions.mode = s.mode;
-      }
-      if (s.roundToInterval !== undefined) {
-        timeOptions.roundToInterval = s.roundToInterval;
       }
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the minute and second interval for timepicker was not working properly when use along useCurrentTime setting with Datagrid.

**Related github/jira issue (required)**:
Closes #4230

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datepicker/example-timeformat.html
- Open the third datepicker `Date Time Picker in Locale (Time to Current)`
- The time portion of the picker should display the current time
- Click on button `Apply`
- Picker should close and field should have picked the current time (it was rounding to interval

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
