### PR TITLE
4498 - Add automation ids to fieldset, contextmenu and popover

### DIFF
--- a/app/views/components/contextmenu/example-index.html
+++ b/app/views/components/contextmenu/example-index.html
@@ -12,17 +12,17 @@
     </div>
 
     <ul id="action-popupmenu" class="popupmenu">
-      <li><a href="#" id="cut">Cut</a></li>
-      <li><a href="#" id="copy">Copy</a></li>
-      <li><a href="#" id="paste">Paste</a></li>
+      <li><a href="#" id="cut" data-automation-id="cut-automation-id">Cut</a></li>
+      <li><a href="#" id="copy" data-automation-id="copy-automation-id">Copy</a></li>
+      <li><a href="#" id="paste" data-automation-id="paste-automation-id">Paste</a></li>
       <li>
         <a id="paste-special" href="#">Paste Special</a>
         <ul class="popupmenu">
-          <li><a id="sub-menu-1" href="#">Sub Menu 1</a></li>
-          <li><a id="sub-menu-2" href="#">Sub Menu 2</a></li>
+          <li><a id="sub-menu-1" data-automation-id="sub-menu-1-automation-id" href="#">Sub Menu 1</a></li>
+          <li><a id="sub-menu-2" data-automation-id="sub-menu-2-automation-id" href="#">Sub Menu 2</a></li>
           <li class="separator"></li>
           <li>
-            <a id="settings" href="#">
+            <a id="settings" data-automation-id="settings-automation-id" href="#">
               <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
                 <use href="#icon-settings"></use>
               </svg>
@@ -33,17 +33,17 @@
       </li>
       <li class="separator"></li>
       <li><a href="#" id="name-project">Name and project range</a></li>
-      <li class="is-disabled"><a href="#" id="insert-comment" disabled="true">Insert comment</a></li>
-      <li class="is-disabled"><a href="#" id="insert-note" disabled="true">Insert note</a></li>
-      <li><a href="#" id="clear-notes">Clear notes</a></li>
+      <li class="is-disabled"><a href="#" id="insert-comment" data-automation-id="insert-comment-automation-id" disabled="true">Insert comment</a></li>
+      <li class="is-disabled"><a href="#" id="insert-note" data-automation-id="insert-note-automation-id" disabled="true">Insert note</a></li>
+      <li><a href="#" id="clear-notes" data-automation-id="clear-notes-automation-id">Clear notes</a></li>
 
       <li class="separator single-selectable-section"></li>
       <li class="heading">Additional Options</li>
-      <li class="is-selectable is-checked"><a href="#" id="conditional-format">Conditional formatting</a></li>
-      <li class="is-selectable"><a href="#" id="data-validation">Data validation</a></li>
+      <li class="is-selectable is-checked"><a href="#" id="conditional-format" data-automation-id="conditional-format-automation-id">Conditional formatting</a></li>
+      <li class="is-selectable"><a href="#" id="data-validation" data-automation-id="data-validation-automation-id">Data validation</a></li>
       <li class="separator"></li>
       <li>
-        <a href="#" id="settings">
+        <a href="#" id="settings" data-automation-id="settings-2-automation-id">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
             <use href="#icon-settings"></use>
           </svg>

--- a/app/views/components/fieldset/example-index.html
+++ b/app/views/components/fieldset/example-index.html
@@ -2,7 +2,7 @@
     <div class="six columns">
 
       <!-- Variation One -->
-      <fieldset>
+      <fieldset id="fieldset" data-automation-id="fieldset-automation-id">
         <legend>Company Information</legend>
         <div class="summary-form">
 
@@ -10,18 +10,18 @@
             <div class="one-half column">
 
               <div class="field">
-                <span class="label" id="fieldset-label-1" data-automation-id="fieldset-label-1-automation-id">Company Name</span>
-                <span class="data" id="fieldset-data-1" data-automation-id="fieldset-data-1-automation-id">Building Suppliers</span>
+                <span class="label">Company Name</span>
+                <span class="data">Building Suppliers</span>
               </div>
 
               <div class="field">
-                <span class="label" id="fieldset-label-2" data-automation-id="fieldset-label-2-automation-id">Company Type</span>
-                <span class="data" id="fieldset-data-2" data-automation-id="fieldset-data-2-automation-id">Contractor</span>
+                <span class="label">Company Type</span>
+                <span class="data">Contractor</span>
               </div>
 
               <div class="field">
