### PR TITLE
Fix side bar height in responsive mode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### v4.34.0 Fixes
 
 - `[Favorites]` Removed the favorites component as its not really a component, info on it can be found under buttons in the toggle example. ([#4405](https://github.com/infor-design/enterprise/issues/4405))
-- `[List Detail]` Fixed css height for list detail in responsive view
+- `[List Detail]` Fixed css height for list detail in responsive view ([#4426](https://github.com/infor-design/enterprise/issues/4426))
 
 ## v4.33.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### v4.34.0 Fixes
 
 - `[Favorites]` Removed the favorites component as its not really a component, info on it can be found under buttons in the toggle example. ([#4405](https://github.com/infor-design/enterprise/issues/4405))
+- `[List Detail]` Fixed css height for list detail in responsive view
 
 ## v4.33.0
 

--- a/src/components/page-layouts/_layouts.scss
+++ b/src/components/page-layouts/_layouts.scss
@@ -353,8 +353,8 @@ body.no-scroll {
       > .main,
       > .sidebar {
         display: block;
-        width: 100%; // Override Inline Css
         height: 100%;
+        width: 100%; // Override Inline Css
       }
     }
 

--- a/src/components/page-layouts/_layouts.scss
+++ b/src/components/page-layouts/_layouts.scss
@@ -354,6 +354,7 @@ body.no-scroll {
       > .sidebar {
         display: block;
         width: 100%; // Override Inline Css
+        height: 100%;
       }
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This fixes the height for the sidebar of a list detail in responsive view.

**Related github/jira issue (required)**:
Closes #4426 

**Steps necessary to review your pull request (required)**:
1. Go to http://localhost:4000/components/page-patterns/example-list-detail-search-paging.html?theme=uplift&variant=light
2. Shrink window down to responsive view
3. Notice the paging bar

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
