### PR TITLE
4411 - Fix incorrect stripping of b tags in the editor

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `[Datagrid]` Fixed an issue where using flex toolbar as a custom toolbar did not work. ([#4385](https://github.com/infor-design/enterprise/issues/4385))
 - `[Datepicker]` Added missing off screen text for the picker buttons in the datepicker month/year view. ([#4318](https://github.com/infor-design/enterprise/issues/4318))
 - `[Editor]` Fixed a bug where the Fontpicker's displayed style wasn't updating to match the current text selection in some cases. ([#4309](https://github.com/infor-design/enterprise/issues/4309))
+- `[Editor]` Fixed a bug where b tags in an empty p tag would be stripped. ([#4411](https://github.com/infor-design/enterprise/issues/4411))
 - `[Lookup]` Fixed an issue where the event `beforeShow` was only triggered the first time. ([#899](https://github.com/infor-design/enterprise-ng/issues/899))
 - `[Locale]` Added a new translation token for Records Per Page with no number. ([#4334](https://github.com/infor-design/enterprise/issues/4334))
 - `[Locale]` Fixed an max stack error when setting `nb-NO` as a language. ([#874](https://github.com/infor-design/enterprise-ng/issues/874))

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -1914,7 +1914,7 @@ Editor.prototype = {
     s = s.replace(/<head\b[^>]*>(.*?)<\/head>/gi, '');
 
     // Remove empty tags
-    s = s.replace(/<[^/>]+>[\s]*<\/[^>]+>/gi, '');
+    s = s.replace(/<[^(br|/>)]+>[\s]*<\/[^>]+>/gi, '');
 
     if (s.indexOf('·') > -1) {
       // Replace span and paragraph tags from bulleted list pasting


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

**Related github/jira issue (required)**:
Fixes #4411 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/editor/example-index.html
- click at the end of the first paragraph and hit enter
- switch to the visual view
- switch back -> See that the formating is the same as previous
- test scenarios of stripping empty tags

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
