### PR TITLE
4376 - Add allowDeselect feature

### DIFF
--- a/app/views/components/listview/example-singleselect-no-deselect.html
+++ b/app/views/components/listview/example-singleselect-no-deselect.html
@@ -1,0 +1,76 @@
+<div class="row">
+  <div class="twelve columns">
+      <h2 class="fieldset-title">ListView  - Single Row Select (No Deselect)</h2>
+  </div>
+</div>
+
+<div class="row">
+  <div class="one-third column">
+    <div class="card" >
+      <div class="card-header">
+        <h2 class="card-title">Tasks</h2>
+        <button class="btn-actions" type="button">
+          <span class="audible">Actions</span>
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-more"></use>
+          </svg>
+        </button>
+        <ul class="popupmenu">
+          <li><a href="#">Add new action item</a></li>
+          <li><a href="#">Regular action</a></li>
+          <li><a href="#">Individual Action</a></li>
+        </ul>
+      </div>
+
+      <div class="card-content">
+        <div class="contextual-toolbar toolbar is-hidden">
+          <div class="buttonset">
+            <button class="btn-tertiary" title="Assign Selected Items" type="button">Assign</button>
+            <button class="btn-tertiary" title="Remove Selected Items" type="button">Remove</button>
+          </div>
+        </div>
+        <div class="listview" id="period-end" data-options="{template: 'period-end-tmpl', selectable: 'single', allowDeselect: false, source: '{{basepath}}api/periods' }"></div>
+      </div>
+    </div>
+
+    {{={{{ }}}=}}
+
+    <script id="period-end-tmpl" type="text/html">
+      <ul>
+        {{#dataset}}
+          {{#alert}}
+            <li class="{{alertClass}}">
+              <p class="listview-heading">{{city}}</p>
+              <p class="listview-subheading">{{location}}</p>
+              <div class="l-pull-right error">
+                  <svg class="icon icon-{{alertClass}}" focusable="false" aria-hidden="true" role="presentation">
+                    <use href="#icon-{{alertClass}}"/>
+                  </svg>
+                  <span class="days">{{daysLeft}}</span><span class="day-sign">d</span>
+                  <span class="hours">{{hoursLeft}}</span><span class="hour-sign">h</span>
+              </div>
+            </li>
+          {{/alert}}
+          {{^alert}}
+            <li>
+              <p class="listview-heading">{{city}}</p>
+              <p class="listview-subheading">{{location}}</p>
+
+              <div class="l-pull-right">
+                <span class="days">{{daysLeft}}</span><span class="day-sign">d</span>
+                <span class="hours">{{hoursLeft}}</span><span class="hour-sign">h</span>
+              </div>
+            </li>
+          {{/alert}}
+        {{/dataset}}
+      </ul>
+    </script>
+
+  </div>
+</div>
+
+<script>
+  $('#period-end').on('selected', function (e, args) {
+    console.log(args.selectedData);
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[Emptymessage]` Added `attributes` setting to set automation ids's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[FieldFilter]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Input]` Add a `revealText` plugin that will add a button to password fields to hide and show sensitive information such as SIN or passwords. ([#4098](https://github.com/infor-design/enterprise/issues/4098))
+- `[Listview]` Added a new setting `allowDeselect` which will make it such that if you select an item you cant deselect, you can only select another item. ([#4376](https://github.com/infor-design/enterprise/issues/4376))
 - `[Locale]` Added a new set of translations from the translation team. ([#4501](https://github.com/infor-design/enterprise/issues/4501))
 - `[Locale/Charts]` The numbers inside charts are now formatted using the current locale's, number settings. This can be disabled/changed in some charts by passing in a localeInfo object to override the default settings. ([#4437](https://github.com/infor-design/enterprise/issues/4437))
 - `[Listview]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -32,6 +32,7 @@ const COMPONENT_NAME = 'listview';
  * @param {boolean} [settings.searchable=false] If true, associates itself with a Searchfield/Autocomplete and allows itself to be filtered
  * @param {boolean} [settings.highlight=true] If false the highlighting of text when using searchable is disabled. You may want to disable this on larger lists.
  * @param {string|boolean} [settings.selectable='single'] selection mode, can be false, 'single', 'multiple' or 'mixed'
+ * @param {boolean} [settings.allowDeselect=true] If using single select you can set this if you want the rows to not be deSelected.
  * @param {boolean} [settings.selectOnFocus=true] If true the first item in the list will be selected as it is focused.
  * @param {boolean} [settings.showCheckboxes=true] If false will not show checkboxes used with multiple selection mode only
  * @param {boolean} [settings.hoverable=true] If true the list element will show a hover action to indicate its actionable.
@@ -64,6 +65,7 @@ const LISTVIEW_DEFAULTS = {
   source: null,
   forceToRenderOnEmptyDs: false,
   disableItemDeactivation: false,
+  allowDeselect: true,
   showPageSizeSelector: false,
   listFilterSettings: null,
   pagerSettings: {
@@ -950,6 +952,10 @@ ListView.prototype = {
   * @param {jquery[]|number} li  Either the actually jQuery list element or a zero based index
   */
   deselect(li) {
+    if (!this.settings.allowDeselect) {
+      return;
+    }
+
     if (typeof li === 'number') {
       li = $(this.element.children()[0]).children().eq(li);
     }
@@ -985,6 +991,10 @@ ListView.prototype = {
     }
 
     isChecked = li.hasClass('is-selected');
+
+    if (isChecked && !this.settings.allowDeselect) {
+      return;
+    }
 
     // focus
     if (!li.is('[tabindex="0"]')) {

--- a/test/components/listview/listview.e2e-spec.js
+++ b/test/components/listview/listview.e2e-spec.js
@@ -552,3 +552,32 @@ describe('Listview flex card empty tests', () => {
     });
   }
 });
+
+describe('Listview allow delselect tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/listview/example-singleselect-no-deselect');
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('ul li'))), config.waitsFor);
+  });
+
+  it('Should disallow deselect on click', async () => {
+    const listviewItemEl = await element(by.css('li[aria-posinset="1"]'));
+    await listviewItemEl.click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.css('li.is-selected'))), config.waitsFor);
+
+    expect(await element(by.css('li.is-selected')).isPresent()).toBeTruthy();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.textToBePresentInElement(element(by.className('selection-count')), '1 Selected'), config.waitsFor);
+
+    expect(await element(by.className('selection-count')).getText()).toContain('1 Selected');
+
+    await listviewItemEl.click();
+
+    expect(await element(by.css('li.is-selected')).isPresent()).toBeTruthy();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.textToBePresentInElement(element(by.className('selection-count')), '1 Selected'), config.waitsFor);
+
+    expect(await element(by.className('selection-count')).getText()).toContain('1 Selected');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adds a new option to listview to prevent the deselection of rows in single select mode.

**Related github/jira issue (required)**:
Fixes #4376 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/listview/example-singleselect-no-deselect.html
- select a row
- select another row
- try and toggle off selection on a row (you cant, this is the new option)

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