-                <span class="label" id="fieldset-label-3" data-automation-id="fieldset-label-3-automation-id">Company Address</span>
-                <span class="data" id="fieldset-data-3" data-automation-id="fieldset-data-3-automation-id">4209 Industrial Avenue <br>Los Angeles, California 90001 USA</span>
+                <span class="label">Company Address</span>
+                <span class="data">4209 Industrial Avenue <br>Los Angeles, California 90001 USA</span>
               </div>
 
             </div>
@@ -29,18 +29,18 @@
             <div class="one-half column">
 
               <div class="field">
-                <span class="label" id="fieldset-label-4" data-automation-id="fieldset-label-4-automation-id">Phone Number</span>
-                <span class="data" id="fieldset-data-4" data-automation-id="fieldset-data-4-automation-id">(999) 810-&zwj;2604</span>
+                <span class="label">Phone Number</span>
+                <span class="data">(999) 810-&zwj;2604</span>
               </div>
 
               <div class="field">
-                <span class="label" id="fieldset-label-5" data-automation-id="fieldset-label-5-automation-id">Website</span>
-                <span class="data" id="fieldset-data-5" data-automation-id="fieldset-data-5-automation-id">www.buildings.com</span>
+                <span class="label">Website</span>
+                <span class="data">www.buildings.com</span>
               </div>
 
               <div class="field">
-                <span class="label" id="fieldset-label-6" data-automation-id="fieldset-label-6-automation-id">Estimated Delivery</span>
-                <span class="data" id="fieldset-data-6" data-automation-id="fieldset-data-6-automation-id">June 21, 2015 <i> (4 days)</i></span>
+                <span class="label">Estimated Delivery</span>
+                <span class="data">June 21, 2015 <i> (4 days)</i></span>
               </div>
 
             </div>
@@ -53,16 +53,16 @@
 
       <!-- Variation Two -->
       <div class="fieldset" role="region" aria-labelledby="fieldset-title">
-        <h2 class="fieldset-title" id="fieldset-title" data-automation-id="fieldset-title-automation-id">Credit Information</h2>
+        <h2 class="fieldset-title">Credit Information</h2>
         <div id="container-1" class="chart-container"></div>
       </div>
 
       <div class="fieldset">
-        <h2 class="fieldset-title" id="fieldset-title-2" data-automation-id="fieldset-title-2-automation-id">Delivery Addresses</h2>
+        <h2 class="fieldset-title">Delivery Addresses</h2>
 
         <div class="summary-form">
           <div class="field">
-            <span class="data" id="fieldset-data-7" data-automation-id="fieldset-data-7-automation-id">4209 Industrial Avenue Los Angeles, California 90001 USA<br>
+            <span class="data">4209 Industrial Avenue Los Angeles, California 90001 USA<br>
               Default Shipping Address</span>
           </div>
         </div>

--- a/app/views/components/fieldset/example-index.html
+++ b/app/views/components/fieldset/example-index.html
@@ -10,18 +10,18 @@
             <div class="one-half column">
 
               <div class="field">
-                <span class="label">Company Name</span>
-                <span class="data">Building Suppliers</span>
+                <span class="label" id="fieldset-label-1" data-automation-id="fieldset-label-1-automation-id">Company Name</span>
+                <span class="data" id="fieldset-data-1" data-automation-id="fieldset-data-1-automation-id">Building Suppliers</span>
               </div>
 
               <div class="field">
-                <span class="label">Company Type</span>
-                <span class="data">Contractor</span>
+                <span class="label" id="fieldset-label-2" data-automation-id="fieldset-label-2-automation-id">Company Type</span>
+                <span class="data" id="fieldset-data-2" data-automation-id="fieldset-data-2-automation-id">Contractor</span>
               </div>
 
               <div class="field">
-                <span class="label">Company Address</span>
-                <span class="data">4209 Industrial Avenue <br>Los Angeles, California 90001 USA</span>
+                <span class="label" id="fieldset-label-3" data-automation-id="fieldset-label-3-automation-id">Company Address</span>
+                <span class="data" id="fieldset-data-3" data-automation-id="fieldset-data-3-automation-id">4209 Industrial Avenue <br>Los Angeles, California 90001 USA</span>
               </div>
 
             </div>
@@ -29,18 +29,18 @@
             <div class="one-half column">
 
               <div class="field">
