### PR TITLE
4383 - Fix an error using arrow keys with pagesize selector

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[Locale]` Added a new translation token for Records Per Page with no number. ([#4334](https://github.com/infor-design/enterprise/issues/4334))
 - `[Locale]` Fixed an max stack error when setting `nb-NO` as a language. ([#874](https://github.com/infor-design/enterprise-ng/issues/874))
 - `[Modal Manager]` Modals now pass `isCancelled` properly when the Modal Manager API detects a request to close by using the Escape key. ([#4298](https://github.com/infor-design/enterprise/issues/4298))
+- `[Pager]` Fixed an error when using arrow keys to select in the pagesize selector. ([#4383](https://github.com/infor-design/enterprise/issues/4383))
 - `[Searchfield]` Allow for search terms to include special characters. ([#4291](https://github.com/infor-design/enterprise/issues/4291))
 - `[Stepprocess]` Fixed a bug where padding and scrolling was missing. Note that this pattern will eventually be removed and we do not suggest any one use it for new development. ([#4249](https://github.com/infor-design/enterprise/issues/4249))
 - `[Tabs]` Fixed multiple bugs where error icon in tabs and the animation bar were not properly aligned in RTL uplift theme. ([#4326](https://github.com/infor-design/enterprise/issues/4326))

--- a/src/components/accordion/_accordion-mixins.scss
+++ b/src/components/accordion/_accordion-mixins.scss
@@ -3,6 +3,7 @@
 
 // Left-to-Right
 //================================================== //
+
 @mixin left-align-cascade-styles-header($a-padding, $icon-margin, $width, $li-padding) {
   > a {
     padding-left: $a-padding;

--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -452,7 +452,7 @@ Pager.prototype = {
 
     self.pagerBar.on('keydown.pager', $(self.focusableElements), (event) => {
       if ($('.popupmenu.is-open').length > 0) {
-        return;
+        return true;
       }
 
       event = event || window.event;

--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -451,6 +451,10 @@ Pager.prototype = {
     });
 
     self.pagerBar.on('keydown.pager', $(self.focusableElements), (event) => {
+      if ($('.popupmenu.is-open').length > 0) {
+        return;
+      }
+
       event = event || window.event;
       const key = event.which || event.keyCode || event.charCode || false;
       let isLeft = key === 37 || key === 40;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Using the arrow key in the page size selector threw an error. This is because the pager's keyboard logic is triggered.


**Related github/jira issue (required)**:
Fixes #4383

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-editable.html
- open the page size selector
- use arrow up and down and the enter to select
- ensure you can still use arrow keys across the pager toolbar

**Included in this Pull Request**:
- [x] A note to the change log.
