### PR TITLE
3927 - Fix toggle node without selection with tree

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `[Locale]` Added a new translation token for Records Per Page with no number. ([#4334](https://github.com/infor-design/enterprise/issues/4334))
 - `[Stepprocess]` Fixed a bug where padding and scrolling was missing. Note that this pattern will eventually be removed and we do not suggest any one use it for new development. ([#4249](https://github.com/infor-design/enterprise/issues/4249))
 - `[Tabs]` Fixed multiple bugs where error icon in tabs and the animation bar were not properly aligned in RTL uplift theme. ([#4326](https://github.com/infor-design/enterprise/issues/4326))
+- `[Tree]` Fixed an issue where toggle node without making select/unselect was not working properly. ([#3927](https://github.com/infor-design/enterprise/issues/3927))
 - `[Tree]` Fixed a bug that adding icons in with the tree text would encode it when using addNode. ([#4305](https://github.com/infor-design/enterprise/issues/4305))
 
 ## v4.32.0

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -438,7 +438,6 @@ Tree.prototype = {
 
   /**
    * Deselects a tree node
-   * @private
    * @param {object} node - a jQuery-wrapped element reference to a tree node.
    * @param {boolean} focus - if defined, causes the node to become focused.
    * @returns {void}
@@ -486,7 +485,6 @@ Tree.prototype = {
 
   /**
    * Selects a tree node
-   * @private
    * @param {object} node - a jQuery-wrapped element reference to a tree node.
    * @param {boolean} focus - if defined, causes the node to become focused.
    * @returns {void}
@@ -698,7 +696,6 @@ Tree.prototype = {
 
   /**
    * Changes a node's open/close status to its opposite form.
-   * @private
    * @param {object} node - a jQuery-wrapped element reference to a tree node.
    * @param {object} e jquery event
    * @returns {void}
@@ -721,6 +718,11 @@ Tree.prototype = {
               }
             });
           } else if (result) { // Boolean is returned instead of a promise
+            self.selectNodeFinish(node, focus, e);
+          }
+        } else if (s.expandTarget === 'icon') {
+          const parent = node[0].parentNode;
+          if (e && DOM.hasClass(e.target, 'icon') && DOM.hasClass(parent, 'folder')) {
             self.selectNodeFinish(node, focus, e);
           }
         } else { // No Callback specified
@@ -767,6 +769,11 @@ Tree.prototype = {
               }
             });
           } else if (result) { // Boolean is returned instead of a promise
+            self.selectNodeFinish(node, focus, e);
+          }
+        } else if (s.expandTarget === 'icon') {
+          const parent = node[0].parentNode;
+          if (e && DOM.hasClass(e.target, 'icon') && DOM.hasClass(parent, 'folder')) {
             self.selectNodeFinish(node, focus, e);
           }
         } else { // No Callback specified


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed toggle node without making select/unselect was not working properly with Tree. For this case we have setting `expandTarget: 'icon'` which was broken when ran thru api `tree.toggleNode(targetNode)`, so this PR should fix it.

**Related github/jira issue (required)**:
Closes #3927

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/tree/test-expand-target.html (example should use setting `expandTarget: 'icon'`)
- Open developer tools
- Run in console below commands, to see toggle/select/unselect node state
```
var treeApi = $('#json-tree').data('tree'); // get tree api
var targetNode = $('#node2'); // get target node

treeApi.toggleNode(targetNode); // toggle given node
treeApi.selectNode(targetNode); // select given node
treeApi.unSelectedNode(targetNode); // unSelected given node
```

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
