### PR TITLE
4498 - Add automation id for area, bubble, line and scatterplot charts

### DIFF
--- a/app/views/components/area/example-index.html
+++ b/app/views/components/area/example-index.html
@@ -18,72 +18,156 @@ $('body').on('initialized', function () {
     var dataset = [{
       data: [{
           name: 'Jan',
-          value: 32
+          value: 32,
+          attributes: [
+           { name: 'id', value: 'area-a-jan' },
+           { name: 'data-automation-id', value: 'automation-id-area-a-jan' }
+         ]
       }, {
           name: 'Feb',
-          value: 31
+          value: 31,
+          attributes: [
+           { name: 'id', value: 'area-a-feb' },
+           { name: 'data-automation-id', value: 'automation-id-area-a-feb' }
+         ]
       }, {
           name: 'Mar',
-          value: 34
+          value: 34,
+          attributes: [
+           { name: 'id', value: 'area-a-mar' },
+           { name: 'data-automation-id', value: 'automation-id-area-a-mar' }
+         ]
       }, {
           name: 'Apr',
-          value: 30
+          value: 30,
+          attributes: [
+           { name: 'id', value: 'area-a-apr' },
+           { name: 'data-automation-id', value: 'automation-id-area-a-apr' }
+         ]
       }, {
           name: 'May',
-          value: 34
+          value: 34,
+          attributes: [
+           { name: 'id', value: 'area-a-may' },
+           { name: 'data-automation-id', value: 'automation-id-area-a-may' }
+         ]
       }, {
           name: 'Jun',
-          value: 38
+          value: 38,
+          attributes: [
+           { name: 'id', value: 'area-a-jun' },
+           { name: 'data-automation-id', value: 'automation-id-area-a-jun' }
+         ]
       }],
       name: 'Component A',
       legendShortName: 'Comp A',
-      legendAbbrName: 'A'
+      legendAbbrName: 'A',
+      attributes: [
+       { name: 'id', value: 'area-comp-a' },
+       { name: 'data-automation-id', value: 'automation-id-area-comp-a' }
+     ]
     }, {
       data: [{
           name: 'Jan',
-          value: 22
+          value: 22,
+          attributes: [
+           { name: 'id', value: 'area-b-jan' },
+           { name: 'data-automation-id', value: 'automation-id-area-b-jan' }
+         ]
       }, {
           name: 'Feb',
-          value: 21
+          value: 21,
+          attributes: [
+           { name: 'id', value: 'area-b-feb' },
+           { name: 'data-automation-id', value: 'automation-id-area-b-feb' }
+         ]
       }, {
           name: 'Mar',
-          value: 24
+          value: 24,
+          attributes: [
+           { name: 'id', value: 'area-b-mar' },
+           { name: 'data-automation-id', value: 'automation-id-area-b-mar' }
+         ]
       }, {
           name: 'Apr',
-          value: 20
+          value: 20,
+          attributes: [
+           { name: 'id', value: 'area-b-apr' },
+           { name: 'data-automation-id', value: 'automation-id-area-b-apr' }
+         ]
       }, {
           name: 'May',
-          value: 24
+          value: 24,
+          attributes: [
+           { name: 'id', value: 'area-b-may' },
+           { name: 'data-automation-id', value: 'automation-id-area-b-may' }
+         ]
       }, {
           name: 'Jun',
-          value: 28
+          value: 28,
+          attributes: [
+           { name: 'id', value: 'area-b-jun' },
+           { name: 'data-automation-id', value: 'automation-id-area-b-jun' }
+         ]
       }],
       name: 'Component B',
       legendShortName: 'Comp B',
-      legendAbbrName: 'B'
+      legendAbbrName: 'B',
+      attributes: [
+       { name: 'id', value: 'area-comp-b' },
+       { name: 'data-automation-id', value: 'automation-id-area-comp-b' }
+     ]
     }, {
       data: [{
           name: 'Jan',
-          value: 12
+          value: 12,
+          attributes: [
+           { name: 'id', value: 'area-c-jan' },
+           { name: 'data-automation-id', value: 'automation-id-area-c-jan' }
+         ]
       }, {
           name: 'Feb',
-          value: 11
+          value: 11,
+          attributes: [
+           { name: 'id', value: 'area-c-feb' },
+           { name: 'data-automation-id', value: 'automation-id-area-c-feb' }
+         ]
       }, {
           name: 'Mar',
-          value: 14
+          value: 14,
+          attributes: [
+           { name: 'id', value: 'area-c-mar' },
+           { name: 'data-automation-id', value: 'automation-id-area-c-mar' }
+         ]
       }, {
           name: 'Apr',
-          value: 10
+          value: 10,
+          attributes: [
+           { name: 'id', value: 'area-c-apr' },
+           { name: 'data-automation-id', value: 'automation-id-area-c-apr' }
+         ]
       }, {
           name: 'May',
-          value: 14
+          value: 14,
+          attributes: [
+           { name: 'id', value: 'area-c-may' },
+           { name: 'data-automation-id', value: 'automation-id-area-c-may' }
+         ]
       }, {
           name: 'Jun',
-          value: 8
+          value: 8,
+          attributes: [
+           { name: 'id', value: 'area-c-jun' },
+           { name: 'data-automation-id', value: 'automation-id-area-c-jun' }
+         ]
       }],
       name: 'Component C',
       legendShortName: 'Comp C',
-      legendAbbrName: 'C'
+      legendAbbrName: 'C',
+      attributes: [
+       { name: 'id', value: 'area-comp-c' },
+       { name: 'data-automation-id', value: 'automation-id-area-comp-c' }
+     ]
     }];
 
   $('#area-example').chart({type: 'area', dataset: dataset});

--- a/app/views/components/bubble/example-index.html
+++ b/app/views/components/bubble/example-index.html
@@ -22,84 +22,132 @@ var dataset = [{
       x: 5,
       y: 3,
       z: 3
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-jan' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-jan' }
+   ]
   }, {
     name: 'February',
     value: {
       x: 37,
       y: 5,
       z: 9
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-feb' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-feb' }
+   ]
   }, {
     name: 'March',
     value: {
       x: 10,
       y: 5.3,
       z: 4
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-mar' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-mar' }
+   ]
   }, {
     name: 'April',
     value: {
       x: 80,
       y: 6,
       z: 10
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-apr' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-apr' }
+   ]
   }, {
     name: 'May',
     value: {
       x: 21,
       y: 4.8,
       z: 4
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-may' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-may' }
+   ]
   }, {
     name: 'June',
     value: {
       x: 72,
       y: 5.2,
       z: 4
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-jun' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-jun' }
+   ]
   }, {
     name: 'July',
     value: {
       x: 26,
       y: 8,
       z: 6
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-jul' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-jul' }
+   ]
   }, {
     name: 'August',
     value: {
       x: 71,
       y: 3.9,
       z: 8
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-aug' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-aug' }
+   ]
   }, {
     name: 'September',
     value: {
       x: 85,
       y: 8,
       z: 2
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-sep' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-sep' }
+   ]
   }, {
     name: 'October',
     value: {
       x: 52,
       y: 3,
       z: 2
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-oct' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-oct' }
+   ]
   }, {
     name: 'November',
     value: {
       x: 44,
       y: 5.9,
       z: 3
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-nov' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-nov' }
+   ]
   }, {
     name: 'December',
     value: {
       x: 110,
       y: 7,
       z: 4
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-dec' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-dec' }
+   ]
   }],
   name: 'Series 01',
   labels: {
@@ -113,7 +161,11 @@ var dataset = [{
   // Use d3 Format - only value will be formated
   valueFormatterString: {
     z: '0.0%'
-  }
+  },
+  attributes: [
+   { name: 'id', value: 'bubble-series1' },
+   { name: 'data-automation-id', value: 'automation-id-bubble-series1' }
+ ]
 },
 {
   data: [{
@@ -122,86 +174,138 @@ var dataset = [{
       x: 9,
       y: 3.2,
       z: 3
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-jan' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-jan' }
+   ]
   }, {
     name: 'February',
     value: {
       x: 12,
       y: 6.3,
       z: 10
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-feb' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-feb' }
+   ]
   }, {
     name: 'March',
     value: {
       x: 65,
       y: 4,
       z: 10
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-mar' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-mar' }
+   ]
   }, {
     name: 'April',
     value: {
       x: 27,
       y: 7,
       z: 2
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-apr' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-apr' }
+   ]
   }, {
     name: 'May',
     value: {
       x: 29,
       y: 8.5,
       z: 4
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-may' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-may' }
+   ]
   }, {
     name: 'June',
     value: {
       x: 81,
       y: 3.9,
       z: 8
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-jun' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-jun' }
+   ]
   }, {
     name: 'July',
     value: {
       x: 33,
       y: 4.1,
       z: 7
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-jul' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-jul' }
+   ]
   }, {
     name: 'August',
     value: {
       x: 75,
       y: 4,
       z: 3
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-aug' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-aug' }
+   ]
   }, {
     name: 'September',
     value: {
       x: 39,
       y: 7,
       z: 4
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-sep' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-sep' }
+   ]
   }, {
     name: 'October',
     value: {
       x: 80,
       y: 2,
       z: 3
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-oct' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-oct' }
+   ]
   }, {
     name: 'November',
     value: {
       x: 48,
       y: 6.2,
       z: 2
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-nov' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-nov' }
+   ]
   }, {
     name: 'December',
     value: {
       x: 99,
       y: 4,
       z: 2
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-dec' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-dec' }
+   ]
   }],
