### PR TITLE
4294 - Fix set status completed on send method with FileUploadAdvanced

### DIFF
--- a/app/views/components/fileupload-advanced/test-send-completed-nodata.html
+++ b/app/views/components/fileupload-advanced/test-send-completed-nodata.html
@@ -1,0 +1,43 @@
+
+<div class="row">
+  <div class="four columns">
+
+    <div class="fileupload-advanced" data-init="false" id="expple-fileupload-adv">
+    </div>
+
+  </div>
+</div>
+
+<script id="test-script">
+  $('body').one('initialized', function () {
+
+    var sendFileToServer = function (formData, status) {
+      var jqXHR = { abort: function() {} };
+      var percent = 0;
+      var total = parseFloat(status.file.size);
+      var timer = new $.fn.timer(() => {
+        status.setCompleted();
+      }, total);
+
+      $(timer.event)
+        .on('update', (e, data) => {
+          percent = Math.ceil((data.counter / total) * 100);
+          status.setProgress(percent);
+        });
+
+      status.setAbort(jqXHR);
+    };
+
+    // Initialize
+    $('#expple-fileupload-adv').fileuploadadvanced({
+      send: sendFileToServer
+    }).on('fileremoved', function (e, file) {
+      $('body').toast({
+        title: 'File removed',
+        message: file && file.name ? file.name : ''
+      });
+    });
+
+
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[Datagrid]` Fixed an issue where the dynamic tooltip was not working properly. ([#4260](https://github.com/infor-design/enterprise/issues/4260))
 - `[Datepicker]` Fixed an issue where the minute and second interval for timepicker was not working properly when use along useCurrentTime setting. ([#4230](https://github.com/infor-design/enterprise/issues/4230))
 - `[Dropdown]` Fixed a bug where italic-style highlighting would represent a matched filter term instead of bold-style on a Dropdown List item in some cases. ([#4141](https://github.com/infor-design/enterprise/issues/4141))
+- `[FileUploadAdvanced]` Fixed an issue where the method `status.setCompleted()` not firing event `fileremoved`. ([#4294](https://github.com/infor-design/enterprise/issues/4294))
 - `[Homepage]` Fixed an issue where the columns were not showing properly after resize by using the maximize button. ([#894](https://github.com/infor-design/enterprise-ng/issues/894))
 - `[Homepage]` Fixed an issue where the columns were not showing properly after resize browser window. ([#895](https://github.com/infor-design/enterprise-ng/issues/895))
 - `[Input]` Fixed a bug where the text input error state border color would be wrong in the vibrant, dark and high contrast. ([#4248](https://github.com/infor-design/enterprise/issues/4248))

--- a/src/components/fileupload-advanced/fileupload-advanced.js
+++ b/src/components/fileupload-advanced/fileupload-advanced.js
@@ -392,6 +392,7 @@ FileUploadAdvanced.prototype = {
 
     // Set completed state
     const setCompleted = function (data) {
+      data = data && typeof data.remove === 'function' ? data : { remove: () => {} };
       container.addClass('completed');
 
       // Add "Completed" icon


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed method `status.setCompleted()` not firing event `fileremoved` with FileUploadAdvanced.

**Related github/jira issue (required)**:
Closes #4230

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/fileupload-advanced/test-send-completed-nodata.html
- Upload any file and after completed
- Press Remove File (X) button
- Should run a toast after click on Remove File (X)` button.

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
