### PR TITLE
4380 - Fix leading spaces on editing cells with datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### v4.34.0 Fixes
 
 - `[Datepicker]` Fixed an issue where range highlight was not aligning for Mac/Safari. ([#4352](https://github.com/infor-design/enterprise/issues/4352))
+- `[Datagrid]` Fixed an issue where the leading spaces were removed on editing cells. ([#4380](https://github.com/infor-design/enterprise/issues/4380))
 - `[Datagrid]` Fixed an issue where the double click event was not firing for checkbox columns. ([#4381](https://github.com/infor-design/enterprise/issues/4381))
 - `[Datagrid]` Fixed an issue where the dropdown in a datagrid would stay open when clicking to the next page of results. ([#4396](https://github.com/infor-design/enterprise/issues/4396))
 - `[Datagrid]` Fixed an issue where calling setFocus on the datagrid would stop open menus from working. ([#4429](https://github.com/infor-design/enterprise/issues/4429))

--- a/src/utils/xss.js
+++ b/src/utils/xss.js
@@ -156,8 +156,11 @@ xssUtils.unescapeHTML = function (value) {
   }
 
   if (typeof value === 'string') {
+    const match = regx => ((value.match(regx) || [''])[0]);
     const doc = new DOMParser().parseFromString(value, 'text/html');
-    return doc.documentElement.textContent;
+
+    // Keep leading/trailing spaces
+    return `${match(/^\s*/)}${doc.documentElement.textContent.trim()}${match(/\s*$/)}`;
   }
   return value;
 };


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the leading spaces were removed on editing cells with Datagrid.

**Related github/jira issue (required)**:
Closes #4380

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/example-editable.html
- Click on any cell in column `Activity` to go in edit mode
- Edit text with leading/trailing spaces
- Click enter key to commit the edit mode
- Click enter key again to go in edit mode
- See it should keep leading/trailing spaces

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
