### PR TITLE
4275 - Add id setting to toast

### DIFF
--- a/app/views/components/toast/example-index.html
+++ b/app/views/components/toast/example-index.html
@@ -5,9 +5,13 @@
 </div>
 
 <script>
-
   $('#show-toast-message').on('click', function() {
-    $('body').toast({title: 'Application Offline', message: 'This is a Toast message.'});
+    $('body').toast({
+        title: 'Application Offline',
+        message: 'This is a Toast message.',
+        attributes: { name: 'id', value: function(args) {
+          return 'toast-id-' + args.toastIndex;
+        }}
+    });
   });
-
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v4.33.0
 
+### v4.33.0 Features
+
+- `[Toast]` Added a setting to enable setting ids or other attributes on the toast element. ([#4275](https://github.com/infor-design/enterprise/issues/4275))
+
 ### v4.33.0 Fixes
 
 - `[Autocomplete]` Fix a bug when connected to NG where pressing the enter key would not select Autocomplete items/. ([ng#901](https://github.com/infor-design/enterprise-ng/issues/901))

--- a/test/components/toast/toast-api.func-spec.js
+++ b/test/components/toast/toast-api.func-spec.js
@@ -112,4 +112,59 @@ describe('Toast API', () => {
     expect(container.getAttribute('class')).toContain('is-draggable');
     expect(container.getAttribute('style')).toContain(left);
   });
+
+  it('Should support setting attributes', () => {
+    let settings = {
+      title: 'Toast Title 2',
+      message: 'Toast Message 2',
+      timeout: 6000,
+      attributes: { name: 'id', value: 'my-unique-id' }
+    };
+
+    toastObj.updated(settings);
+    let container = document.body.querySelector('#my-unique-id');
+
+    expect(container.getAttribute('id')).toEqual('my-unique-id');
+
+    settings = {
+      title: 'Toast Title 2',
+      message: 'Toast Message 2',
+      timeout: 6000,
+      attributes: { name: 'data-automation-id', value: 'my-unique-id' }
+    };
+
+    toastObj.updated(settings);
+    container = document.body.querySelector('[data-automation-id="my-unique-id"]');
+
+    expect(container.getAttribute('data-automation-id')).toEqual('my-unique-id');
+  });
+
+  it('Should support setting attributes as a function', () => {
+    const settings = {
+      title: 'Toast Title 2',
+      message: 'Toast Message 2',
+      timeout: 6000,
+      attributes: { name: 'id', value: args => `toast-id-${args.toastIndex}` }
+    };
+
+    toastObj.updated(settings);
+    const container = document.body.querySelector('#toast-id-2');
+
+    expect(container.getAttribute('id')).toEqual('toast-id-2');
+  });
+
+  it('Should support setting attributes as an array', () => {
+    const settings = {
+      title: 'Toast Title 2',
+      message: 'Toast Message 2',
+      timeout: 6000,
+      attributes: [{ name: 'id', value: 'my-unique-id' }, { name: 'data-automation-id', value: 'my-unique-id' }]
+    };
+
+    toastObj.updated(settings);
+    const container = document.body.querySelector('#my-unique-id');
+
+    expect(container.getAttribute('id')).toEqual('my-unique-id');
+    expect(container.getAttribute('data-automation-id')).toEqual('my-unique-id');
+  });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adds the ability to set id's or arbitrary attribute on/in the toast API. This can be done by straight string or use a function that has the toast count in it. And you can set one or more at a time

**Related github/jira issue (required)**:
Fixes #4275

**Steps necessary to review your pull request (required)**:
- cases covered by tests but can be tested manually:
- go to http://localhost:4000/components/toast/example-index.html
- click show toast
- (quickly) inspect the DOM and notice an ID is appended

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
