### PR TITLE
3559 - Fix Colorpicker selection issue

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### v4.33.0 Fixes
 
 - `[Autocomplete]` Fix a bug when connected to NG where pressing the enter key would not select Autocomplete items/. ([ng#901](https://github.com/infor-design/enterprise-ng/issues/901))
+- `[Colorpicker]` Fixed an issue where the colorpicker closes when pressing or clicking outside the swatch. ([#3559](https://github.com/infor-design/enterprise/issues/3559))
 - `[Datagrid]` Fixed an issue where activated row on 2nd or any subsequent page was not highlighting for mixed selection mode. ([ng#900](https://github.com/infor-design/enterprise-ng/issues/900))
 - `[Datagrid]` Added support to disable column buttons. ([1590](https://github.com/infor-design/enterprise/issues/1590))
 - `[Datagrid]` Fixed an issue where short field icon padding was misaligned in RTL mode. ([#1812](https://github.com/infor-design/enterprise/issues/1812))

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -1841,7 +1841,9 @@ PopupMenu.prototype = {
         }
 
         if ($(thisE.target).hasClass('swatch')) {
-          self.close();
+          setTimeout(() => {
+            self.close();
+          }, 150);
         }
       });
 

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -1840,7 +1840,7 @@ PopupMenu.prototype = {
           self.close(true, self.settings.trigger === 'rightClick');
         }
 
-        if ($(thisE.target).hasClass('colorpicker')) {
+        if ($(thisE.target).hasClass('swatch')) {
           self.close();
         }
       });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed an issue where the Colorpicker closes when pressing or clicking outside the swatch but inside the colorpicker popup.

**Related github/jira issue (required)**:
closes #3559 

**Steps necessary to review your pull request (required)**:
- Pull and run branch
- Go to http://localhost:4000/components/colorpicker/example-index.html 
- Click on the whitespace in between or outside of the swatches.
- The Colorpicker should stay open.
- Click on a swatch and the Colorpicker should behave as expected.

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
