### PR TITLE
4305 - Add ability to add icon in node text

### DIFF
--- a/app/views/components/tree/example-plus-minus-folders.html
+++ b/app/views/components/tree/example-plus-minus-folders.html
@@ -19,7 +19,7 @@
     "href": '/somelink/'
   }, {
     "id": "node2",
-    "text": "Node Two",
+    "text": "Node Two <svg class=\"icon icon-info\" focusable=\"false\" aria-hidden=\"true\" role=\"presentation\"><use href=\"#icon-info-alert\"></use></svg>",
     "open": true,
     "selected": false,
     "children": [{
@@ -41,9 +41,12 @@
   }];
 
 
-  $('#json-tree').tree({
+  var api = $('#json-tree').tree({
     dataset: sampleData,
     folderIconOpen: 'plusminus-folder-open',
     folderIconClosed: 'plusminus-folder-closed'
-  });
+  }).data('tree');
+
+  api.addNode({text: 'New Item <svg class="icon icon-info" focusable="false" aria-hidden="true" role="presentation"><use href="#icon-info-alert"></use></svg>', parent: 'new1', disabled: true});
+
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v4.33.0 Fixes
 
-- Placeholder Item
+- `[Tree]` Fixed a bug that adding icons in with the tree text would encode it when using addNode. ([#4305](https://github.com/infor-design/enterprise/issues/4305))
 
 ## v4.32.0
 

--- a/src/components/tree/_tree-uplift.scss
+++ b/src/components/tree/_tree-uplift.scss
@@ -6,7 +6,7 @@
   }
 
   a {
-    padding: 5px;
+    padding: 3px 5px;
 
     .tree-badge {
       line-height: 17px;

--- a/src/components/tree/_tree.scss
+++ b/src/components/tree/_tree.scss
@@ -49,6 +49,11 @@
       border-bottom: 1px solid transparent;
       color: $tree-link-color;
       margin: 0 0 0 4px;
+
+      .icon {
+        left: 1px;
+        top: 7px;
+      }
     }
 
     // Icons

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -1,5 +1,6 @@
 import * as debug from '../../utils/debug';
 import { utils } from '../../utils/utils';
+import { xssUtils } from '../../utils/xss';
 import { DOM } from '../../utils/dom';
 import { Environment as env } from '../../utils/environment';
 import { Locale } from '../locale/locale';
@@ -268,6 +269,11 @@ Tree.prototype = {
     const span = document.createElement('span');
     DOM.addClass(span, 'tree-text');
     span.textContent = text;
+
+    if (span.innerHTML.indexOf('&lt;svg') > 0) {
+      span.innerHTML = xssUtils.unescapeHTML(span.innerHTML);
+    }
+
     a[0].appendChild(span);
 
     // Inject children count


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

We used to be able to add an svg icon the text node of the tree. But changes/encoding broke this. So added it back

**Related github/jira issue (required)**:
Fixes #4305

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/tree/example-plus-minus-folders.html
- should see one icon in the main JS and one added via addNode
- should look good now and everything else works
- also try uplift mode.

**Included in this Pull Request**:
- [x] A note to the change log.
