### PR TITLE
4332 - Fix the position of animated bar when more button is visible (RTL)

### DIFF
--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -3499,7 +3499,7 @@ Tabs.prototype = {
       (paddingRight + target.position().left + target.outerWidth(true)) : (target.position().left);
 
     if (Locale.isRTL()) {
-      style.right = `${tablistScrollWidth + paddingRight -  (left + tablistScrollLeft) - tabListDifferWidth}px`;
+      style.right = `${tablistScrollWidth + paddingRight - (left + tablistScrollLeft) - tabListDifferWidth}px`;
     } else {
       style.left = `${left + tablistScrollLeft}px`;
     }

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -3484,6 +3484,7 @@ Tabs.prototype = {
     const scrollingTablist = this.tablistContainer;
     const tablistScrollLeft = scrollingTablist[0].scrollLeft;
     const tablistScrollWidth = scrollingTablist[0].scrollWidth;
+    const tabListDifferWidth = tablistScrollWidth - this.tablistContainer[0].offsetWidth;
 
     const targetStyle = window.getComputedStyle(target[0], null);
     let paddingRight = parseInt(targetStyle.getPropertyValue('padding-right'), 10) || 0;
@@ -3498,7 +3499,7 @@ Tabs.prototype = {
       (paddingRight + target.position().left + target.outerWidth(true)) : (target.position().left);
 
     if (Locale.isRTL()) {
-      style.right = `${tablistScrollWidth + paddingRight - (left + tablistScrollLeft)}px`;
+      style.right = `${tablistScrollWidth + paddingRight -  (left + tablistScrollLeft) - tabListDifferWidth}px`;
     } else {
       style.left = `${left + tablistScrollLeft}px`;
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This is a follow up fix for https://github.com/infor-design/enterprise/issues/4332. When `tab-more` element is visible, the animated bar is not correctly position in their respective tab when selected.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/4332
Related/Previous PR https://github.com/infor-design/enterprise/pull/4397

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/tabs/example-index.html?theme=uplift&variant=light&colors=0066D4&locale=ar-EG
- Resize the page until the `tab-more` el will show
- The animated bar should perfectly position to the selected tab
- Even if you play around via resizing the page, it should stay still

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