-                <span class="label">Phone Number</span>
-                <span class="data">(999) 810-&zwj;2604</span>
+                <span class="label" id="fieldset-label-4" data-automation-id="fieldset-label-4-automation-id">Phone Number</span>
+                <span class="data" id="fieldset-data-4" data-automation-id="fieldset-data-4-automation-id">(999) 810-&zwj;2604</span>
               </div>
 
               <div class="field">
-                <span class="label">Website</span>
-                <span class="data">www.buildings.com</span>
+                <span class="label" id="fieldset-label-5" data-automation-id="fieldset-label-5-automation-id">Website</span>
+                <span class="data" id="fieldset-data-5" data-automation-id="fieldset-data-5-automation-id">www.buildings.com</span>
               </div>
 
               <div class="field">
-                <span class="label">Estimated Delivery</span>
-                <span class="data">June 21, 2015 <i> (4 days)</i></span>
+                <span class="label" id="fieldset-label-6" data-automation-id="fieldset-label-6-automation-id">Estimated Delivery</span>
+                <span class="data" id="fieldset-data-6" data-automation-id="fieldset-data-6-automation-id">June 21, 2015 <i> (4 days)</i></span>
               </div>
 
             </div>
@@ -53,16 +53,16 @@
 
       <!-- Variation Two -->
       <div class="fieldset" role="region" aria-labelledby="fieldset-title">
-        <h2 class="fieldset-title" id="fieldset-title">Credit Information</h2>
+        <h2 class="fieldset-title" id="fieldset-title" data-automation-id="fieldset-title-automation-id">Credit Information</h2>
         <div id="container-1" class="chart-container"></div>
       </div>
 
       <div class="fieldset">
-        <h2 class="fieldset-title">Delivery Addresses</h2>
+        <h2 class="fieldset-title" id="fieldset-title-2" data-automation-id="fieldset-title-2-automation-id">Delivery Addresses</h2>
 
         <div class="summary-form">
           <div class="field">
-            <span class="data">4209 Industrial Avenue Los Angeles, California 90001 USA<br>
+            <span class="data" id="fieldset-data-7" data-automation-id="fieldset-data-7-automation-id">4209 Industrial Avenue Los Angeles, California 90001 USA<br>
               Default Shipping Address</span>
           </div>
         </div>

--- a/app/views/components/popover/example-index.html
+++ b/app/views/components/popover/example-index.html
@@ -2,7 +2,7 @@
   <div class="twelve columns">
 
     <div class="field">
-      <button id="popover-trigger" class="btn-secondary" type="button">
+      <button id="popover-trigger" data-automation-id="popover-trigger-automation-id" class="btn-secondary" type="button">
         <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
           <use href="#icon-upload"></use>
         </svg>
@@ -13,7 +13,7 @@
   </div>
 </div>
 
-<div id="popover-contents" class="popover-content-area hidden">
+<div id="popover-contents" class="popover-content-area hidden" data-automation-id="popover-contents-automation-id">
   <p>Purchase <strong>2</strong> more to save <a href="#" class="hyperlink"><strong>$100</strong></a> total</p>
   <div class="demo-popover">
     <table role="grid" class="l-pull-left">
@@ -32,10 +32,10 @@
         </tr>
       </tbody>
     </table>
-    <button class="btn-primary" type="button">Apply</button>
+    <button class="btn-primary" id="popover-btn-apply" data-automation-id="popover-btn-apply-automation-id" type="button">Apply</button>
   </div>
   <div class="modal-buttonset">
-    <button type="button" class="btn-modal-primary">View more</button>
+    <button type="button" class="btn-modal-primary" id="popover-btn-view-more" data-automation-id="popover-btn-view-more-automation-id" >View more</button>
   </div>
 </div>
 

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -27,7 +27,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [x] Column Grouped
 - [x] Column Stacked
 - [ ] Completion Chart
-- [ ] Contextmenu
+- [x] Contextmenu
 - [x] Contextualactionpanel
 - [ ] Datagrid
 - [ ] Datepicker
@@ -39,7 +39,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [ ] Expandablearea
 - [ ] Field Filter
 - [ ] Field Options
-- [ ] Fieldset
+- [x] Fieldset
 - [ ] Fileupload
 - [ ] Fileupload Advanced
 - [ ] Header
@@ -62,7 +62,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [x] Pager
 - [x] Pie
 - [ ] Popdown
