### PR TITLE
4320 - Fix error in datepicker

### DIFF
--- a/app/views/components/datepicker/example-index.html
+++ b/app/views/components/datepicker/example-index.html
@@ -23,6 +23,6 @@
 
 <script>
   $('#date-field-normal').on('change', function () {
-    console.log('Change EVent Fired')
+    console.log('Change Event Fired')
   });
 </script>

--- a/src/components/monthview/monthview.js
+++ b/src/components/monthview/monthview.js
@@ -1097,8 +1097,11 @@ MonthView.prototype = {
 
     const selectPicklistItem = (target, cssClass) => {
       const selectedElem = this.monthYearPane[0].querySelector(`.picklist.${cssClass} .is-selected`);
+
       DOM.removeClass(selectedElem, 'is-selected');
-      selectedElem.querySelector('a').setAttribute('tabindex', '-1');
+      if (selectedElem) {
+        selectedElem.querySelector('a').setAttribute('tabindex', '-1');
+      }
 
       DOM.addClass(target.parentNode, 'is-selected');
       target.setAttribute('tabindex', '0');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixed a small error clicking the edge and then clicking another item in the month/year picker.

**Related github/jira issue (required)**:
Fixes #4320

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datepicker/example-index.html
- click the month/year to open the month year picker
- select the selected month in the dom and remove class 'is-selected"
- click another month
- should be no error - and work as expected
- note that this happens clicking the edge as well but this was easier to reproduce

**Included in this Pull Request**:
- [x] A note to the change log.
