### PR TITLE
4447 - Added a better fix for calendar colors [v4.33.x]

### DIFF
--- a/src/components/calendar/calendar-shared.js
+++ b/src/components/calendar/calendar-shared.js
@@ -221,14 +221,16 @@ calendarShared.getEventTypeColor = function getEventTypeColor(event, eventTypes)
     return color;
   }
 
-  if (event.color) {
+  if (event.color?.substr(0, 1) === '#') {
     return event.color;
   }
 
   const eventInfo = eventTypes.filter(eventType => eventType.id === event.type);
   if (eventInfo.length === 1) {
     color = eventInfo[0].color || 'azure';
+    return color;
   }
+
   return color;
 };
 

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -1469,7 +1469,6 @@ Calendar.prototype = {
       for (let i = 0; i < inputs.length; i++) {
         event[inputs[i].id] = inputs[i].getAttribute('type') === 'checkbox' ? inputs[i].checked : inputs[i].value;
       }
-      event.color = ''; // Color set by tiying it to eventTypes later
 
       if (isAdd) {
         this.addEvent(event);

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -1178,10 +1178,10 @@ describe('Datepicker Range Tests', () => {
     await element.all(by.cssContainingText('.monthview-table td', '11')).get(0).click();
 
     const testDate1 = new Date();
-    testDate1.setMonth(8);
+    testDate1.setMonth(9);
     testDate1.setDate(11);
     const testDate2 = new Date(testDate1);
-    testDate2.setMonth(8);
+    testDate2.setMonth(9);
     testDate2.setDate(12);
 
     expect(await datepickerEl.getAttribute('value')).toEqual(`${(testDate1.getMonth() + 1)}/11/${testDate1.getFullYear()} - ${(testDate2.getMonth() + 1)}/${testDate2.getDate()}/${testDate2.getFullYear()}`);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Added a better fix for calendar colors as the previous fix did not fix it all. This continues on #4439

**Related github/jira issue (required)**:
Fixes #4447

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/calendar/example-index.html
- dbl click a day and add an event and pick admin -> color should be purple when inserted (try others as well)
- in the + menu select Add Event modal, and make the same test. this should now be fixed
- confirm the two events on http://localhost:4000/components/calendar/test-event-color-override.html still are fixed colors

