### PR TITLE
4309 - Fix Fontpicker to correctly match partially modified Editor content

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### v4.33.0 Fixes
 
 - `[Datepicker]` Added missing off screen text for the picker buttons in the datepicker month/year view. ([#4318](https://github.com/infor-design/enterprise/issues/4318))
+- `[Editor]` Fixed a bug where the Fontpicker's displayed style wasn't updating to match the current text selection in some cases. ([#4309](https://github.com/infor-design/enterprise/issues/4309))
 - `[Locale]` Added a new translation token for Records Per Page with no number. ([#4334](https://github.com/infor-design/enterprise/issues/4334))
 - `[Stepprocess]` Fixed a bug where padding and scrolling was missing. Note that this pattern will eventually be removed and we do not suggest any one use it for new development. ([#4249](https://github.com/infor-design/enterprise/issues/4249))
 - `[Tabs]` Fixed multiple bugs where error icon in tabs and the animation bar were not properly aligned in RTL uplift theme. ([#4326](https://github.com/infor-design/enterprise/issues/4326))

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -2560,7 +2560,7 @@ Editor.prototype = {
    * Formats the currently-selected block of content in the editor with a predefined HTML element
    * and style, if applicable.
    * @param {string} el, the desired block-level element with which to wrap the current block.
-   * @returns {void|boolean} same return value as [`document.execCommand()`](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand)
+   * @returns {void}
    */
   execFormatBlock(el) {
     if (this.selection === undefined) {
@@ -2627,8 +2627,8 @@ Editor.prototype = {
       document.execCommand('removeFormat', false, el);
     }
 
+    document.execCommand('formatBlock', false, el);
     this.checkActiveButtons();
-    return document.execCommand('formatBlock', false, el);
   },
 
   // Get What is Selected

--- a/test/components/editor/editor.e2e-spec.js
+++ b/test/components/editor/editor.e2e-spec.js
@@ -77,6 +77,34 @@ describe('Editor example-index tests', () => {
 
     expect(await element(by.css('.editor')).getAttribute('innerHTML')).toEqual('<h3>test test</h3>');
   });
+
+  it('should update fontpicker\'s displayed text type when the selected text\'s block is modified', async () => {
+    const elem = await element(by.css('.editor'));
+
+    // Clear contents and put some fresh text in
+    await elem.clear();
+    await elem.sendKeys('test test');
+    await elem.click();
+
+    // Simulate text selection of just the first word "test"
+    await browser.actions()
+      .keyDown(protractor.Key.SHIFT)
+      .sendKeys(protractor.Key.ARROW_RIGHT)
+      .sendKeys(protractor.Key.ARROW_RIGHT)
+      .sendKeys(protractor.Key.ARROW_RIGHT)
+      .sendKeys(protractor.Key.ARROW_RIGHT)
+      .keyUp(protractor.Key.SHIFT)
+      .perform();
+    await browser.driver.sleep(config.sleepShort);
+
+    // Open the fontpicker and select "Header 1"
+    await element(by.css('.fontpicker')).click();
+    await element(by.css('a[data-val="header1"]')).click();
+
+    // Check that the <h3> was applied, and the text inside the fontpicker is up to date.
+    expect(await element(by.css('.editor')).getAttribute('innerHTML')).toEqual('<h3>test test</h3>');
+    expect(await element(by.css('.fontpicker')).getText()).toEqual('Header 1');
+  });
 });
 
 describe('Editor visual regression tests', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a bug in the Editor where when text is partially selected and changed by the Fontpicker, the Fontpicker's state wasn't correctly updated.

**Related github/jira issue (required)**:
Closes #4309 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the demoapp
- Open http://localhost:4000/components/editor/example-index.html
- Clear the editor contents and type "test test"
- Use either keyboard or mouse to select just the first "test".
- Open the Fontpicker and choose "Header 1".  The entire block of text should change from `<p>`-wrapped to `<h3>`-wrapped, and the text inside the Fontpicker should immediately read "Header 1".

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.