### PR TITLE
4498 - Add automation id for donut, pie, cap and about

### DIFF
--- a/app/views/components/about/example-index.html
+++ b/app/views/components/about/example-index.html
@@ -15,7 +15,11 @@
       appName: 'IDS Enterprise',
       productName: 'Controls',
       version: 'Example Application Version No. XX',
-      content: '<p>Fashionable components for fashionable applications.</p>'
+      content: '<p>Fashionable components for fashionable applications.</p>',
+      attributes: [
+          { name: 'id', value: 'about-modal' },
+          { name: 'data-automation-id', value: 'about-modal-automation-id' }
+      ],
     });
 
   });

--- a/app/views/components/contextualactionpanel/example-workspaces.html
+++ b/app/views/components/contextualactionpanel/example-workspaces.html
@@ -2,13 +2,13 @@
 <div class="row">
   <div class="six columns">
 
-    <button type="button" id="workspace-cap" class="btn-secondary contextual-action-panel-trigger" data-options="{ modalSettings: { fullsize: 'responsive' } }">
+    <button type="button" id="show-cap" class="btn-secondary contextual-action-panel-trigger" data-init="false">
       Show Contextual Action Panel
     </button>
-    <div class="contextual-action-panel" style="display:none;">
+    <div class="contextual-action-panel">
       <div class="flex-toolbar">
         <div class="toolbar-section">
-          <button id="cancel" class="btn">
+          <button id="btn-cancel" data-automation-id="btn-cancel-automation" class="btn">
             <span>Cancel</span>
           </button>
         </div>
@@ -16,7 +16,7 @@
         <div class="toolbar-section title center-text">
           <h2>
             <span>Promote Pearl Reynolds Promote Pearl Reynolds</span>
-            <button id="launch" class="btn-icon">
+            <button id="btn-launch" data-automation-id="btn-launch-automation" class="btn-icon">
               <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
                 <use href="#icon-launch"></use>
               </svg>
@@ -26,7 +26,7 @@
         </div>
 
         <div class="toolbar-section">
-          <button id="submit" class="btn">
+          <button id="btn-submit" data-automation-id="btn-submit-automation" class="btn">
             <span>Submit</span>
           </button>
         </div>
@@ -118,9 +118,20 @@
 
 </div>
 
