### PR TITLE
4270 - Fix filter while type slow for treegrid with datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[Autocomplete]` Fix a bug when connected to NG where pressing the enter key would not select Autocomplete items/. ([ng#901](https://github.com/infor-design/enterprise-ng/issues/901))
 - `[Datagrid]` Fixed an issue where short field icon padding was misaligned in RTL mode. ([#1812](https://github.com/infor-design/enterprise/issues/1812))
 - `[Datagrid]` Added support to `In Range` filter operator for numeric columns. ([#3988](https://github.com/infor-design/enterprise/issues/3988))
+- `[Datagrid]` Fixed an issue where filter was not working if user types slow in the filter input for treegrid. ([#4270](https://github.com/infor-design/enterprise/issues/4270))
 - `[Datepicker]` Added missing off screen text for the picker buttons in the datepicker month/year view. ([#4318](https://github.com/infor-design/enterprise/issues/4318))
 - `[Editor]` Fixed a bug where the Fontpicker's displayed style wasn't updating to match the current text selection in some cases. ([#4309](https://github.com/infor-design/enterprise/issues/4309))
 - `[Lookup]` Fixed an issue where the event `beforeShow` was only triggered the first time. ([#899](https://github.com/infor-design/enterprise-ng/issues/899))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -2415,6 +2415,20 @@ Datagrid.prototype = {
           }
         }
       };
+      const setParents = function (nodeData) {
+        let found = false;
+        for (let i = 0, l = nodeData.length; i < l; i++) {
+          const node = nodeData[i];
+          if (node._isFilteredOut && !found && node.children?.length) {
+            node._isFilteredOut = !setParents(node.children);
+          }
+          if (typeof node._isFilteredOut === 'boolean' && !node._isFilteredOut) {
+            found = true;
+          }
+        }
+        return found;
+      };
+      setParents(s.dataset);
       checkNodes(s.dataset, 0);
     }
   },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed filter was not working if user types slow in the filter input for treegrid with Datagrid.

**Related github/jira issue (required)**:
Closes #4270

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/test-tree-filter.html
- Use filter for column `Order Date`
- Type slow `06/02/2014` (DO NOT: use picker, copy/paste, or type fast) and press enter
- Should show only two rows with id: 7 and 8 (row id: 7 - date not match but show, because parent node)

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
