### PR TITLE
4298 - Make Modal Manager respect `isCancelled` property of Modal's `close` API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Datepicker]` Added missing off screen text for the picker buttons in the datepicker month/year view. ([#4318](https://github.com/infor-design/enterprise/issues/4318))
 - `[Locale]` Added a new translation token for Records Per Page with no number. ([#4334](https://github.com/infor-design/enterprise/issues/4334))
+- `[Modal Manager]` Modals now pass `isCancelled` properly when the Modal Manager API detects a request to close by using the Escape key. ([#4298](https://github.com/infor-design/enterprise/issues/4298))
 - `[Stepprocess]` Fixed a bug where padding and scrolling was missing. Note that this pattern will eventually be removed and we do not suggest any one use it for new development. ([#4249](https://github.com/infor-design/enterprise/issues/4249))
 - `[Tabs]` Fixed multiple bugs where error icon in tabs and the animation bar were not properly aligned in RTL uplift theme. ([#4326](https://github.com/infor-design/enterprise/issues/4326))
 - `[Tree]` Fixed a bug that adding icons in with the tree text would encode it when using addNode. ([#4305](https://github.com/infor-design/enterprise/issues/4305))

--- a/src/components/modal/modal.manager.js
+++ b/src/components/modal/modal.manager.js
@@ -341,7 +341,7 @@ ModalManager.prototype = {
       switch (keyCode) {
         // Escape Key
         case 27:
-          this.close(modalTargetElem);
+          this.close(modalTargetElem, true);
           break;
         case 9:
           this.setModalFocus(e.shiftKey ? 'last' : 'first', e);

--- a/test/components/editor/editor.e2e-spec.js
+++ b/test/components/editor/editor.e2e-spec.js
@@ -77,6 +77,25 @@ describe('Editor example-index tests', () => {
 
     expect(await element(by.css('.editor')).getAttribute('innerHTML')).toEqual('<h3>test test</h3>');
   });
+
+  it('Should not insert images if the modals are cancelled', async () => {
+    const imageBtn = await element(by.css('.editor-toolbar .btn[data-action="image"]'));
+
+    // Open the Image Modal
+    await imageBtn.click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.css('.editor-modal-image.is-visible'))), config.waitsFor);
+
+    // Press the escape key and wait for the modal to close
+    await browser.driver.sleep(config.sleep);
+    await browser.driver.actions().sendKeys(protractor.Key.ESCAPE).perform();
+    await browser.driver.sleep(config.sleep);
+    await browser.driver
+      .wait(protractor.ExpectedConditions.invisibilityOf(await element(by.css('.editor-modal-image'))), config.waitsFor);
+
+    // Scan the editor content for image tags and make sure none exist
+    expect(await element(by.css('.editor img')).isPresent()).toBeFalsy();
+  });
 });
 
 describe('Editor visual regression tests', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR makes a change to the Modal Manager API's listener for global keypresses, which will now close a currently-open modal with the `isCancelled` property set to true.  Previously this was not happening, which was causing bugs in Modals that required this property to be set.  This was discovered in our Editor modals, which were improperly inserting blank content when the Escape key was pressed.

**Related github/jira issue (required)**:
Closes #4298

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the demoapp
- Open http://localhost:4000/components/editor/example-index.html
- Click the "insert image" button on the formatter toolbar to open the Image Editor Modal.
- Press the Escape key to close the modal.  When the modal closes, no image should be inserted.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.