-  name: 'Series 02'
+  name: 'Series 02',
+  attributes: [
+   { name: 'id', value: 'bubble-series2' },
+   { name: 'data-automation-id', value: 'automation-id-bubble-series2' }
+ ]
 }];
 
 $('#bubble-example').chart({type: 'bubble', dataset: dataset, animate: false});

--- a/app/views/components/line/example-index.html
+++ b/app/views/components/line/example-index.html
@@ -19,72 +19,156 @@ $('body').on('initialized', function () {
     data: [{
         name: 'Jan',
         value: 3211,
-        depth: 4
+        depth: 4,
+        attributes: [
+         { name: 'id', value: 'line-a-jan' },
+         { name: 'data-automation-id', value: 'automation-id-line-a-jan' }
+       ]
     }, {
         name: 'Feb',
-        value: 3111
+        value: 3111,
+        attributes: [
+         { name: 'id', value: 'line-a-feb' },
+         { name: 'data-automation-id', value: 'automation-id-line-a-feb' }
+       ]
     }, {
         name: 'Mar',
-        value: 3411
+        value: 3411,
+        attributes: [
+         { name: 'id', value: 'line-a-mar' },
+         { name: 'data-automation-id', value: 'automation-id-line-a-mar' }
+       ]
     }, {
         name: 'Apr',
-        value: 3011
+        value: 3011,
+        attributes: [
+         { name: 'id', value: 'line-a-apr' },
+         { name: 'data-automation-id', value: 'automation-id-line-a-apr' }
+       ]
     }, {
         name: 'May',
-        value: 3411
+        value: 3411,
+        attributes: [
+         { name: 'id', value: 'line-a-may' },
+         { name: 'data-automation-id', value: 'automation-id-line-a-may' }
+       ]
     }, {
         name: 'Jun',
-        value: 3111
+        value: 3111,
+        attributes: [
+         { name: 'id', value: 'line-a-jun' },
+         { name: 'data-automation-id', value: 'automation-id-line-a-jun' }
+       ]
     }],
     name: 'Component A',
     legendShortName: 'Comp A',
-    legendAbbrName: 'A'
+    legendAbbrName: 'A',
+    attributes: [
+     { name: 'id', value: 'line-comp-a' },
+     { name: 'data-automation-id', value: 'automation-id-line-comp-a' }
+   ]
   }, {
     data: [{
         name: 'Jan',
-        value: 2211
+        value: 2211,
+        attributes: [
+         { name: 'id', value: 'line-b-jan' },
+         { name: 'data-automation-id', value: 'automation-id-line-b-jan' }
+       ]
     }, {
         name: 'Feb',
-        value: 2111
+        value: 2111,
+        attributes: [
+         { name: 'id', value: 'line-b-feb' },
+         { name: 'data-automation-id', value: 'automation-id-line-b-feb' }
+       ]
     }, {
         name: 'Mar',
-        value: 2411
+        value: 2411,
+        attributes: [
+         { name: 'id', value: 'line-b-mar' },
+         { name: 'data-automation-id', value: 'automation-id-line-b-mar' }
+       ]
     }, {
         name: 'Apr',
-        value: 2011
+        value: 2011,
+        attributes: [
+         { name: 'id', value: 'line-b-apr' },
+         { name: 'data-automation-id', value: 'automation-id-line-b-apr' }
+       ]
     }, {
         name: 'May',
-        value: 2411
+        value: 2411,
+        attributes: [
+         { name: 'id', value: 'line-b-may' },
+         { name: 'data-automation-id', value: 'automation-id-line-b-may' }
+       ]
     }, {
         name: 'Jun',
-        value: 2811
+        value: 2811,
+        attributes: [
+         { name: 'id', value: 'line-b-jun' },
+         { name: 'data-automation-id', value: 'automation-id-line-b-jun' }
+       ]
     }],
     name: 'Component B',
     legendShortName: 'Comp B',
-    legendAbbrName: 'A'
+    legendAbbrName: 'B',
+    attributes: [
+     { name: 'id', value: 'line-comp-b' },
+     { name: 'data-automation-id', value: 'automation-id-line-comp-b' }
+   ]
   }, {
     data: [{
         name: 'Jan',
-        value: 1211
+        value: 1211,
+        attributes: [
+         { name: 'id', value: 'line-c-jan' },
+         { name: 'data-automation-id', value: 'automation-id-line-c-jan' }
+       ]
     }, {
         name: 'Feb',
-        value: 1111
+        value: 1111,
+        attributes: [
+         { name: 'id', value: 'line-c-feb' },
+         { name: 'data-automation-id', value: 'automation-id-line-c-feb' }
+       ]
     }, {
         name: 'Mar',
-        value: 1411
+        value: 1411,
+        attributes: [
+         { name: 'id', value: 'line-c-mar' },
+         { name: 'data-automation-id', value: 'automation-id-line-c-mar' }
+       ]
     }, {
         name: 'Apr',
-        value: 1011
+        value: 1011,
+        attributes: [
+         { name: 'id', value: 'line-c-apr' },
+         { name: 'data-automation-id', value: 'automation-id-line-c-apr' }
+       ]
     }, {
         name: 'May',
-        value: 1411
+        value: 1411,
+        attributes: [
+         { name: 'id', value: 'line-c-may' },
+         { name: 'data-automation-id', value: 'automation-id-line-c-may' }
+       ]
     }, {
         name: 'Jun',
-        value: 1811
+        value: 1811,
+        attributes: [
+         { name: 'id', value: 'line-c-jun' },
+         { name: 'data-automation-id', value: 'automation-id-line-c-jun' }
+       ]
     }],
     name: 'Component C',
     legendShortName: 'Comp C',
-    legendAbbrName: 'C'
+    legendAbbrName: 'C',
+    attributes: [
+     { name: 'id', value: 'line-comp-c' },
+     { name: 'data-automation-id', value: 'automation-id-line-comp-c' }
+   ]
   }];
 
   $('#line-example').chart({type: 'line', dataset: dataset, yAxis: {ticks: {number: 10, format: 's'} } });

--- a/app/views/components/scatterplot/example-index.html
+++ b/app/views/components/scatterplot/example-index.html
@@ -21,73 +21,121 @@ $('body').on('initialized', function () {
       value: {
         x: 5,
         y: 3
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s1-jan' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-jan' }
+     ]
     }, {
       name: 'February',
       value: {
         x: 37,
         y: 5
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s1-feb' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-feb' }
+     ]
     }, {
       name: 'March',
       value: {
         x: 10,
         y: 5.3
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s1-mar' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-mar' }
+     ]
     }, {
       name: 'April',
       value: {
         x: 80,
         y: 6
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s1-apr' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-apr' }
+     ]
     }, {
       name: 'May',
       value: {
         x: 21,
         y: 4.8
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s1-may' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-may' }
+     ]
     }, {
       name: 'June',
       value: {
         x: 72,
         y: 5.2
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s1-jun' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-jun' }
+     ]
     }, {
       name: 'July',
       value: {
         x: 26,
         y: 8
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s1-jul' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-jul' }
+     ]
     }, {
       name: 'August',
       value: {
         x: 71,
         y: 3.9
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s1-aug' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-aug' }
+     ]
     }, {
       name: 'September',
       value: {
         x: 85,
         y: 8
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s1-sep' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-sep' }
+     ]
     }, {
       name: 'October',
       value: {
         x: 52,
         y: 3
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s1-oct' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-oct' }
+     ]
     }, {
       name: 'November',
       value: {
         x: 44,
         y: 5.9
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s1-nov' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-nov' }
+     ]
     }, {
       name: 'December',
       value: {
         x: 110,
         y: 7
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s1-dec' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-dec' }
+     ]
     }],
     name: 'Series 01',
     labels: {
@@ -100,7 +148,11 @@ $('body').on('initialized', function () {
     // Use d3 Format - only value will be formated
     valueFormatterString: {
       z: '0.0%'
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-series1' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-series1' }
+   ]
   },
   {
     data: [{
@@ -108,75 +160,127 @@ $('body').on('initialized', function () {
       value: {
         x: 9,
         y: 3.2
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s2-jan' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-jan' }
+     ]
     }, {
       name: 'February',
       value: {
         x: 12,
         y: 6.3
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s2-feb' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-feb' }
+     ]
     }, {
       name: 'March',
       value: {
         x: 65,
         y: 4
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s2-mar' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-mar' }
+     ]
     }, {
       name: 'April',
       value: {
         x: 27,
         y: 7
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s2-apr' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-apr' }
+     ]
     }, {
       name: 'May',
       value: {
         x: 29,
         y: 8.5
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s2-may' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-may' }
+     ]
     }, {
       name: 'June',
       value: {
         x: 81,
         y: 3.9
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s2-jun' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-jun' }
+     ]
     }, {
       name: 'July',
       value: {
         x: 33,
         y: 4.1
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s2-jul' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-jul' }
+     ]
     }, {
       name: 'August',
       value: {
         x: 75,
         y: 4
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s2-aug' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-aug' }
+     ]
     }, {
       name: 'September',
       value: {
         x: 39,
         y: 7
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s2-sep' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-sep' }
+     ]
     }, {
       name: 'October',
       value: {
         x: 80,
         y: 2
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s2-oct' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-oct' }
+     ]
     }, {
       name: 'November',
       value: {
         x: 48,
         y: 6.2
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s2-nov' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-nov' }
+     ]
     }, {
       name: 'December',
       value: {
         x: 99,
         y: 4
-      }
+      },
+      attributes: [
+       { name: 'id', value: 'scatterplot-s2-dec' },
+       { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-dec' }
+     ]
     }],
