### PR TITLE
4429 - Add a fix for setfocus and arrow keys

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### v4.34.0 Fixes
 
 - `[Datagrid]` Fixed an issue where the double click event was not firing for checkbox columns. ([#4381](https://github.com/infor-design/enterprise/issues/4381))
+- `[Datagrid]` Fixed an issue where calling setFocus on the datagrid would stop open menus from working. ([#4429](https://github.com/infor-design/enterprise/issues/4429))
 - `[Favorites]` Removed the favorites component as its not really a component, info on it can be found under buttons in the toggle example. ([#4405](https://github.com/infor-design/enterprise/issues/4405))
 
 ## v4.33.0

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10372,7 +10372,7 @@ Datagrid.prototype = {
       self.activeCell = prevCell;
     }
 
-    if ((!$('input, button:not(.btn-secondary, .row-btn, .datagrid-expand-btn, .datagrid-drilldown, .btn-icon)', self.activeCell.node).length) || (self.activeCell.node.is('.has-btn-actions') && self.activeCell.node.find('.btn-actions').length)) {
+    if ((!$('input, select, button:not(.btn-secondary, .row-btn, .datagrid-expand-btn, .datagrid-drilldown, .btn-icon)', self.activeCell.node).length) || (self.activeCell.node.is('.has-btn-actions') && self.activeCell.node.find('.btn-actions').length)) {
       self.activeCell.node.focus();
       if (isGroupRow) {
         self.activeCell.groupNode = self.activeCell.node;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Added PR for contribution / fix as noted on https://github.com/infor-design/enterprise/issues/4429

**Related github/jira issue (required)**:
Fixes #4429

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-editable.html
- Click dropdown cell on first row (column/cell 9) - up/down arrow and it works fine
- Open up DevTools and in the developer console type:-
```
$('#datagrid').data('datagrid').setActiveCell(0, 9)
```
- Click back into browser with grid and attempt to use up/down keys on the list. Notice that the up/down arorw is working now

**Included in this Pull Request**:
- [x] A note to the change log.
