### PR TITLE
4437 - Add localization to charts

### DIFF
--- a/app/views/components/line/example-localize.html
+++ b/app/views/components/line/example-localize.html
@@ -1,0 +1,47 @@
+<div class="row">
+  <div class="two-thirds column">
+    <h2 class="widget-title">Line Chart &mdash; Localized</h2>
+    <p>Change the URL to see localized data (for example add ?locale=de-DE)</p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="two-thirds column">
+      <div class="widget">
+        <div class="widget-header">
+          <h2 class="widget-title">Line Chart Title</h2>
+        </div>
+        <div class="widget-content">
+          <div id="line-example" class="chart-container">
+          </div>
+        </div>
+      </div>
+  </div>
+</div>
+
+<script>
+$('body').on('initialized', function () {
+
+  var  dataset = [{
+    "name": "Figures",
+    "data": [
+      {"name": "Q1", "value": 10011.8 },
+      {"name": "Q2", "value": 10011 },
+      {"name": "Q3", "value": 1051.1 },
+      {"name": "Q4", "value": 2050.50 }
+    ]
+  }];
+
+  $('#line-example').chart({
+    type: 'line',
+    animate: false,
+    dataset: dataset,
+    yAxis: {
+      ticks: {
+        number: 3,
+      }
+    }
+  });
+
+});
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.34.0
 
-### v4.33.0 Features
+### v4.34.0 Features
 
 - `[Locale/Charts]` The numbers inside charts are now formatted using the current locale's, number settings. This can be disabled/changed in some charts by passing in a localeInfo object to override the default settings. ([#4437](https://github.com/infor-design/enterprise/issues/4437))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v4.34.0
 
