### PR TITLE
4335 - Fix focus on toolbar buttons with editor

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,7 +20,7 @@
 - `[Datagrid]` Fixed a bug where a scroll bar shows even when there's no data in datagrid. ([#4228](https://github.com/infor-design/enterprise/issues/4228))
 - `[Datagrid]` Fixed an issue where calling setFocus on the datagrid would stop open menus from working. ([#4429](https://github.com/infor-design/enterprise/issues/4429))
 - `[Datagrid]` To allow for some script tools to work we now set draggable to true. ([#4490](https://github.com/infor-design/enterprise/issues/4490))
-- `[Editor]` Fixed an issue where the focus was getting lost after execute toolbar buttons. ([#4335](https://github.com/infor-design/enterprise/issues/4335))
+- `[Editor]` Fixed an issue where the focus was getting lost after pressing toolbar buttons. ([#4335](https://github.com/infor-design/enterprise/issues/4335))
 - `[Editor]` Fixed an issue where the color picker was not opening the popup for overflow menu and had name as undefined in list. ([#4398](https://github.com/infor-design/enterprise/issues/4398))
 - `[Favorites]` Removed the favorites component as its not really a component, info on it can be found under buttons in the toggle example. ([#4405](https://github.com/infor-design/enterprise/issues/4405))
 - `[Fieldset]` Fixed a bug where summary form data gets cut off on a smaller viewport. ([#3861](https://github.com/infor-design/enterprise/issues/3861))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `[Datagrid]` Fixed a bug where a scroll bar shows even when there's no data in datagrid. ([#4228](https://github.com/infor-design/enterprise/issues/4228))
 - `[Datagrid]` Fixed an issue where calling setFocus on the datagrid would stop open menus from working. ([#4429](https://github.com/infor-design/enterprise/issues/4429))
 - `[Datagrid]` To allow for some script tools to work we now set draggable to true. ([#4490](https://github.com/infor-design/enterprise/issues/4490))
+- `[Editor]` Fixed an issue where the focus was getting lost after execute toolbar buttons. ([#4335](https://github.com/infor-design/enterprise/issues/4335))
 - `[Editor]` Fixed an issue where the color picker was not opening the popup for overflow menu and had name as undefined in list. ([#4398](https://github.com/infor-design/enterprise/issues/4398))
 - `[Favorites]` Removed the favorites component as its not really a component, info on it can be found under buttons in the toggle example. ([#4405](https://github.com/infor-design/enterprise/issues/4405))
 - `[Fieldset]` Fixed a bug where summary form data gets cut off on a smaller viewport. ([#3861](https://github.com/infor-design/enterprise/issues/3861))

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -1067,6 +1067,7 @@ Editor.prototype = {
 
       if (action) {
         self.execAction(action, e);
+        btn.focus();
       }
 
       if (env.browser.name === 'ie' || env.browser.isEdge()) {
@@ -1100,7 +1101,7 @@ Editor.prototype = {
   bindModals() {
     const self = this;
     const modalSettings = {
-      noRefocus: true
+      noRefocus: false
     };
 
     this.modals = {
@@ -2210,7 +2211,7 @@ Editor.prototype = {
          * @property {string} content Additional argument
          */
         this.element.triggerHandler('afterpreviewmode', content);
-        this.element.focus();
+        this.toolbar?.find('[data-action="source"]').focus();
       }, 0);
     };
 
@@ -2246,6 +2247,7 @@ Editor.prototype = {
        * @property {string} content Additional argument
        */
       this.element.triggerHandler('aftersourcemode', content);
+      this.toolbar?.find('[data-action="visual"]').focus();
     };
 
     // Check the false value
@@ -2570,10 +2572,6 @@ Editor.prototype = {
           }
         }, 0);
       }
-
-      setTimeout(() => {
-        this.getCurrentElement().focus();
-      }, 0);
     });
 
     // Toggle colorpicker


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the focus was getting lost after execute toolbar buttons with Editor.

**Related github/jira issue (required)**:
Closes #4335

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/editor/example-index.html
- Tab to editor toolbar button `B`
- Press `Enter`
- See the focus should remain on the button

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
