### PR TITLE
4271 - Fix the check box filter with datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[Contextual Action Panel]` Made the close button work in cases where subcomponents are open inside the CAP. ([#4112](https://github.com/infor-design/enterprise/issues/4112))
 - `[Datagrid]` Fixed an issue where the selectedRows array contents continued to multiply each time running `selectAllRows`. ([#4195](https://github.com/infor-design/enterprise/issues/4195))
 - `[Datagrid]` Fixed an issue where the dynamic tooltip was not working properly. ([#4260](https://github.com/infor-design/enterprise/issues/4260))
+- `[Datagrid]` Fixed an issue where the check box filter was not working. ([#4271](https://github.com/infor-design/enterprise/issues/4271))
 - `[Datepicker]` Fixed an issue where the minute and second interval for timepicker was not working properly when use along useCurrentTime setting. ([#4230](https://github.com/infor-design/enterprise/issues/4230))
 - `[Dropdown]` Fixed a bug where italic-style highlighting would represent a matched filter term instead of bold-style on a Dropdown List item in some cases. ([#4141](https://github.com/infor-design/enterprise/issues/4141))
 - `[FileUploadAdvanced]` Fixed an issue where the method `status.setCompleted()` not firing event `fileremoved`. ([#4294](https://github.com/infor-design/enterprise/issues/4294))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -2238,7 +2238,7 @@ Datagrid.prototype = {
         const isFilterEmpty = () => {
           let isEmpty = true;
           for (let i = 0, len = conditions.length; i < len; i++) {
-            if (conditions[i].value.toString().trim() !== '') {
+            if (conditions[i].filterType === 'checkbox' || conditions[i].value.toString().trim() !== '') {
               isEmpty = false;
             }
           }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the check box filter was not working with Datagrid.

**Related github/jira issue (required)**:
Closes #4271

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/test-tree-filter.html
- Use filter on column `Portable`
- The check box filter should work properly
- Use toggle `+/-` button to show/hide
- Also some nodes checkbox checked(true/false opposite as filter), but included because as parent node
- If choose to filter `Selected` (6, 7, 10-parentnode, 11, 15-parentnode, 17, 18-parentnode, 20)
- If choose to filter `Not Selected` (1, 2, 3, 4, 5, 7-parentnode, 8, 9, 10, 12, 13, 14, 15, 16, 18, 19, 20-parentnode, 21, 22)

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
