### PR TITLE
3984 - Fix shortcut text breakpoint and spacing

### DIFF
--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -769,11 +769,11 @@ html[dir='rtl'] {
 }
 
 // Fixing minor issue with shortcut text on small phones
-@media (max-width: $breakpoint-phone) {
+@media (max-width: $breakpoint-slim) {
   .popupmenu {
     .shortcut-text {
       font-size: 12px;
-      margin-left: $theme-number-spacing-base * 1.5;
+      margin-left: $theme-number-spacing-base - 1;
       margin-top: 1px;
     }
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR contains QA fixes for the Popupmenu shortcut text on small screens. Made adjustments to shortcut text breakpoint and spacing on screens below 400px.

**Related github/jira issue (required)**:
closes #3984

**Steps necessary to review your pull request (required)**:
- Pull and run branch
- Go http://localhost:4000/components/popupmenu/example-shortcut-text.html?theme=uplift&variant=light&colors=2578a9
- Open dev tools to iPhone 5/SE and check in Mac/Safari on a small screen.
- Make sure the shortcut text does not break to second line.
- Check both themes.

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
