### PR TITLE
4179 - Allow special characters to be used in Tab titles

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `[Splitter]` Fixes an issue where the collapse button was not working when splitter is on the right. ([#1730](https://github.com/infor-design/enterprise-ng/issues/1730))
 - `[Tabs]` Added detection for width/height/style changes on a Tabs component, which now triggers a resize event. ([ng#860](https://github.com/infor-design/enterprise-ng/issues/860))
 - `[Tabs]` Fixed a small error by removing a - 1 involved with testing. ([#4093](https://github.com/infor-design/enterprise/issues/4093))
+- `[Tabs]` Fixed a bug where using `#` in a Tab title was not possible. ([#4179](https://github.com/infor-design/enterprise/issues/4179))
 - `[Toolbar Searchfield]` Fixed a bug where the searchfield doesn't perfectly align together with flex toolbar. [[#4226](https://github.com/infor-design/enterprise/issues/4226)]
 - `[Tree]` Fixed an issue where the return focus state was not working properly after closing the context menu. ([#4252](https://github.com/infor-design/enterprise/issues/4252))
 - `[Vertical Tabs]` Fixed an issue where the error icon was misaligning. ([#873](https://github.com/infor-design/enterprise-ng/issues/873))

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -2278,7 +2278,7 @@ Tabs.prototype = {
 
       switch (contentType) {
         case 'string':
-          hasId = sourceString.match(/#/g);
+          hasId = sourceString.match(/^#/g);
           // Text Content or a Selector.
           if (hasId !== null) {
             const obj = $(sourceString);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes an issue in the Tabs `add()` API, where it was incorrectly picking up `#` at any location in the string and attempting to use the whole string as an ID selector.  This behavior has been fixed, and now allows special characters in Tab titles.

**Related github/jira issue (required)**:
Closes #4179

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the demoapp
- Open http://localhost:4000/components/tabs-module/example-legacy-style.html
- Uncheck the "fill with garbage" box, enter `!@#$%^&*()` in the "Tab Name" field, and click the "Create New Tab" button
- There should be a new tab created with `!@#$%^&*()` as the title, with no JS errors in the console.

**Included in this Pull Request**:
- [x] A note to the change log.