### PR TITLE
4347 - Fix special characters export to csv with datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### v4.34.0 Fixes
 
 - `[Datepicker]` Fixed an issue where range highlight was not aligning for Mac/Safari. ([#4352](https://github.com/infor-design/enterprise/issues/4352))
+- `[Datagrid]` Fixed an issue where the special characters (é, à, ü, û, ...) export to csv was not generated them correctly. ([#4347](https://github.com/infor-design/enterprise/issues/4347))
 - `[Datagrid]` Fixed an issue where the leading spaces were removed on editing cells. ([#4380](https://github.com/infor-design/enterprise/issues/4380))
 - `[Datagrid]` Fixed an issue where the double click event was not firing for checkbox columns. ([#4381](https://github.com/infor-design/enterprise/issues/4381))
 - `[Datagrid]` Fixed an issue where the dropdown in a datagrid would stay open when clicking to the next page of results. ([#4396](https://github.com/infor-design/enterprise/issues/4396))

--- a/src/components/bar/bar.js
+++ b/src/components/bar/bar.js
@@ -491,7 +491,10 @@ Bar.prototype = {
         // Replace key/value and set type as string
         const replaceMatchAndSetType = () => {
           if (typeof content === 'string') {
-            content = replaceMatch(content, (match, key) => format(d[key]));
+            content = replaceMatch(content, (match, key) => {
+              const r = format(d[key]);
+              return isNaN(r) ? d[key] : r;
+            });
           } else if (typeof content === 'number') {
             content = content.toString();
           }

--- a/src/components/column/column.js
+++ b/src/components/column/column.js
@@ -744,7 +744,10 @@ Column.prototype = {
         // Replace key/value and set type as string
         const replaceMatchAndSetType = () => {
           if (typeof content === 'string') {
-            content = replaceMatch(content, (match, key) => format(d[key]));
+            content = replaceMatch(content, (match, key) => {
+              const r = format(d[key]);
+              return isNaN(r) ? d[key] : r;
+            });
           } else if (typeof content === 'number') {
             content = content.toString();
           }

--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -383,10 +383,10 @@ excel.exportToCsv = function (fileName, customDs, sep = 'sep=,', self) {
       cols.forEach(col => rowContent.push(col.textContent.replace(/\r?\n|\r/g, '').replace(/"/g, '""').trim()));
       csv.push(rowContent.join(`"${separator.char}"`));
     });
-    if (separator.firstLine) {
+    if (separator.firstLine && separator.char !== ',') {
       csv.unshift([`sep=${separator.char}`]);
     }
-    return `"${csv.join('"\n"')}"`;
+    return `\uFEFF"${csv.join('"\n"')}"`;
   };
 
   const table = excel.cleanExtra(customDs, self);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the special characters (é, à, ü, û, ...) export to csv was not generated them correctly with Datagrid.

**Related github/jira issue (required)**:
Closes #4347

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/example-export-from-button.html
- Click on toolbar button `Export To Csv`
- It should download file `muExport.csv`
- Open this download file with `MS Excel`
- See in column `Extra`, all the special characters should be generated correctly

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
