### PR TITLE
4293 - Fix the filter and paging for treegrid with datagrid

### DIFF
--- a/app/views/components/datagrid/test-tree-filter-paging.html
+++ b/app/views/components/datagrid/test-tree-filter-paging.html
@@ -1,0 +1,74 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    var columns = [];
+    var data = [
+      {id: 1, parentId: 0, escalated: 2, depth: 1, expanded: false, taskName: 'Header', desc: '', comments: null, time: '', position: 1, children: [
+        {id: 2, parentId: 1, escalated: 1, depth: 2, taskName: 'Quotes due to expire',  desc: 'Update pending quotes and send out again to customers.', comments: 3, time: '7:10 AM', position: 2},
+        {id: 3, parentId: 1, escalated: 0, depth: 2, taskName: 'Follow up action with Universal Shipping Logistics Customers', desc: 'Contact sales representative with the updated purchase order.', comments: 2, time: '9:10 AM', position: 3},
+        {id: 4, parentId: 1, escalated: 0, depth: 2, taskName: 'Follow up action with Acme Trucking', desc: 'Contact sales representative with the updated purchase order.', comments: 2, time: '14:10 PM', position: 4},
+        {id: 5, parentId: 1, escalated: 0, depth: 2, taskName: 'Follow up action with Residental Housing', desc: 'Contact sales representative with the updated purchase order.', comments: 2, time: '18:10 PM', position: 2},
+        {id: 6, parentId: 1, escalated: 0, depth: 2, taskName: 'Follow up action with HMM Global', desc: 'Contact sales representative with the updated purchase order.', comments: 2, time: '20:10 PM', position: 3},
+        {id: 7, parentId: 1, escalated: 0, depth: 2, expanded: false, taskName: 'First Child', desc: 'Contact sales representative with the updated purchase order.', comments: 2, time: '22:10 PM', position: 4, children: [
+          {id: 8, parentId: 5, escalated: 0, depth: 3, taskName: 'Follow up action with Universal HMM Logistics', desc: 'Contact sales representative.', comments: 2, time: '22:10 PM', position: 5},
+          {id: 9, parentId: 5, escalated: 0, depth: 3, taskName: 'Follow up action with Acme Shipping', desc: 'Contact sales representative.', comments: 2, time: '22:10 PM', position: 6},
+          {id: 10, parentId: 5, escalated: 0, depth: 3, expanded: false, taskName: 'Follow up action with Residental Shipping Logistics ', desc: 'Contact sales representative.', comments: 2, time: '7:04 AM', position: 3, children: [
+            {id: 11, parentId: 10, escalated: 0, depth: 4, taskName: 'Follow up action with Universal Shipping Logistics Customers', desc: 'Contact sales representative.', comments: 2, time: '14:10 PM', position: 4},
+            {id: 12, parentId: 10, escalated: 0, depth: 4, expanded: false, taskName: 'Follow up action with Acme Universal Logistics Customers', desc: 'Contact sales representative.', comments: 2, time: '7:04 AM', position: 5, children: [
+              {id: 13, parentId: 12, escalated: 0, depth: 5, taskName: 'More Contact', desc: 'Contact sales representative.', comments: 2, time: '14:10 PM', position: 6},
+              {id: 14, parentId: 12, escalated: 0, depth: 5, taskName: 'More Follow up', desc: 'Contact sales representative.', comments: 2, time: '7:04 AM', position: 2},
+            ]},
+          ]}
+        ]},
+        {id: 15, parentId: 0, escalated: 0, depth: 2, taskName: 'Follow up action with Residental Housing', desc: 'Contact sales representative with the updated purchase order. This is a ver long description.', comments: 2, time: '18:10 PM', position: 3},
+        {id: 16, parentId: 0, escalated: 0, depth: 2, taskName: 'Follow up action with HMM Global', desc: 'Contact sales representative with the updated purchase order. This is a ver long description.', comments: 2, time: '20:10 PM', position: 4},
+        {id: 17, parentId: 0, escalated: 0, depth: 2, expanded: false, taskName: 'Second Child', desc: 'Contact sales representative with the updated purchase order.  This is a ver long description.', comments: 2, time: '22:10 PM', position: 5, children: [
+          {id: 18, parentId: 17, escalated: 0, depth: 3, taskName: 'Follow up action with Universal HMM Logistics', desc: 'Contact sales representative.  This is a ver long description.', comments: 2, time: '22:10 PM', position: 6},
+          {id: 19, parentId: 17, escalated: 0, depth: 3, taskName: 'Follow up action with Acme Shipping', desc: 'Contact sales representative.  This is a ver long description.', comments: 2, time: '22:10 PM', position: 7},
+          {id: 20, parentId: 17, escalated: 0, depth: 3, expanded: false, taskName: 'Follow up action with Residental Shipping Logistics ', desc: 'Contact sales representative.  This is a ver long description.', comments: 2, time: '7:04 AM', position: 2, children: [
+            {id: 21, parentId: 20,  escalated: 0, depth: 4, taskName: 'Follow up action with Universal Shipping Logistics Customers', desc: 'Contact sales representative.', comments: 2, time: '14:10 PM', position: 3},
+            {id: 22, parentId: 20, escalated: 0, depth: 4, expanded: false, taskName: 'Follow up action with Acme Universal Logistics Customers', desc: 'Contact sales representative.  This is a ver long description.', comments: 2, time: '7:04 AM', position: 4, children: [
+              {id: 23, parentId: 22, escalated: 0, depth: 5, taskName: 'More Contact', desc: 'Contact sales representative.', comments: 2, time: '14:10 PM', position: 5},
+              {id: 24, parentId: 22, escalated: 0, depth: 5, taskName: 'More Follow up', desc: 'Contact sales representative.', comments: 2, time: '7:04 AM', position: 6},
+            ]},
+          ]}
+        ]}
+      ]},
+      {id: 25, parentId: 0, escalated: 2, depth: 1, expanded: false, taskName: 'Test 1', desc: '', comments: null, time: '', position: 7},
+      {id: 26, parentId: 0, escalated: 2, depth: 1, expanded: false, taskName: 'Test 2', desc: '', comments: null, time: '', position: 8},
+      {id: 27, parentId: 0, escalated: 2, depth: 1, expanded: false, taskName: 'Test 3', desc: '', comments: null, time: '', position: 9},
+      {id: 28, parentId: 0, escalated: 2, depth: 1, expanded: false, taskName: 'Test 4', desc: '', comments: null, time: '', position: 10},
+      {id: 29, parentId: 0, escalated: 2, depth: 1, expanded: false, taskName: 'Test 5', desc: '', comments: null, time: '', position: 11},
+      {id: 30, parentId: 0, escalated: 2, depth: 1, expanded: false, taskName: 'No 6', desc: '', comments: null, time: '', position: 30},
+      {id: 31, parentId: 0, escalated: 2, depth: 1, expanded: false, taskName: 'No 7', desc: '', comments: null, time: '', position: 37},
+      {id: 32, parentId: 0, escalated: 2, depth: 1, expanded: false, taskName: 'No 8', desc: '', comments: null, time: '', position: 38},
+      {id: 33, parentId: 0, escalated: 2, depth: 1, expanded: false, taskName: 'Test 9', desc: '', comments: null, time: '', position: 40},
+    ];
+
+    //Define Columns for the Grid.
+    columns.push({ id: 'taskName', name: 'Task', field: 'taskName', expanded: 'expanded', textOverflow: 'ellipsis', formatter: Formatters.Tree, filterType: 'text', width: 120 });
+    columns.push({ id: 'id', name: 'Id', field: 'id', filterType: 'text', width: 75 });
+    columns.push({ id: 'desc', name: 'Description', field: 'desc', filterType: 'text', textOverflow: 'ellipsis' });
+    columns.push({ id: 'position', name: 'Position', field:'position', sortable: true, filterType: 'integer', filterConditions: ['equals', 'does-not-equal', 'less-than', 'less-equals', 'greater-than', 'greater-equals'] });
+
+    $('#datagrid').datagrid({
+      columns: columns,
+      dataset: data,
+      treeGrid: true,
+      filterable: true,
+      paging: true,
+      pagesize: 5,
+      stretchColumn: 'desc',
+      emptyMessage: {title: 'No Data Found', icon: 'icon-empty-generic'},
+      toolbar: {title: 'Tasks (Hierarchical)', results: true, personalize: true}
+    });
+
+  });
+</script>

