### PR TITLE
874 - Fixed stack overflow when setting nb-NO

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Editor]` Fixed a bug where the Fontpicker's displayed style wasn't updating to match the current text selection in some cases. ([#4309](https://github.com/infor-design/enterprise/issues/4309))
 - `[Lookup]` Fixed an issue where the event `beforeShow` was only triggered the first time. ([#899](https://github.com/infor-design/enterprise-ng/issues/899))
 - `[Locale]` Added a new translation token for Records Per Page with no number. ([#4334](https://github.com/infor-design/enterprise/issues/4334))
+- `[Locale]` Fixed an max stack error when setting `nb-NO` as a language. ([#874](https://github.com/infor-design/enterprise-ng/issues/874))
 - `[Modal Manager]` Modals now pass `isCancelled` properly when the Modal Manager API detects a request to close by using the Escape key. ([#4298](https://github.com/infor-design/enterprise/issues/4298))
 - `[Searchfield]` Allow for search terms to include special characters. ([#4291](https://github.com/infor-design/enterprise/issues/4291))
 - `[Stepprocess]` Fixed a bug where padding and scrolling was missing. Note that this pattern will eventually be removed and we do not suggest any one use it for new development. ([#4249](https://github.com/infor-design/enterprise/issues/4249))

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -231,7 +231,7 @@ const Locale = {  // eslint-disable-line
       correctLanguage = 'he';
     }
     // Another special case
-    if (lang === 'nb' || lang === 'nn') {
+    if (lang === 'nb' || lang === 'nn' || lang === 'nb-NO' || lang === 'nn-NO') {
       correctLanguage = 'no';
     }
     return correctLanguage;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When nb-NO is used as a language (normal is to use the language `'nb`) then for some reason in angular you may get a max stack error. This fixes that issue.

**Related github/jira issue (required)**:
Fixes infor-design/enterprise-ng#874

**Steps necessary to review your pull request (required)**:
- build this branch
- copy it to a NG local running project (node_modules)
- edit src/app/datagrid/datagrid-dynamic.demo.ts so the constructor is
```
  constructor(
    private service: DataGridDemoService
  ) {

    Soho.Locale.setLanguage('nb-NO').done(function () {
     Soho.Locale.translate('AboutText');
    });
  }
```
- go to http://localhost:4200/ids-enterprise-ng-demo/datagrid-dynamic
- should not get an error in the console

**Included in this Pull Request**:
- [x] A note to the change log.
