### PR TITLE
1812 - Fix short field icon padding in rtl with lookup

### DIFF
--- a/app/views/components/lookup/test-short-field-custom.html
+++ b/app/views/components/lookup/test-short-field-custom.html
@@ -1,0 +1,15 @@
+<div class="row top-padding">
+  <div class="six columns">
+    <h2>Lookup:  Short Field</h2>
+    <p>Custom width "54px" and two character value, also test in RTL mode</p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="five columns">
+    <div class="field-short">
+      <label for="lookup-custom">Lookup Field</label>
+      <input id="lookup-custom" class="lookup" value="DA" type="text" style="width: 54px;">
+    </div>
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### v4.33.0 Fixes
 
 - `[Autocomplete]` Fix a bug when connected to NG where pressing the enter key would not select Autocomplete items/. ([ng#901](https://github.com/infor-design/enterprise-ng/issues/901))
+- `[Datagrid]` Fixed an issue where short field icon padding was misaligned in RTL mode. ([#1812](https://github.com/infor-design/enterprise/issues/1812))
 - `[Datagrid]` Added support to `In Range` filter operator for numeric columns. ([#3988](https://github.com/infor-design/enterprise/issues/3988))
 - `[Datepicker]` Added missing off screen text for the picker buttons in the datepicker month/year view. ([#4318](https://github.com/infor-design/enterprise/issues/4318))
 - `[Editor]` Fixed a bug where the Fontpicker's displayed style wasn't updating to match the current text selection in some cases. ([#4309](https://github.com/infor-design/enterprise/issues/4309))

--- a/src/components/lookup/_lookup.scss
+++ b/src/components/lookup/_lookup.scss
@@ -307,7 +307,7 @@ html[dir='rtl'] {
   }
 
   .lookup-wrapper .lookup {
-    padding-left: 35px;
+    padding-left: 22px;
     padding-right: 10px;
     text-align: right;
     text-overflow: ellipsis;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed short field icon padding was misaligned in RTL mode with Lookup.

**Related github/jira issue (required)**:
Closes #1812

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to:
- http://localhost:4000/components/lookup/test-short-field-custom.html?locale=ar-EG
- http://localhost:4000/components/lookup/test-short-field-custom.html?theme=uplift&variant=light&colors=0066D4&locale=ar-EG
- See lookup input text `DA` and icon should not overlap

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
