### PR TITLE
4356 - Fix Removing Nested Tabs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `[Locale]` Added a new translation token for Records Per Page with no number. ([#4334](https://github.com/infor-design/enterprise/issues/4334))
 - `[Stepprocess]` Fixed a bug where padding and scrolling was missing. Note that this pattern will eventually be removed and we do not suggest any one use it for new development. ([#4249](https://github.com/infor-design/enterprise/issues/4249))
 - `[Tabs]` Fixed multiple bugs where error icon in tabs and the animation bar were not properly aligned in RTL uplift theme. ([#4326](https://github.com/infor-design/enterprise/issues/4326))
+- `[Tabs]` Fixed a bug where removing a nested tab would cause an error due to being invisible. ([#4356](https://github.com/infor-design/enterprise/issues/4356))
 - `[Tree]` Fixed a bug that adding icons in with the tree text would encode it when using addNode. ([#4305](https://github.com/infor-design/enterprise/issues/4305))
 
 ## v4.32.0

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -2435,7 +2435,7 @@ Tabs.prototype = {
     const targetPanel = this.getPanel(tabId);
     const hasTargetPanel = (targetPanel && targetPanel.length);
     const targetLiIndex = this.tablist.children('li').index(targetLi);
-    const notATab = '.application-menu-trigger, .separator, .is-disabled, :hidden';
+    const notATab = '.application-menu-trigger, .separator, .is-disabled';
     let prevLi = targetLi.prev();
 
     if (!disableBeforeClose) {
@@ -2544,7 +2544,7 @@ Tabs.prototype = {
     }
 
     // If we find nothing, search for ANY available tab
-    if (!prevLi.length) {
+    if (!prevLi || !prevLi.length) {
       prevLi = this.tablist.children('li').not(notATab).first();
     }
 

--- a/test/components/tabs/tabs.e2e-spec.js
+++ b/test/components/tabs/tabs.e2e-spec.js
@@ -554,3 +554,34 @@ describe('Tabs focus after enable/disable programmatically', () => {
     expect(await browser.driver.switchTo().activeElement().getAttribute('id')).toEqual('enable');
   });
 });
+
+describe('Tabs nested tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/tabs/test-nested-horizontal-tabs');
+    const tabsContainerEl = await element(by.id('main-tabs-container'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(tabsContainerEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  // See Github #4356
+  it('can remove nested child tabs', async () => {
+    // Ensure nested tab container is loaded
+    const nestedTabsContainerEl = await element(by.id('nested-tabs-container'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(nestedTabsContainerEl), config.waitsFor);
+
+    // Check that Tab #4 exists
+    expect(await element(by.id('tab4')).isPresent()).toBeTruthy();
+
+    // Call the `destroy()` method
+    const removeScript = "$('#nested-tabs-container').data('tabs').remove('tab4')";
+    browser.executeScript(removeScript);
+
+    // Check that Tab #4 no longer exists
+    expect(await element(by.id('tab4')).isPresent()).toBeFalsy();
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR makes a quick change to the `remove()` method to account for tabs that might be hidden by a nested parent.  Previously removing tabs that were contained by a hidden tab panel would throw a JS error.  This has been fixed.

**Related github/jira issue (required)**:
Closes #4356

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the demoapp
- Open http://localhost:4000/components/tabs/test-nested-horizontal-tabs.html
- Click on "Tab #2" to reveal the nested tabs container.  Ensure "Tab #4" is present.
- Click on "Tab #1" to hide the nested tabs container again.
- Open a dev tools console and type `$('#nested-tabs-container').data('tabs').remove('tab4')` to call the API and remove the tab.  There should be no errors present in the console after running this method.
- Click on "Tab #2" again.  Tab #4 should no longer be present.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.