-- [ ] Popover
+- [x] Popover
 - [ ] Popupmenu
 - [x] Positive Negative
 - [ ] Processindicator

--- a/src/components/contextmenu/readme.md
+++ b/src/components/contextmenu/readme.md
@@ -61,24 +61,6 @@ For all additional information, see the [popup menu](./popupmenu) as this compon
 
 ## Testability
 
-The contextmenu can have custom id's/automation id's that can be used for scripting. To add them use the option `attributes` to set an id on the contextmenu. This can take either an object or an array if doing several id's, and you can configure the automation id name. For example:
-
-```js
-  attributes: { name: 'id', value: args => `contextmenu-id-${args.id}` }
-```
-
-Setting the id/automation id with a string value:
-
-```js
-  attributes: { name: 'data-automation-id', value: 'my-unique-id' }
-```
-
-Setting the id/automation id with a string value:
-
-```js
-  attributes: [{ name: 'id', value: 'my-unique-id' }, { name: 'data-automation-id', value: 'my-unique-id' }]
-```
-
-If setting the id/automation id with a function, the id will be a running total of open contextmenu.
+You can add custom id's/automation id's to the contextmenu component in the input markup inline. For this reason there is no `attributes` setting like some other components.
 
 Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.

--- a/src/components/contextmenu/readme.md
+++ b/src/components/contextmenu/readme.md
@@ -61,4 +61,24 @@ For all additional information, see the [popup menu](./popupmenu) as this compon
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+The contextmenu can have custom id's/automation id's that can be used for scripting. To add them use the option `attributes` to set an id on the contextmenu. This can take either an object or an array if doing several id's, and you can configure the automation id name. For example:
+
+```js
+  attributes: { name: 'id', value: args => `contextmenu-id-${args.id}` }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: { name: 'data-automation-id', value: 'my-unique-id' }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: [{ name: 'id', value: 'my-unique-id' }, { name: 'data-automation-id', value: 'my-unique-id' }]
+```
+
+If setting the id/automation id with a function, the id will be a running total of open contextmenu.
+
+Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.

--- a/src/components/fieldset/readme.md
+++ b/src/components/fieldset/readme.md
@@ -65,25 +65,7 @@ There are some added classes to style sections to look like `<fieldsets>` in cas
 
 ## Testability
 
-The fieldset can have custom id's/automation id's that can be used for scripting. To add them use the option `attributes` to set an id on the fieldset. This can take either an object or an array if doing several id's, and you can configure the automation id name. For example:
-
-```js
-  attributes: { name: 'id', value: args => `fieldset-id-${args.id}` }
-```
-
-Setting the id/automation id with a string value:
-
-```js
-  attributes: { name: 'data-automation-id', value: 'my-unique-id' }
-```
-
-Setting the id/automation id with a string value:
-
-```js
-  attributes: [{ name: 'id', value: 'my-unique-id' }, { name: 'data-automation-id', value: 'my-unique-id' }]
-```
-
-If setting the id/automation id with a function, the id will be a running total of open fieldset.
+You can add custom id's/automation id's to the fieldset component in the input markup inline. For this reason there is no `attributes` setting like some other components.
 
 Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
 

--- a/src/components/fieldset/readme.md
+++ b/src/components/fieldset/readme.md
@@ -65,7 +65,27 @@ There are some added classes to style sections to look like `<fieldsets>` in cas
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+The fieldset can have custom id's/automation id's that can be used for scripting. To add them use the option `attributes` to set an id on the fieldset. This can take either an object or an array if doing several id's, and you can configure the automation id name. For example:
+
+```js
+  attributes: { name: 'id', value: args => `fieldset-id-${args.id}` }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: { name: 'data-automation-id', value: 'my-unique-id' }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: [{ name: 'id', value: 'my-unique-id' }, { name: 'data-automation-id', value: 'my-unique-id' }]
+```
+
+If setting the id/automation id with a function, the id will be a running total of open fieldset.
+
+Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
 
 ## Upgrading from 3.X
 

--- a/src/components/popover/readme.md
+++ b/src/components/popover/readme.md
@@ -54,4 +54,24 @@ Focus should always return to the object on which the popover is called from onc
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+The popover can have custom id's/automation id's that can be used for scripting. To add them use the option `attributes` to set an id on the popover. This can take either an object or an array if doing several id's, and you can configure the automation id name. For example:
+
+```js
+  attributes: { name: 'id', value: args => `popover-id-${args.id}` }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: { name: 'data-automation-id', value: 'my-unique-id' }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: [{ name: 'id', value: 'my-unique-id' }, { name: 'data-automation-id', value: 'my-unique-id' }]
+```
+
+If setting the id/automation id with a function, the id will be a running total of open popover.
+
+Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.

