### PR TITLE
4202 - Fix too much spacing level in application menu

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### v4.32.0 Fixes
 
 - `[Accordion]` Fixed a bug where disabled headers texts and icons were barely recognizable as disabled in uplift theme. ([#4065](https://github.com/infor-design/enterprise/issues/4065))
+- `[Application Menu]` Fixed too much spacing level when there's an icon in accordion header in uplift theme. ([#4202](http://localhost:4000/components/applicationmenu/test-six-levels-icons.html?theme=uplift&variant=light&colors=0066D4))
 - `[Contextual Action Panel]` Made the close button work in cases where subcomponents are open inside the CAP. ([#4112](https://github.com/infor-design/enterprise/issues/4112))
 - `[Datagrid]` Fixed an issue where the selectedRows array contents continued to multiply each time running `selectAllRows`. ([#4195](https://github.com/infor-design/enterprise/issues/4195))
 - `[Datagrid]` Fixed an issue where the dynamic tooltip was not working properly. ([#4260](https://github.com/infor-design/enterprise/issues/4260))

--- a/src/components/applicationmenu/_applicationmenu-uplift.scss
+++ b/src/components/applicationmenu/_applicationmenu-uplift.scss
@@ -609,57 +609,57 @@ html[dir='rtl'] {
 
     // Level 1 Pane
     .accordion-pane {
-      @include left-align-cascade-styles-pane(55px, 78px, 56px);
+      @include left-align-cascade-styles-pane(55px, 56px, 56px);
 
       .accordion-header {
-        @include left-align-cascade-styles-header(54px, 50px, 78px, 61px);
+        @include left-align-cascade-styles-header(54px, 30px, 78px, 41px);
       }
 
       // Level 2 Pane
       .accordion-pane {
-        @include left-align-cascade-styles-pane(55px, 102px, 78px);
+        @include left-align-cascade-styles-pane(59px, 76px, 60px);
 
         // Level 3 Header
         .accordion-header {
-          @include left-align-cascade-styles-header(59px, 74px, 102px, 85px);
+          @include left-align-cascade-styles-header(59px, 50px, 102px, 61px);
         }
 
         // Level 3 Pane
         .accordion-pane {
-          @include left-align-cascade-styles-pane(79px, 127px, 102px);
+          @include left-align-cascade-styles-pane(79px, 95px, 76px);
 
           // Level 4 Header
           .accordion-header {
-            @include left-align-cascade-styles-header(59px, 99px, 127px, 110px);
+            @include left-align-cascade-styles-header(59px, 68px, 127px, 80px);
           }
 
           // Level 4 Pane
           .accordion-pane {
-            @include left-align-cascade-styles-pane(104px, 152px, 128px);
+            @include left-align-cascade-styles-pane(98px, 114px, 128px);
 
             // Level 5 Header
             .accordion-header {
-              @include left-align-cascade-styles-header(78px, 124px, 152px, 135px);
+              @include left-align-cascade-styles-header(78px, 87px, 152px, 99px);
             }
 
             // Level 5 Pane
             .accordion-pane {
-              @include left-align-cascade-styles-pane(130px, 152px, 153px);
+              @include left-align-cascade-styles-pane(115px, 133px, 153px);
 
               // Level 6 Header
               .accordion-header {
-                @include left-align-cascade-styles-header(122px, 152px, 180px, 162px);
+                @include left-align-cascade-styles-header(122px, 106px, 180px, 118px);
 
                 &.no-icon {
                   > a {
-                    padding-left: 182px;
+                    padding-left: 114px;
                   }
                 }
               }
 
               // Level 6 Pane
               .accordion-pane {
-                @include left-align-cascade-styles-pane(158px, 182px, 122px);
+                @include left-align-cascade-styles-pane(135px, 182px, 122px);
               }
             }
           }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixed too much spacing level when there's an icon in accordion header in uplift theme.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/4202

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Navigate to http://localhost:4000/components/applicationmenu/test-six-levels-icons.html?theme=uplift&variant=light&colors=0066D4
- Expand the Level 1 with the globe icon
- Expand per level and it's sub menu
- It should well spaced now

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
