### PR TITLE
4289 - Fix page layout and add more icon size

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## v4.33.0 Fixes
 
-- `[Tabs Header]` Fixed a bug where the add icon were too small and the page form layout has a big space on top of it. ([#4289](https://github.com/infor-design/enterprise/issues/4289))
-
 ### v4.32.0 Important Notes
 
 - `[Colors]` In Uplift (Vibrant) theme there is no longer any colors in graphite. All are slate. This involved bringing in a new version 3.0 of the design system with some breaking changes you should not if using the tokens directly. See the [design system change log](https://github.com/infor-design/design-system/blob/master/docs/CHANGELOG.md) for details. ([#4206](https://github.com/infor-design/enterprise/issues/4206))
@@ -41,6 +39,7 @@
 - `[Tabs]` Added detection for width/height/style changes on a Tabs component, which now triggers a resize event. ([ng#860](https://github.com/infor-design/enterprise-ng/issues/860))
 - `[Tabs]` Fixed a small error by removing a - 1 involved with testing. ([#4093](https://github.com/infor-design/enterprise/issues/4093))
 - `[Tabs]` Fixed a bug where using `#` in a Tab title was not possible. ([#4179](https://github.com/infor-design/enterprise/issues/4179))
+- `[Tabs Header]` Fixed a bug where the add icon were too small and the page form layout has a big space on top of it. ([#4289](https://github.com/infor-design/enterprise/issues/4289))
 - `[Toolbar Flex]` Fixed a bug where in some cases a un-needed scrollbar would appear. [[#4325](https://github.com/infor-design/enterprise/issues/4325)]
 - `[Toolbar Searchfield]` Fixed a bug where the searchfield doesn't perfectly align together with flex toolbar. [[#4226](https://github.com/infor-design/enterprise/issues/4226)]
 - `[Tree]` Fixed an issue where the return focus state was not working properly after closing the context menu. ([#4252](https://github.com/infor-design/enterprise/issues/4252))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,8 @@
 # What's New with Enterprise
 
-## v4.32.0
+## v4.33.0 Fixes
+
+- `[Tabs Header]` Fixed a bug where the add icon were too small and the page form layout has a big space on top of it. ([#4289](https://github.com/infor-design/enterprise/issues/4289))
 
 ### v4.32.0 Important Notes
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,12 @@
 # What's New with Enterprise
 
-## v4.33.0 Fixes
+## v4.33.0
+
+### v4.33.0 Fixes
+
+- Placeholder Item
+
+## v4.32.0
 
 ### v4.32.0 Important Notes
 
@@ -44,6 +50,8 @@
 - `[Toolbar Searchfield]` Fixed a bug where the searchfield doesn't perfectly align together with flex toolbar. [[#4226](https://github.com/infor-design/enterprise/issues/4226)]
 - `[Tree]` Fixed an issue where the return focus state was not working properly after closing the context menu. ([#4252](https://github.com/infor-design/enterprise/issues/4252))
 - `[Vertical Tabs]` Fixed an issue where the error icon was misaligning. ([#873](https://github.com/infor-design/enterprise-ng/issues/873))
+
+(49 Issues Solved This Release, Backlog Enterprise 196, Backlog Ng 51, 1079 Functional Tests, 1525 e2e Tests)
 
 ## v4.31.2
 

--- a/scripts/data/expected-files.json
+++ b/scripts/data/expected-files.json
@@ -271,6 +271,7 @@
 	"/dist/sass/src/components/swaplist/_swaplist-uplift.scss",
 	"/dist/sass/src/components/swaplist/_swaplist.scss",
 	"/dist/sass/src/components/switch/_switch.scss",
+	"/dist/sass/src/components/tabs-header/_tabs-header-uplift.scss",
 	"/dist/sass/src/components/tabs-header/_tabs-header.scss",
 	"/dist/sass/src/components/tabs-module/_tabs-module-uplift.scss",
 	"/dist/sass/src/components/tabs-module/_tabs-module.scss",

--- a/src/components/tabs-header/_tabs-header-uplift.scss
+++ b/src/components/tabs-header/_tabs-header-uplift.scss
@@ -1,0 +1,14 @@
+// Styles for Header Tabs Uplift
+//================================================== //
+
+.tab-container {
+  &.header-tabs {
+    .add-tab-button {
+      padding: 4px 4px 1px 6px;
+    }
+
+    .tab-more {
+      padding: 9px 4px 11px 14px;
+    }
+  }
+}

--- a/src/components/tabs-header/_tabs-header.scss
+++ b/src/components/tabs-header/_tabs-header.scss
@@ -151,7 +151,7 @@
   }
 
   .add-tab-button {
-    padding: 12px 4px 12px 14px;
+    padding: 8px 4px 5px;
   }
 
   // Alternate Header-Tab Backgrounds (Page Context)

--- a/src/components/tabs-vertical/_tabs-vertical.scss
+++ b/src/components/tabs-vertical/_tabs-vertical.scss
@@ -99,7 +99,7 @@
 
 .tab-panel-container {
   height: inherit;
-  
+
   &.no-scroll {
     .tab-panel {
       padding-left: 0;

--- a/src/components/tabs-vertical/_tabs-vertical.scss
+++ b/src/components/tabs-vertical/_tabs-vertical.scss
@@ -75,6 +75,10 @@
       margin-top: 0;
       position: relative;
     }
+
+    &.tab-panel-container {
+      position: absolute;
+    }
   }
 }
 
@@ -95,6 +99,13 @@
 
 .tab-panel-container {
   height: inherit;
+  
+  &.no-scroll {
+    .tab-panel {
+      padding-left: 0;
+      padding-right: 0;
+    }
+  }
 
   .tab-panel {
     @media (max-width: $breakpoint-phone-to-tablet - 1) {

--- a/src/components/tabs/_tabs-uplift.scss
+++ b/src/components/tabs/_tabs-uplift.scss
@@ -26,6 +26,12 @@
       }
     }
   }
+
+  .add-tab-button {
+    span[aria-hidden] {
+      @include font-size(24);
+    }
+  }
 }
 
 .popupmenu.tab-list-spillover,

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -1,5 +1,6 @@
 // Tabs (Vertical and Horizontal)
 //==================================================/
+
 @mixin tab-outline {
   border: 1px solid transparent;
   border-radius: 2px;
@@ -223,6 +224,17 @@
     font-size: $ids-size-font-base;
   }
 
+}
+
+// Page containers without scroll
+.page-container {
+  .tab-panel-container {
+    &.no-scroll {
+      .tab-panel {
+        padding-top: 0;
+      }
+    }
+  }
 }
 
 // More Button

--- a/src/core/_controls-uplift.scss
+++ b/src/core/_controls-uplift.scss
@@ -101,6 +101,8 @@
 @import '../components/swaplist/swaplist-uplift';
 @import '../components/tabs/tabs';
 @import '../components/tabs/tabs-uplift';
+@import '../components/tabs-header/tabs-header';
+@import '../components/tabs-header/tabs-header-uplift';
 @import '../components/timeline/timeline';
 @import '../components/timeline/timeline-uplift';
 @import '../components/timepicker/timepicker';


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes the page container layout, add more icon focus, and add more icon size on uplift theme, mobile view. 

Also added possible related issue that I noticed when testing the page:
- Fix caret icon position on dropdown when it exceeds the tab

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/4289

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/tabs-header/example-add-tab-button.html?theme=uplift&variant=light
- Resize the page down to `766px`
- The page layout should not contain a big white space on top and should not have paddings both left and right. (It should retain the same layout on a bigger screen)
- Add more icon should much bigger now compare to the older look.
- Click the add more icon.
- The focus state should look correctly.

Optional:
- Click the add more until it shows the caret dropdown
- Caret icon should position vertically centered

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