--- a/src/components/popover/readme.md
+++ b/src/components/popover/readme.md
@@ -54,24 +54,6 @@ Focus should always return to the object on which the popover is called from onc
 
 ## Testability
 
-The popover can have custom id's/automation id's that can be used for scripting. To add them use the option `attributes` to set an id on the popover. This can take either an object or an array if doing several id's, and you can configure the automation id name. For example:
-
-```js
-  attributes: { name: 'id', value: args => `popover-id-${args.id}` }
-```
-
-Setting the id/automation id with a string value:
-
-```js
-  attributes: { name: 'data-automation-id', value: 'my-unique-id' }
-```
-
-Setting the id/automation id with a string value:
-
-```js
-  attributes: [{ name: 'id', value: 'my-unique-id' }, { name: 'data-automation-id', value: 'my-unique-id' }]
-```
-
-If setting the id/automation id with a function, the id will be a running total of open popover.
+You can add custom id's/automation id's to the popover component in the input markup inline. For this reason there is no `attributes` setting like some other components.
 
 Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.

--- a/test/components/fieldset/fieldset.e2e-spec.js
+++ b/test/components/fieldset/fieldset.e2e-spec.js
@@ -18,6 +18,14 @@ describe('Fieldset Tests', () => {
       expect(await browser.imageComparison.checkElement(containerEl, 'fieldset-index')).toEqual(0);
     });
 
+    it('Should be able to set id/automation id', async () => {
+      await utils.setPage('/components/fieldset/example-index.html?layout=nofrills');
+      await browser.driver.sleep(config.sleep);
+
+      expect(await element(by.id('fieldset')).getAttribute('id')).toEqual('fieldset');
+      expect(await element(by.id('fieldset')).getAttribute('data-automation-id')).toEqual('fieldset-automation-id');
+    });
+
     it('Should not visual regress on short layouts', async () => {
       await utils.setPage('/components/fieldset/example-short.html?layout=nofrills');
       const containerEl = await element(by.className('container'));

--- a/test/components/popover/popover.e2e-spec.js
+++ b/test/components/popover/popover.e2e-spec.js
@@ -24,6 +24,22 @@ describe('Popover Index Tests', () => {
     expect(await element(by.css('.popover')).isDisplayed()).toBeTruthy();
   });
 
+  it('Should be able to set id/automation id', async () => {
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.id('popover-trigger')).getAttribute('id')).toEqual('popover-trigger');
+    expect(await element(by.id('popover-trigger')).getAttribute('data-automation-id')).toEqual('popover-trigger-automation-id');
+
+    expect(await element(by.id('popover-contents')).getAttribute('id')).toEqual('popover-contents');
+    expect(await element(by.id('popover-contents')).getAttribute('data-automation-id')).toEqual('popover-contents-automation-id');
+
+    expect(await element(by.id('popover-btn-apply')).getAttribute('id')).toEqual('popover-btn-apply');
+    expect(await element(by.id('popover-btn-apply')).getAttribute('data-automation-id')).toEqual('popover-btn-apply-automation-id');
+
+    expect(await element(by.id('popover-btn-view-more')).getAttribute('id')).toEqual('popover-btn-view-more');
+    expect(await element(by.id('popover-btn-view-more')).getAttribute('data-automation-id')).toEqual('popover-btn-view-more-automation-id');
+  });
+
   if (utils.isChrome() && utils.isCI()) {
     it('Should not visual regress', async () => {
       await element(by.id('popover-trigger')).click();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Add automation ids to fieldset, contextmenu and popover

**Related github/jira issue (required)**:
related to #4498 

**Steps necessary to review your pull request (required)**:
- pull and run branch
- go to http://localhost:4000/components/fieldset/example-index.html make sure the root element has an id/automation-id
- go to http://localhost:4000/components/contextmenu/example-index.html make sure all the menu items have an id/automation-id
- go to http://localhost:4000/components/popover/example-index.html make sure all the menu items have an id/automation-id make sure the `popover-contents` element, the apply button and the view more buttons have an id/automation-id

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
