### PR TITLE
4498 - Add automation id for bullet and stepchart charts

### DIFF
--- a/app/views/components/bullet/example-index.html
+++ b/app/views/components/bullet/example-index.html
@@ -26,7 +26,11 @@ $('body').on('initialized', function () {
           palette.turquoise[Soho.theme.uplift ? '100': '90'].value
         ],
         lineColors: ['#000000', '#000000', '#000000'],
-        markerColors: ['#000000']
+        markerColors: ['#000000'],
+        attributes: [
+          { name: 'id', value: 'bullet-example1' },
+          { name: 'data-automation-id', value: 'automation-id-bullet-example1' }
+        ]
       }];
 
     $('#bullet-example1').chart({type: 'bullet', dataset: dataset1})

--- a/app/views/components/bullet/test-data-group-automation.html
+++ b/app/views/components/bullet/test-data-group-automation.html
@@ -1,0 +1,69 @@
+
+<div class="row">
+    <div class="full column center" style="height: 610px">
+      <div id="bullet-example" class="chart-container">
+      </div>
+    </div>
+</div>
+
+<script>
+$('body').on('initialized', function () {
+  var palette = Soho.theme.themeColors().palette;
+
+  // Example grouped
+  var dataset = [{
+    data: [
+      {
+        title: 'Schedule Adherence By Quantity',
+        subtitle: '',
+        url: '/some-path/some-url-1',
+        ranges: [2, 4, 6],
+        measures: [2, 2],
+        markers: [6]
+      }, {
+        title: 'Schedule Adherence By Date',
+        subtitle: '',
+        url: '/some-path/some-url-2',
+        ranges: [2, 4, 6],
+        measures: [2, 2],
+        markers: [6]
+      }, {
+        title: 'Receiving Accuracy',
+        subtitle: '',
+        url: '/some-path/some-url-3',
+        ranges: [2, 4, 6],
+        measures: [2, 2],
+        markers: [6]
+      }, {
+        title: 'Premium Freight Charges',
+        subtitle: '',
+        url: '/some-path/some-url-4',
+        ranges: [2, 4, 6],
+        measures: [2, 2],
+        markers: [6]
+      }, {
+        title: 'Overall Rating',
+        subtitle: '',
+        url: '/some-path/some-url-5',
+        ranges: [2, 4, 6],
+        measures: [2, 2],
+        markers: [6]
+      }
+    ],
+    barColors: [
+      palette.emerald['20'].value,
+      palette.emerald['40'].value,
+      palette.emerald['60'].value
+    ],
+    lineColors: ['#000000', '#000000', '#000000'],
+    markerColors: ['#000000'],
+    attributes: [
+      { name: 'id', value: 'bullet-group-example1' },
+      { name: 'data-automation-id', value: 'automation-id-bullet-group-example1' }
+    ]
+  }];
+
+  // Invoke Chart
+  $('#bullet-example').chart({ type: 'bullet', dataset: dataset });
+});
+</script>

--- a/app/views/components/stepchart/example-index.html
+++ b/app/views/components/stepchart/example-index.html
@@ -19,7 +19,7 @@
       </div>
       <div class="card-content">
 
-        <div class="step-chart" id="completed" data-options="{steps: 7, completed: 7}">
+        <div class="step-chart" id="completed" data-options="{steps: 7, completed: 7, attributes: [ { name: 'id', value: 'stepchart-example1' }, { name: 'data-automation-id', value: 'automation-id-stepchart-example1' }]}">
         </div>
 
         <div class="step-chart" data-options="{steps: 7, completed: 2}">
@@ -28,7 +28,7 @@
         <div class="step-chart" data-options="{steps: 7, completed: 2, extraText: '{0} Days Remaining'}">
         </div>
 
