### PR TITLE
4452 - Fix readonly and non-selectable listview should not have hover state

### DIFF
--- a/app/views/components/popupmenu/test-return-focus.html
+++ b/app/views/components/popupmenu/test-return-focus.html
@@ -1,0 +1,23 @@
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="field">
+      <button id="popupmenu-trigger" class="btn-menu" data-init="false" >
+        <span>Normal Menu</span>
+        <svg role="presentation" aria-hidden="true" focusable="false" class="icon icon-dropdown">
+          <use href="#icon-dropdown"></use>
+        </svg>
+      </button>
+      <ul class="popupmenu">
+        <li><a href="#" id="test1">Menu Option #1</a></li>
+        <li><a href="#" id="test2">Menu Option #2</a></li>
+        <li><a href="#" id="test3">Menu Option #3</a></li>
+      </ul>
+    </div>
+
+  </div>
+</div>
+
+<script>
+  $('#popupmenu-trigger').popupmenu({ returnFocus: false });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[MenuButton]` Removed the menubutton component sections as its not really a component, info on it can be found under buttons in the MenuButton examples. ([#4416](https://github.com/infor-design/enterprise/issues/4416))
 - `[Message]` Added support for lists in the message, also fixed a problem when doing so, with screen readers. ([#4400](https://github.com/infor-design/enterprise/issues/4400))
 - `[List Detail]` Fixed css height for list detail in responsive view ([#4426](https://github.com/infor-design/enterprise/issues/4426))
+- `[Listview]` Fixed a bug where readonly and non-selectable listview should not have hover/selected state. ([#4452](https://github.com/infor-design/enterprise/issues/4452))
 - `[Lookup]` Fixed a bug where the filter header together with the checkbox column is not properly align. ([#3774](https://github.com/infor-design/enterprise/issues/3774))
 - `[Splitter]` Added missing audible labels in splitter collapse button and splitter handle. ([#4404](https://github.com/infor-design/enterprise/issues/4404))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,7 +26,7 @@
 - `[MenuButton]` Removed the menubutton component sections as its not really a component, info on it can be found under buttons in the MenuButton examples. ([#4416](https://github.com/infor-design/enterprise/issues/4416))
 - `[Message]` Added support for lists in the message, also fixed a problem when doing so, with screen readers. ([#4400](https://github.com/infor-design/enterprise/issues/4400))
 - `[List Detail]` Fixed css height for list detail in responsive view ([#4426](https://github.com/infor-design/enterprise/issues/4426))
-- `[Listview]` Fixed a bug where readonly and non-selectable listview should not have hover/selected state. ([#4452](https://github.com/infor-design/enterprise/issues/4452))
+- `[Listview]` Fixed a bug where readonly and non-selectable listview should not have hover state. ([#4452](https://github.com/infor-design/enterprise/issues/4452))
 - `[Lookup]` Fixed a bug where the filter header together with the checkbox column is not properly align. ([#3774](https://github.com/infor-design/enterprise/issues/3774))
 - `[Splitter]` Added missing audible labels in splitter collapse button and splitter handle. ([#4404](https://github.com/infor-design/enterprise/issues/4404))
 

--- a/src/components/listview/_listview-uplift.scss
+++ b/src/components/listview/_listview-uplift.scss
@@ -1,16 +1,6 @@
 // Uplift Listview
 //================================================== //
 
-.listview {
-  &.disable-hover {
-    li {
-      &:first-child:focus {
-        border-top: 1px solid $listview-border-color !important;
-      }
-    }
-  }
-}
-
 .listview .alert-text {
   font-size: 12px;
   line-height: 25px;

--- a/src/components/listview/_listview-uplift.scss
+++ b/src/components/listview/_listview-uplift.scss
@@ -1,6 +1,16 @@
 // Uplift Listview
 //================================================== //
 
+.listview {
+  &.disable-hover {
+    li {
+      &:first-child:focus {
+        border-top: 1px solid $listview-border-color !important;
+      }
+    }
+  }
+}
+
 .listview .alert-text {
   font-size: 12px;
   line-height: 25px;

--- a/src/components/listview/_listview.scss
+++ b/src/components/listview/_listview.scss
@@ -254,18 +254,6 @@
     li:hover {
       background: none;
     }
-
-    li {
-      &:first-child:focus {
-        border-top: 1px solid transparent !important;
-      }
-
-      &:focus {
-        border: 1px solid transparent;
-        border-color: transparent transparent $listview-border-color transparent !important;
-        box-shadow: none;
-      }
-    }
   }
 
   i {

--- a/src/components/listview/_listview.scss
+++ b/src/components/listview/_listview.scss
@@ -252,7 +252,19 @@
 
   &.disable-hover {
     li:hover {
-      background-color: $listview-hover-bg-color;
+      background: none;
+    }
+
+    li {
+      &:first-child:focus {
+        border-top: 1px solid transparent !important;
+      }
+
+      &:focus {
+        border: 1px solid transparent;
+        border-color: transparent transparent $listview-border-color transparent !important;
+        box-shadow: none;
+      }
     }
   }
 

--- a/src/themes/theme-soho-contrast.scss
+++ b/src/themes/theme-soho-contrast.scss
@@ -815,3 +815,12 @@ $calendar-disabled-color: $ids-color-palette-graphite-100;
     }
   }
 }
+
+//Override background color when hover on high contrast
+.listview {
+  &.disable-hover {
+    li:hover {
+      background-color: $ids-color-palette-white;
+    }
+  }
+}

--- a/src/themes/theme-uplift-contrast.scss
+++ b/src/themes/theme-uplift-contrast.scss
@@ -858,3 +858,12 @@ html.is-chrome:not(.is-mac) {
     }
   }
 }
+
+//Override background color when hover on high contrast
+.listview {
+  &.disable-hover {
+    li:hover {
+      background-color: $ids-color-palette-white;
+    }
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Readonly and non-selectable listview should not have hover state.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/4452

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/listview/example-index?theme=uplift&variant=light&colors=0066D4
- Hover the items
- It should not have hover styling
- Test this also on all themes and variants combinations

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