-    name: 'Series 02'
+    name: 'Series 02',
+    attributes: [
+     { name: 'id', value: 'scatterplot-series2' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-series2' }
+   ]
   }];
 
   $('#scatterplot-example').chart({type: 'scatterplot', dataset: dataset});

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -6,7 +6,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [ ] Accordion
 - [x] Alerts (not needed id can be directly applied)
 - [ ] Applicationmenu
-- [ ] Area
+- [x] Area
 - [ ] Autocomplete
 - [x] Badges (not needed id can be directly applied)
 - [ ] Bar
@@ -14,7 +14,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [ ] Bar Stacked
 - [ ] Blockgrid
 - [ ] Breadcrumb
-- [ ] Bubble
+- [x] Bubble
 - [ ] Bullet
 - [ ] Busyindicator
 - [ ] Button
@@ -49,7 +49,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [x] Icons (not needed id can be directly applied)
 - [x] Images (not needed id can be directly applied)
 - [ ] Input
-- [ ] Line
+- [x] Line
 - [ ] Listbuilder
 - [ ] Listview
 - [ ] Lookup
@@ -70,7 +70,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [ ] Radar
 - [x] Radios (not needed id can be directly applied)
 - [ ] Rating
-- [ ] Scatterplot
+- [x] Scatterplot
 - [ ] Searchfield
 - [ ] Signin
 - [x] Skiplink (not needed id can be directly applied)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Datagrid]` Fixed an issue with a custom toolbar, where buttons would click twice. ([#4471](https://github.com/infor-design/enterprise/issues/4471))
 - `[About]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
+- `[Area/Bubble/Line/Scatterplot]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[ContextualActionPanel]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Donut/Pie]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Message]` Added `attributes` setting to set automation id's and id's. ([#4277](https://github.com/infor-design/enterprise/issues/4277))

--- a/src/components/area/readme.md
+++ b/src/components/area/readme.md
@@ -23,66 +23,150 @@ we pass a dataset with x and y axis values to make three lines.
 var dataset = [{
   data: [{
       name: 'Jan',
-      value: 12
+      value: 12,
+      attributes: [
+       { name: 'id', value: 'area-a-jan' },
+       { name: 'data-automation-id', value: 'automation-id-area-a-jan' }
+     ]
   }, {
       name: 'Feb',
-      value: 11
+      value: 11,
+      attributes: [
+       { name: 'id', value: 'area-a-feb' },
+       { name: 'data-automation-id', value: 'automation-id-area-a-feb' }
+     ]
   }, {
       name: 'Mar',
-      value: 14
+      value: 14,
+      attributes: [
+       { name: 'id', value: 'area-a-mar' },
+       { name: 'data-automation-id', value: 'automation-id-area-a-mar' }
+     ]
   }, {
       name: 'Apr',
-      value: 10
+      value: 10,
+      attributes: [
+       { name: 'id', value: 'area-a-apr' },
+       { name: 'data-automation-id', value: 'automation-id-area-a-apr' }
+     ]
   }, {
       name: 'May',
-      value: 14
+      value: 14,
+      attributes: [
+       { name: 'id', value: 'area-a-may' },
+       { name: 'data-automation-id', value: 'automation-id-area-a-may' }
+     ]
   }, {
       name: 'Jun',
-      value: 8
+      value: 8,
+      attributes: [
+       { name: 'id', value: 'area-a-jun' },
+       { name: 'data-automation-id', value: 'automation-id-area-a-jun' }
+     ]
   }],
-  name: 'Component A'
+  name: 'Component A',
+  attributes: [
+   { name: 'id', value: 'area-comp-a' },
+   { name: 'data-automation-id', value: 'automation-id-area-comp-a' }
+ ]
 }, {
   data: [{
       name: 'Jan',
-      value: 22
+      value: 22,
+      attributes: [
+       { name: 'id', value: 'area-b-jan' },
+       { name: 'data-automation-id', value: 'automation-id-area-b-jan' }
+     ]
   }, {
       name: 'Feb',
-      value: 21
+      value: 21,
+      attributes: [
+       { name: 'id', value: 'area-b-feb' },
+       { name: 'data-automation-id', value: 'automation-id-area-b-feb' }
+     ]
   }, {
       name: 'Mar',
-      value: 24
+      value: 24,
+      attributes: [
+       { name: 'id', value: 'area-b-mar' },
+       { name: 'data-automation-id', value: 'automation-id-area-b-mar' }
+     ]
   }, {
       name: 'Apr',
-      value: 20
+      value: 20,
+      attributes: [
+       { name: 'id', value: 'area-b-apr' },
+       { name: 'data-automation-id', value: 'automation-id-area-b-apr' }
+     ]
   }, {
       name: 'May',
-      value: 24
+      value: 24,
+      attributes: [
+       { name: 'id', value: 'area-b-may' },
+       { name: 'data-automation-id', value: 'automation-id-area-b-may' }
+     ]
   }, {
       name: 'Jun',
-      value: 28
+      value: 28,
+      attributes: [
+       { name: 'id', value: 'area-b-jun' },
+       { name: 'data-automation-id', value: 'automation-id-area-b-jun' }
+     ]
   }],
-  name: 'Component B'
+  name: 'Component B',
+  attributes: [
+   { name: 'id', value: 'area-comp-b' },
+   { name: 'data-automation-id', value: 'automation-id-area-comp-b' }
+ ]
 }, {
   data: [{
       name: 'Jan',
-      value: 32
+      value: 32,
+      attributes: [
+       { name: 'id', value: 'area-c-jan' },
+       { name: 'data-automation-id', value: 'automation-id-area-c-jan' }
+     ]
   }, {
       name: 'Feb',
-      value: 31
+      value: 31,
+      attributes: [
+       { name: 'id', value: 'area-c-feb' },
+       { name: 'data-automation-id', value: 'automation-id-area-c-feb' }
+     ]
   }, {
       name: 'Mar',
-      value: 34
+      value: 34,
+      attributes: [
+       { name: 'id', value: 'area-c-mar' },
+       { name: 'data-automation-id', value: 'automation-id-area-c-mar' }
+     ]
   }, {
       name: 'Apr',
-      value: 30
+      value: 30,
+      attributes: [
+       { name: 'id', value: 'area-c-apr' },
+       { name: 'data-automation-id', value: 'automation-id-area-c-apr' }
+     ]
   }, {
       name: 'May',
-      value: 34
+      value: 34,
+      attributes: [
+       { name: 'id', value: 'area-c-may' },
+       { name: 'data-automation-id', value: 'automation-id-area-c-may' }
+     ]
   }, {
       name: 'Jun',
-      value: 38
+      value: 38,
+      attributes: [
+       { name: 'id', value: 'area-c-jun' },
+       { name: 'data-automation-id', value: 'automation-id-area-c-jun' }
+     ]
   }],
-  name: 'Component C'
+  name: 'Component C',
+  attributes: [
+   { name: 'id', value: 'area-comp-c' },
+   { name: 'data-automation-id', value: 'automation-id-area-comp-c' }
+ ]
 }];
 
 $('#area-example').chart({type: 'area', dataset: dataset});
@@ -130,7 +214,31 @@ name: 'Component C'
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+You can add custom id's/automation id's to the area chart that can be used for scripting using the `attributes` data attribute. This data attribute can be either an object or an array for setting multiple values such as an automation-id or other attributes. For example:
+
+Setting the id/automation id with a string value or function. The function will give you the data as a parameter for making things more dynamic.
+
+```js
+{
+  data: [{
+    name: 'Jan',
+    value: 12,
+    attributes: [
+      { name: 'id', value: 'area-a-jan' },
+      { name: 'data-automation-id', value: 'automation-id-area-a-jan' }
+    ]
+  }],
+  name: 'Component A',
+  attributes: [
+   { name: 'id', value: 'area-comp-a' },
+   { name: 'data-automation-id', value: 'automation-id-area-comp-a' }
+ ]
+}
+```
+
+Providing the data this will add an ID added to the area with `-area` appended, line with `-line` appended and dot with `-dot` appended. In addition the related legend item will get the same id with `-legend` appended after it.
+
+ Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for general information.
 
 ## Keyboard Shortcuts
 

--- a/src/components/bubble/readme.md
+++ b/src/components/bubble/readme.md
@@ -28,84 +28,132 @@ var dataset = [{
       x: 5,
       y: 3,
       z: 3
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-jan' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-jan' }
+   ]
   }, {
     name: 'February',
     value: {
       x: 37,
       y: 5,
       z: 9
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-feb' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-feb' }
+   ]
   }, {
     name: 'March',
     value: {
       x: 10,
       y: 5.3,
       z: 4
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-mar' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-mar' }
+   ]
   }, {
     name: 'April',
     value: {
       x: 80,
       y: 6,
       z: 10
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-apr' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-apr' }
+   ]
   }, {
     name: 'May',
     value: {
       x: 21,
       y: 4.8,
       z: 4
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-may' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-may' }
+   ]
   }, {
     name: 'June',
     value: {
       x: 72,
       y: 5.2,
       z: 4
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-jun' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-jun' }
+   ]
   }, {
     name: 'July',
     value: {
       x: 26,
       y: 8,
       z: 6
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-jul' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-jul' }
+   ]
   }, {
     name: 'August',
     value: {
       x: 71,
       y: 3.9,
       z: 8
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-aug' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-aug' }
+   ]
   }, {
     name: 'September',
     value: {
       x: 85,
       y: 8,
       z: 2
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-sep' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-sep' }
+   ]
   }, {
     name: 'October',
     value: {
       x: 52,
       y: 3,
       z: 2
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-oct' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-oct' }
+   ]
   }, {
     name: 'November',
     value: {
       x: 44,
       y: 5.9,
       z: 3
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-nov' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-nov' }
+   ]
   }, {
     name: 'December',
     value: {
       x: 110,
       y: 7,
       z: 4
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-dec' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-dec' }
+   ]
   }],
   name: 'Series 01',
   labels: {
@@ -118,7 +166,11 @@ var dataset = [{
   },
   valueFormatterString: {
     z: '0.0%'
-  }
+  },
+  attributes: [
+   { name: 'id', value: 'bubble-series1' },
+   { name: 'data-automation-id', value: 'automation-id-bubble-series1' }
+ ]
 },
 {
   data: [{
@@ -127,86 +179,138 @@ var dataset = [{
       x: 9,
       y: 3.2,
       z: 3
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-jan' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-jan' }
+   ]
   }, {
     name: 'February',
     value: {
       x: 12,
       y: 6.3,
       z: 10
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-feb' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-feb' }
+   ]
   }, {
     name: 'March',
     value: {
       x: 65,
       y: 4,
       z: 10
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-mar' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-mar' }
+   ]
   }, {
     name: 'April',
     value: {
       x: 27,
       y: 7,
       z: 2
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-apr' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-apr' }
+   ]
   }, {
     name: 'May',
     value: {
       x: 29,
       y: 8.5,
       z: 4
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-may' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-may' }
+   ]
   }, {
     name: 'June',
     value: {
       x: 81,
       y: 3.9,
       z: 8
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-jun' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-jun' }
+   ]
   }, {
     name: 'July',
     value: {
       x: 33,
       y: 4.1,
       z: 7
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-jul' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-jul' }
+   ]
   }, {
     name: 'August',
     value: {
       x: 75,
       y: 4,
       z: 3
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-aug' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-aug' }
+   ]
   }, {
     name: 'September',
     value: {
       x: 39,
       y: 7,
       z: 4
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-sep' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-sep' }
+   ]
   }, {
     name: 'October',
     value: {
       x: 80,
       y: 2,
       z: 3
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-oct' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-oct' }
+   ]
   }, {
     name: 'November',
     value: {
       x: 48,
       y: 6.2,
       z: 2
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-nov' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-nov' }
+   ]
   }, {
     name: 'December',
     value: {
       x: 99,
       y: 4,
       z: 2
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s2-dec' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s2-dec' }
+   ]
   }],
