### PR TITLE
4398 - Fix color picker for overflow menu with editor

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Datagrid]` Fixed an issue where the double click event was not firing for checkbox columns. ([#4381](https://github.com/infor-design/enterprise/issues/4381))
 - `[Datagrid]` Fixed an issue where the dropdown in a datagrid would stay open when clicking to the next page of results. ([#4396](https://github.com/infor-design/enterprise/issues/4396))
 - `[Datagrid]` Fixed an issue where calling setFocus on the datagrid would stop open menus from working. ([#4429](https://github.com/infor-design/enterprise/issues/4429))
+- `[Editor]` Fixed an issue where the color picker was not opening the popup for overflow menu and had name as undefined in list. ([#4398](https://github.com/infor-design/enterprise/issues/4398))
 - `[Favorites]` Removed the favorites component as its not really a component, info on it can be found under buttons in the toggle example. ([#4405](https://github.com/infor-design/enterprise/issues/4405))
 - `[MenuButton]` Removed the menubutton component sections as its not really a component, info on it can be found under buttons in the MenuButton examples. ([#4416](https://github.com/infor-design/enterprise/issues/4416))
 - `[List Detail]` Fixed css height for list detail in responsive view ([#4426](https://github.com/infor-design/enterprise/issues/4426))

--- a/src/components/colorpicker/colorpicker.js
+++ b/src/components/colorpicker/colorpicker.js
@@ -398,7 +398,18 @@ ColorPicker.prototype = {
         }
 
         // Editor colorpicker
-        const cpEditorNotVisible = this.element.is('.colorpicker-editor-button') && !utils.isInViewport(this.element[0]);
+        let cpEditorNotVisible = false;
+        if (this.element.is('.colorpicker-editor-button')) {
+          const toolbarItem = this.element.data('toolbaritem') || this.element.data('toolbarflexitem');
+          const toolbarAPI = toolbarItem ? toolbarItem.toolbarAPI : null;
+          if (toolbarAPI) {
+            toolbarAPI.overflowedItems.forEach((thisItem) => {
+              if (thisItem.type === 'colorpicker') {
+                cpEditorNotVisible = true;
+              }
+            });
+          }
+        }
 
         if (!cpEditorNotVisible) {
           this.element.focus();

--- a/src/components/colorpicker/colorpicker.js
+++ b/src/components/colorpicker/colorpicker.js
@@ -396,7 +396,13 @@ ColorPicker.prototype = {
         if (!this.isEditor) {
           this.setColor(item.data('value'), item.data('label'));
         }
-        this.element.focus();
+
+        // Editor colorpicker
+        const cpEditorNotVisible = this.element.is('.colorpicker-editor-button') && !utils.isInViewport(this.element[0]);
+
+        if (!cpEditorNotVisible) {
+          this.element.focus();
+        }
 
         /**
         *  Fires after the color picker is changed

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -494,6 +494,29 @@ Editor.prototype = {
     // Invoke Tooltips
     this.toolbar.find('button[title]').tooltip();
 
+    // Adjust color picker alignment, for opened by toolbar overflowed items
+    cpElements.on('beforeopen.editor', (e, menu) => {
+      const toolbarApi = this.toolbar.data('toolbar') || this.toolbar.data('toolbar-flex');
+      if (toolbarApi) {
+        toolbarApi.overflowedItems.forEach((item) => {
+          if (item.type === 'colorpicker' && menu) {
+            menu.parent('.popupmenu-wrapper')
+              .off('afterplace.editor') // if reached more then once
+              .one('afterplace.editor', (evt, args) => {
+                if (typeof args.width === 'undefined') {
+                  const containerW = args.container?.outerWidth() || -1;
+                  const elementW = args.element?.outerWidth() || -1;
+                  const left = (containerW - elementW) / 2;
+                  if (left > -1) {
+                    args.element.css('left', `${left}px`);
+                  }
+                }
+              });
+          }
+        });
+      }
+    });
+
     return this;
   },
 
@@ -993,7 +1016,7 @@ Editor.prototype = {
       justifyRight: this.getIcon('JustifyRight', 'right-text-align'),
       clearFormatting: this.getIcon('ClearFormatting', 'clear-formatting'),
       source: this.getIcon('ViewSource', 'html', 'html-icon'),
-      visual: this.getIcon('ViewSource', 'visual', 'visual-icon')
+      visual: this.getIcon('ViewVisual', 'visual', 'visual-icon')
     };
 
     let customButtonLabels;

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -2414,7 +2414,10 @@ PopupMenu.prototype = {
 
     delete this.openedWithTouch;
 
-    if (noFocus || !this.settings.returnFocus || env.features.touch) {
+    // Editor colorpicker
+    const cpEditorNotVisible = this.element.is('.colorpicker-editor-button') && !utils.isInViewport(this.element[0]);
+
+    if (noFocus || !this.settings.returnFocus || env.features.touch || cpEditorNotVisible) {
       return;
     }
 

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -2415,7 +2415,18 @@ PopupMenu.prototype = {
     delete this.openedWithTouch;
 
     // Editor colorpicker
-    const cpEditorNotVisible = this.element.is('.colorpicker-editor-button') && !utils.isInViewport(this.element[0]);
+    let cpEditorNotVisible = false;
+    if (this.element.is('.colorpicker-editor-button')) {
+      const toolbarItem = this.element.data('toolbaritem') || this.element.data('toolbarflexitem');
+      const toolbarAPI = toolbarItem ? toolbarItem.toolbarAPI : null;
+      if (toolbarAPI) {
+        toolbarAPI.overflowedItems.forEach((thisItem) => {
+          if (thisItem.type === 'colorpicker') {
+            cpEditorNotVisible = true;
+          }
+        });
+      }
+    }
 
     if (noFocus || !this.settings.returnFocus || env.features.touch || cpEditorNotVisible) {
       return;

--- a/src/components/toolbar-flex/toolbar-flex.item.js
+++ b/src/components/toolbar-flex/toolbar-flex.item.js
@@ -227,7 +227,7 @@ ToolbarFlexItem.prototype = {
   triggerSelectedEvent() {
     // Searchfields and Colorpickers aren't "selectable" in the same way actionable
     // items are, so they shouldn't fire the "selected" event.
-    const disallowedTypes = ['colorpicker', 'searchfield', 'toolbarsearchfield'];
+    const disallowedTypes = ['searchfield', 'toolbarsearchfield'];
     if (disallowedTypes.indexOf(this.type) > -1) {
       return;
     }
@@ -762,7 +762,7 @@ ToolbarFlexItem.prototype = {
       itemData.icon = icon.getAttribute('xlink:href').replace('#icon-', '');
     }
 
-    if (this.type === 'button' || this.type === 'menubutton') {
+    if (/\b(button|menubutton|colorpicker)\b/g.test(this.type)) {
       itemData.text = this.element.textContent.trim();
     }
 
@@ -835,7 +835,7 @@ ToolbarFlexItem.prototype = {
       itemData.icon = icon.getAttribute('xlink:href').replace('#icon-', '');
     }
 
-    if (this.type === 'button' || this.type === 'menubutton') {
+    if (/\b(button|menubutton|colorpicker)\b/g.test(this.type)) {
       itemData.text = this.element.textContent.trim();
     }
 

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -1178,10 +1178,10 @@ describe('Datepicker Range Tests', () => {
     await element.all(by.cssContainingText('.monthview-table td', '11')).get(0).click();
 
     const testDate1 = new Date();
-    testDate1.setMonth(8);
+    testDate1.setMonth(9);
     testDate1.setDate(11);
     const testDate2 = new Date(testDate1);
-    testDate2.setMonth(8);
+    testDate2.setMonth(9);
     testDate2.setDate(12);
 
     expect(await datepickerEl.getAttribute('value')).toEqual(`${(testDate1.getMonth() + 1)}/11/${testDate1.getFullYear()} - ${(testDate2.getMonth() + 1)}/${testDate2.getDate()}/${testDate2.getFullYear()}`);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the color picker was not opening the popup for overflow menu and had name as undefined in list with Editor.

**Related github/jira issue (required)**:
Closes #4398

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/editor/example-index.html
- Make the browser window small so that the button `Text color` NOT fit in toolbar ( can use device toolbar mode in dev tools)
- Click the `...` action button to open menu
- See color picker button name should list as `Text color`
- Click on it and see it should open the color picker popup

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
