### PR TITLE
4498 - Automation IDs for autocomplete, field filter, dropdown and popupmenu

### DIFF
--- a/app/views/components/autocomplete/example-index.html
+++ b/app/views/components/autocomplete/example-index.html
@@ -12,6 +12,10 @@
   elem.autocomplete({
     attributes: [
       {
+        name: 'id',
+        value: 'autocomplete'
+      },
+      {
         name: 'data-automation-id',
         value: 'autocomplete-automation-id'
       }

--- a/app/views/components/autocomplete/example-index.html
+++ b/app/views/components/autocomplete/example-index.html
@@ -2,7 +2,16 @@
   <div class="twelve columns">
     <div class="field">
       <label for="autocomplete-default">States</label>
-      <input type="text" autocomplete="off" class="autocomplete" data-options="{source: '{{basepath}}api/states?term='}" placeholder="Type to Search" id="autocomplete-default"/>
+      <input type="text" autocomplete="off" id="autocomplete" class="autocomplete" data-options="{source: '{{basepath}}api/states?term='}" placeholder="Type to Search" id="autocomplete-default"/>
     </div>
   </div>
 </div>
+
+<script type="text/javascript">
+  $('#autocomplete').autocomplete({
+    attributes: [{
+      name: 'data-automation-id',
+      value: 'autocomplete-automation-id'
+    }]
+  });
+</script>

--- a/app/views/components/autocomplete/example-index.html
+++ b/app/views/components/autocomplete/example-index.html
@@ -2,16 +2,19 @@
   <div class="twelve columns">
     <div class="field">
       <label for="autocomplete-default">States</label>
-      <input type="text" autocomplete="off" id="autocomplete" class="autocomplete" data-options="{source: '{{basepath}}api/states?term='}" placeholder="Type to Search" id="autocomplete-default"/>
+      <input type="text" autocomplete="off" id="autocomplete" class="autocomplete" data-init="false" data-options="{source: '{{basepath}}api/states?term='}" placeholder="Type to Search" id="autocomplete-default"/>
     </div>
   </div>
 </div>
 
-<script type="text/javascript">
-  $('#autocomplete').autocomplete({
-    attributes: [{
-      name: 'data-automation-id',
-      value: 'autocomplete-automation-id'
-    }]
+<script>
+  const elem = $('#autocomplete');
+  elem.autocomplete({
+    attributes: [
+      {
+        name: 'data-automation-id',
+        value: 'autocomplete-automation-id'
+      }
+    ]
   });
 </script>

--- a/app/views/components/dropdown/example-index.html
+++ b/app/views/components/dropdown/example-index.html
@@ -58,3 +58,14 @@
     </div>
   </div>
 </div>
+
+<script>
+  $('.dropdown').dropdown({
+    attributes: [
+      {
+        name: 'data-automation-id',
+        value: 'dropdown-automation-id'
+      }
+    ]
+  });
+</script>

--- a/app/views/components/dropdown/example-index.html
+++ b/app/views/components/dropdown/example-index.html
@@ -64,11 +64,11 @@
     attributes: [
       {
         name: 'id',
-        value: 'my-id'
+        value: 'custom-dropdown-id-1'
       },
       {
         name: 'data-automation-id',
-        value: 'dropdown-automation-id'
+        value: 'custom-automation-dropdown-id'
       }
     ]
   });

--- a/app/views/components/dropdown/example-index.html
+++ b/app/views/components/dropdown/example-index.html
@@ -63,6 +63,10 @@
   $('.dropdown').dropdown({
     attributes: [
       {
+        name: 'id',
+        value: 'my-id'
+      },
+      {
         name: 'data-automation-id',
         value: 'dropdown-automation-id'
       }

--- a/app/views/components/field-filter/example-index.html
+++ b/app/views/components/field-filter/example-index.html
@@ -171,7 +171,15 @@
     };
 
     // Init Field Filter and bind `filtered` event
-    $('.field-filter').fieldfilter({ dataset: fieldfilterData });
+    $('.field-filter').fieldfilter({
+      dataset: fieldfilterData,
+      attributes: [
+        {
+          name: 'data-automation-id',
+          value: 'field-filter-automation-id'
+        }
+      ]
+     });
 
     var setEvents = function() {
       $('.field-filter').on('filtered', function (e, args) {

--- a/app/views/components/field-filter/example-index.html
+++ b/app/views/components/field-filter/example-index.html
@@ -176,11 +176,11 @@
       attributes: [
         {
           name: 'id',
-          value: 'my-id'
+          value: 'custom-field-filter-id-1'
         },
         {
           name: 'data-automation-id',
-          value: 'field-filter-automation-id'
+          value: 'custom-automation-field-filter-id'
         }
       ]
      });

--- a/app/views/components/field-filter/example-index.html
+++ b/app/views/components/field-filter/example-index.html
@@ -175,6 +175,10 @@
       dataset: fieldfilterData,
       attributes: [
         {
+          name: 'id',
+          value: 'my-id'
+        },
+        {
           name: 'data-automation-id',
           value: 'field-filter-automation-id'
         }

--- a/app/views/components/popupmenu/example-index.html
+++ b/app/views/components/popupmenu/example-index.html
@@ -8,7 +8,7 @@
           <use href="#icon-dropdown"></use>
         </svg>
       </button>
-      <ul class="popupmenu">
+      <ul class="popupmenu" data-init="false">
         <li><a href="#" id="test1">Menu Option #1</a></li>
         <li><a href="#" id="test2">Menu Option #2</a></li>
         <li><a href="#" id="test3">Menu Option #3</a></li>
@@ -17,3 +17,18 @@
 
   </div>
 </div>
+
+<script>
+  $('.popupmenu').popupmenu({
+    attributes: [
+      {
+        name: 'id',
+        value: 'popupmenu-id'
+      },
+      {
+        name: 'data-automation-id',
+        value: 'popupmenu-automation-id'
+      }
+    ]
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,8 +6,11 @@
 
 - `[Datagrid]` Fixed an issue with a custom toolbar, where buttons would click twice. ([#4471](https://github.com/infor-design/enterprise/issues/4471))
 - `[About]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
+- `[Autocomplete]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[ContextualActionPanel]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Donut/Pie]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
+- `[Dropdown]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
+- `[FieldFilter]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Message]` Added `attributes` setting to set automation id's and id's. ([#4277](https://github.com/infor-design/enterprise/issues/4277))
 - `[Modal]` Added `attributes` setting to set automation id's and id's. ([#4277](https://github.com/infor-design/enterprise/issues/4277))
 - `[Pager]` Added `attributes` setting to set automation id's and id's. ([#4277](https://github.com/infor-design/enterprise/issues/4277))

--- a/src/components/autocomplete/autocomplete.js
+++ b/src/components/autocomplete/autocomplete.js
@@ -253,6 +253,15 @@ Autocomplete.prototype = {
       this.list = $('<ul id="autocomplete-list" aria-expanded="true"></ul>').appendTo('body');
     }
 
+    // Add test automation ids
+    utils.addAttributes(this.list, this, this.settings.attributes, 'list');
+    setTimeout(() => {
+      const options = this.list.find('li a');
+      [...options].forEach((opt, i) => {
+        utils.addAttributes($(opt), this, this.settings.attributes, `list-option${i}`);
+      });
+    });
+
     this.list[0].style.height = 'auto';
     this.list[0].style.width = `${this.element.outerWidth()}px`;
     this.list.addClass('autocomplete');

--- a/src/components/autocomplete/autocomplete.js
+++ b/src/components/autocomplete/autocomplete.js
@@ -222,8 +222,8 @@ Autocomplete.prototype = {
       role: 'combobox',
       autocomplete: 'off'
     });
-    console.log(this.element);
-    utils.addAttributes(this.element, this, this.settings.attributes, 'autocomplete');
+    // Add test automation ids
+    utils.addAttributes(this.element, this, this.settings.attributes);
   },
 
   isLoading() {

--- a/src/components/autocomplete/autocomplete.js
+++ b/src/components/autocomplete/autocomplete.js
@@ -222,6 +222,8 @@ Autocomplete.prototype = {
       role: 'combobox',
       autocomplete: 'off'
     });
+    console.log(this.element);
+    utils.addAttributes(this.element, this, this.settings.attributes, 'autocomplete');
   },
 
   isLoading() {

--- a/src/components/autocomplete/readme.md
+++ b/src/components/autocomplete/readme.md
@@ -94,8 +94,4 @@ Setting the id/automation id with a string value:
 
 If setting the id/automation id with a function, the id will be a running total of open autocomplete.
 
-For the autocomplete, `attributes` can be set either on the root settings or in each button element. For the button elements you can also use the `id` as before or the new attributes setting to set an id or automation id on the button.
-
-If you set the attributes on the root message, you will get an ID added to the root of the message dialog. Also the message area will get an id with `-message` appended after the id given. And the h1 area will get an id with `-title` appended after the id given. And finally the close button (if used) with get `btn-close` appended.
-
 Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.

--- a/src/components/autocomplete/readme.md
+++ b/src/components/autocomplete/readme.md
@@ -74,4 +74,28 @@ The data returned should be an array with a specific data structure containing `
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+The autocomplete can have custom id's/automation id's that can be used for scripting. To add them use the option `attributes` to set an id on the autocomplete. This can take either an object or an array if doing several id's, and you can configure the automation id name. For example:
+
+```js
+  attributes: { name: 'id', value: args => `autocomplete-id-${args.id}` }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: { name: 'data-automation-id', value: 'my-unique-id' }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: [{ name: 'id', value: 'my-unique-id' }, { name: 'data-automation-id', value: 'my-unique-id' }]
+```
+
+If setting the id/automation id with a function, the id will be a running total of open autocomplete.
+
+For the autocomplete, `attributes` can be set either on the root settings or in each button element. For the button elements you can also use the `id` as before or the new attributes setting to set an id or automation id on the button.
+
+If you set the attributes on the root message, you will get an ID added to the root of the message dialog. Also the message area will get an id with `-message` appended after the id given. And the h1 area will get an id with `-title` appended after the id given. And finally the close button (if used) with get `btn-close` appended.
+
+Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1867,6 +1867,7 @@ Dropdown.prototype = {
     utils.addAttributes(this.list.find('input'), this, this.settings.attributes, 'input');
     utils.addAttributes(this.list.find('.trigger'), this, this.settings.attributes, 'trigger');
     utils.addAttributes(this.list.find('ul'), this, this.settings.attributes, 'listbox');
+    utils.addAttributes(this.list.find('.dropdown-option a'), this, this.settings.attributes, 'option');
 
     this.searchInput.attr('aria-activedescendant', current.children('a').attr('id'));
     if (this.settings.showSearchUnderSelected) {

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -786,11 +786,6 @@ Dropdown.prototype = {
         <ul role="listbox" aria-label="${Locale.translate('Dropdown')}">`;
     }
 
-    console.log(listExists);
-    console.log($(listContents));
-    console.log(this);
-    utils.addAttributes($(listContents), this, this.settings.attributes);
-
     // Get a current list of <option> elements
     // If none are available, simply return out
     let opts = this.element.find('option');

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -786,6 +786,11 @@ Dropdown.prototype = {
         <ul role="listbox" aria-label="${Locale.translate('Dropdown')}">`;
     }
 
+    console.log(listExists);
+    console.log($(listContents));
+    console.log(this);
+    utils.addAttributes($(listContents), this, this.settings.attributes);
+
     // Get a current list of <option> elements
     // If none are available, simply return out
     let opts = this.element.find('option');
@@ -1860,6 +1865,13 @@ Dropdown.prototype = {
     this.pseudoElem
       .attr('aria-expanded', 'true')
       .addClass('is-open');
+
+    // Add test automation ids
+    utils.addAttributes(this.list, this, this.settings.attributes);
+    utils.addAttributes(this.list.find('label'), this, this.settings.attributes, 'label');
+    utils.addAttributes(this.list.find('input'), this, this.settings.attributes, 'input');
+    utils.addAttributes(this.list.find('.trigger'), this, this.settings.attributes, 'trigger');
+    utils.addAttributes(this.list.find('ul'), this, this.settings.attributes, 'listbox');
 
     this.searchInput.attr('aria-activedescendant', current.children('a').attr('id'));
     if (this.settings.showSearchUnderSelected) {

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1867,7 +1867,10 @@ Dropdown.prototype = {
     utils.addAttributes(this.list.find('input'), this, this.settings.attributes, 'input');
     utils.addAttributes(this.list.find('.trigger'), this, this.settings.attributes, 'trigger');
     utils.addAttributes(this.list.find('ul'), this, this.settings.attributes, 'listbox');
-    utils.addAttributes(this.list.find('.dropdown-option a'), this, this.settings.attributes, 'option');
+    const options = this.list.find('.dropdown-option a');
+    [...options].forEach((opt, i) => {
+      utils.addAttributes($(opt), this, this.settings.attributes, `option-${i}`);
+    });
 
     this.searchInput.attr('aria-activedescendant', current.children('a').attr('id'));
     if (this.settings.showSearchUnderSelected) {

--- a/src/components/dropdown/readme.md
+++ b/src/components/dropdown/readme.md
@@ -77,7 +77,31 @@ The dropdown list has been coded to act similar to the [aria best practices coll
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+The dropdown can have custom id's/automation id's that can be used for scripting. To add them use the option `attributes` to set an id on the dropdown. This can take either an object or an array if doing several id's, and you can configure the automation id name. For example:
+
+```js
+  attributes: { name: 'id', value: args => `dropdown-id-${args.id}` }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: { name: 'data-automation-id', value: 'my-unique-id' }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: [{ name: 'id', value: 'my-unique-id' }, { name: 'data-automation-id', value: 'my-unique-id' }]
+```
+
+If setting the id/automation id with a function, the id will be a running total of open dropdown.
+
+For the dropdown, `attributes` can be set either on the root settings or in each button element. For the button elements you can also use the `id` as before or the new attributes setting to set an id or automation id on the button.
+
+If you set the attributes on the root message, you will get an ID added to the root of the message dialog. Also the message area will get an id with `-message` appended after the id given. And the h1 area will get an id with `-title` appended after the id given. And finally the close button (if used) with get `btn-close` appended.
+
+Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
 
 ## Keyboard Shortcuts
 

--- a/src/components/dropdown/readme.md
+++ b/src/components/dropdown/readme.md
@@ -97,10 +97,6 @@ Setting the id/automation id with a string value:
 
 If setting the id/automation id with a function, the id will be a running total of open dropdown.
 
-For the dropdown, `attributes` can be set either on the root settings or in each button element. For the button elements you can also use the `id` as before or the new attributes setting to set an id or automation id on the button.
-
-If you set the attributes on the root message, you will get an ID added to the root of the message dialog. Also the message area will get an id with `-message` appended after the id given. And the h1 area will get an id with `-title` appended after the id given. And finally the close button (if used) with get `btn-close` appended.
-
 Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
 
 ## Keyboard Shortcuts

--- a/src/components/field-filter/field-filter.js
+++ b/src/components/field-filter/field-filter.js
@@ -138,6 +138,11 @@ FieldFilter.prototype = {
       if (this.ddApi && this.ddApi.icon) {
         this.ddApi.icon.addClass('ffdropdown-icon');
       }
+
+      // Add test automation ids
+      utils.addAttributes(this.field, this, this.settings.attributes);
+      utils.addAttributes(this.field.find('label:not(.audible)'), this, this.settings.attributes, 'label');
+      utils.addAttributes(this.field.find('select'), this, this.settings.attributes, 'select');
     }
   },
 

--- a/src/components/field-filter/readme.md
+++ b/src/components/field-filter/readme.md
@@ -15,4 +15,28 @@ You can use this information in addition to the field value to conduct form base
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+The filter fields can have custom id's/automation id's that can be used for scripting. To add them use the option `attributes` to set an id on the filter fields. This can take either an object or an array if doing several id's, and you can configure the automation id name. For example:
+
+```js
+  attributes: { name: 'id', value: args => `filter-field-id-${args.id}` }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: { name: 'data-automation-id', value: 'my-unique-id' }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: [{ name: 'id', value: 'my-unique-id' }, { name: 'data-automation-id', value: 'my-unique-id' }]
+```
+
+If setting the id/automation id with a function, the id will be a running total of open filter fields.
+
+For the filter fields, `attributes` can be set either on the root settings or in each button element. For the button elements you can also use the `id` as before or the new attributes setting to set an id or automation id on the button.
+
+If you set the attributes on the root message, you will get an ID added to the root of the message dialog. Also the message area will get an id with `-message` appended after the id given. And the h1 area will get an id with `-title` appended after the id given. And finally the close button (if used) with get `btn-close` appended.
+
+Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.

--- a/src/components/field-filter/readme.md
+++ b/src/components/field-filter/readme.md
@@ -35,8 +35,4 @@ Setting the id/automation id with a string value:
 
 If setting the id/automation id with a function, the id will be a running total of open filter fields.
 
-For the filter fields, `attributes` can be set either on the root settings or in each button element. For the button elements you can also use the `id` as before or the new attributes setting to set an id or automation id on the button.
-
-If you set the attributes on the root message, you will get an ID added to the root of the message dialog. Also the message area will get an id with `-message` appended after the id given. And the h1 area will get an id with `-title` appended after the id given. And finally the close button (if used) with get `btn-close` appended.
-
 Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -166,7 +166,7 @@ PopupMenu.prototype = {
     const options = this.element.find('li a');
     [...options].forEach((opt, i) => {
       utils.addAttributes($(opt), this, this.settings.attributes, `option-${i}`);
-    })
+    });
   },
 
   /**

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -160,6 +160,13 @@ PopupMenu.prototype = {
     // Set a reference collection for containing "pre-defined" menu items that should never
     // be replaced during an AJAX call.
     this.predefinedItems = $().add(this.settings.predefined);
+
+    // Add test automation ids
+    utils.addAttributes(this.element, this, this.settings.attributes);
+    const options = this.element.find('li a');
+    [...options].forEach((opt, i) => {
+      utils.addAttributes($(opt), this, this.settings.attributes, `option-${i}`);
+    })
   },
 
   /**

--- a/test/components/autocomplete/autocomplete.e2e-spec.js
+++ b/test/components/autocomplete/autocomplete.e2e-spec.js
@@ -88,6 +88,8 @@ describe('Autocomplete example-index tests', () => {
   }
 
   it('Should be able to set id/automation id', async () => {
+    await browser.driver.sleep(config.sleep);
+
     expect(await element(by.id('custom-id-autocomplete')).getAttribute('id')).toEqual('custom-id-autocomplete');
     expect(await element(by.id('custom-automation-id-autocomplete')).getAttribute('data-automation-id')).toEqual('custom-automation-id-autocomplete');
   });

--- a/test/components/autocomplete/autocomplete.e2e-spec.js
+++ b/test/components/autocomplete/autocomplete.e2e-spec.js
@@ -88,7 +88,6 @@ describe('Autocomplete example-index tests', () => {
   }
 
   it('Should be able to set id/automation id', async () => {
-    expect(await element(by.id('custom-id-autocomplete')).getAttribute('id')).toEqual('custom-id-autocomplete');
     expect(await element(by.id('custom-id-autocomplete')).getAttribute('data-automation-id')).toEqual('custom-automation-id-autocomplete');
   });
 });

--- a/test/components/autocomplete/autocomplete.e2e-spec.js
+++ b/test/components/autocomplete/autocomplete.e2e-spec.js
@@ -92,6 +92,24 @@ describe('Autocomplete example-index tests', () => {
 
     expect(await element(by.id('autocomplete')).getAttribute('id')).toEqual('autocomplete');
     expect(await element(by.id('autocomplete')).getAttribute('data-automation-id')).toEqual('custom-automation-id-autocomplete');
+
+    expect(await element(by.id('autocomplete-list')).getAttribute('id')).toEqual('autocomplete-list');
+    expect(await element(by.id('autocomplete-list')).getAttribute('data-automation-id')).toEqual('autocomplete-automation-id-list');
+
+    expect(await element(by.id('autocomplete-list-option0')).getAttribute('id')).toEqual('autocomplete-list-option0');
+    expect(await element(by.id('autocomplete-list-option0')).getAttribute('data-automation-id')).toEqual('autocomplete-automation-id-list-option0');
+
+    expect(await element(by.id('autocomplete-list-option1')).getAttribute('id')).toEqual('autocomplete-list-option1');
+    expect(await element(by.id('autocomplete-list-option1')).getAttribute('data-automation-id')).toEqual('autocomplete-automation-id-list-option1');
+
+    expect(await element(by.id('autocomplete-list-option2')).getAttribute('id')).toEqual('autocomplete-list-option2');
+    expect(await element(by.id('autocomplete-list-option2')).getAttribute('data-automation-id')).toEqual('autocomplete-automation-id-list-option2');
+
+    expect(await element(by.id('autocomplete-list-option3')).getAttribute('id')).toEqual('autocomplete-list-option3');
+    expect(await element(by.id('autocomplete-list-option3')).getAttribute('data-automation-id')).toEqual('autocomplete-automation-id-list-option3');
+
+    expect(await element(by.id('autocomplete-list-option4')).getAttribute('id')).toEqual('autocomplete-list-option4');
+    expect(await element(by.id('autocomplete-list-option4')).getAttribute('data-automation-id')).toEqual('autocomplete-automation-id-list-option4');
   });
 });
 

--- a/test/components/autocomplete/autocomplete.e2e-spec.js
+++ b/test/components/autocomplete/autocomplete.e2e-spec.js
@@ -88,7 +88,8 @@ describe('Autocomplete example-index tests', () => {
   }
 
   it('Should be able to set id/automation id', async () => {
-    expect(await element(by.id('custom-id-autocomplete')).getAttribute('data-automation-id')).toEqual('custom-automation-id-autocomplete');
+    expect(await element(by.id('custom-id-autocomplete')).getAttribute('id')).toEqual('custom-id-autocomplete');
+    expect(await element(by.id('custom-automation-id-autocomplete')).getAttribute('data-automation-id')).toEqual('custom-automation-id-autocomplete');
   });
 });
 

--- a/test/components/autocomplete/autocomplete.e2e-spec.js
+++ b/test/components/autocomplete/autocomplete.e2e-spec.js
@@ -86,6 +86,11 @@ describe('Autocomplete example-index tests', () => {
       await utils.checkForErrors();
     });
   }
+
+  it('Should be able to set id/automation id', async () => {
+    expect(await element(by.id('custom-id-autocomplete')).getAttribute('id')).toEqual('custom-id-autocomplete');
+    expect(await element(by.id('custom-id-autocomplete')).getAttribute('data-automation-id')).toEqual('custom-automation-id-autocomplete');
+  });
 });
 
 describe('Autocomplete ajax tests', () => {

--- a/test/components/autocomplete/autocomplete.e2e-spec.js
+++ b/test/components/autocomplete/autocomplete.e2e-spec.js
@@ -90,8 +90,8 @@ describe('Autocomplete example-index tests', () => {
   it('Should be able to set id/automation id', async () => {
     await browser.driver.sleep(config.sleep);
 
-    expect(await element(by.id('custom-id-autocomplete')).getAttribute('id')).toEqual('custom-id-autocomplete');
-    expect(await element(by.id('custom-automation-id-autocomplete')).getAttribute('data-automation-id')).toEqual('custom-automation-id-autocomplete');
+    expect(await element(by.id('autocomplete')).getAttribute('id')).toEqual('autocomplete');
+    expect(await element(by.id('autocomplete')).getAttribute('data-automation-id')).toEqual('custom-automation-id-autocomplete');
   });
 });
 

--- a/test/components/autocomplete/autocomplete.e2e-spec.js
+++ b/test/components/autocomplete/autocomplete.e2e-spec.js
@@ -91,7 +91,7 @@ describe('Autocomplete example-index tests', () => {
     await browser.driver.sleep(config.sleep);
 
     expect(await element(by.id('autocomplete')).getAttribute('id')).toEqual('autocomplete');
-    expect(await element(by.id('autocomplete')).getAttribute('data-automation-id')).toEqual('custom-automation-id-autocomplete');
+    expect(await element(by.id('autocomplete')).getAttribute('data-automation-id')).toEqual('autocomplete-automation-id');
 
     expect(await element(by.id('autocomplete-list')).getAttribute('id')).toEqual('autocomplete-list');
     expect(await element(by.id('autocomplete-list')).getAttribute('data-automation-id')).toEqual('autocomplete-automation-id-list');

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -244,6 +244,21 @@ describe('Dropdown example-index tests', () => {
 
       expect(await element(by.id('custom-dropdown-id-1')).getAttribute('id')).toEqual('custom-dropdown-id-1');
       expect(await element(by.id('custom-dropdown-id-1')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id');
+
+      expect(await element(by.id('custom-dropdown-id-1-label')).getAttribute('id')).toEqual('custom-dropdown-id-1-label');
+      expect(await element(by.id('custom-dropdown-id-1-label')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-label');
+
+      expect(await element(by.id('custom-dropdown-id-1-input')).getAttribute('id')).toEqual('custom-dropdown-id-1-input');
+      expect(await element(by.id('custom-dropdown-id-1-input')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-input');
+
+      expect(await element(by.id('custom-dropdown-id-1-trigger')).getAttribute('id')).toEqual('custom-dropdown-id-1-trigger');
+      expect(await element(by.id('custom-dropdown-id-1-trigger')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-trigger');
+
+      expect(await element(by.id('custom-dropdown-id-1-listbox')).getAttribute('id')).toEqual('custom-dropdown-id-1-listbox');
+      expect(await element(by.id('custom-dropdown-id-1-listbox')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-listbox');
+
+      expect(await element(by.id('custom-dropdown-id-1-option')).getAttribute('id')).toEqual('custom-dropdown-id-1-option');
+      expect(await element(by.id('custom-dropdown-id-1-option')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-option');
     });
   }
 

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -257,8 +257,17 @@ describe('Dropdown example-index tests', () => {
       expect(await element(by.id('custom-dropdown-id-1-listbox')).getAttribute('id')).toEqual('custom-dropdown-id-1-listbox');
       expect(await element(by.id('custom-dropdown-id-1-listbox')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-listbox');
 
-      expect(await element(by.id('custom-dropdown-id-1-option')).getAttribute('id')).toEqual('custom-dropdown-id-1-option');
-      expect(await element(by.id('custom-dropdown-id-1-option')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-option');
+      expect(await element(by.id('custom-dropdown-id-1-option-0')).getAttribute('id')).toEqual('custom-dropdown-id-1-option-0');
+      expect(await element(by.id('custom-dropdown-id-1-option-0')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-option-0');
+
+      expect(await element(by.id('custom-dropdown-id-1-option-1')).getAttribute('id')).toEqual('custom-dropdown-id-1-option-1');
+      expect(await element(by.id('custom-dropdown-id-1-option-1')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-option-1');
+
+      expect(await element(by.id('custom-dropdown-id-1-option-2')).getAttribute('id')).toEqual('custom-dropdown-id-1-option-2');
+      expect(await element(by.id('custom-dropdown-id-1-option-2')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-option-2');
+
+      expect(await element(by.id('custom-dropdown-id-1-option-3')).getAttribute('id')).toEqual('custom-dropdown-id-1-option-3');
+      expect(await element(by.id('custom-dropdown-id-1-option-3')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-option-3');
     });
   }
 

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -242,12 +242,8 @@ describe('Dropdown example-index tests', () => {
     it('Should be able to set id/automation id', async () => {
       await browser.driver.sleep(config.sleep);
 
-      expect(await element(by.id('custom-id-dropdown')).getAttribute('id')).toEqual('custom-id-dropdown');
-      expect(await element(by.id('custom-id-dropdown')).getAttribute('data-automation-id')).toEqual('custom-automation-id-dropdown');
-      expect(await element(by.id('custom-id-dropdown-label')).getAttribute('id')).toEqual('custom-id-dropdown-label');
-      expect(await element(by.id('custom-id-dropdown-label')).getAttribute('data-automation-id')).toEqual('custom-automation-id-dropdown-label');
-      expect(await element(by.id('custom-id-dropdown-select')).getAttribute('id')).toEqual('custom-id-dropdown-select');
-      expect(await element(by.id('custom-id-dropdown-select')).getAttribute('data-automation-id')).toEqual('custom-automation-id-dropdown-select');
+      expect(await element(by.id('custom-dropdown-id-1')).getAttribute('id')).toEqual('custom-dropdown-id-1');
+      expect(await element(by.id('custom-dropdown-id-1')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id');
     });
   }
 

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -240,12 +240,14 @@ describe('Dropdown example-index tests', () => {
     });
 
     it('Should be able to set id/automation id', async () => {
+      await browser.driver.sleep(config.sleep);
+
       expect(await element(by.id('custom-id-dropdown')).getAttribute('id')).toEqual('custom-id-dropdown');
-      expect(await element(by.id('custom-automation-id-dropdown')).getAttribute('data-automation-id')).toEqual('custom-automation-id-dropdown');
+      expect(await element(by.id('custom-id-dropdown')).getAttribute('data-automation-id')).toEqual('custom-automation-id-dropdown');
       expect(await element(by.id('custom-id-dropdown-label')).getAttribute('id')).toEqual('custom-id-dropdown-label');
-      expect(await element(by.id('custom-automation-id-dropdown-label')).getAttribute('data-automation-id')).toEqual('custom-automation-id-dropdown-label');
+      expect(await element(by.id('custom-id-dropdown-label')).getAttribute('data-automation-id')).toEqual('custom-automation-id-dropdown-label');
       expect(await element(by.id('custom-id-dropdown-select')).getAttribute('id')).toEqual('custom-id-dropdown-select');
-      expect(await element(by.id('custom-automation-id-dropdown-select')).getAttribute('data-automation-id')).toEqual('custom-automation-id-dropdown-select');
+      expect(await element(by.id('custom-id-dropdown-select')).getAttribute('data-automation-id')).toEqual('custom-automation-id-dropdown-select');
     });
   }
 

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -241,11 +241,11 @@ describe('Dropdown example-index tests', () => {
 
     it('Should be able to set id/automation id', async () => {
       expect(await element(by.id('custom-id-dropdown')).getAttribute('id')).toEqual('custom-id-dropdown');
-      expect(await element(by.id('custom-id-dropdown')).getAttribute('data-automation-id')).toEqual('custom-automation-id-dropdown');
+      expect(await element(by.id('custom-automation-id-dropdown')).getAttribute('data-automation-id')).toEqual('custom-automation-id-dropdown');
       expect(await element(by.id('custom-id-dropdown-label')).getAttribute('id')).toEqual('custom-id-dropdown-label');
-      expect(await element(by.id('custom-id-dropdown-label')).getAttribute('data-automation-id')).toEqual('custom-automation-id-dropdown-label');
+      expect(await element(by.id('custom-automation-id-dropdown-label')).getAttribute('data-automation-id')).toEqual('custom-automation-id-dropdown-label');
       expect(await element(by.id('custom-id-dropdown-select')).getAttribute('id')).toEqual('custom-id-dropdown-select');
-      expect(await element(by.id('custom-id-dropdown-select')).getAttribute('data-automation-id')).toEqual('custom-automation-id-dropdown-select');
+      expect(await element(by.id('custom-automation-id-dropdown-select')).getAttribute('data-automation-id')).toEqual('custom-automation-id-dropdown-select');
     });
   }
 

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -238,6 +238,15 @@ describe('Dropdown example-index tests', () => {
       // The Dropdown Pseudo element should no longer have focus
       expect(await element(by.css('div.dropdown')).getAttribute('class')).not.toContain('is-open');
     });
+
+    it('Should be able to set id/automation id', async () => {
+      expect(await element(by.id('custom-id-dropdown')).getAttribute('id')).toEqual('custom-id-dropdown');
+      expect(await element(by.id('custom-id-dropdown')).getAttribute('data-automation-id')).toEqual('custom-automation-id-dropdown');
+      expect(await element(by.id('custom-id-dropdown-label')).getAttribute('id')).toEqual('custom-id-dropdown-label');
+      expect(await element(by.id('custom-id-dropdown-label')).getAttribute('data-automation-id')).toEqual('custom-automation-id-dropdown-label');
+      expect(await element(by.id('custom-id-dropdown-select')).getAttribute('id')).toEqual('custom-id-dropdown-select');
+      expect(await element(by.id('custom-id-dropdown-select')).getAttribute('data-automation-id')).toEqual('custom-automation-id-dropdown-select');
+    });
   }
 
   it('Should be able to reopen when closed by a menu button', async () => {

--- a/test/components/field-filter/field-filter.e2e-spec.js
+++ b/test/components/field-filter/field-filter.e2e-spec.js
@@ -56,6 +56,8 @@ describe('FieldFilter example-index tests', () => {
   });
 
   it('Should be able to set id/automation id', async () => {
+    await browser.driver.sleep(config.sleep);
+
     expect(await element(by.id('custom-id-field-filter')).getAttribute('id')).toEqual('custom-id-field-filter');
     expect(await element(by.id('custom-id-field-filter')).getAttribute('data-automation-id')).toEqual('custom-automation-id-field-filter');
     expect(await element(by.id('custom-id-field-filter-label')).getAttribute('id')).toEqual('custom-id-field-filter-label');

--- a/test/components/field-filter/field-filter.e2e-spec.js
+++ b/test/components/field-filter/field-filter.e2e-spec.js
@@ -54,6 +54,19 @@ describe('FieldFilter example-index tests', () => {
     expect(await element(by.css('#example-textfield')).element(by.xpath('..')).element(by.className('is-open')).isDisplayed()).toBe(true);
     expect(await element(by.css('#example-textfield')).element(by.xpath('..')).element(by.css('#dropdown-search')).isPresent()).toBe(false);
   });
+
+  it('Should be able to set id/automation id', async () => {
+    expect(await element(by.id('custom-id-field-filter')).getAttribute('id')).toEqual('custom-id-field-filter');
+    expect(await element(by.id('custom-id-field-filter')).getAttribute('data-automation-id')).toEqual('custom-automation-id-field-filter');
+    expect(await element(by.id('custom-id-field-filter-label')).getAttribute('id')).toEqual('custom-id-field-filter-label');
+    expect(await element(by.id('custom-id-field-filter-label')).getAttribute('data-automation-id')).toEqual('custom-automation-id-field-filter-label');
+    expect(await element(by.id('custom-id-field-filter-input')).getAttribute('id')).toEqual('custom-id-field-filter-input');
+    expect(await element(by.id('custom-id-field-filter-input')).getAttribute('data-automation-id')).toEqual('custom-automation-id-field-filter-input');
+    expect(await element(by.id('custom-id-field-filter-trigger')).getAttribute('id')).toEqual('custom-id-field-filter-trigger');
+    expect(await element(by.id('custom-id-field-filter-trigger')).getAttribute('data-automation-id')).toEqual('custom-automation-id-field-filter-trigger');
+    expect(await element(by.id('custom-id-field-filter-listbox')).getAttribute('id')).toEqual('custom-id-field-filter-listbox');
+    expect(await element(by.id('custom-id-field-filter-listbox')).getAttribute('data-automation-id')).toEqual('custom-automation-id-field-filter-listbox');
+  });
 });
 
 describe('FieldFilter filter type tests', () => {

--- a/test/components/field-filter/field-filter.e2e-spec.js
+++ b/test/components/field-filter/field-filter.e2e-spec.js
@@ -58,16 +58,8 @@ describe('FieldFilter example-index tests', () => {
   it('Should be able to set id/automation id', async () => {
     await browser.driver.sleep(config.sleep);
 
-    expect(await element(by.id('custom-id-field-filter')).getAttribute('id')).toEqual('custom-id-field-filter');
-    expect(await element(by.id('custom-id-field-filter')).getAttribute('data-automation-id')).toEqual('custom-automation-id-field-filter');
-    expect(await element(by.id('custom-id-field-filter-label')).getAttribute('id')).toEqual('custom-id-field-filter-label');
-    expect(await element(by.id('custom-id-field-filter-label')).getAttribute('data-automation-id')).toEqual('custom-automation-id-field-filter-label');
-    expect(await element(by.id('custom-id-field-filter-input')).getAttribute('id')).toEqual('custom-id-field-filter-input');
-    expect(await element(by.id('custom-id-field-filter-input')).getAttribute('data-automation-id')).toEqual('custom-automation-id-field-filter-input');
-    expect(await element(by.id('custom-id-field-filter-trigger')).getAttribute('id')).toEqual('custom-id-field-filter-trigger');
-    expect(await element(by.id('custom-id-field-filter-trigger')).getAttribute('data-automation-id')).toEqual('custom-automation-id-field-filter-trigger');
-    expect(await element(by.id('custom-id-field-filter-listbox')).getAttribute('id')).toEqual('custom-id-field-filter-listbox');
-    expect(await element(by.id('custom-id-field-filter-listbox')).getAttribute('data-automation-id')).toEqual('custom-automation-id-field-filter-listbox');
+    expect(await element(by.id('custom-field-filter-id-1')).getAttribute('id')).toEqual('custom-field-filter-id-1');
+    expect(await element(by.id('custom-field-filter-id-1')).getAttribute('data-automation-id')).toEqual('custom-automation-field-filter-id');
   });
 });
 

--- a/test/components/field-filter/field-filter.e2e-spec.js
+++ b/test/components/field-filter/field-filter.e2e-spec.js
@@ -60,6 +60,12 @@ describe('FieldFilter example-index tests', () => {
 
     expect(await element(by.id('custom-field-filter-id-1')).getAttribute('id')).toEqual('custom-field-filter-id-1');
     expect(await element(by.id('custom-field-filter-id-1')).getAttribute('data-automation-id')).toEqual('custom-automation-field-filter-id');
+
+    expect(await element(by.id('custom-field-filter-id-1-label')).getAttribute('id')).toEqual('custom-field-filter-id-1-label');
+    expect(await element(by.id('custom-field-filter-id-1-label')).getAttribute('data-automation-id')).toEqual('custom-automation-field-filter-id-label');
+
+    expect(await element(by.id('custom-field-filter-id-1-select')).getAttribute('id')).toEqual('custom-field-filter-id-1-select');
+    expect(await element(by.id('custom-field-filter-id-1-select')).getAttribute('data-automation-id')).toEqual('custom-automation-field-filter-id-select');
   });
 });
 

--- a/test/components/popupmenu/popupmenu.e2e-spec.js
+++ b/test/components/popupmenu/popupmenu.e2e-spec.js
@@ -51,6 +51,22 @@ describe('Contextmenu index tests', () => {
     expect(await element.all(by.css('#action-popupmenu li')).first().getAttribute('role')).toEqual('none');
     expect(await element.all(by.css('#action-popupmenu li a')).first().getAttribute('role')).toEqual('menuitem');
   });
+
+  it('Should be able to set id/automation id', async () => {
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.id('popupmenu-id')).getAttribute('id')).toEqual('popupmenu-id');
+    expect(await element(by.id('popupmenu-id')).getAttribute('data-automation-id')).toEqual('popupmenu-automation-id');
+
+    expect(await element(by.id('popupmenu-id-option-0')).getAttribute('id')).toEqual('popupmenu-id-option-0');
+    expect(await element(by.id('popupmenu-id-option-0')).getAttribute('data-automation-id')).toEqual('popupmenu-automation-id-option-0');
+
+    expect(await element(by.id('popupmenu-id-option-1')).getAttribute('id')).toEqual('popupmenu-id-option-1');
+    expect(await element(by.id('popupmenu-id-option-1')).getAttribute('data-automation-id')).toEqual('popupmenu-automation-id-option-1');
+
+    expect(await element(by.id('popupmenu-id-option-2')).getAttribute('id')).toEqual('popupmenu-id-option-2');
+    expect(await element(by.id('popupmenu-id-option-2')).getAttribute('data-automation-id')).toEqual('popupmenu-automation-id-option-2');
+  });
 });
 
 describe('Popupmenu example-selectable tests', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adds automation is attributes for autocomplete, field filter, dropdown and popupmenu

**Related github/jira issue (required)**:
related to #4498 

**Steps necessary to review your pull request (required)**:
- pull and run branch
- go to http://localhost:4000/components/autocomplete/example-index.html and make sure the element gets automation id from the settings
- go to http://localhost:4000/components/field-filter/example-index.html and make sure the field wrapper, label and select get an automation id from the settings
- go to http://localhost:4000/components/dropdown/example-index.html open the dropdown and make sure the dropdown list, label, input, trigger and listbox get an automation id from the settings
- go to http://localhost:4000/components/popupmenu/example-index.html open the dropdown and make sure the popupmenu and options get an automation id from the settings

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