-  name: 'Series 02'
+  name: 'Series 02',
+  attributes: [
+   { name: 'id', value: 'bubble-series2' },
+   { name: 'data-automation-id', value: 'automation-id-bubble-series2' }
+ ]
 }];
 
 $('#line-example').chart({type: 'bubble', dataset: dataset});
@@ -267,7 +371,35 @@ let options = {
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+You can add custom id's/automation id's to the bubble chart that can be used for scripting using the `attributes` data attribute. This data attribute can be either an object or an array for setting multiple values such as an automation-id or other attributes. For example:
+
+Setting the id/automation id with a string value or function. The function will give you the data as a parameter for making things more dynamic.
+
+```js
+{
+  data: [{
+    name: 'January',
+    value: {
+      x: 5,
+      y: 3,
+      z: 3
+    },
+    attributes: [
+     { name: 'id', value: 'bubble-s1-jan' },
+     { name: 'data-automation-id', value: 'automation-id-bubble-s1-jan' }
+   ]
+  }],
+  name: 'Series 01',
+  attributes: [
+   { name: 'id', value: 'bubble-series1' },
+   { name: 'data-automation-id', value: 'automation-id-bubble-series1' }
+ ]
+}
+```
+
+Providing the data this will add an ID added to the line with `-line` appended and dot with `-dot` appended. In addition the related legend item will get the same id with `-legend` appended after it.
+
+Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for general information.
 
 ## Keyboard Shortcuts
 

--- a/src/components/line/line.js
+++ b/src/components/line/line.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-nested-ternary, prefer-arrow-callback */
+/* eslint-disable no-nested-ternary, prefer-arrow-callback, no-underscore-dangle */
 
 // Other Shared Imports
 import { Environment as env } from '../../utils/environment';
@@ -457,7 +457,14 @@ Line.prototype = {
           .attr('fill', () => charts.chartColor(lineIdx, 'line', d))
           .style('opacity', '.2')
           .attr('class', 'area')
-          .attr('d', area);
+          .attr('d', area)
+          .call((d2) => {
+            d2._groups.forEach((lines) => {
+              lines.forEach((thisLine) => {
+                utils.addAttributes($(thisLine), d, d.attributes, 'area');
+              });
+            });
+          });
       }
 
       const path = lineGroups.append('path')
@@ -467,6 +474,13 @@ Line.prototype = {
         .attr('stroke-width', 2)
         .attr('fill', 'none')
         .attr('class', 'line')
+        .call((d2) => {
+          d2._groups.forEach((lines) => {
+            lines.forEach((thisLine) => {
+              utils.addAttributes($(thisLine), d, d.attributes, 'line');
+            });
+          });
+        })
         .on(`click.${self.namespace}`, function () {
           charts.selectElement(d3.select(this.parentNode), self.svg.selectAll('.line-group'), d, self.element, dataset, self.initialSelectCall);
         })
@@ -521,7 +535,7 @@ Line.prototype = {
               } else {
                 const obj2 = mouseEnterData[key];
                 for (const key2 in obj2) {  //eslint-disable-line
-                  if (obj2.hasOwnProperty(key2)) {  //eslint-disable-line
+                  if (obj2.hasOwnProperty(key2) && labels[key]) {  //eslint-disable-line
                     content += `${'' +
                         '<div class="swatch-row">' +
                           '<span class="text-capitalize">'}${labels[key][key2]}</span>` +
@@ -576,6 +590,14 @@ Line.prototype = {
             .enter()
             .append('circle')
             .attr('class', dots.class)
+            .call((d2) => {
+              d2._groups.forEach((thisDots) => {
+                thisDots.forEach((dot) => {
+                  const dat = dot.__data__;
+                  utils.addAttributes($(dot), dat, dat.attributes, 'dot');
+                });
+              });
+            })
             .attr('cx', function (dd, p) {
               if (!!s.xAxis && !!s.xAxis.parser) {
                 return xScale(s.xAxis.parser(dd, p));
@@ -612,6 +634,14 @@ Line.prototype = {
             .enter()
             .append('path')
             .attr('class', 'symbol')
+            .call((d2) => {
+              d2._groups.forEach((thisSymbols) => {
+                thisSymbols.forEach((symbol) => {
+                  const dat = symbol.__data__;
+                  utils.addAttributes($(symbol), dat, dat.attributes, 'symbol');
+                });
+              });
+            })
             .attr('transform', function (ds) {
               return `translate(${xScale(ds.value.x)},${yScale(ds.value.y)})`;
             })

--- a/src/components/line/readme.md
+++ b/src/components/line/readme.md
@@ -34,66 +34,150 @@ This example shows how to invoke the line chart option in the charts component. 
 var dataset = [{
   data: [{
       name: 'Jan',
-      value: 12
+      value: 12,
+      attributes: [
+       { name: 'id', value: 'line-a-jan' },
+       { name: 'data-automation-id', value: 'automation-id-line-a-jan' }
+     ]
   }, {
       name: 'Feb',
-      value: 11
+      value: 11,
+      attributes: [
+       { name: 'id', value: 'line-a-feb' },
+       { name: 'data-automation-id', value: 'automation-id-line-a-feb' }
+     ]
   }, {
       name: 'Mar',
-      value: 14
+      value: 14,
+      attributes: [
+       { name: 'id', value: 'line-a-mar' },
+       { name: 'data-automation-id', value: 'automation-id-line-a-mar' }
+     ]
   }, {
       name: 'Apr',
-      value: 10
+      value: 10,
+      attributes: [
+       { name: 'id', value: 'line-a-apr' },
+       { name: 'data-automation-id', value: 'automation-id-line-a-apr' }
+     ]
   }, {
       name: 'May',
-      value: 14
+      value: 14,
+      attributes: [
+       { name: 'id', value: 'line-a-may' },
+       { name: 'data-automation-id', value: 'automation-id-line-a-may' }
+     ]
   }, {
       name: 'Jun',
-      value: 8
+      value: 8,
+      attributes: [
+       { name: 'id', value: 'line-a-jun' },
+       { name: 'data-automation-id', value: 'automation-id-line-a-jun' }
+     ]
   }],
-  name: 'Component A'
+  name: 'Component A',
+  attributes: [
+   { name: 'id', value: 'line-comp-a' },
+   { name: 'data-automation-id', value: 'automation-id-line-comp-a' }
+ ]
 }, {
   data: [{
       name: 'Jan',
-      value: 22
+      value: 22,
+      attributes: [
+       { name: 'id', value: 'line-b-jan' },
+       { name: 'data-automation-id', value: 'automation-id-line-b-jan' }
+     ]
   }, {
       name: 'Feb',
-      value: 21
+      value: 21,
+      attributes: [
+       { name: 'id', value: 'line-b-feb' },
+       { name: 'data-automation-id', value: 'automation-id-line-b-feb' }
+     ]
   }, {
       name: 'Mar',
-      value: 24
+      value: 24,
+      attributes: [
+       { name: 'id', value: 'line-b-mar' },
+       { name: 'data-automation-id', value: 'automation-id-line-b-mar' }
+     ]
   }, {
       name: 'Apr',
-      value: 20
+      value: 20,
+      attributes: [
+       { name: 'id', value: 'line-b-apr' },
+       { name: 'data-automation-id', value: 'automation-id-line-b-apr' }
+     ]
   }, {
       name: 'May',
-      value: 24
+      value: 24,
+      attributes: [
+       { name: 'id', value: 'line-b-may' },
+       { name: 'data-automation-id', value: 'automation-id-line-b-may' }
+     ]
   }, {
       name: 'Jun',
-      value: 28
+      value: 28,
+      attributes: [
+       { name: 'id', value: 'line-b-jun' },
+       { name: 'data-automation-id', value: 'automation-id-line-b-jun' }
+     ]
   }],
-  name: 'Component B'
+  name: 'Component B',
+  attributes: [
+   { name: 'id', value: 'line-comp-b' },
+   { name: 'data-automation-id', value: 'automation-id-line-comp-b' }
+ ]
 }, {
   data: [{
       name: 'Jan',
-      value: 32
+      value: 32,
+      attributes: [
+       { name: 'id', value: 'line-c-jan' },
+       { name: 'data-automation-id', value: 'automation-id-line-c-jan' }
+     ]
   }, {
       name: 'Feb',
-      value: 31
+      value: 31,
+      attributes: [
+       { name: 'id', value: 'line-c-feb' },
+       { name: 'data-automation-id', value: 'automation-id-line-c-feb' }
+     ]
   }, {
       name: 'Mar',
-      value: 34
+      value: 34,
+      attributes: [
+       { name: 'id', value: 'line-c-mar' },
+       { name: 'data-automation-id', value: 'automation-id-line-c-mar' }
+     ]
   }, {
       name: 'Apr',
-      value: 30
+      value: 30,
+      attributes: [
+       { name: 'id', value: 'line-c-apr' },
+       { name: 'data-automation-id', value: 'automation-id-line-c-apr' }
+     ]
   }, {
       name: 'May',
-      value: 34
+      value: 34,
+      attributes: [
+       { name: 'id', value: 'line-c-may' },
+       { name: 'data-automation-id', value: 'automation-id-line-c-may' }
+     ]
   }, {
       name: 'Jun',
-      value: 38
+      value: 38,
+      attributes: [
+       { name: 'id', value: 'line-c-jun' },
+       { name: 'data-automation-id', value: 'automation-id-line-c-jun' }
+     ]
   }],
-  name: 'Component C'
+  name: 'Component C',
+  attributes: [
+   { name: 'id', value: 'line-comp-c' },
+   { name: 'data-automation-id', value: 'automation-id-line-comp-c' }
+ ]
 }];
 
 $('#area-example').chart({type: 'line', dataset: dataset});
@@ -101,7 +185,31 @@ $('#area-example').chart({type: 'line', dataset: dataset});
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+You can add custom id's/automation id's to the line chart that can be used for scripting using the `attributes` data attribute. This data attribute can be either an object or an array for setting multiple values such as an automation-id or other attributes. For example:
+
+Setting the id/automation id with a string value or function. The function will give you the data as a parameter for making things more dynamic.
+
+```js
+{
+  data: [{
+      name: 'Jan',
+      value: 12,
+      attributes: [
+       { name: 'id', value: 'line-a-jan' },
+       { name: 'data-automation-id', value: 'automation-id-line-a-jan' }
+     ]
+  }],
+  name: 'Component A',
+  attributes: [
+   { name: 'id', value: 'line-comp-a' },
+   { name: 'data-automation-id', value: 'automation-id-line-comp-a' }
+ ]
+}
+```
+
+Providing the data this will add an ID added to the line with `-line` appended and dot with `-dot` appended. In addition the related legend item will get the same id with `-legend` appended after it.
+
+Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for general information.
 
 ## Keyboard Shortcuts
 

--- a/src/components/scatterplot/readme.md
+++ b/src/components/scatterplot/readme.md
@@ -31,73 +31,121 @@ var dataset = [{
     value: {
       x: 5,
       y: 3
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s1-jan' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-jan' }
+   ]
   }, {
     name: 'February',
     value: {
       x: 37,
       y: 5
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s1-feb' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-feb' }
+   ]
   }, {
     name: 'March',
     value: {
       x: 10,
       y: 5.3
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s1-mar' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-mar' }
+   ]
   }, {
     name: 'April',
     value: {
       x: 80,
       y: 6
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s1-apr' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-apr' }
+   ]
   }, {
     name: 'May',
     value: {
       x: 21,
       y: 4.8
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s1-may' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-may' }
+   ]
   }, {
     name: 'June',
     value: {
       x: 72,
       y: 5.2
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s1-jun' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-jun' }
+   ]
   }, {
     name: 'July',
     value: {
       x: 26,
       y: 8
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s1-jul' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-jul' }
+   ]
   }, {
     name: 'August',
     value: {
       x: 71,
       y: 3.9
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s1-aug' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-aug' }
+   ]
   }, {
     name: 'September',
     value: {
       x: 85,
       y: 8
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s1-sep' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-sep' }
+   ]
   }, {
     name: 'October',
     value: {
       x: 52,
       y: 3
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s1-oct' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-oct' }
+   ]
   }, {
     name: 'November',
     value: {
       x: 44,
       y: 5.9
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s1-nov' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-nov' }
+   ]
   }, {
     name: 'December',
     value: {
       x: 110,
       y: 7
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s1-dec' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-dec' }
+   ]
   }],
   name: 'Series 01',
   labels: {
@@ -110,7 +158,11 @@ var dataset = [{
   },
   valueFormatterString: {
     z: '0.0%'
-  }
+  },
+  attributes: [
+   { name: 'id', value: 'scatterplot-series1' },
+   { name: 'data-automation-id', value: 'automation-id-scatterplot-series1' }
+ ]
 },
 {
   data: [{
@@ -118,75 +170,127 @@ var dataset = [{
     value: {
       x: 9,
       y: 3.2
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s2-jan' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-jan' }
+   ]
   }, {
     name: 'February',
     value: {
       x: 12,
       y: 6.3
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s2-feb' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-feb' }
+   ]
   }, {
     name: 'March',
     value: {
       x: 65,
       y: 4
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s2-mar' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-mar' }
+   ]
   }, {
     name: 'April',
     value: {
       x: 27,
       y: 7
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s2-apr' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-apr' }
+   ]
   }, {
     name: 'May',
     value: {
       x: 29,
       y: 8.5
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s2-may' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-may' }
+   ]
   }, {
     name: 'June',
     value: {
       x: 81,
       y: 3.9
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s2-jun' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-jun' }
+   ]
   }, {
     name: 'July',
     value: {
       x: 33,
       y: 4.1
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s2-jul' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-jul' }
+   ]
   }, {
     name: 'August',
     value: {
       x: 75,
       y: 4
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s2-aug' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-aug' }
+   ]
   }, {
     name: 'September',
     value: {
       x: 39,
       y: 7
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s2-sep' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-sep' }
+   ]
   }, {
     name: 'October',
     value: {
       x: 80,
       y: 2
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s2-oct' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-oct' }
+   ]
   }, {
     name: 'November',
     value: {
       x: 48,
       y: 6.2
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s2-nov' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-nov' }
+   ]
   }, {
     name: 'December',
     value: {
       x: 99,
       y: 4
-    }
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s2-dec' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s2-dec' }
+   ]
   }],
