### PR TITLE
4259 - Fix error after reset form with validation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `[Toolbar Flex]` Fixed detection of overflow in some toolbars where items were not properly displaying all overflowed items in the "More Actions" menu. ([#4296](https://github.com/infor-design/enterprise/issues/4296))
 - `[Tree]` Fixed an issue where calling togglenode without first doing a select/unselect was not working properly. ([#3927](https://github.com/infor-design/enterprise/issues/3927))
 - `[Tree]` Fixed a bug that adding icons in with the tree text would encode it when using addNode. ([#4305](https://github.com/infor-design/enterprise/issues/4305))
+- `[Validation]` Fixed an issue where after the execution `resetForm()` was not resting dropdown and editor the fields. ([#4259](https://github.com/infor-design/enterprise/issues/4259))
 
 ## v4.32.0
 

--- a/src/components/validation/validator.js
+++ b/src/components/validation/validator.js
@@ -1082,7 +1082,7 @@ Validator.prototype = {
    * @param {jQuery[]} form The form to reset.
    */
   resetForm(form) {
-    const formFields = form.find('input, select, textarea');
+    const formFields = form.find('input, select, textarea, div.dropdown, div.editor');
 
     // Clear Errors
     formFields.removeClass('error');
@@ -1120,6 +1120,8 @@ Validator.prototype = {
     Object.keys(validationTypes).forEach((validationType) => {
       formFields.removeData(`${validationType}message`);
     });
+
+    formFields.removeData('isValid');
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed after the execution resetForm() was not resting dropdown and editor the fields with Validation.

**Related github/jira issue (required)**:
Closes #4259

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/validation/example-validation-form.html
- Open developer tools
- Select the blank item in dropdown `State` and click anywhere to trigger the validation
- Run in console as below
- `$('body').resetForm();` it should remove validation error
- `$('#states').data();`, it should return `dropdown` api which should NOT contain key/value for `isValid`
- `$('div.dropdown').data();`, it should return `{}` empty
- Select again the blank item in dropdown `State` and click anywhere to trigger the validation
- Should show again the validation error-icon and error-text

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
