### PR TITLE
899 - Fix before show event with lookup

### DIFF
--- a/app/views/components/lookup/test-beforeshow-cancel.html
+++ b/app/views/components/lookup/test-beforeshow-cancel.html
@@ -1,0 +1,21 @@
+
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="field">
+      <label for="product-lookup" class="label">Products</label>
+      <input id="product-lookup" data-init="false" class="lookup" name="product-lookup" type="text"/>
+    </div>
+
+  </div>
+</div>
+
+<script id="test-script">
+  $('#product-lookup').lookup({
+    field: 'productId',
+    beforeShow: function (api, response) {
+      $('body').toast({ title: 'Lookup Test', message: 'Canceled to open lookup window by settings method "beforeShow()"' });
+      response(false);
+    }
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@
 - `[Datagrid]` Added support to `In Range` filter operator for numeric columns. ([#3988](https://github.com/infor-design/enterprise/issues/3988))
 - `[Datepicker]` Added missing off screen text for the picker buttons in the datepicker month/year view. ([#4318](https://github.com/infor-design/enterprise/issues/4318))
 - `[Editor]` Fixed a bug where the Fontpicker's displayed style wasn't updating to match the current text selection in some cases. ([#4309](https://github.com/infor-design/enterprise/issues/4309))
-- `[Lookup]` Fixed an issue where the event `beforeShow` was only triggers one time. ([#899](https://github.com/infor-design/enterprise-ng/issues/899))
+- `[Lookup]` Fixed an issue where the event `beforeShow` was only triggered the first time. ([#899](https://github.com/infor-design/enterprise-ng/issues/899))
 - `[Locale]` Added a new translation token for Records Per Page with no number. ([#4334](https://github.com/infor-design/enterprise/issues/4334))
 - `[Searchfield]` Allow for search terms to include special characters. ([#4291](https://github.com/infor-design/enterprise/issues/4291))
 - `[Stepprocess]` Fixed a bug where padding and scrolling was missing. Note that this pattern will eventually be removed and we do not suggest any one use it for new development. ([#4249](https://github.com/infor-design/enterprise/issues/4249))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[Datagrid]` Added support to `In Range` filter operator for numeric columns. ([#3988](https://github.com/infor-design/enterprise/issues/3988))
 - `[Datepicker]` Added missing off screen text for the picker buttons in the datepicker month/year view. ([#4318](https://github.com/infor-design/enterprise/issues/4318))
 - `[Editor]` Fixed a bug where the Fontpicker's displayed style wasn't updating to match the current text selection in some cases. ([#4309](https://github.com/infor-design/enterprise/issues/4309))
+- `[Lookup]` Fixed an issue where the event `beforeShow` was only triggers one time. ([#899](https://github.com/infor-design/enterprise-ng/issues/899))
 - `[Locale]` Added a new translation token for Records Per Page with no number. ([#4334](https://github.com/infor-design/enterprise/issues/4334))
 - `[Searchfield]` Allow for search terms to include special characters. ([#4291](https://github.com/infor-design/enterprise/issues/4291))
 - `[Stepprocess]` Fixed a bug where padding and scrolling was missing. Note that this pattern will eventually be removed and we do not suggest any one use it for new development. ([#4249](https://github.com/infor-design/enterprise/issues/4249))

--- a/src/components/lookup/lookup.js
+++ b/src/components/lookup/lookup.js
@@ -284,6 +284,7 @@ Lookup.prototype = {
         }
 
         if (typeof grid === 'boolean' && grid === false) {
+          self.isOpen = false;
           return false;
         }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the event `beforeShow` was only triggers one time with Lookup.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#899

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/lookup/test-beforeshow-cancel.html
- Click on the lookup icon
- Toast shows (but lookup modal should not open)
- Click as many times, it should show toast every time it clicked

Test in NG
- Pull and build this branch
- Pull and build ([NG master](https://github.com/infor-design/enterprise-ng.git))
- Copy and replace "dist" folder from `enterprise` to `⁨enterprise-ng⁩/node_modules⁩/ids-enterprise`
- Run NG demo app
- Navigate to http://localhost:4200/ids-enterprise-ng-demo/lookup
- Use lookup label as `Products (Cancel Before Open)`
- Click on the lookup icon
- Toast shows (but lookup modal should not open)
- Click as many times, it should show toast every time it clicked

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