-  name: 'Series 02'
+  name: 'Series 02',
+  attributes: [
+   { name: 'id', value: 'scatterplot-series2' },
+   { name: 'data-automation-id', value: 'automation-id-scatterplot-series2' }
+ ]
 }];
 
 $('#line-example').chart({type: 'scatterplot', dataset: dataset});
@@ -215,7 +319,34 @@ valueFormatterString: {
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+You can add custom id's/automation id's to the scatterplot chart that can be used for scripting using the `attributes` data attribute. This data attribute can be either an object or an array for setting multiple values such as an automation-id or other attributes. For example:
+
+Setting the id/automation id with a string value or function. The function will give you the data as a parameter for making things more dynamic.
+
+```js
+{
+  data: [{
+    name: 'January',
+    value: {
+      x: 5,
+      y: 3
+    },
+    attributes: [
+     { name: 'id', value: 'scatterplot-s1-jan' },
+     { name: 'data-automation-id', value: 'automation-id-scatterplot-s1-jan' }
+   ]
+  }],
+  name: 'Series 01',
+  attributes: [
+   { name: 'id', value: 'scatterplot-series1' },
+   { name: 'data-automation-id', value: 'automation-id-scatterplot-series1' }
+ ]
+}
+```
+
+Providing the data this will add an ID added to the line with `-line` appended and symbol with `-symbol` appended. In addition the related legend item will get the same id with `-legend` appended after it.
+
+Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for general information.
 
 ## Keyboard Shortcuts
 

--- a/test/components/area/area.e2e-spec.js
+++ b/test/components/area/area.e2e-spec.js
@@ -5,6 +5,73 @@ requireHelper('rejection');
 
 jasmine.getEnv().addReporter(browserStackErrorReporter);
 
+describe('Area Chart tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/area/example-index?layout=nofrills');
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should be able to set id/automation id', async () => {
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.id('area-a-jan-dot')).getAttribute('id')).toEqual('area-a-jan-dot');
+    expect(await element(by.id('area-a-jan-dot')).getAttribute('data-automation-id')).toEqual('automation-id-area-a-jan-dot');
+    expect(await element(by.id('area-a-feb-dot')).getAttribute('id')).toEqual('area-a-feb-dot');
+    expect(await element(by.id('area-a-feb-dot')).getAttribute('data-automation-id')).toEqual('automation-id-area-a-feb-dot');
+    expect(await element(by.id('area-a-mar-dot')).getAttribute('id')).toEqual('area-a-mar-dot');
+    expect(await element(by.id('area-a-mar-dot')).getAttribute('data-automation-id')).toEqual('automation-id-area-a-mar-dot');
+    expect(await element(by.id('area-a-apr-dot')).getAttribute('id')).toEqual('area-a-apr-dot');
+    expect(await element(by.id('area-a-apr-dot')).getAttribute('data-automation-id')).toEqual('automation-id-area-a-apr-dot');
+    expect(await element(by.id('area-a-may-dot')).getAttribute('id')).toEqual('area-a-may-dot');
+    expect(await element(by.id('area-a-may-dot')).getAttribute('data-automation-id')).toEqual('automation-id-area-a-may-dot');
+    expect(await element(by.id('area-a-jun-dot')).getAttribute('id')).toEqual('area-a-jun-dot');
+    expect(await element(by.id('area-a-jun-dot')).getAttribute('data-automation-id')).toEqual('automation-id-area-a-jun-dot');
+
+    expect(await element(by.id('area-b-jan-dot')).getAttribute('id')).toEqual('area-b-jan-dot');
+    expect(await element(by.id('area-b-jan-dot')).getAttribute('data-automation-id')).toEqual('automation-id-area-b-jan-dot');
+    expect(await element(by.id('area-b-feb-dot')).getAttribute('id')).toEqual('area-b-feb-dot');
+    expect(await element(by.id('area-b-feb-dot')).getAttribute('data-automation-id')).toEqual('automation-id-area-b-feb-dot');
+    expect(await element(by.id('area-b-mar-dot')).getAttribute('id')).toEqual('area-b-mar-dot');
+    expect(await element(by.id('area-b-mar-dot')).getAttribute('data-automation-id')).toEqual('automation-id-area-b-mar-dot');
+    expect(await element(by.id('area-b-apr-dot')).getAttribute('id')).toEqual('area-b-apr-dot');
+    expect(await element(by.id('area-b-apr-dot')).getAttribute('data-automation-id')).toEqual('automation-id-area-b-apr-dot');
+    expect(await element(by.id('area-b-may-dot')).getAttribute('id')).toEqual('area-b-may-dot');
+    expect(await element(by.id('area-b-may-dot')).getAttribute('data-automation-id')).toEqual('automation-id-area-b-may-dot');
+    expect(await element(by.id('area-b-jun-dot')).getAttribute('id')).toEqual('area-b-jun-dot');
+    expect(await element(by.id('area-b-jun-dot')).getAttribute('data-automation-id')).toEqual('automation-id-area-b-jun-dot');
+
+    expect(await element(by.id('area-c-jan-dot')).getAttribute('id')).toEqual('area-c-jan-dot');
+    expect(await element(by.id('area-c-jan-dot')).getAttribute('data-automation-id')).toEqual('automation-id-area-c-jan-dot');
+    expect(await element(by.id('area-c-feb-dot')).getAttribute('id')).toEqual('area-c-feb-dot');
+    expect(await element(by.id('area-c-feb-dot')).getAttribute('data-automation-id')).toEqual('automation-id-area-c-feb-dot');
+    expect(await element(by.id('area-c-mar-dot')).getAttribute('id')).toEqual('area-c-mar-dot');
+    expect(await element(by.id('area-c-mar-dot')).getAttribute('data-automation-id')).toEqual('automation-id-area-c-mar-dot');
+    expect(await element(by.id('area-c-apr-dot')).getAttribute('id')).toEqual('area-c-apr-dot');
+    expect(await element(by.id('area-c-apr-dot')).getAttribute('data-automation-id')).toEqual('automation-id-area-c-apr-dot');
+    expect(await element(by.id('area-c-may-dot')).getAttribute('id')).toEqual('area-c-may-dot');
+    expect(await element(by.id('area-c-may-dot')).getAttribute('data-automation-id')).toEqual('automation-id-area-c-may-dot');
+    expect(await element(by.id('area-c-jun-dot')).getAttribute('id')).toEqual('area-c-jun-dot');
+    expect(await element(by.id('area-c-jun-dot')).getAttribute('data-automation-id')).toEqual('automation-id-area-c-jun-dot');
+
+    expect(await element(by.id('area-comp-a-line')).getAttribute('id')).toEqual('area-comp-a-line');
+    expect(await element(by.id('area-comp-a-line')).getAttribute('data-automation-id')).toEqual('automation-id-area-comp-a-line');
+    expect(await element(by.id('area-comp-b-line')).getAttribute('id')).toEqual('area-comp-b-line');
+    expect(await element(by.id('area-comp-b-line')).getAttribute('data-automation-id')).toEqual('automation-id-area-comp-b-line');
+    expect(await element(by.id('area-comp-c-line')).getAttribute('id')).toEqual('area-comp-c-line');
+    expect(await element(by.id('area-comp-c-line')).getAttribute('data-automation-id')).toEqual('automation-id-area-comp-c-line');
+
+    expect(await element(by.id('area-comp-a-legend')).getAttribute('id')).toEqual('area-comp-a-legend');
+    expect(await element(by.id('area-comp-a-legend')).getAttribute('data-automation-id')).toEqual('automation-id-area-comp-a-legend');
+    expect(await element(by.id('area-comp-b-legend')).getAttribute('id')).toEqual('area-comp-b-legend');
+    expect(await element(by.id('area-comp-b-legend')).getAttribute('data-automation-id')).toEqual('automation-id-area-comp-b-legend');
+    expect(await element(by.id('area-comp-c-legend')).getAttribute('id')).toEqual('area-comp-c-legend');
+    expect(await element(by.id('area-comp-c-legend')).getAttribute('data-automation-id')).toEqual('automation-id-area-comp-c-legend');
+  });
+});
+
 describe('Area empty tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/area/test-empty');

