### PR TITLE
4926 - Fix missing "More Actions" items in Flex Toolbars

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `[Locale]` Added a new translation token for Records Per Page with no number. ([#4334](https://github.com/infor-design/enterprise/issues/4334))
 - `[Stepprocess]` Fixed a bug where padding and scrolling was missing. Note that this pattern will eventually be removed and we do not suggest any one use it for new development. ([#4249](https://github.com/infor-design/enterprise/issues/4249))
 - `[Tabs]` Fixed multiple bugs where error icon in tabs and the animation bar were not properly aligned in RTL uplift theme. ([#4326](https://github.com/infor-design/enterprise/issues/4326))
+- `[Toolbar Flex]` Fixed detection of overflow in some toolbars where items were not properly displaying all overflowed items in the "More Actions" menu. ([#4296](https://github.com/infor-design/enterprise/issues/4296))
 - `[Tree]` Fixed a bug that adding icons in with the tree text would encode it when using addNode. ([#4305](https://github.com/infor-design/enterprise/issues/4305))
 
 ## v4.32.0

--- a/src/components/editor/_editor.scss
+++ b/src/components/editor/_editor.scss
@@ -802,4 +802,14 @@ html[dir='rtl'] {
       }
     }
   }
+
+  // Flex Toolbar-specific styles
+  .flex-toolbar.formatter-toolbar {
+    .toolbar-section.more {
+      .btn-actions {
+        margin-left: 8px;
+        margin-right: auto;
+      }
+    }
+  }
 }

--- a/src/components/toolbar-flex/toolbar-flex.item.js
+++ b/src/components/toolbar-flex/toolbar-flex.item.js
@@ -600,8 +600,6 @@ ToolbarFlexItem.prototype = {
       return;
     }
 
-    this.hasNoOverflowedItems = true;
-
     // If there are toolbar items, but no predefined items, render the more-actions menu
     if ((!menuAPI.settings.beforeOpen && (!this.predefinedItems || !this.predefinedItems.length)) &&
       this.toolbarAPI.items.length) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR makes a small change to the timing of calculation of the overflow in Flex Toolbars.  Previously, this was causing issues in certain toolbars (very prevalent in the Formatter Toolbar/Editors) where some items that were overflowed were not being displayed in the menu.  This has been fixed.

**Related github/jira issue (required)**:
Closes #4296

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the demoapp
- Open http://localhost:4000/components/editor/example-index.html
- Shrink the page so that one or more buttons on the formatter toolbar are cut off by the edge of the editor.
- Click the "..." More Actions button.  Ensure that all buttons that are cut off or hidden completely appear as list items in the menu.

**Included in this Pull Request**:
- [x] A note to the change log.

@SofiK 