### PR TITLE
4418 - Fix flex toolbar tabbing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `[Tabs]` Fixed a bug where removing a nested tab would cause an error due to being invisible. ([#4356](https://github.com/infor-design/enterprise/issues/4356))
 - `[Tabs]` Fixed a bug where the focus/activated state does not display correctly in RTL. ([#4332](https://github.com/infor-design/enterprise/issues/4332))
 - `[Toolbar Flex]` Fixed detection of overflow in some toolbars where items were not properly displaying all overflowed items in the "More Actions" menu. ([#4296](https://github.com/infor-design/enterprise/issues/4296))
+- `[Toolbar Flex]` Fixed an issue where in some examples/cases the first item did not get an initial tabindex. ([#4418](https://github.com/infor-design/enterprise/issues/4418))
 - `[Tree]` Fixed an issue where calling togglenode without first doing a select/unselect was not working properly. ([#3927](https://github.com/infor-design/enterprise/issues/3927))
 - `[Tree]` Fixed a bug that adding icons in with the tree text would encode it when using addNode. ([#4305](https://github.com/infor-design/enterprise/issues/4305))
 - `[Validation]` Fixed an issue where after the execution `resetForm()` was not resting dropdown and editor the fields. ([#4259](https://github.com/infor-design/enterprise/issues/4259))

--- a/src/components/toolbar-flex/toolbar-flex.js
+++ b/src/components/toolbar-flex/toolbar-flex.js
@@ -93,6 +93,7 @@ ToolbarFlex.prototype = {
       if (!this.focusedItem) {
         this.focusedItem = this.items[0];
       }
+      this.focusedItem.focused = true;
     }
 
     this.render();

--- a/src/components/toolbar-flex/toolbar-flex.js
+++ b/src/components/toolbar-flex/toolbar-flex.js
@@ -93,7 +93,9 @@ ToolbarFlex.prototype = {
       if (!this.focusedItem) {
         this.focusedItem = this.items[0];
       }
-      this.focusedItem.focused = true;
+      if (this.focusedItem) {
+        this.focusedItem.focused = true;
+      }
     }
 
     this.render();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Found that in this example the tabindex is not set on the initial item. This is actually (at least partly) because if updated is called it will reset the tabindex. Applied a fix

**Related github/jira issue (required)**:
Fixes #4418

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/header/example-flex-toolbar.html
- tab to toolbar - you should hit the hamburger and it should show

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