--- a/test/components/bubble/bubble.e2e-spec.js
+++ b/test/components/bubble/bubble.e2e-spec.js
@@ -24,4 +24,68 @@ describe('Bubble example-index tests', () => {
       expect(await browser.imageComparison.checkScreen('bubble')).toEqual(0);
     });
   }
+
+  it('Should be able to set id/automation id', async () => {
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.id('bubble-s1-jan-dot')).getAttribute('id')).toEqual('bubble-s1-jan-dot');
+    expect(await element(by.id('bubble-s1-jan-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s1-jan-dot');
+    expect(await element(by.id('bubble-s1-feb-dot')).getAttribute('id')).toEqual('bubble-s1-feb-dot');
+    expect(await element(by.id('bubble-s1-feb-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s1-feb-dot');
+    expect(await element(by.id('bubble-s1-mar-dot')).getAttribute('id')).toEqual('bubble-s1-mar-dot');
+    expect(await element(by.id('bubble-s1-mar-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s1-mar-dot');
+    expect(await element(by.id('bubble-s1-apr-dot')).getAttribute('id')).toEqual('bubble-s1-apr-dot');
+    expect(await element(by.id('bubble-s1-apr-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s1-apr-dot');
+    expect(await element(by.id('bubble-s1-may-dot')).getAttribute('id')).toEqual('bubble-s1-may-dot');
+    expect(await element(by.id('bubble-s1-may-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s1-may-dot');
+    expect(await element(by.id('bubble-s1-jun-dot')).getAttribute('id')).toEqual('bubble-s1-jun-dot');
+    expect(await element(by.id('bubble-s1-jun-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s1-jun-dot');
+    expect(await element(by.id('bubble-s1-jul-dot')).getAttribute('id')).toEqual('bubble-s1-jul-dot');
+    expect(await element(by.id('bubble-s1-jul-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s1-jul-dot');
+    expect(await element(by.id('bubble-s1-aug-dot')).getAttribute('id')).toEqual('bubble-s1-aug-dot');
+    expect(await element(by.id('bubble-s1-aug-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s1-aug-dot');
+    expect(await element(by.id('bubble-s1-sep-dot')).getAttribute('id')).toEqual('bubble-s1-sep-dot');
+    expect(await element(by.id('bubble-s1-sep-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s1-sep-dot');
+    expect(await element(by.id('bubble-s1-oct-dot')).getAttribute('id')).toEqual('bubble-s1-oct-dot');
+    expect(await element(by.id('bubble-s1-oct-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s1-oct-dot');
+    expect(await element(by.id('bubble-s1-nov-dot')).getAttribute('id')).toEqual('bubble-s1-nov-dot');
+    expect(await element(by.id('bubble-s1-nov-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s1-nov-dot');
+    expect(await element(by.id('bubble-s1-dec-dot')).getAttribute('id')).toEqual('bubble-s1-dec-dot');
+    expect(await element(by.id('bubble-s1-dec-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s1-dec-dot');
+
+    expect(await element(by.id('bubble-s2-jan-dot')).getAttribute('id')).toEqual('bubble-s2-jan-dot');
+    expect(await element(by.id('bubble-s2-jan-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s2-jan-dot');
+    expect(await element(by.id('bubble-s2-feb-dot')).getAttribute('id')).toEqual('bubble-s2-feb-dot');
+    expect(await element(by.id('bubble-s2-feb-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s2-feb-dot');
+    expect(await element(by.id('bubble-s2-mar-dot')).getAttribute('id')).toEqual('bubble-s2-mar-dot');
+    expect(await element(by.id('bubble-s2-mar-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s2-mar-dot');
+    expect(await element(by.id('bubble-s2-apr-dot')).getAttribute('id')).toEqual('bubble-s2-apr-dot');
+    expect(await element(by.id('bubble-s2-apr-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s2-apr-dot');
+    expect(await element(by.id('bubble-s2-may-dot')).getAttribute('id')).toEqual('bubble-s2-may-dot');
+    expect(await element(by.id('bubble-s2-may-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s2-may-dot');
+    expect(await element(by.id('bubble-s2-jun-dot')).getAttribute('id')).toEqual('bubble-s2-jun-dot');
+    expect(await element(by.id('bubble-s2-jun-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s2-jun-dot');
+    expect(await element(by.id('bubble-s2-jul-dot')).getAttribute('id')).toEqual('bubble-s2-jul-dot');
+    expect(await element(by.id('bubble-s2-jul-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s2-jul-dot');
+    expect(await element(by.id('bubble-s2-aug-dot')).getAttribute('id')).toEqual('bubble-s2-aug-dot');
+    expect(await element(by.id('bubble-s2-aug-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s2-aug-dot');
+    expect(await element(by.id('bubble-s2-sep-dot')).getAttribute('id')).toEqual('bubble-s2-sep-dot');
+    expect(await element(by.id('bubble-s2-sep-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s2-sep-dot');
+    expect(await element(by.id('bubble-s2-oct-dot')).getAttribute('id')).toEqual('bubble-s2-oct-dot');
+    expect(await element(by.id('bubble-s2-oct-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s2-oct-dot');
+    expect(await element(by.id('bubble-s2-nov-dot')).getAttribute('id')).toEqual('bubble-s2-nov-dot');
+    expect(await element(by.id('bubble-s2-nov-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s2-nov-dot');
+    expect(await element(by.id('bubble-s2-dec-dot')).getAttribute('id')).toEqual('bubble-s2-dec-dot');
+    expect(await element(by.id('bubble-s2-dec-dot')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-s2-dec-dot');
+
+    expect(await element(by.id('bubble-series1-line')).getAttribute('id')).toEqual('bubble-series1-line');
+    expect(await element(by.id('bubble-series1-line')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-series1-line');
+    expect(await element(by.id('bubble-series2-line')).getAttribute('id')).toEqual('bubble-series2-line');
+    expect(await element(by.id('bubble-series2-line')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-series2-line');
+
+    expect(await element(by.id('bubble-series1-legend')).getAttribute('id')).toEqual('bubble-series1-legend');
+    expect(await element(by.id('bubble-series1-legend')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-series1-legend');
+    expect(await element(by.id('bubble-series2-legend')).getAttribute('id')).toEqual('bubble-series2-legend');
+    expect(await element(by.id('bubble-series2-legend')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-series2-legend');
+  });
 });

--- a/test/components/line/line.e2e-spec.js
+++ b/test/components/line/line.e2e-spec.js
@@ -26,6 +26,63 @@ describe('Line Chart tests', () => {
       expect(await browser.imageComparison.checkElement(containerEl, 'line')).toEqual(0);
     });
   }
+
+  it('Should be able to set id/automation id', async () => {
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.id('line-a-jan-dot')).getAttribute('id')).toEqual('line-a-jan-dot');
+    expect(await element(by.id('line-a-jan-dot')).getAttribute('data-automation-id')).toEqual('automation-id-line-a-jan-dot');
+    expect(await element(by.id('line-a-feb-dot')).getAttribute('id')).toEqual('line-a-feb-dot');
+    expect(await element(by.id('line-a-feb-dot')).getAttribute('data-automation-id')).toEqual('automation-id-line-a-feb-dot');
+    expect(await element(by.id('line-a-mar-dot')).getAttribute('id')).toEqual('line-a-mar-dot');
+    expect(await element(by.id('line-a-mar-dot')).getAttribute('data-automation-id')).toEqual('automation-id-line-a-mar-dot');
+    expect(await element(by.id('line-a-apr-dot')).getAttribute('id')).toEqual('line-a-apr-dot');
+    expect(await element(by.id('line-a-apr-dot')).getAttribute('data-automation-id')).toEqual('automation-id-line-a-apr-dot');
+    expect(await element(by.id('line-a-may-dot')).getAttribute('id')).toEqual('line-a-may-dot');
+    expect(await element(by.id('line-a-may-dot')).getAttribute('data-automation-id')).toEqual('automation-id-line-a-may-dot');
+    expect(await element(by.id('line-a-jun-dot')).getAttribute('id')).toEqual('line-a-jun-dot');
+    expect(await element(by.id('line-a-jun-dot')).getAttribute('data-automation-id')).toEqual('automation-id-line-a-jun-dot');
+
+    expect(await element(by.id('line-b-jan-dot')).getAttribute('id')).toEqual('line-b-jan-dot');
+    expect(await element(by.id('line-b-jan-dot')).getAttribute('data-automation-id')).toEqual('automation-id-line-b-jan-dot');
+    expect(await element(by.id('line-b-feb-dot')).getAttribute('id')).toEqual('line-b-feb-dot');
+    expect(await element(by.id('line-b-feb-dot')).getAttribute('data-automation-id')).toEqual('automation-id-line-b-feb-dot');
+    expect(await element(by.id('line-b-mar-dot')).getAttribute('id')).toEqual('line-b-mar-dot');
+    expect(await element(by.id('line-b-mar-dot')).getAttribute('data-automation-id')).toEqual('automation-id-line-b-mar-dot');
+    expect(await element(by.id('line-b-apr-dot')).getAttribute('id')).toEqual('line-b-apr-dot');
+    expect(await element(by.id('line-b-apr-dot')).getAttribute('data-automation-id')).toEqual('automation-id-line-b-apr-dot');
+    expect(await element(by.id('line-b-may-dot')).getAttribute('id')).toEqual('line-b-may-dot');
+    expect(await element(by.id('line-b-may-dot')).getAttribute('data-automation-id')).toEqual('automation-id-line-b-may-dot');
+    expect(await element(by.id('line-b-jun-dot')).getAttribute('id')).toEqual('line-b-jun-dot');
+    expect(await element(by.id('line-b-jun-dot')).getAttribute('data-automation-id')).toEqual('automation-id-line-b-jun-dot');
+
+    expect(await element(by.id('line-c-jan-dot')).getAttribute('id')).toEqual('line-c-jan-dot');
+    expect(await element(by.id('line-c-jan-dot')).getAttribute('data-automation-id')).toEqual('automation-id-line-c-jan-dot');
+    expect(await element(by.id('line-c-feb-dot')).getAttribute('id')).toEqual('line-c-feb-dot');
+    expect(await element(by.id('line-c-feb-dot')).getAttribute('data-automation-id')).toEqual('automation-id-line-c-feb-dot');
+    expect(await element(by.id('line-c-mar-dot')).getAttribute('id')).toEqual('line-c-mar-dot');
+    expect(await element(by.id('line-c-mar-dot')).getAttribute('data-automation-id')).toEqual('automation-id-line-c-mar-dot');
+    expect(await element(by.id('line-c-apr-dot')).getAttribute('id')).toEqual('line-c-apr-dot');
+    expect(await element(by.id('line-c-apr-dot')).getAttribute('data-automation-id')).toEqual('automation-id-line-c-apr-dot');
+    expect(await element(by.id('line-c-may-dot')).getAttribute('id')).toEqual('line-c-may-dot');
+    expect(await element(by.id('line-c-may-dot')).getAttribute('data-automation-id')).toEqual('automation-id-line-c-may-dot');
+    expect(await element(by.id('line-c-jun-dot')).getAttribute('id')).toEqual('line-c-jun-dot');
+    expect(await element(by.id('line-c-jun-dot')).getAttribute('data-automation-id')).toEqual('automation-id-line-c-jun-dot');
+
+    expect(await element(by.id('line-comp-a-line')).getAttribute('id')).toEqual('line-comp-a-line');
+    expect(await element(by.id('line-comp-a-line')).getAttribute('data-automation-id')).toEqual('automation-id-line-comp-a-line');
+    expect(await element(by.id('line-comp-b-line')).getAttribute('id')).toEqual('line-comp-b-line');
+    expect(await element(by.id('line-comp-b-line')).getAttribute('data-automation-id')).toEqual('automation-id-line-comp-b-line');
+    expect(await element(by.id('line-comp-c-line')).getAttribute('id')).toEqual('line-comp-c-line');
+    expect(await element(by.id('line-comp-c-line')).getAttribute('data-automation-id')).toEqual('automation-id-line-comp-c-line');
+
+    expect(await element(by.id('line-comp-a-legend')).getAttribute('id')).toEqual('line-comp-a-legend');
+    expect(await element(by.id('line-comp-a-legend')).getAttribute('data-automation-id')).toEqual('automation-id-line-comp-a-legend');
+    expect(await element(by.id('line-comp-b-legend')).getAttribute('id')).toEqual('line-comp-b-legend');
+    expect(await element(by.id('line-comp-b-legend')).getAttribute('data-automation-id')).toEqual('automation-id-line-comp-b-legend');
+    expect(await element(by.id('line-comp-c-legend')).getAttribute('id')).toEqual('line-comp-c-legend');
+    expect(await element(by.id('line-comp-c-legend')).getAttribute('data-automation-id')).toEqual('automation-id-line-comp-c-legend');
+  });
 });
 
 describe('Line Localization tests', () => {

--- a/test/components/scatterplot/scatterplot.e2e-spec.js
+++ b/test/components/scatterplot/scatterplot.e2e-spec.js
@@ -1,0 +1,80 @@
+const { browserStackErrorReporter } = requireHelper('browserstack-error-reporter');
+const utils = requireHelper('e2e-utils');
+const config = requireHelper('e2e-config');
+
+requireHelper('rejection');
+
+jasmine.getEnv().addReporter(browserStackErrorReporter);
+
+describe('Scatterplot Chart tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/scatterplot/example-index?layout=nofrills');
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should be able to set id/automation id', async () => {
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.id('scatterplot-s1-jan-symbol')).getAttribute('id')).toEqual('scatterplot-s1-jan-symbol');
+    expect(await element(by.id('scatterplot-s1-jan-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s1-jan-symbol');
+    expect(await element(by.id('scatterplot-s1-feb-symbol')).getAttribute('id')).toEqual('scatterplot-s1-feb-symbol');
+    expect(await element(by.id('scatterplot-s1-feb-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s1-feb-symbol');
+    expect(await element(by.id('scatterplot-s1-mar-symbol')).getAttribute('id')).toEqual('scatterplot-s1-mar-symbol');
+    expect(await element(by.id('scatterplot-s1-mar-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s1-mar-symbol');
+    expect(await element(by.id('scatterplot-s1-apr-symbol')).getAttribute('id')).toEqual('scatterplot-s1-apr-symbol');
+    expect(await element(by.id('scatterplot-s1-apr-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s1-apr-symbol');
+    expect(await element(by.id('scatterplot-s1-may-symbol')).getAttribute('id')).toEqual('scatterplot-s1-may-symbol');
+    expect(await element(by.id('scatterplot-s1-may-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s1-may-symbol');
+    expect(await element(by.id('scatterplot-s1-jun-symbol')).getAttribute('id')).toEqual('scatterplot-s1-jun-symbol');
+    expect(await element(by.id('scatterplot-s1-jun-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s1-jun-symbol');
+    expect(await element(by.id('scatterplot-s1-jul-symbol')).getAttribute('id')).toEqual('scatterplot-s1-jul-symbol');
+    expect(await element(by.id('scatterplot-s1-jul-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s1-jul-symbol');
+    expect(await element(by.id('scatterplot-s1-aug-symbol')).getAttribute('id')).toEqual('scatterplot-s1-aug-symbol');
+    expect(await element(by.id('scatterplot-s1-aug-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s1-aug-symbol');
+    expect(await element(by.id('scatterplot-s1-sep-symbol')).getAttribute('id')).toEqual('scatterplot-s1-sep-symbol');
+    expect(await element(by.id('scatterplot-s1-sep-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s1-sep-symbol');
+    expect(await element(by.id('scatterplot-s1-oct-symbol')).getAttribute('id')).toEqual('scatterplot-s1-oct-symbol');
+    expect(await element(by.id('scatterplot-s1-oct-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s1-oct-symbol');
+    expect(await element(by.id('scatterplot-s1-nov-symbol')).getAttribute('id')).toEqual('scatterplot-s1-nov-symbol');
+    expect(await element(by.id('scatterplot-s1-nov-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s1-nov-symbol');
+    expect(await element(by.id('scatterplot-s1-dec-symbol')).getAttribute('id')).toEqual('scatterplot-s1-dec-symbol');
+    expect(await element(by.id('scatterplot-s1-dec-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s1-dec-symbol');
+    expect(await element(by.id('scatterplot-s2-jan-symbol')).getAttribute('id')).toEqual('scatterplot-s2-jan-symbol');
+    expect(await element(by.id('scatterplot-s2-jan-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s2-jan-symbol');
+    expect(await element(by.id('scatterplot-s2-feb-symbol')).getAttribute('id')).toEqual('scatterplot-s2-feb-symbol');
+    expect(await element(by.id('scatterplot-s2-feb-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s2-feb-symbol');
+    expect(await element(by.id('scatterplot-s2-mar-symbol')).getAttribute('id')).toEqual('scatterplot-s2-mar-symbol');
+    expect(await element(by.id('scatterplot-s2-mar-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s2-mar-symbol');
+    expect(await element(by.id('scatterplot-s2-apr-symbol')).getAttribute('id')).toEqual('scatterplot-s2-apr-symbol');
+    expect(await element(by.id('scatterplot-s2-apr-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s2-apr-symbol');
+    expect(await element(by.id('scatterplot-s2-may-symbol')).getAttribute('id')).toEqual('scatterplot-s2-may-symbol');
+    expect(await element(by.id('scatterplot-s2-may-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s2-may-symbol');
+    expect(await element(by.id('scatterplot-s2-jun-symbol')).getAttribute('id')).toEqual('scatterplot-s2-jun-symbol');
+    expect(await element(by.id('scatterplot-s2-jun-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s2-jun-symbol');
+    expect(await element(by.id('scatterplot-s2-jul-symbol')).getAttribute('id')).toEqual('scatterplot-s2-jul-symbol');
+    expect(await element(by.id('scatterplot-s2-jul-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s2-jul-symbol');
+    expect(await element(by.id('scatterplot-s2-aug-symbol')).getAttribute('id')).toEqual('scatterplot-s2-aug-symbol');
+    expect(await element(by.id('scatterplot-s2-aug-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s2-aug-symbol');
+    expect(await element(by.id('scatterplot-s2-sep-symbol')).getAttribute('id')).toEqual('scatterplot-s2-sep-symbol');
+    expect(await element(by.id('scatterplot-s2-sep-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s2-sep-symbol');
+    expect(await element(by.id('scatterplot-s2-oct-symbol')).getAttribute('id')).toEqual('scatterplot-s2-oct-symbol');
+    expect(await element(by.id('scatterplot-s2-oct-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s2-oct-symbol');
+    expect(await element(by.id('scatterplot-s2-nov-symbol')).getAttribute('id')).toEqual('scatterplot-s2-nov-symbol');
+    expect(await element(by.id('scatterplot-s2-nov-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s2-nov-symbol');
+    expect(await element(by.id('scatterplot-s2-dec-symbol')).getAttribute('id')).toEqual('scatterplot-s2-dec-symbol');
+    expect(await element(by.id('scatterplot-s2-dec-symbol')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-s2-dec-symbol');
+
+    expect(await element(by.id('scatterplot-series1-line')).getAttribute('id')).toEqual('scatterplot-series1-line');
+    expect(await element(by.id('scatterplot-series1-line')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-series1-line');
+    expect(await element(by.id('scatterplot-series2-line')).getAttribute('id')).toEqual('scatterplot-series2-line');
+    expect(await element(by.id('scatterplot-series2-line')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-series2-line');
+
+    expect(await element(by.id('scatterplot-series1-legend')).getAttribute('id')).toEqual('scatterplot-series1-legend');
+    expect(await element(by.id('scatterplot-series1-legend')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-series1-legend');
+    expect(await element(by.id('scatterplot-series2-legend')).getAttribute('id')).toEqual('scatterplot-series2-legend');
+    expect(await element(by.id('scatterplot-series2-legend')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-series2-legend');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adds the attributes/automation id/ id functionality for area, bubble, line and scatterplot charts.

**Related github/jira issue (required)**:
related to #4498

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to:
- http://localhost:4000/components/area/example-index.html
- http://localhost:4000/components/bubble/example-index.html
- http://localhost:4000/components/line/example-index.html
- http://localhost:4000/components/scatterplot/example-index.html
- Check for `id` and `data-automation-id` attributes, get from the settings (each line, dot, symbol and legend)
- Review the text in the docs

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
