### PR TITLE
900 - Fix activated row highlight with datagrid

### DIFF
--- a/app/views/components/datagrid/test-paging-select-serverside-mixed.html
+++ b/app/views/components/datagrid/test-paging-select-serverside-mixed.html
@@ -1,0 +1,68 @@
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid"></div>
+  </div>
+</div>
+
+<script id="test-script">
+  $('body').one('initialized', function () {
+
+    // Define Columns
+    var columns = [];
+    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center' });
+    columns.push({ id: 'rowStatus', sortable: false, resizable: false, formatter: Formatters.Status, align: 'center' });
+    columns.push({ id: 'id', name: 'Row Id', field: 'id', formatter: Formatters.Readonly });
+    columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink });
+    columns.push({ id: 'activity', name: 'Activity', field: 'activity' });
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, width: 120 });
+    columns.push({ id: '', name: '', field: '' });
+
+    var baseUrl = '{{basepath}}api/compressors';
+    $.getJSON(baseUrl + '?pageNum=1&pageSize=100', function(res) {
+      // Initialize the grid
+      $('#datagrid').datagrid({
+        columns: columns,
+        selectable: 'mixed',
+        paging: true,
+        pagesize: 7,
+        source: function(req, response) {
+          // Set url to get data
+          var url = baseUrl + '?pageNum='+ req.activePage +'&pageSize='+ req.pagesize;
+          if (req.sortField) {
+            url += '&sortField=' + req.sortField + '&sortAsc=' + req.sortAsc;
+          }
+          if (req.filterExpr && req.filterExpr[0]) {
+            url += '&filterValue=' + req.filterExpr[0].value;
+            url += '&filterOp=' + req.filterExpr[0].operator;
+            url += '&filterColumn=' + req.filterExpr[0].columnId;
+          }
+
+          // Get the data based on info in req, and return results into response.
+          $.getJSON(url, function(res) {
+            // This is the total going into the grid so the pager works (filtered total or total)
+            req.total = res.total;
+            if ((req.filterExpr && req.filterExpr[0])) {
+              req.total = res.total;
+              req.grandTotal = res.grandTotal; // This is the total amount on the server
+            }
+            response(res.data, req);
+          });
+        },
+        toolbar: { title: 'Compressors', results: true, actions: true, rowHeight: true, personalize: true }
+      })
+      .on('selected', function (e, args) {
+        console.log('Row Selected');
+      })
+      .on('rowactivated', function (e, args) {
+        console.log('Row Activated');
+        if (args && args.item && typeof args.item.id !== 'undefined') {
+          $('body').toast({
+            title: '',
+            message: 'Row Activated (Row Id: '+ args.item.id +')'
+          });
+        }
+      });
+    });
+
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### v4.33.0 Fixes
 
 - `[Autocomplete]` Fix a bug when connected to NG where pressing the enter key would not select Autocomplete items/. ([ng#901](https://github.com/infor-design/enterprise-ng/issues/901))
+- `[Datagrid]` Fixed an issue where activated row on 2nd or any subsequent page was not highlighting for mixed selection mode. ([ng#900](https://github.com/infor-design/enterprise-ng/issues/900))
 - `[Datagrid]` Fixed an issue where short field icon padding was misaligned in RTL mode. ([#1812](https://github.com/infor-design/enterprise/issues/1812))
 - `[Datagrid]` Added support to `In Range` filter operator for numeric columns. ([#3988](https://github.com/infor-design/enterprise/issues/3988))
 - `[Datagrid]` Fixed an issue where filter was not working if user types slow in the filter input for treegrid. ([#4270](https://github.com/infor-design/enterprise/issues/4270))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7798,7 +7798,7 @@ Datagrid.prototype = {
     let args = [{ row: idx, item: dataset[idx] }];
 
     const doRowactivated = () => {
-      const rowNodes = this.rowNodes(idx).toArray();
+      const rowNodes = s.paging && s.source && s.selectable === 'mixed' ? this.rowNodesByDataIndex(idx).toArray() : this.rowNodes(idx).toArray();
       rowNodes.forEach((rowElem) => {
         rowElem.classList.add('is-rowactivated');
       });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed activated row on 2nd or any subsequent page was not highlighting for mixed selection mode with Datagrid.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#900

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/test-paging-select-serverside-mixed.html
- Click any row in 1st page to make it active (blue background should apply)
- Goto 2nd or any subsequent page
- Click any row
- See it should make row active as 1st page (blue background should apply)

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