+### v4.33.0 Features
+
+- `[Locale/Charts]` The numbers inside charts are now formatted using the current locale's, number settings. This can be disabled/changed in some charts by passing in a localeInfo object to override the default settings. ([#4437](https://github.com/infor-design/enterprise/issues/4437))
+
 ### v4.34.0 Fixes
 
 - `[Datepicker]` Fixed an issue where range highlight was not aligning for Mac/Safari. ([#4352](https://github.com/infor-design/enterprise/issues/4352))

--- a/src/components/bar/bar.js
+++ b/src/components/bar/bar.js
@@ -33,7 +33,7 @@ const COMPONENT_NAME = 'bar';
  * @param {number} [settings.labelFactor=1.27] How far out than the outer circle should the labels be placed, this
  * may be useful to adjust for some labels.
  * @param {number} [settings.wrapWidth=60] The number of pixels after which a label needs to be given a new line.
- * @pram {boolean} [settings.fitHeight=true] If true chart height will fit in parent available height.
+ * @param {boolean} [settings.fitHeight=true] If true chart height will fit in parent available height.
  * You may want to change this based on label data.
  * @param {object} [settings.emptyMessage={
  *  title: (Locale ? Locale.translate('NoData') : 'No Data Available'),
@@ -45,6 +45,7 @@ const COMPONENT_NAME = 'bar';
  *  icon: 'icon-empty-no-data',
  *  button: {text: 'xxx', click: <function>}  }`
  * Set this to null for no message or will default to 'No Data Found with an icon.'
+ * @param {object} [settings.localeInfo] If passed in you can override the default formatting https://github.com/d3/d3-format/blob/master/README.md#formatDefaultLocale
  */
 const BAR_DEFAULTS = {
   dataset: [],
@@ -89,6 +90,11 @@ Bar.prototype = {
     this.namespace = utils.uniqueId({ classList: [this.settings.type, 'chart'] });
     this.width = 0;
     this.initialSelectCall = false;
+
+    if (this.settings.localeInfo) {
+      d3.formatDefaultLocale(this.settings.localeInfo);
+    }
+
     this
       .build()
       .handleEvents();
@@ -120,7 +126,7 @@ Bar.prototype = {
     const parent = this.element.parent();
     const isPersonalizable = this.element.closest('.is-personalizable').length > 0;
     const isFormatter = !!s.formatterString;
-    const format = value => (isFormatter ? d3.format(s.formatterString)(value) : value);
+    const format = value => d3.format(self.settings.formatterString || ',')(value);
 
     let maxTextWidth;
     let largestText;

--- a/src/components/column/column.js
+++ b/src/components/column/column.js
@@ -28,7 +28,7 @@ const COMPONENT_NAME = 'column';
 * @param {string} [settings.format = null] The d3 axis format
 * @param {string} [settings.formatterString] Use d3 format some examples can be found on http://bit.ly/1IKVhHh
 * @param {number} [settings.ticks = 9] The number of ticks to show.
-* @pram {boolean} [settings.fitHeight=true] If true chart height will fit in parent available height.
+* @param {boolean} [settings.fitHeight=true] If true chart height will fit in parent available height.
 * @param {function} [settings.xAxis.formatText] A function that passes the text element and a counter.
 * You can return a formatted svg markup element to replace the current element.
 * For example you could use tspans to wrap the strings or color them.
@@ -41,6 +41,7 @@ const COMPONENT_NAME = 'column';
 *   button: {text: 'xxx', click: <function>
 *   }`
 * Set this to null for no message or will default to 'No Data Found with an icon.'
+* @param {object} [settings.localeInfo] If passed in you can override the default formatting https://github.com/d3/d3-format/blob/master/README.md#formatDefaultLocale
 */
 
 const COLUMN_DEFAULTS = {
@@ -79,6 +80,10 @@ Column.prototype = {
     this.width = 0;
     this.initialSelectCall = false;
 
+    if (this.settings.localeInfo) {
+      d3.formatDefaultLocale(this.settings.localeInfo);
+    }
+
     this
       .build()
       .handleEvents();
@@ -99,10 +104,7 @@ Column.prototype = {
   build() {
     const self = this;
     const isPersonalizable = this.element.closest('.is-personalizable').length > 0;
-    const isFormatter = !!this.settings.formatterString;
-    const format = function (value) {
-      return isFormatter ? d3.format(self.settings.formatterString)(value) : value;
-    };
+    const format = value => d3.format(self.settings.formatterString || ',')(value);
 
     let datasetStacked;
     const dataset = this.settings.dataset;

--- a/src/components/completion-chart/completion-chart.js
+++ b/src/components/completion-chart/completion-chart.js
@@ -110,7 +110,7 @@ CompletionChart.prototype = {
       if (formatterString === '.0%') {
         return localePercent(toPercent(value, ds));
       }
-      return d3.format(formatterString || '')(value);
+      return d3.format(formatterString || 'm')(value);
     };
 
     const fixPercent = function (value, ds) {

--- a/src/components/line/line.js
+++ b/src/components/line/line.js
@@ -19,14 +19,13 @@ const COMPONENT_NAME = 'line';
  * @class Line
  * @param {string} element The plugin element for the constuctor
  * @param {string} [settings] The settings element.
- *
  * @param {array} [settings.dataset=[]] The data to use in the line/area/bubble.
  * @param {function|string} [settings.tooltip] A custom tooltip or tooltip renderer function
  * for the whole chart.
  * @param {string} [settings.isArea] Render as an area chart.
  * @param {string} [settings.isBubble=false] Render as a bubble chart.
  * @param {string} [settings.isScatterPlot=false] Render as a Scatter Plot Chart.
-* @param {string} [settings.showLegend=true] If false the label will not be shown.
+ * @param {string} [settings.showLegend=true] If false the label will not be shown.
  * @param {object} [settings.xAxis] A series of options for the xAxis
  * @param {number} [settings.xAxis.rotate] Rotate the elements on the x axis.
  * Recommend -65 deg but this can be tweaked depending on look.
@@ -50,7 +49,7 @@ const COMPONENT_NAME = 'line';
  * the size on hover and stroke or even add a custom class.
  * Example `dots: { radius: 3, radiusOnHover: 4, strokeWidth: 0, class: 'custom-dots'}`
  * @param {string} [settings.formatterString] Use d3 format some examples can be found on http://bit.ly/1IKVhHh
- * @pram {boolean} [settings.fitHeight=true] If true chart height will fit in parent available height.
+ * @param {boolean} [settings.fitHeight=true] If true chart height will fit in parent available height.
  * @param {object} [settings.emptyMessage] An empty message will be displayed when there is no chart data.
  * This accepts an object of the form emptyMessage:
  * `{title: 'No Data Available',
@@ -58,6 +57,7 @@ const COMPONENT_NAME = 'line';
  *  button: {text: 'xxx', click: <function>}
  *  }`
  *  Set this to null for no message or will default to 'No Data Found with an icon.'
+ * @param {object} [settings.localeInfo] If passed in you can override the default formatting https://github.com/d3/d3-format/blob/master/README.md#formatDefaultLocale
  */
 const LINE_DEFAULTS = {
   dataset: [],
@@ -91,6 +91,11 @@ Line.prototype = {
   init() {
     this.namespace = utils.uniqueId({ classList: [this.settings.type, 'chart'] });
     this.initialSelectCall = false;
+
+    if (this.settings.localeInfo) {
+      d3.formatDefaultLocale(this.settings.localeInfo);
+    }
+
     this
       .build()
       .handleEvents();
@@ -121,8 +126,7 @@ Line.prototype = {
     const self = this;
     const s = this.settings;
     const isPersonalizable = this.element.closest('.is-personalizable').length > 0;
-    const isFormatter = !!s.formatterString;
-    const format = value => (isFormatter ? d3.format(s.formatterString)(value) : value);
+    const format = value => d3.format(s.formatterString || ',')(value);
 
     // Add css class
     let cssClass = 'line-chart';

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -517,8 +517,8 @@ const Locale = {  // eslint-disable-line
         decimal: data?.numbers?.decimal || '.',
         thousands: data?.numbers?.group || ',',
         grouping: data?.numbers?.groupSizes || [3],
-        currency: data?.currencySign || '$',
         percent: data?.numbers?.percentSign || '%',
+        currency: !data?.currencySign ? ['$', ''] : data.currencyFormat.split('¤')[0] === '' ? [data.currencySign, ''] : ['', data.currencySign],
         minus: data?.numbers?.minusSign || '-'
       });
     }

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -514,12 +514,12 @@ const Locale = {  // eslint-disable-line
 
       // Set the d3 locale for charts (unless disabled)
       d3.formatDefaultLocale({
-        decimal: data.numbers.decimal,
-        thousands: data.numbers.group,
-        grouping: data.numbers.groupSizes,
-        currency: data.currencySign,
-        percent: data.numbers.percentSign,
-        minus: data.numbers.minusSign
+        decimal: data?.numbers?.decimal || '.',
+        thousands: data?.numbers?.group || ',',
+        grouping: data?.numbers?.groupSizes || [3],
+        currency: data?.currencySign || '$',
+        percent: data?.numbers?.percentSign || '%',
+        minus: data?.numbers?.minusSign || '-'
       });
     }
   },

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -9,6 +9,7 @@ import { ummalquraData } from './info/umalqura-data';
 // culture files. This allows manually setting the directory for the culture files.
 let existingCulturePath = '';
 let minifyCultures = false;
+
 if (typeof window.SohoConfig === 'object') {
   if (typeof window.SohoConfig.culturesPath === 'string') {
     existingCulturePath = window.SohoConfig.culturesPath;
@@ -510,6 +511,16 @@ const Locale = {  // eslint-disable-line
           nativeName: data.nativeName
         };
       }
+
+      // Set the d3 locale for charts (unless disabled)
+      d3.formatDefaultLocale({
+        decimal: data.numbers.decimal,
+        thousands: data.numbers.group,
+        grouping: data.numbers.groupSizes,
+        currency: data.currencySign,
+        percent: data.numbers.percentSign,
+        minus: data.numbers.minusSign
+      });
     }
   },
 

--- a/src/components/pie/pie.js
+++ b/src/components/pie/pie.js
@@ -42,7 +42,7 @@ const COMPONENT_NAME = 'pie';
  * @param {string} [settings.tooltip.show='label (value)'] Controls what is visible in
   the tooltip, this can be value, label or percent or custom function.
  * @param {string} [settings.tooltip.formatter='.0f'] The d3.formatter string.
- * @pram {boolean} [settings.fitHeight=true] If true chart height will fit in parent available height.
+ * @param {boolean} [settings.fitHeight=true] If true chart height will fit in parent available height.
  * @param {object} [settings.emptyMessage] An empty message will be displayed when there is no chart data.
  * This accepts an object of the form emptyMessage:
  * `{title: 'No Data Available',

--- a/test/components/line/line.e2e-spec.js
+++ b/test/components/line/line.e2e-spec.js
@@ -28,6 +28,28 @@ describe('Line Chart tests', () => {
   }
 });
 
+describe('Line Localization tests', () => {
+  it('Should Localize Numbers - en-US', async () => {
+    await utils.setPage('/components/line/example-localize.html');
+    await utils.checkForErrors();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element.all(by.css('.y .tick text')).get(0).getText()).toEqual('0');
+    expect(await element.all(by.css('.y .tick text')).get(1).getText()).toEqual('5,000');
+    expect(await element.all(by.css('.y .tick text')).get(2).getText()).toEqual('10,000');
+  });
+
+  it('Should Localize Numbers - de-DE', async () => {
+    await utils.setPage('/components/line/example-localize.html?locale=de-DE');
+    await utils.checkForErrors();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element.all(by.css('.y .tick text')).get(0).getText()).toEqual('0');
+    expect(await element.all(by.css('.y .tick text')).get(1).getText()).toEqual('5.000');
+    expect(await element.all(by.css('.y .tick text')).get(2).getText()).toEqual('10.000');
+  });
+});
+
 describe('Line Chart Zero Millions tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/line/example-zero-millions?layout=nofrills');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Changed the charts so that when you set the locale it will set d2 defaultLocale. This all the numbers in charts (for example decimal and group seperator). The K for example 1K is not common in other languages so is not localized but still can be used


**Related github/jira issue (required)**:
Fixes #4437

**Steps necessary to review your pull request (required)**:
- compare http://localhost:4000/components/line/example-localize.html?locale=de-DE
 and http://localhost:4000/components/line/example-localize.html
- notice the numbers have group separator which changes from comma to decimal
- also check in the tooltip
- since this applies now to ALL d3 charts - smoke test some charts, test as many charts as you want

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