--- a/app/views/components/datagrid/test-tree-filter-paging.html
+++ b/app/views/components/datagrid/test-tree-filter-paging.html
@@ -54,7 +54,7 @@
 
     //Define Columns for the Grid.
     columns.push({ id: 'taskName', name: 'Task', field: 'taskName', expanded: 'expanded', textOverflow: 'ellipsis', formatter: Formatters.Tree, filterType: 'text', width: 120 });
-    columns.push({ id: 'id', name: 'Id', field: 'id', filterType: 'text', width: 75 });
+    columns.push({ id: 'id', name: 'Id', field: 'id', filterType: 'text', width: 110 });
     columns.push({ id: 'desc', name: 'Description', field: 'desc', filterType: 'text', textOverflow: 'ellipsis' });
     columns.push({ id: 'position', name: 'Position', field:'position', sortable: true, filterType: 'integer', filterConditions: ['equals', 'does-not-equal', 'less-than', 'less-equals', 'greater-than', 'greater-equals'] });
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[Datagrid]` Fixed an issue where the selectedRows array contents continued to multiply each time running `selectAllRows`. ([#4195](https://github.com/infor-design/enterprise/issues/4195))
 - `[Datagrid]` Fixed an issue where the dynamic tooltip was not working properly. ([#4260](https://github.com/infor-design/enterprise/issues/4260))
 - `[Datagrid]` Fixed an issue where the check box filter was not working. ([#4271](https://github.com/infor-design/enterprise/issues/4271))
+- `[Datagrid]` Fixed an issue where the filter and paging for treegrid was not working properly. ([#4293](https://github.com/infor-design/enterprise/issues/4293))
 - `[Datepicker]` Fixed an issue where the minute and second interval for timepicker was not working properly when use along useCurrentTime setting. ([#4230](https://github.com/infor-design/enterprise/issues/4230))
 - `[Dropdown]` Fixed a bug where italic-style highlighting would represent a matched filter term instead of bold-style on a Dropdown List item in some cases. ([#4141](https://github.com/infor-design/enterprise/issues/4141))
 - `[FileUploadAdvanced]` Fixed an issue where the method `status.setCompleted()` not firing event `fileremoved`. ([#4294](https://github.com/infor-design/enterprise/issues/4294))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1951,6 +1951,18 @@ Datagrid.prototype = {
     const self = this;
     let filterChanged = false;
 
+    // Remove all nested key/value `_isFilteredOut` from given dataset
+    const removeFilteredOut = (dataset) => {
+      for (let i = 0, len = dataset.length; i < len; i++) {
+        if (typeof dataset[i]._isFilteredOut !== 'undefined') {
+          delete dataset[i]._isFilteredOut;
+        }
+        if (dataset[i].children) {
+          removeFilteredOut(dataset[i].children);
+        }
+      }
+    };
+
     if (conditions) {
       this.setFilterConditions(conditions);
     } else {
@@ -1963,6 +1975,10 @@ Datagrid.prototype = {
     if (this.pagerAPI && JSON.stringify(conditions) !== JSON.stringify(this.filterExpr)) {
       this.filterExpr = conditions;
       filterChanged = true;
+
+      if (this.settings.treeGrid) {
+        removeFilteredOut(this.settings.dataset);
+      }
     }
 
     const checkRow = function (rowData) {
@@ -2243,18 +2259,6 @@ Datagrid.prototype = {
             }
           }
           return isEmpty;
-        };
-
-        // Remove all nested key/value `_isFilteredOut` from given dataset
-        const removeFilteredOut = (dataset) => {
-          for (let i = 0, len = dataset.length; i < len; i++) {
-            if (typeof dataset[i]._isFilteredOut !== 'undefined') {
-              delete dataset[i]._isFilteredOut;
-            }
-            if (dataset[i].children) {
-              removeFilteredOut(dataset[i].children);
-            }
-          }
         };
 
         if (isFilterEmpty()) {
@@ -3313,6 +3317,12 @@ Datagrid.prototype = {
       }
       if (rowHtml.center) {
         tableHtml += rowHtml.center;
+
+        if (s.treeGrid && this.filterExpr?.length) {
+          if ($(`<table>${rowHtml.center}</table>`).find('tr:first').is('.is-hidden')) {
+            this.filteredCount++;
+          }
+        }
       }
       if (self.hasRightPane && rowHtml.right) {
         tableHtmlRight += rowHtml.right;

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -645,6 +645,51 @@ describe('Datagrid filter short row tests', () => {
   }
 });
 
+describe('Datagrid filter treeGrid paging', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/test-tree-filter-paging?layout=nofrills');
+
+    const datagridEl = await element(by.css('#datagrid .datagrid-wrapper tbody tr:nth-child(5)'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should filter treeGrid with paging', async () => {
+    const sel = {
+      rows: '#datagrid .datagrid-wrapper tbody tr',
+      filter: '#datagrid th[data-field="position"] .datagrid-filter-wrapper',
+      filterGreaterThan: '.popupmenu.is-open .greater-than a'
+    };
+    const getVisibleRowsCount = async () => {
+      const all = await element.all(by.css(sel.rows)).count();
+      const hidden = await element.all(by.css(`${sel.rows}.is-hidden`)).count();
+      return all - hidden;
+    };
+
+    expect(await getVisibleRowsCount()).toEqual(5);
+    await element(by.css(`${sel.filter} .btn-filter`)).click();
+    const popupEl = await element(by.css('.popupmenu.is-open'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(popupEl), config.waitsFor);
+    await element(by.css(sel.filterGreaterThan)).click();
+    await element(by.css(`${sel.filter} input[type="text"]`)).clear();
+    await element(by.css(`${sel.filter} input[type="text"]`)).sendKeys('30');
+    await element(by.css(`${sel.filter} input[type="text"]`)).sendKeys(protractor.Key.ENTER);
+    await browser.driver.sleep(config.sleep);
+
+    expect(await getVisibleRowsCount()).toEqual(3);
+    await element(by.css(`${sel.filter} input[type="text"]`)).clear();
+    await element(by.css(`${sel.filter} input[type="text"]`)).sendKeys(protractor.Key.ENTER);
+    await browser.driver.sleep(config.sleep);
+
+    expect(await getVisibleRowsCount()).toEqual(5);
+  });
+});
+
 describe('Datagrid form button tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-form-buttons?layout=nofrills');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the filter and paging for treegrid was not working properly with Datagrid.

**Related github/jira issue (required)**:
Closes #4293

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/test-tree-filter-paging.html
- Use filter on column `Position`
- Apply the filter `> 30`
- See only rows with `Position` values 37, 38 and 40 should be displayed

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
