### PR TITLE
4327 - Add fix for RTL bullets in editor

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@
 - `[Datagrid]` Fixed an issue where the filter and paging for treegrid was not working properly. ([#4293](https://github.com/infor-design/enterprise/issues/4293))
 - `[Datepicker]` Fixed an issue where the minute and second interval for timepicker was not working properly when use along useCurrentTime setting. ([#4230](https://github.com/infor-design/enterprise/issues/4230))
 - `[Dropdown]` Fixed a bug where italic-style highlighting would represent a matched filter term instead of bold-style on a Dropdown List item in some cases. ([#4141](https://github.com/infor-design/enterprise/issues/4141))
+- `[Editor]` Fixed issue with incorrect padding when using bullets in RTL mode. ([#4327](https://github.com/infor-design/enterprise/issues/4327))
 - `[FileUploadAdvanced]` Fixed an issue where the method `status.setCompleted()` not firing event `fileremoved`. ([#4294](https://github.com/infor-design/enterprise/issues/4294))
 - `[Homepage]` Fixed an issue where the columns were not showing properly after resize by using the maximize button. ([#894](https://github.com/infor-design/enterprise-ng/issues/894))
 - `[Homepage]` Fixed an issue where the columns were not showing properly after resize browser window. ([#895](https://github.com/infor-design/enterprise-ng/issues/895))

--- a/src/components/editor/_editor.scss
+++ b/src/components/editor/_editor.scss
@@ -272,12 +272,11 @@
 
   ul,
   ol {
-    @include rem(line-height, 2.2rem);
-    @include rem(margin-left, 2rem);
-
     color: $input-color;
     font-size: $input-size-regular-font-size;
+    line-height: 2.2rem;
     list-style: disc;
+    margin-left: 2rem;
 
     li {
       line-height: inherit;
@@ -778,6 +777,12 @@ html[dir='rtl'] {
         left: 40px;
       }
     }
+  }
+
+  .editor ul,
+  .editor ol {
+    margin-left: 0;
+    margin-right: 2rem;
   }
 
   .toolbar,


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Bullets in RTL mode did not have the margin negated in RTL mode. Added a quick fix.


**Related github/jira issue (required)**:
Fixes #4327

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/editor/example-index.html?locale=ar-SA
- clear all text
- type Test (enter) Test
- select all text
- click bullet list
- list should be visible and look lovely now

**Included in this Pull Request**:
- [x] A note to the change log.
