### PR TITLE
4355 - Fix icons right text alignment with datagrid

### DIFF
--- a/app/views/components/datagrid/test-alerts-right-align.html
+++ b/app/views/components/datagrid/test-alerts-right-align.html
@@ -1,0 +1,55 @@
+
+<div class="row">
+  <div class="full-width">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    var data = [];
+    var columns = [];
+
+    // Some Sample Data
+    data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action' });
+    data.push({ id: 2, productId: 2241202, productName: '1 Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold' });
+    data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action' });
+    data.push({ id: 4, productId: 2445204, productName: '1 Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action' });
+    data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold' });
+    data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold' });
+    data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold' });
+
+    // Define Columns for the Grid.
+    columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Readonly });
+    columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink, href: 'http://www.google.com' });
+    columns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity' });
+    columns.push({ id: 'alert', name: 'Alert w Text', field: 'quantity', align: 'right', formatter: Formatters.Alert, ranges: [{ 'min': 0, 'max': 8, 'classes': 'info', 'text': ' Alert Text' }, { 'min': 9, 'max': 1000, 'classes': 'error', 'text': ' Alert Text' }]});
+    columns.push({ id: 'price', name: 'Alert Choose Header', field: 'price', formatter: Formatters.Alert, ranges: [{ 'min': 0, 'max': 150, 'classes': 'success', text: ' ' }, { 'min': 151, 'max': 9999, 'classes': 'error', text: ' ' }]});
+    columns.push({ id: 'price2', name: 'Alert', field: 'price', align: 'center', formatter: Formatters.Alert, ranges: [{ 'min': 0, 'max': 150, 'classes': 'success', text: ' ' }, { 'min': 151, 'max': 9999, 'classes': 'alert', text: ' ' }]});
+    columns.push({ id: 'quantity', name: 'Badge', field: 'quantity', align: 'center', formatter: Formatters.Badge, sortable: false, ranges: [{ 'min': 0, 'max': 2, 'classes': 'error' }, { 'value': 41, 'classes': 'good' }]});
+    columns.push({ id: 'price3', name: 'Tag', field: 'price', align: 'center', formatter: Formatters.Tag, ranges: [{ 'min': 151, 'max': 9999, 'classes': 'info' }]});
+    columns.push({ id: 'price4', name: 'Tag (Clickable)', field: 'price', align: 'center', formatter: Formatters.Tag, editorOptions: { clickable: true }, ranges: [{ 'min': 151, 'max': 9999, 'classes': 'info' }]});
+    columns.push({ id: 'price5', name: 'Price', field: 'price', formatter: Formatters.Decimal });
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy' });
+
+    // Init and get the api for the grid
+    $('#datagrid').datagrid({
+      columns: columns,
+      dataset: data,
+      enableTooltips: true,
+      selectable: 'single',
+      cellNavigation: false,
+      clickToSelect: true,
+      columnSizing: 'data',
+      frozenColumns: {
+        left: ['productId']
+      },
+      toolbar: {title: 'Data Grid Header Title', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: true,  collapsibleFilter: true}
+    }).on('click', function (e, args) {
+      if (args) {
+        $('body').toast({ title: 'Row ' + args.row + ' was clicked', message: 'Tag Data: ' + args.cellElem.text().trim() });
+      }
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Datagrid]` Fixed an issue where short field icon padding was misaligned in RTL mode. ([#1812](https://github.com/infor-design/enterprise/issues/1812))
 - `[Datagrid]` Added support to `In Range` filter operator for numeric columns. ([#3988](https://github.com/infor-design/enterprise/issues/3988))
 - `[Datagrid]` Fixed an issue where filter was not working if user types slow in the filter input for treegrid. ([#4270](https://github.com/infor-design/enterprise/issues/4270))
+- `[Datagrid]` Fixed an issue where the icons right text was truncated for extra-small row height. ([#4355](https://github.com/infor-design/enterprise/issues/4355))
 - `[Datagrid]` Fixed an issue where using flex toolbar as a custom toolbar did not work. ([#4385](https://github.com/infor-design/enterprise/issues/4385))
 - `[Datepicker]` Added missing off screen text for the picker buttons in the datepicker month/year view. ([#4318](https://github.com/infor-design/enterprise/issues/4318))
 - `[Editor]` Fixed a bug where the Fontpicker's displayed style wasn't updating to match the current text selection in some cases. ([#4309](https://github.com/infor-design/enterprise/issues/4309))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1932,6 +1932,10 @@ $datagrid-small-row-height: 25px;
       width: inherit;
     }
 
+    .l-right-text .datagrid-alert-text {
+      margin-right: auto;
+    }
+
     .datagrid-alert-icon {
       display: inline-block;
       height: 20px;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed icons right text alignment for extra-small row height with Datagrid.

**Related github/jira issue (required)**:
Closes #4355

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/test-alerts-right-align.html
- Change row height to extra-small
- Make the column `Alert w Text` width wider
- See column text should not be truncated

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
