### PR TITLE
4420 - Correct back color and exit early

### DIFF
--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -3555,6 +3555,12 @@ td .btn-actions {
       @include trigger-icon-background($datagrid-row-hover-color);
     }
 
+    &.error:hover .icon,
+    &.error.icon,
+    &.datagrid-trigger-cell.error .icon {
+      @include trigger-icon-background(transparent);
+    }
+
     &.is-editing:hover .icon {
       @include trigger-icon-background($datagrid-cell-bg-color);
     }

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -189,6 +189,7 @@ Toast.prototype = {
       setting.forEach((item) => {
         elem.attr(item.name, item.value);
       });
+      return;
     }
     const value = typeof setting.value === 'function' ? setting.value(this) : setting.value;
     elem.attr(setting.name, value);

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -187,10 +187,12 @@ Toast.prototype = {
 
     if (Array.isArray(setting)) {
       setting.forEach((item) => {
-        elem.attr(item.name, item.value);
+        const value = typeof item.value === 'function' ? item.value(this) : item.value;
+        elem.attr(item.name, value);
       });
       return;
     }
+
     const value = typeof setting.value === 'function' ? setting.value(this) : setting.value;
     elem.attr(setting.name, value);
   },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixed a comment on https://github.com/infor-design/enterprise/commit/54c5234d128dce769d64056d141ed0c30abfa9ca#commitcomment-42722706 and fixed an issue with the background color and errors on a recent fix

**Related github/jira issue (required)**:
Fixes #4420

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-editable.html
- make the order date have an error by existing after edit mode
- try hovering and making sure the background color doesnt bleed
