### PR TITLE
4325 - Remove extraneous scrollbar

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@
 - `[Tabs]` Added detection for width/height/style changes on a Tabs component, which now triggers a resize event. ([ng#860](https://github.com/infor-design/enterprise-ng/issues/860))
 - `[Tabs]` Fixed a small error by removing a - 1 involved with testing. ([#4093](https://github.com/infor-design/enterprise/issues/4093))
 - `[Tabs]` Fixed a bug where using `#` in a Tab title was not possible. ([#4179](https://github.com/infor-design/enterprise/issues/4179))
+- `[Toolbar Flex]` Fixed a bug where in some cases a un-needed scrollbar would appear. [[#4325](https://github.com/infor-design/enterprise/issues/4325)]
 - `[Toolbar Searchfield]` Fixed a bug where the searchfield doesn't perfectly align together with flex toolbar. [[#4226](https://github.com/infor-design/enterprise/issues/4226)]
 - `[Tree]` Fixed an issue where the return focus state was not working properly after closing the context menu. ([#4252](https://github.com/infor-design/enterprise/issues/4252))
 - `[Vertical Tabs]` Fixed an issue where the error icon was misaligning. ([#873](https://github.com/infor-design/enterprise-ng/issues/873))

--- a/src/components/toolbar-flex/_toolbar-flex.scss
+++ b/src/components/toolbar-flex/_toolbar-flex.scss
@@ -72,7 +72,7 @@
     .page-title,
     .section-title {
       display: block;
-      overflow-x: hidden;
+      overflow: hidden;
       padding: 0;
       text-overflow: ellipsis;
     }

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -1136,8 +1136,10 @@ describe('Datepicker Range Tests', () => {
     await element.all(by.cssContainingText('.monthview-table td', '6')).get(1).click();
 
     const testDate1 = new Date();
+    testDate1.setMonth(7);
     testDate1.setDate(3);
     const testDate2 = new Date(testDate1);
+    testDate2.setMonth(7);
     testDate2.setDate(6);
 
     expect(await datepickerEl.getAttribute('value')).toEqual(`${(testDate1.getMonth() + 1)}/3/${testDate1.getFullYear()} - ${(testDate2.getMonth() + 1)}/${testDate2.getDate()}/${testDate2.getFullYear()}`);
@@ -1155,8 +1157,10 @@ describe('Datepicker Range Tests', () => {
     await element.all(by.cssContainingText('.monthview-table td', '4')).get(0).click();
 
     const testDate1 = new Date();
+    testDate1.setMonth(7);
     testDate1.setDate(4);
     const testDate2 = new Date(testDate1);
+    testDate2.setMonth(7);
     testDate2.setDate(7);
 
     expect(await datepickerEl.getAttribute('value')).toEqual(`${(testDate1.getMonth() + 1)}/4/${testDate1.getFullYear()} - ${(testDate2.getMonth() + 1)}/${testDate2.getDate()}/${testDate2.getFullYear()}`);
@@ -1174,8 +1178,10 @@ describe('Datepicker Range Tests', () => {
     await element.all(by.cssContainingText('.monthview-table td', '11')).get(0).click();
 
     const testDate1 = new Date();
+    testDate1.setMonth(8);
     testDate1.setDate(11);
     const testDate2 = new Date(testDate1);
+    testDate2.setMonth(8);
     testDate2.setDate(12);
 
     expect(await datepickerEl.getAttribute('value')).toEqual(`${(testDate1.getMonth() + 1)}/11/${testDate1.getFullYear()} - ${(testDate2.getMonth() + 1)}/${testDate2.getDate()}/${testDate2.getFullYear()}`);
@@ -1192,8 +1198,10 @@ describe('Datepicker Range Tests', () => {
     await element.all(by.cssContainingText('.monthview-table td', '17')).get(0).click();
 
     const testDate1 = new Date();
+    testDate1.setMonth(7);
     testDate1.setDate(16);
     const testDate2 = new Date(testDate1);
+    testDate2.setMonth(7);
     testDate2.setDate(21);
 
     expect(await datepickerEl.getAttribute('value')).toEqual(`${(testDate1.getMonth() + 1)}/16/${testDate1.getFullYear()} - ${(testDate2.getMonth() + 1)}/${testDate2.getDate()}/${testDate2.getFullYear()}`);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

H2's had an extra scrollbar

**Related github/jira issue (required)**:
Fixes #4325

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/toolbar-flex/example-index?theme=uplift&variant=light
- look for an extra scroll bar item as per the original issue, you wont see it because i fixed it :)

**Included in this Pull Request**:
- [x] A note to the change log.