-        <div class="step-chart" data-options="{steps: 7, completed: 2, inProgress: 3, iconType: 'icon-error', extraText: '{1} Days Overdue'}">
+        <div class="step-chart" data-options="{steps: 7, completed: 2, inProgress: 3, iconType: 'icon-error', extraText: '{1} Days Overdue', attributes: [ { name: 'id', value: 'stepchart-example4' }, { name: 'data-automation-id', value: 'automation-id-stepchart-example4' }]}">
         </div>
 
         <div class="step-chart" id="manual" data-options="{steps: 7, completed: 2}">

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -15,7 +15,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [ ] Blockgrid
 - [x] Breadcrumb
 - [x] Bubble
-- [ ] Bullet
+- [x] Bullet
 - [ ] Busyindicator
 - [ ] Button
 - [x] Calendar
@@ -78,7 +78,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [x] Sparkline
 - [ ] Spinbox
 - [ ] Splitter
-- [ ] Stepchart
+- [x] Stepchart
 - [ ] Swaplist
 - [ ] Switch
 - [ ] Tabs

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Area/Bubble/Line/Scatterplot]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Bar/Bar Grouped/Bar Stacked]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Breadcrumb]` Added `attributes` setting to Breadcrumb Items for setting automation id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
+- `[Bullet/Stepchart]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Calendar/Monthview/WeekView/CalendarToolbar]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Circlepager]` Added `attributes` setting to set automation ids's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Column/Column Grouped/Column Stacked/Positive Negative]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))

--- a/src/components/bullet/readme.md
+++ b/src/components/bullet/readme.md
@@ -38,7 +38,68 @@ $('#bullet-example1').chart({type: 'bullet', dataset: dataset1});
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+You can add custom id's/automation id's to the bullet chart that can be used for scripting using the `attributes` data attribute. This data attribute can be either an object or an array for setting multiple values such as an automation-id or other attributes. For example:
+
+Setting the id/automation id with a string value or function. The function will give you the data as a parameter for making things more dynamic.
+
+```js
+// Example single
+var dataSingleBullet = [{
+  data: [
+    {'title': 'Revenue','subtitle': 'US$, in thousands','ranges': [150, 225, 300, 400, 600], 'measures': [220,270], 'markers': [250], url: 'http://someplace.com',
+      tooltip: ['<b>Poor</b> 150', '<b>Ok</b> 225', '<b>Good</b> 300', '<b>Excellent</b> 400', '<b>Revenue</b> 600']}
+  ],
+  barColors: [
+    palette.turquoise[Soho.theme.uplift ? '20': '10'].value,
+    palette.turquoise[Soho.theme.uplift ? '30': '30'].value,
+    palette.turquoise[Soho.theme.uplift ? '60': '50'].value,
+    palette.turquoise[Soho.theme.uplift ? '80': '70'].value,
+    palette.turquoise[Soho.theme.uplift ? '100': '90'].value
+  ],
+  lineColors: ['#000000', '#000000', '#000000'],
+  markerColors: ['#000000'],
+  attributes: [
+    { name: 'id', value: 'bullet-example1' },
+    { name: 'data-automation-id', value: 'automation-id-bullet-example1' }
+  ]
+}];
+
+// Example grouped
+var dataGroupedBullet = [{
+  data: [
+    {
+      title: 'Schedule Adherence By Quantity',
+      subtitle: '',
+      url: '/some-path/some-url-1',
+      ranges: [2, 4, 6],
+      measures: [2, 2],
+      markers: [6, 6]
+    }, {
+      title: 'Schedule Adherence By Date',
+      subtitle: '',
+      url: '/some-path/some-url-2',
+      ranges: [2, 4, 6],
+      measures: [2, 2],
+      markers: [6, 6]
+    }
+  ],
+  barColors: [
+    palette.emerald['20'].value,
+    palette.emerald['40'].value,
+    palette.emerald['60'].value
+  ],
+  lineColors: ['#000000', '#000000', '#000000'],
+  markerColors: ['#000000'],
+  attributes: [
+    { name: 'id', value: 'bullet-group-example1' },
+    { name: 'data-automation-id', value: 'automation-id-bullet-group-example1' }
+  ]
+}];
+```
+
+Providing the data this will add an ID added to each range with `-range{index}`, measure with `-measure{index}`, difference with `-difference`, title with `-title`, subtitle with `-subtitle`, marker with `-marker` and if more then one marker `-marker{index}` appended. In addition if data grouped the related items will get the same id with `-group{index}` appended after it.
+
+- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for general information.
 
 ## Keyboard Shortcuts
 

--- a/src/components/stepchart/readme.md
+++ b/src/components/stepchart/readme.md
@@ -42,7 +42,27 @@ $('#manual').stepchart({
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+You can add custom id's/automation id's to the step chart that can be used for scripting using the `attributes` data attribute. This data attribute can be either an object or an array for setting multiple values such as an automation-id or other attributes. For example:
+
+Setting the id/automation id with a string value or function. The function will give you the data as a parameter for making things more dynamic.
+
+```js
+{
+  steps: 7,
+  completed: 2,
+  inProgress: 3,
+  iconType: 'icon-error',
+  extraText: '{1} Days Overdue',
+  attributes: [
+    { name: 'id', value: 'stepchart-example' },
+    { name: 'data-automation-id', value: 'automation-id-stepchart-example' }
+  ]
+}
+```
+
+Providing the data this will add an ID added to each label with `-label`, label-icon with `-label-icon`, label-small with `-label-small`, and step with `-step{index}` appended after it.
+
+- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for general information.
 
 ## Keyboard Shortcuts
 

--- a/src/components/stepchart/stepchart.js
+++ b/src/components/stepchart/stepchart.js
@@ -14,7 +14,8 @@ const DEFAULT_STEPCHART_OPTIONS = {
   extraText: '',
   completedColor: null,
   allCompletedColor: null,
-  inProgressColor: null
+  inProgressColor: null,
+  attributes: null
 };
 
 /**
@@ -33,8 +34,9 @@ const DEFAULT_STEPCHART_OPTIONS = {
  *  can use {0} to replace with the steps remaining count and {1} to replace the number of steps.
  * @param {string} [settings.completedColor = null] The color to show completed steps. Defaults to primary color.
  * @param {string} [settings.allCompletedColor = null] The color to steps when all are completed. Defaults to primary color.
- * @param {string} i[settings.nProgressColor The color to show in-progress steps. Defaults to ruby02.
- */
+ * @param {string} [settings.inProgressColor = null] The color to show in-progress steps. Defaults to ruby02.
+ * @param {string|array} [settings.attributes = null] Add extra attributes like id's to the chart elements. For example `attributes: { name: 'id', value: 'my-unique-id' }`
+*/
 function StepChart(element, settings) {
   return this.init(element, settings);
 }
@@ -90,6 +92,7 @@ StepChart.prototype = {
 
     for (let i = 0; i < this.settings.steps; i++) {
       const step = $('<div class="step-chart-step"></div>');
+      utils.addAttributes(step, this.settings, this.settings.attributes, `step${i}`);
 
       // Set up ticks
       if (i < this.settings.completed) {
@@ -146,6 +149,11 @@ StepChart.prototype = {
       container.find('.step-chart-step').css('background-color', this.settings.allCompletedColor);
       label.find('.icon').attr('style', `fill: ${this.settings.allCompletedColor}!important`);
     }
+
+    // Add automation attributes
+    utils.addAttributes(label, this.settings, this.settings.attributes, 'label');
+    utils.addAttributes(label.find('.icon'), this.settings, this.settings.attributes, 'icon');
+    utils.addAttributes(label.find('.step-chart-label-small'), this.settings, this.settings.attributes, 'label-small');
 
     return this;
   },

--- a/test/components/bullet/bullet.e2e-spec.js
+++ b/test/components/bullet/bullet.e2e-spec.js
@@ -16,6 +16,38 @@ describe('Bullet example-index tests', () => {
     await utils.checkForErrors();
   });
 
+  it('Should be able to set id/automation id single', async () => {
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.id('bullet-example1-title')).getAttribute('id')).toEqual('bullet-example1-title');
+    expect(await element(by.id('bullet-example1-title')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-example1-title');
+
+    expect(await element(by.id('bullet-example1-subtitle')).getAttribute('id')).toEqual('bullet-example1-subtitle');
+    expect(await element(by.id('bullet-example1-subtitle')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-example1-subtitle');
+
+    expect(await element(by.id('bullet-example1-difference')).getAttribute('id')).toEqual('bullet-example1-difference');
+    expect(await element(by.id('bullet-example1-difference')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-example1-difference');
+
+    expect(await element(by.id('bullet-example1-marker')).getAttribute('id')).toEqual('bullet-example1-marker');
+    expect(await element(by.id('bullet-example1-marker')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-example1-marker');
+
+    expect(await element(by.id('bullet-example1-measure0')).getAttribute('id')).toEqual('bullet-example1-measure0');
+    expect(await element(by.id('bullet-example1-measure0')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-example1-measure0');
+    expect(await element(by.id('bullet-example1-measure1')).getAttribute('id')).toEqual('bullet-example1-measure1');
+    expect(await element(by.id('bullet-example1-measure1')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-example1-measure1');
+
+    expect(await element(by.id('bullet-example1-range0')).getAttribute('id')).toEqual('bullet-example1-range0');
+    expect(await element(by.id('bullet-example1-range0')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-example1-range0');
+    expect(await element(by.id('bullet-example1-range1')).getAttribute('id')).toEqual('bullet-example1-range1');
+    expect(await element(by.id('bullet-example1-range1')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-example1-range1');
+    expect(await element(by.id('bullet-example1-range2')).getAttribute('id')).toEqual('bullet-example1-range2');
+    expect(await element(by.id('bullet-example1-range2')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-example1-range2');
+    expect(await element(by.id('bullet-example1-range3')).getAttribute('id')).toEqual('bullet-example1-range3');
+    expect(await element(by.id('bullet-example1-range3')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-example1-range3');
+    expect(await element(by.id('bullet-example1-range4')).getAttribute('id')).toEqual('bullet-example1-range4');
+    expect(await element(by.id('bullet-example1-range4')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-example1-range4');
+  });
+
   if (utils.isChrome() && utils.isCI()) {
     it('Should not visual regress', async () => {
       const containerEl = await element(by.css('div[role=main]'));
@@ -47,6 +79,116 @@ describe('Bullet data group tests', () => {
       expect(await browser.imageComparison.checkScreen('bullet-data-group')).toEqual(0);
     });
   }
+});
+
+describe('Bullet data group automation tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/bullet/test-data-group-automation?layout=nofrills');
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should be able to set id/automation id grouped', async () => {
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.id('bullet-group-example1-title-group0')).getAttribute('id')).toEqual('bullet-group-example1-title-group0');
+    expect(await element(by.id('bullet-group-example1-title-group0')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-title-group0');
+    expect(await element(by.id('bullet-group-example1-title-group1')).getAttribute('id')).toEqual('bullet-group-example1-title-group1');
+    expect(await element(by.id('bullet-group-example1-title-group1')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-title-group1');
+    expect(await element(by.id('bullet-group-example1-title-group2')).getAttribute('id')).toEqual('bullet-group-example1-title-group2');
+    expect(await element(by.id('bullet-group-example1-title-group2')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-title-group2');
+    expect(await element(by.id('bullet-group-example1-title-group3')).getAttribute('id')).toEqual('bullet-group-example1-title-group3');
+    expect(await element(by.id('bullet-group-example1-title-group3')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-title-group3');
+    expect(await element(by.id('bullet-group-example1-title-group4')).getAttribute('id')).toEqual('bullet-group-example1-title-group4');
+    expect(await element(by.id('bullet-group-example1-title-group4')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-title-group4');
+
+    expect(await element(by.id('bullet-group-example1-subtitle-group0')).getAttribute('id')).toEqual('bullet-group-example1-subtitle-group0');
+    expect(await element(by.id('bullet-group-example1-subtitle-group0')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-subtitle-group0');
+    expect(await element(by.id('bullet-group-example1-subtitle-group1')).getAttribute('id')).toEqual('bullet-group-example1-subtitle-group1');
+    expect(await element(by.id('bullet-group-example1-subtitle-group1')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-subtitle-group1');
+    expect(await element(by.id('bullet-group-example1-subtitle-group2')).getAttribute('id')).toEqual('bullet-group-example1-subtitle-group2');
+    expect(await element(by.id('bullet-group-example1-subtitle-group2')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-subtitle-group2');
+    expect(await element(by.id('bullet-group-example1-subtitle-group3')).getAttribute('id')).toEqual('bullet-group-example1-subtitle-group3');
+    expect(await element(by.id('bullet-group-example1-subtitle-group3')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-subtitle-group3');
+    expect(await element(by.id('bullet-group-example1-subtitle-group4')).getAttribute('id')).toEqual('bullet-group-example1-subtitle-group4');
+    expect(await element(by.id('bullet-group-example1-subtitle-group4')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-subtitle-group4');
+
+    expect(await element(by.id('bullet-group-example1-difference-group0')).getAttribute('id')).toEqual('bullet-group-example1-difference-group0');
+    expect(await element(by.id('bullet-group-example1-difference-group0')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-difference-group0');
+    expect(await element(by.id('bullet-group-example1-difference-group1')).getAttribute('id')).toEqual('bullet-group-example1-difference-group1');
+    expect(await element(by.id('bullet-group-example1-difference-group1')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-difference-group1');
+    expect(await element(by.id('bullet-group-example1-difference-group2')).getAttribute('id')).toEqual('bullet-group-example1-difference-group2');
+    expect(await element(by.id('bullet-group-example1-difference-group2')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-difference-group2');
+    expect(await element(by.id('bullet-group-example1-difference-group3')).getAttribute('id')).toEqual('bullet-group-example1-difference-group3');
+    expect(await element(by.id('bullet-group-example1-difference-group3')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-difference-group3');
+    expect(await element(by.id('bullet-group-example1-difference-group4')).getAttribute('id')).toEqual('bullet-group-example1-difference-group4');
+    expect(await element(by.id('bullet-group-example1-difference-group4')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-difference-group4');
+
+    expect(await element(by.id('bullet-group-example1-marker-group0')).getAttribute('id')).toEqual('bullet-group-example1-marker-group0');
+    expect(await element(by.id('bullet-group-example1-marker-group0')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-marker-group0');
+    expect(await element(by.id('bullet-group-example1-marker-group1')).getAttribute('id')).toEqual('bullet-group-example1-marker-group1');
+    expect(await element(by.id('bullet-group-example1-marker-group1')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-marker-group1');
+    expect(await element(by.id('bullet-group-example1-marker-group2')).getAttribute('id')).toEqual('bullet-group-example1-marker-group2');
+    expect(await element(by.id('bullet-group-example1-marker-group2')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-marker-group2');
+    expect(await element(by.id('bullet-group-example1-marker-group3')).getAttribute('id')).toEqual('bullet-group-example1-marker-group3');
+    expect(await element(by.id('bullet-group-example1-marker-group3')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-marker-group3');
+    expect(await element(by.id('bullet-group-example1-marker-group4')).getAttribute('id')).toEqual('bullet-group-example1-marker-group4');
+    expect(await element(by.id('bullet-group-example1-marker-group4')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-marker-group4');
+
+    expect(await element(by.id('bullet-group-example1-measure0-group0')).getAttribute('id')).toEqual('bullet-group-example1-measure0-group0');
+    expect(await element(by.id('bullet-group-example1-measure0-group0')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-measure0-group0');
+    expect(await element(by.id('bullet-group-example1-measure1-group0')).getAttribute('id')).toEqual('bullet-group-example1-measure1-group0');
+    expect(await element(by.id('bullet-group-example1-measure1-group0')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-measure1-group0');
+    expect(await element(by.id('bullet-group-example1-measure0-group1')).getAttribute('id')).toEqual('bullet-group-example1-measure0-group1');
+    expect(await element(by.id('bullet-group-example1-measure0-group1')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-measure0-group1');
+    expect(await element(by.id('bullet-group-example1-measure1-group1')).getAttribute('id')).toEqual('bullet-group-example1-measure1-group1');
+    expect(await element(by.id('bullet-group-example1-measure1-group1')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-measure1-group1');
+    expect(await element(by.id('bullet-group-example1-measure0-group2')).getAttribute('id')).toEqual('bullet-group-example1-measure0-group2');
+    expect(await element(by.id('bullet-group-example1-measure0-group2')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-measure0-group2');
+    expect(await element(by.id('bullet-group-example1-measure1-group2')).getAttribute('id')).toEqual('bullet-group-example1-measure1-group2');
+    expect(await element(by.id('bullet-group-example1-measure1-group2')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-measure1-group2');
+    expect(await element(by.id('bullet-group-example1-measure0-group3')).getAttribute('id')).toEqual('bullet-group-example1-measure0-group3');
+    expect(await element(by.id('bullet-group-example1-measure0-group3')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-measure0-group3');
+    expect(await element(by.id('bullet-group-example1-measure1-group3')).getAttribute('id')).toEqual('bullet-group-example1-measure1-group3');
+    expect(await element(by.id('bullet-group-example1-measure1-group3')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-measure1-group3');
+    expect(await element(by.id('bullet-group-example1-measure0-group4')).getAttribute('id')).toEqual('bullet-group-example1-measure0-group4');
+    expect(await element(by.id('bullet-group-example1-measure0-group4')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-measure0-group4');
+    expect(await element(by.id('bullet-group-example1-measure1-group4')).getAttribute('id')).toEqual('bullet-group-example1-measure1-group4');
+    expect(await element(by.id('bullet-group-example1-measure1-group4')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-measure1-group4');
+
+    expect(await element(by.id('bullet-group-example1-range0-group0')).getAttribute('id')).toEqual('bullet-group-example1-range0-group0');
+    expect(await element(by.id('bullet-group-example1-range0-group0')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-range0-group0');
+    expect(await element(by.id('bullet-group-example1-range1-group0')).getAttribute('id')).toEqual('bullet-group-example1-range1-group0');
+    expect(await element(by.id('bullet-group-example1-range1-group0')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-range1-group0');
+    expect(await element(by.id('bullet-group-example1-range2-group0')).getAttribute('id')).toEqual('bullet-group-example1-range2-group0');
+    expect(await element(by.id('bullet-group-example1-range2-group0')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-range2-group0');
+    expect(await element(by.id('bullet-group-example1-range0-group1')).getAttribute('id')).toEqual('bullet-group-example1-range0-group1');
+    expect(await element(by.id('bullet-group-example1-range0-group1')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-range0-group1');
+    expect(await element(by.id('bullet-group-example1-range1-group1')).getAttribute('id')).toEqual('bullet-group-example1-range1-group1');
+    expect(await element(by.id('bullet-group-example1-range1-group1')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-range1-group1');
+    expect(await element(by.id('bullet-group-example1-range2-group1')).getAttribute('id')).toEqual('bullet-group-example1-range2-group1');
+    expect(await element(by.id('bullet-group-example1-range2-group1')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-range2-group1');
+    expect(await element(by.id('bullet-group-example1-range0-group2')).getAttribute('id')).toEqual('bullet-group-example1-range0-group2');
+    expect(await element(by.id('bullet-group-example1-range0-group2')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-range0-group2');
+    expect(await element(by.id('bullet-group-example1-range1-group2')).getAttribute('id')).toEqual('bullet-group-example1-range1-group2');
+    expect(await element(by.id('bullet-group-example1-range1-group2')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-range1-group2');
+    expect(await element(by.id('bullet-group-example1-range2-group2')).getAttribute('id')).toEqual('bullet-group-example1-range2-group2');
+    expect(await element(by.id('bullet-group-example1-range2-group2')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-range2-group2');
+    expect(await element(by.id('bullet-group-example1-range0-group3')).getAttribute('id')).toEqual('bullet-group-example1-range0-group3');
+    expect(await element(by.id('bullet-group-example1-range0-group3')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-range0-group3');
+    expect(await element(by.id('bullet-group-example1-range1-group3')).getAttribute('id')).toEqual('bullet-group-example1-range1-group3');
+    expect(await element(by.id('bullet-group-example1-range1-group3')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-range1-group3');
+    expect(await element(by.id('bullet-group-example1-range2-group3')).getAttribute('id')).toEqual('bullet-group-example1-range2-group3');
+    expect(await element(by.id('bullet-group-example1-range2-group3')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-range2-group3');
+    expect(await element(by.id('bullet-group-example1-range0-group4')).getAttribute('id')).toEqual('bullet-group-example1-range0-group4');
+    expect(await element(by.id('bullet-group-example1-range0-group4')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-range0-group4');
+    expect(await element(by.id('bullet-group-example1-range1-group4')).getAttribute('id')).toEqual('bullet-group-example1-range1-group4');
+    expect(await element(by.id('bullet-group-example1-range1-group4')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-range1-group4');
+    expect(await element(by.id('bullet-group-example1-range2-group4')).getAttribute('id')).toEqual('bullet-group-example1-range2-group4');
+    expect(await element(by.id('bullet-group-example1-range2-group4')).getAttribute('data-automation-id')).toEqual('automation-id-bullet-group-example1-range2-group4');
+  });
 });
 
 describe('Bullet negative positive tests', () => {

--- a/test/components/stepchart/stepchart.e2e-spec.js
+++ b/test/components/stepchart/stepchart.e2e-spec.js
@@ -1,0 +1,64 @@
+const { browserStackErrorReporter } = requireHelper('browserstack-error-reporter');
+const utils = requireHelper('e2e-utils');
+requireHelper('rejection');
+
+jasmine.getEnv().addReporter(browserStackErrorReporter);
+
+describe('Stepchart example-index tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/stepchart/example-index?layout=nofrills');
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should be able to set id/automation id example one', async () => {
+    expect(await element(by.id('stepchart-example1-label')).getAttribute('id')).toEqual('stepchart-example1-label');
+    expect(await element(by.id('stepchart-example1-label')).getAttribute('data-automation-id')).toEqual('automation-id-stepchart-example1-label');
+
+    expect(await element(by.id('stepchart-example1-icon')).getAttribute('id')).toEqual('stepchart-example1-icon');
+    expect(await element(by.id('stepchart-example1-icon')).getAttribute('data-automation-id')).toEqual('automation-id-stepchart-example1-icon');
+
+    expect(await element(by.id('stepchart-example1-step0')).getAttribute('id')).toEqual('stepchart-example1-step0');
+    expect(await element(by.id('stepchart-example1-step0')).getAttribute('data-automation-id')).toEqual('automation-id-stepchart-example1-step0');
+    expect(await element(by.id('stepchart-example1-step1')).getAttribute('id')).toEqual('stepchart-example1-step1');
+    expect(await element(by.id('stepchart-example1-step1')).getAttribute('data-automation-id')).toEqual('automation-id-stepchart-example1-step1');
+    expect(await element(by.id('stepchart-example1-step2')).getAttribute('id')).toEqual('stepchart-example1-step2');
+    expect(await element(by.id('stepchart-example1-step2')).getAttribute('data-automation-id')).toEqual('automation-id-stepchart-example1-step2');
+    expect(await element(by.id('stepchart-example1-step3')).getAttribute('id')).toEqual('stepchart-example1-step3');
+    expect(await element(by.id('stepchart-example1-step3')).getAttribute('data-automation-id')).toEqual('automation-id-stepchart-example1-step3');
+    expect(await element(by.id('stepchart-example1-step4')).getAttribute('id')).toEqual('stepchart-example1-step4');
+    expect(await element(by.id('stepchart-example1-step4')).getAttribute('data-automation-id')).toEqual('automation-id-stepchart-example1-step4');
+    expect(await element(by.id('stepchart-example1-step5')).getAttribute('id')).toEqual('stepchart-example1-step5');
+    expect(await element(by.id('stepchart-example1-step5')).getAttribute('data-automation-id')).toEqual('automation-id-stepchart-example1-step5');
+    expect(await element(by.id('stepchart-example1-step6')).getAttribute('id')).toEqual('stepchart-example1-step6');
+    expect(await element(by.id('stepchart-example1-step6')).getAttribute('data-automation-id')).toEqual('automation-id-stepchart-example1-step6');
+  });
+
+  it('Should be able to set id/automation id example four', async () => {
+    expect(await element(by.id('stepchart-example4-label')).getAttribute('id')).toEqual('stepchart-example4-label');
+    expect(await element(by.id('stepchart-example4-label')).getAttribute('data-automation-id')).toEqual('automation-id-stepchart-example4-label');
+
+    expect(await element(by.id('stepchart-example4-label-small')).getAttribute('id')).toEqual('stepchart-example4-label-small');
+    expect(await element(by.id('stepchart-example4-label-small')).getAttribute('data-automation-id')).toEqual('automation-id-stepchart-example4-label-small');
+
+    expect(await element(by.id('stepchart-example4-icon')).getAttribute('id')).toEqual('stepchart-example4-icon');
+    expect(await element(by.id('stepchart-example4-icon')).getAttribute('data-automation-id')).toEqual('automation-id-stepchart-example4-icon');
+
+    expect(await element(by.id('stepchart-example4-step0')).getAttribute('id')).toEqual('stepchart-example4-step0');
+    expect(await element(by.id('stepchart-example4-step0')).getAttribute('data-automation-id')).toEqual('automation-id-stepchart-example4-step0');
+    expect(await element(by.id('stepchart-example4-step1')).getAttribute('id')).toEqual('stepchart-example4-step1');
+    expect(await element(by.id('stepchart-example4-step1')).getAttribute('data-automation-id')).toEqual('automation-id-stepchart-example4-step1');
+    expect(await element(by.id('stepchart-example4-step2')).getAttribute('id')).toEqual('stepchart-example4-step2');
+    expect(await element(by.id('stepchart-example4-step2')).getAttribute('data-automation-id')).toEqual('automation-id-stepchart-example4-step2');
+    expect(await element(by.id('stepchart-example4-step3')).getAttribute('id')).toEqual('stepchart-example4-step3');
+    expect(await element(by.id('stepchart-example4-step3')).getAttribute('data-automation-id')).toEqual('automation-id-stepchart-example4-step3');
+    expect(await element(by.id('stepchart-example4-step4')).getAttribute('id')).toEqual('stepchart-example4-step4');
+    expect(await element(by.id('stepchart-example4-step4')).getAttribute('data-automation-id')).toEqual('automation-id-stepchart-example4-step4');
+    expect(await element(by.id('stepchart-example4-step5')).getAttribute('id')).toEqual('stepchart-example4-step5');
+    expect(await element(by.id('stepchart-example4-step5')).getAttribute('data-automation-id')).toEqual('automation-id-stepchart-example4-step5');
+    expect(await element(by.id('stepchart-example4-step6')).getAttribute('id')).toEqual('stepchart-example4-step6');
+    expect(await element(by.id('stepchart-example4-step6')).getAttribute('data-automation-id')).toEqual('automation-id-stepchart-example4-step6');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adds the attributes/automation id/ id functionality for Bullet and Stepchart Charts.

**Related github/jira issue (required)**:
related to #4498

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app

Bullet
- Navigate to:
- http://localhost:4000/components/bullet/example-index.html
- http://localhost:4000/components/bullet/test-data-group-automation.html
- Check for `id` and `data-automation-id` attributes, get from the settings (each title, subtitle, range, measure, marker for single and grouped)
- Review the text in the docs

Stepchart
- Navigate to:
- http://localhost:4000/components/stepchart/example-index.html
- Check for `id` and `data-automation-id` attributes, get from the settings (each step, label, label-icon, label-small for 1st and 4th chart)
- Review the text in the docs

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