-<script>
-  // Close modal on click
-  $('#submit, #cancel').on('click', function() {
-    $('#contextual-action-modal-1').data('modal').close();
+<script id="test-script">
+  $('body').on('initialized', function() {
+    $('#btn-submit, #btn-cancel').on('click', function() {
+      $('#show-cap').data('contextualactionpanel').close();
+    });
+
+    $('#show-cap').contextualactionpanel({
+        modalSettings: {
+          fullsize: 'responsive',
+          attributes: [
+            { name: 'id', value: 'cap' },
+            { name: 'data-automation-id', value: 'cap-automation-id' }
+          ]
+        }
+    });
   });
 </script>

--- a/app/views/components/donut/example-index.html
+++ b/app/views/components/donut/example-index.html
@@ -20,13 +20,25 @@ $('body').on('initialized', function () {
   var donutData = [{
     data: [{
         name: 'Component A',
-        value: 16
+        value: 16,
+        attributes: [
+          { name: 'id', value: 'comp-a' },
+          { name: 'data-automation-id', value: 'comp-a-automation-id' }
+        ]
     }, {
         name: 'Component B',
-        value: 12
+        value: 12,
+        attributes: [
+          { name: 'id', value: 'comp-b' },
+          { name: 'data-automation-id', value: 'comp-ba-automation-id' }
+        ]
     }, {
         name: 'Component C',
-        value: 14
+        value: 14,
+        attributes: [
+          { name: 'id', value: 'comp-c' },
+          { name: 'data-automation-id', value: 'comp-c-automation-id' }
+        ]
     }],
     centerLabel: 'Donut Chart'
   }];

--- a/app/views/components/pie/example-index.html
+++ b/app/views/components/pie/example-index.html
@@ -22,29 +22,57 @@ $('body').on('initialized', function () {
       data: [{
           name: 'Item A',
           value: 10.1,
-          //  url: '/componentA',
-          id: 'ca',
+          id: 'item-a',
+          attributes: [
+            { name: 'id', value: 'item-a' },
+            { name: 'data-automation-id', value: 'item-a-automation-id' }
+          ],
           tooltip: 'Item A <b>{{percent}}</b>'
       }, {
           name: 'Item B',
           value: 12.2,
-          id: 'cb',
+          id: 'item-b',
+          attributes: [
+            { name: 'id', value: 'item-b' },
+            { name: 'data-automation-id', value: 'item-b-automation-id' }
+          ],
           tooltip: 'Item B <b>{{percent}}</b>'
       }, {
           name: 'Item C',
           value: 14.35,
+          id: 'item-c',
+          attributes: [
+            { name: 'id', value: 'item-c' },
+            { name: 'data-automation-id', value: 'item-c-automation-id' }
+          ],
           tooltip: 'Item C <b>{{percent}}</b>'
       }, {
           name: 'Item D',
           value: 15.6,
+          id: 'item-d',
+          attributes: [
+            { name: 'id', value: 'item-d' },
+            { name: 'data-automation-id', value: 'item-d-automation-id' }
+          ],
           tooltip: 'Item D <b>{{percent}}</b>'
       }, {
           name: 'Item E',
           value: 21.6,
+          id: 'item-e',
+          attributes: [
+            { name: 'id', value: 'item-c' },
+            { name: 'data-automation-id', value: 'item-e-automation-id' }
+          ],
           tooltip: 'Item E <b>{{percent}}</b>'
       }, {
           name: 'Item F',
           value: 41.6,
+          id: 'item-f',
+          id: 'item-f',
+          attributes: [
+            { name: 'id', value: 'item-f' },
+            { name: 'data-automation-id', value: 'item-f-automation-id' }
+          ],
           tooltip: 'Item F <b>{{percent}}</b>'
       }]
     }];

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -2,7 +2,7 @@
 
 This list is a list of elements that have clickable items that need to be handled or tested and confirmed with the new automation attributes settings. The checkbox may be checked if the component is implemented to handle all clickable items with custom id's or custom ids + suffix and the doc testability section is filled out. See toast/message/pager for initial code.
 
-- [ ] About (implemented in modal - needs testing)
+- [x] About
 - [ ] Accordion
 - [x] Alerts (not needed id can be directly applied)
 - [ ] Applicationmenu
@@ -28,10 +28,10 @@ This list is a list of elements that have clickable items that need to be handle
 - [ ] Column Stacked
 - [ ] Completion Chart
 - [ ] Contextmenu
-- [ ] Contextualactionpanel (implemented in modal - needs testing)
+- [x] Contextualactionpanel
 - [ ] Datagrid
 - [ ] Datepicker
-- [ ] Donut
+- [x] Donut
 - [ ] Dropdown
 - [ ] Editor
 - [ ] Emptymessage
@@ -60,7 +60,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [ ] Multiselect
 - [ ] Notification
 - [x] Pager
-- [ ] Pie
+- [x] Pie
 - [ ] Popdown
 - [ ] Popover
 - [ ] Popupmenu

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### v4.34.0 Features
 
 - `[Datagrid]` Fixed an issue with a custom toolbar, where buttons would click twice. ([#4471](https://github.com/infor-design/enterprise/issues/4471))
+- `[About]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
+- `[ContextualActionPanel]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
+- `[Donut/Pie]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Message]` Added `attributes` setting to set automation id's and id's. ([#4277](https://github.com/infor-design/enterprise/issues/4277))
 - `[Modal]` Added `attributes` setting to set automation id's and id's. ([#4277](https://github.com/infor-design/enterprise/issues/4277))
 - `[Pager]` Added `attributes` setting to set automation id's and id's. ([#4277](https://github.com/infor-design/enterprise/issues/4277))

--- a/docs/CSP.md
+++ b/docs/CSP.md
@@ -1,0 +1,103 @@
+# Content Security Policy (CSP) Notes
+
+Created these notes while attempting to pass [CSP](https://csp.withgoogle.com/docs/adopting-csp.html) checking for general xss issues.
+
+## Content Security Policy (CSP)
+
+### In order to pass CSP scans in your application you will need to
+
+- Make your app return the csp headers. To do this i used express-csp as we are using express. We use the following policy.
+
+    ```bash
+    Content-Security-Policy:
+    default-src 'self';
+    img-src 'self' https://externalsite1.com http://externalsite1.com;
+    object-src 'none';
+    script-src 'strict-dynamic' 'nonce-04111658';
+    style-src * data: http://* 'unsafe-inline'
+    ```
+
+    Notes: Everything should be secure with the following exceptions.
+
+    `img-src` - We need to add some paths for random image generator sites we use in the examples on blockgrid, hierarchy, and image components. You may need to include your own trusted sites.
+
+    `style-src` We need to allow the soho script to set inline styles. We set this to `http://*` for the various sites we use. If we don't do this many components cannot function until we can refactor them to use CSSDOM instead of style tags (search style= in all *.js files). Some of the components needing work are mentioned on [Issue 628](https://github.com/infor-design/enterprise/issues/628)
+- Replace all `style="display: none;"` with class `hidden` and use CSSDOM or classes for all styles you use
+- Can testing with [CSP mitigator](https://chrome.google.com/webstore/detail/csp-mitigator/gijlobangojajlbodabkpjpheeeokhfa?hl=en)
+    Then note that we can test pages like <http://localhost:4000/components/personalize/example-index> using:
+
+    ```html
+    script-src 'self';
+    style-src 'self';
+    frame-ancestors 'self';
+    object-src 'none'
+    ```
+
+## Common Errors and remediation
+
+### Context Escaping
+
+[Escaping Info](http://jehiah.cz/a/guide-to-escape-sequences)
+
+### Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
+
+Something like `elem.html(markup);` will trigger this warning. To address we should use whitelisting for example:
+
+```javascript
+DOM.html(elem, markup, '<span><div>');'
+```
+
+If this cannot be limited to a few types then sanitizing can be used.
+
+```javascript
+DOM.html(elem, markup, '*');'
+```
+
+Even better if all tags can be stripped.
+
+```javascript
+xssUtils.stripTags(string);
+```
+
+Or a pure alphanumeric value.
+
+```javascript
+xssUtils.ensureAlphaNumeric(string);
+```
+
+### URL Redirection to Untrusted Site ('Open Redirect')
+
+Something like `window.location = href` will generate this error. To address we should use code to ensure the URL is relative.
+
+```javascript
+Soho.xss.isUrlLocal(url)
+```
+
+### Improper Output Neutralization for Logs
+
+Something like `console.log` will generate this error. For client side code this is a false positive. But can generate a lot of scan error. To address we should use toast instead to show example output.
+
+```javascript
+$('body').toast({
+  'title': '<some> Event Triggered',
+  'message': 'The value was changed to : ' + value + ' .. ect'
+});
+```
+
+### XML Injection (aka Blind XPath Injection)
+
+Something like `this.listUl.find(`li[data-val="${value.replace(/"/g, '/quot/')}"]`);` will generate this error. If the value is not external this is a false positive if using newer than jQuery 1.9. But to be safe we can use:
+
+```javascript
+xssUtils.stripTags(string);
+```
+
+```javascript
+xssUtils.sanitizeHTML(string);
+```
+
+Or a pure alphanumeric value.
+
+```javascript
+xssUtils.ensureAlphaNumeric(string);
+```

--- a/src/components/about/about.js
+++ b/src/components/about/about.js
@@ -18,7 +18,8 @@ const COMPONENT_NAME = 'about';
  * @param {string} [settings.productName] Additional product name information to display.
  * @param {boolean} [settings.useDefaultCopyright=true] Add the Legal Approved Infor Copyright Text.
  * @param {string} [settings.version] Semantic Version Number for example (4.0.0).
- */
+ * @param {string} [settings.attributes] Add extra attributes like id's to the toast element. For example `attributes: { name: 'id', value: 'my-unique-id' }`
+*/
 const ABOUT_DEFAULTS = {
   appName: 'Infor Application Name',
   content: undefined,
@@ -90,7 +91,7 @@ About.prototype = {
 
     const header = $('<div class="modal-header"></div>').appendTo(this.modal.find('.modal-content'));
     $('<div class="close-container"></div>')
-      .append($('<button name="close" type="button" class="btn-icon hide-focus"></button>')
+      .append($('<button name="close" type="button" class="btn-icon btn-close hide-focus"></button>')
         .append($.createIconElement({ icon: 'close', classes: 'icon-close' }))
         .append(`<span>${Locale.translate('Close')}'</span>`))
       .appendTo(header);
@@ -141,7 +142,7 @@ About.prototype = {
     $('.modal-body', this.modal)[0].tabIndex = 0;
 
     this.modal.appendTo('body');
-    this.modal.modal({ trigger: this.isBody ? 'immediate' : 'click' });
+    this.modal.modal({ trigger: this.isBody ? 'immediate' : 'click', attributes: this.settings.attributes });
     return this;
   },
 

--- a/src/components/about/readme.md
+++ b/src/components/about/readme.md
@@ -30,7 +30,27 @@ The about component example by default adds the current year's copyright, and us
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+You can add custom id's/automation id's to the about dialog that can be used for scripting using the `attributes` setting. This setting takes either an object or an array for setting multiple values such as an automation-id or other attributes. For example:
+
+```js
+  attributes: { name: 'id', value: args => `message-id-${args.id}` }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: { name: 'data-automation-id', value: 'my-unique-id' }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: [{ name: 'id', value: 'my-unique-id' }, { name: 'data-automation-id', value: 'my-unique-id' }]
+```
+
+If you set the attributes on the about dialog, you will get an ID added to the root of the dialog. Also the close button will get an id with `-btn-close` appended after the id provided.
+
+Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
 
 ## Keyboard Shortcuts
 

--- a/src/components/charts/charts.js
+++ b/src/components/charts/charts.js
@@ -394,6 +394,7 @@ charts.addLegend = function (series, chartType, settings, container) {
     }
     seriesLine = $(seriesLine);
     seriesLine.append(color, textBlock);
+    utils.addAttributes(seriesLine, series[i], series[i]?.data?.attributes, 'legend');
 
     if ((chartType === 'pie' || chartType === 'donut') && settings.showMobile) {
       legend.find('.container').append(seriesLine);

--- a/src/components/contextualactionpanel/contextualactionpanel.js
+++ b/src/components/contextualactionpanel/contextualactionpanel.js
@@ -23,6 +23,7 @@ const COMPONENT_NAME = 'contextualactionpanel';
 * @param {boolean} [settings.modalSettings.showCloseBtn = false] if true, displays a "close (X)" button in the button row that cancels the CAP's Modal action.
 * @param {string} [settings.modalSettings.trigger = 'click'] Can be 'click' or 'immediate'.
 * @param {boolean} [settings.modalSettings.useFlexToolbar = false] If true the new flex toolbar will be used (For CAP)
+* @param {string} [settings.modalSettings.attributes] Add extra attributes like id's to the toast element. For example `attributes: { name: 'id', value: 'my-unique-id' }`
 */
 const CONTEXTUALACTIONPANEL_DEFAULTS = {
   content: null,

--- a/src/components/contextualactionpanel/readme.md
+++ b/src/components/contextualactionpanel/readme.md
@@ -103,4 +103,24 @@ The contextual action panel responds similarly to a [modal](./modal), in that it
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+You can add custom id's/automation id's to the contextual action panel dialog that can be used for scripting using the `modalSettings.attributes` setting. This setting takes either an object or an array for setting multiple values such as an automation-id or other attributes. For example:
+
+```js
+  modalSettings.attributes: { name: 'id', value: args => `message-id-${args.id}` }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  modalSettings.attributes: { name: 'data-automation-id', value: 'my-unique-id' }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  modalSettings.attributes: [{ name: 'id', value: 'my-unique-id' }, { name: 'data-automation-id', value: 'my-unique-id' }]
+```
+
+If you set the attributes on the contextual action panel, you will get an ID added to the root of the dialog. Also the close button will get an id with `-btn-close` appended after the id provided. Note that if you provide buttons on the toolbar you can manually set the id/automation id on the button markup for these.
+
+Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.

--- a/src/components/donut/readme.md
+++ b/src/components/donut/readme.md
@@ -32,10 +32,18 @@ This example shows how to invoke a dount bar chart with a dataset controlling th
   var donutData = [{
     data: [{
         name: 'Component A',
-        value: 30
+        value: 30,
+        attributes: [
+          { name: 'id', value: 'comp-a' },
+          { name: 'data-automation-id', value: 'comp-ac-automation-id' }
+        ]
     }, {
         name: 'Component B',
-        value: 40
+        value: 40,
+        attributes: [
+          { name: 'id', value: 'comp-a' },
+          { name: 'data-automation-id', value: 'comp-ac-automation-id' }
+        ]
     }],
     centerLabel: 'Donut Chart'
   }];
@@ -56,9 +64,27 @@ This may include possibly using an inset margin in some cases.
 
 See also pie chart
 
+
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+You can add custom id's/automation id's to the donut chart that can be used for scripting using the `attributes` data attribute. This data attribute can be either an object or an array for setting multiple values such as an automation-id or other attributes. For example:
+
+Setting the id/automation id with a string value or function. The function will give you the data as a parameter for making things more dynamic.
+
+```js
+{
+    name: 'Component C',
+    value: 14,
+    attributes: [
+      { name: 'id', value: 'comp-c' },
+      { name: 'data-automation-id', value: 'comp-c-automation-id' }
+    ]
+}
+```
+
+Providing the data this will add an ID added to the pie slice. In addition the related legend item will get the same id with `-legend` appended after it.
+
+Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for general information.
 
 ## Keyboard Shortcuts
 

--- a/src/components/donut/readme.md
+++ b/src/components/donut/readme.md
@@ -62,8 +62,7 @@ This example shows how to invoke a dount bar chart with a dataset controlling th
 You can control the size of the donut chart by setting the size of the parent element the donut lives in.
 This may include possibly using an inset margin in some cases.
 
-See also pie chart
-
+See also pie chart.
 
 ## Testability
 

--- a/src/components/pie/pie.js
+++ b/src/components/pie/pie.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-nested-ternary, prefer-arrow-callback */
+/* eslint-disable no-nested-ternary, prefer-arrow-callback, no-underscore-dangle */
 // Other Shared Imports
 import * as debug from '../../utils/debug';
 import { Environment as env } from '../../utils/environment';
@@ -286,7 +286,7 @@ Pie.prototype = {
         if (d.name === 'Empty-Pie') {
           name = '';
         }
-        return { name, display: 'twocolumn', placement: s.legendPlacement, color: d.color };
+        return { name, display: 'twocolumn', placement: s.legendPlacement, color: d.color, data: d };
       });
 
       s.svg = self.svg;
@@ -424,6 +424,14 @@ Pie.prototype = {
         return charts.chartColor(i, 'pie', d.data);
       })
       .attr('class', 'slice')
+      .call((d) => {
+        d._groups.forEach((slices) => {
+          slices.forEach((pieSlice) => {
+            const dat = pieSlice.__data__;
+            utils.addAttributes($(pieSlice), dat, dat.data.attributes);
+          });
+        });
+      })
       .on(`contextmenu.${self.namespace}`, function (d) {
         charts.triggerContextMenu(self.element, d3.select(this).nodes()[0], d);
         // charts.triggerContextMenu(self.element, d3.select(this).select('path').nodes()[0], d);

--- a/src/components/pie/readme.md
+++ b/src/components/pie/readme.md
@@ -30,16 +30,28 @@ This example shows how to invoke a pie bar chart with a dataset controlling the 
           name: 'Component A',
           value: 10.1,
           id: 'A',
+          attributes: [
+            { name: 'id', value: 'item-a' },
+            { name: 'data-automation-id', value: 'item-a-automation-id' }
+          ],
           tooltip: 'Component A <b>{{percent}}</b>'
       }, {
           name: 'Component B',
           value: 12.2,
           id: 'B',
+          attributes: [
+            { name: 'id', value: 'item-a' },
+            { name: 'data-automation-id', value: 'item-a-automation-id' }
+          ],
           tooltip: 'Component B <b>{{percent}}</b>'
       }, {
           name: 'Component C',
           value: 14.35,
           id: 'C',
+          attributes: [
+            { name: 'id', value: 'item-a' },
+            { name: 'data-automation-id', value: 'item-a-automation-id' }
+          ],
           tooltip: 'Component C Is Very Cool<b>{{percent}}</b>'
       }]
     }];
@@ -61,7 +73,26 @@ See also [Donut Chart Example](./demo/components/donut/example-index?font=source
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+You can add custom id's/automation id's to the pie chart that can be used for scripting using the `attributes` data attribute. This data attribute can be either an object or an array for setting multiple values such as an automation-id or other attributes. For example:
+
+Setting the id/automation id with a string value or function. The function will give you the data as a parameter for making things more dynamic.
+
+```js
+{
+    name: 'Item E',
+    value: 21.6,
+    id: 'item-e',
+    attributes: [
+        { name: 'id', value: 'item-c' },
+        { name: 'data-automation-id', value: 'item-e-automation-id' }
+    ],
+    tooltip: 'Item E <b>{{percent}}</b>'
+}
+```
+
+Providing the data this will add an ID added to the pie slice. In addition the related legend item will get the same id with `-legend` appended after it.
+
+Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for general information.
 
 ## Keyboard Shortcuts
 

--- a/test/components/about/about.e2e-spec.js
+++ b/test/components/about/about.e2e-spec.js
@@ -55,6 +55,15 @@ describe('About index tests', () => {
 
     expect(await element(by.id('about-modal')).isDisplayed()).toBeTruthy();
   });
+
+  it('Should be able to set id/automation id', async () => {
+    const button = await element(by.id('about-trigger'));
+    await button.click();
+    await browser.driver.sleep(config.sleepShort);
+
+    expect(await element(by.id('about-modal')).getAttribute('id')).toEqual('about-modal');
+    expect(await element(by.id('about-modal-btn-close')).getAttribute('id')).toEqual('about-modal-btn-close');
+  });
 });
 
 describe('About translation tests', () => {

--- a/test/components/contextualactionpanel/contextualactionpanel.e2e-spec.js
+++ b/test/components/contextualactionpanel/contextualactionpanel.e2e-spec.js
@@ -116,10 +116,22 @@ describe('Contextual Action Panel example-workspace tests', () => {
   });
 
   it('Should open popup on click', async () => {
-    await element(by.id('workspace-cap')).click();
-    await browser.driver.sleep(config.sleepLonger);
+    await element(by.id('show-cap')).click();
+    await browser.driver.sleep(config.sleep);
 
-    expect(await element(by.css('#contextual-action-modal-1')).isDisplayed()).toBe(true);
+    expect(await element(by.id('cap')).isDisplayed()).toBe(true);
+  });
+
+  it('Should be able to set id/automation id', async () => {
+    await element(by.id('show-cap')).click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.id('cap')).getAttribute('id')).toEqual('cap');
+    expect(await element(by.id('cap')).getAttribute('data-automation-id')).toEqual('cap-automation-id');
+    expect(await element(by.id('btn-cancel')).getAttribute('id')).toEqual('btn-cancel');
+    expect(await element(by.id('btn-cancel')).getAttribute('data-automation-id')).toEqual('btn-cancel-automation');
+    expect(await element(by.id('btn-submit')).getAttribute('id')).toEqual('btn-submit');
+    expect(await element(by.id('btn-submit')).getAttribute('data-automation-id')).toEqual('btn-submit-automation');
   });
 });
 

--- a/test/components/dount/donut.e2e-spec.js
+++ b/test/components/dount/donut.e2e-spec.js
@@ -5,13 +5,20 @@ requireHelper('rejection');
 
 jasmine.getEnv().addReporter(browserStackErrorReporter);
 
-describe('Donut Chart tests', () => {
+fdescribe('Donut Chart tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/donut/example-index?layout=nofrills');
   });
 
   it('Should not have errors', async () => {
     await utils.checkForErrors();
+  });
+
+  it('Should be able to set id/automation id', async () => {
+    expect(await element(by.id('comp-a')).getAttribute('id')).toEqual('comp-a');
+    expect(await element(by.id('comp-a')).getAttribute('data-automation-id')).toEqual('comp-a-automation-id');
+    expect(await element(by.id('comp-a-legend')).getAttribute('id')).toEqual('comp-a-legend');
+    expect(await element(by.id('comp-a-legend')).getAttribute('data-automation-id')).toEqual('comp-a-automation-id-legend');
   });
 
   if (utils.isChrome() && utils.isCI()) {

--- a/test/components/dount/donut.e2e-spec.js
+++ b/test/components/dount/donut.e2e-spec.js
@@ -5,7 +5,7 @@ requireHelper('rejection');
 
 jasmine.getEnv().addReporter(browserStackErrorReporter);
 
-fdescribe('Donut Chart tests', () => {
+describe('Donut Chart tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/donut/example-index?layout=nofrills');
   });

--- a/test/components/pie/pie.e2e-spec.js
+++ b/test/components/pie/pie.e2e-spec.js
@@ -14,6 +14,13 @@ describe('Pie Chart tests', () => {
     await utils.checkForErrors();
   });
 
+  it('Should be able to set id/automation id', async () => {
+    expect(await element(by.id('item-a')).getAttribute('id')).toEqual('item-a');
+    expect(await element(by.id('item-a')).getAttribute('data-automation-id')).toEqual('item-a-automation-id');
+    expect(await element(by.id('item-a-legend')).getAttribute('id')).toEqual('item-a-legend');
+    expect(await element(by.id('item-a-legend')).getAttribute('data-automation-id')).toEqual('item-a-automation-id-legend');
+  });
+
   if (utils.isChrome() && utils.isCI()) {
     it('Should not visual regress', async () => {
       const containerEl = await element(by.className('container'));


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adds the attributes/automation id / id functionality for donut, cap, pie and about. this included docs and tests.
Also updated the SECURITY.md since its shown on the github page in the wrong context. 

@deep7102 checkout that i added the legend code and how i did it with PIE. this might be done the same on other charts

**Related github/jira issue (required)**:
Part of 4498 but doesnt close it all

**Steps necessary to review your pull request (required)**:
- review the text in the docs
- go to http://localhost:4000/components/donut/example-index.html and http://localhost:4000/components/pie/example-index.html and check that the slices get an id from the data
- go to http://localhost:4000/components/about/example-index.html and body and close button get an id 
- go to http://localhost:4000/components/about/example-index.html and body and close button get an id 
- go to http://localhost:4000/components/contextualactionpanel/example-workspaces.html and check that the body of the cap and the buttons all get id's

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
