### PR TITLE
4498 - Add ids and automation ids for Rating, Slider and Spinbox

### DIFF
--- a/app/views/components/rating/example-index.html
+++ b/app/views/components/rating/example-index.html
@@ -2,10 +2,10 @@
 <div class="row">
   <div class="twelve columns">
     <div class="field">
-      <div class="rating">
+      <div class="rating" id="rating-id-1" data-automation-id="rating-automation-id-1">
         <fieldset>
           <legend class="audible">Rate Your Experience</legend>
-          <input type="radio" class="is-filled" name="rating-id1" id="one-star-id1"/>
+          <input type="radio" class="is-filled" name="rating-id1" id="one-star-id1" data-automation-id="one-star-automation-id1"/>
           <label for="one-star-id1">
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
               <use href="#icon-star-filled"></use>
@@ -13,7 +13,7 @@
             <span class="audible">1 out of 5 Stars</span>
           </label>
 
-          <input type="radio" class="is-filled" name="rating-id1" id="two-star-id1"/>
+          <input type="radio" class="is-filled" name="rating-id1" id="two-star-id1" data-automation-id="two-star-automation-id1"/>
           <label for="two-star-id1">
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
               <use href="#icon-star-filled"></use>
@@ -21,7 +21,7 @@
             <span class="audible">2 out of 5 Stars</span>
           </label>
 
-          <input type="radio" class="is-filled" name="rating-id1" id="three-star-id1"/>
+          <input type="radio" class="is-filled" name="rating-id1" id="three-star-id1" data-automation-id="three-star-automation-id1"/>
           <label for="three-star-id1">
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
               <use href="#icon-star-filled"></use>
@@ -29,7 +29,7 @@
             <span class="audible">3 out of 5 Stars</span>
           </label>
 
-          <input type="radio" checked="true" name="rating-id1" id="four-star-id1"/>
+          <input type="radio" checked="true" name="rating-id1" id="four-star-id1" data-automation-id="four-star-automation-id1"/>
           <label for="four-star-id1">
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
               <use href="#icon-star-half"></use>
@@ -37,7 +37,7 @@
             <span class="audible">4 out of 5 Stars</span>
           </label>
 
-          <input type="radio" name="rating-id1" id="five-star-id1"/>
+          <input type="radio" name="rating-id1" id="five-star-id1" data-automation-id="five-star-automation-id1"/>
           <label for="five-star-id1">
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
               <use href="#icon-star-outlined"></use>

--- a/app/views/components/slider/example-index.html
+++ b/app/views/components/slider/example-index.html
@@ -2,7 +2,7 @@
   <div class="twelve columns">
     <div class="field">
       <label for="slider-regular">Regular</label>
-      <input id="slider-regular" name="slider-regular" value="10" class="slider" type="range" data-options="{'persistTooltip': false, tooltipContent: ['']}"/>
+      <input id="slider-regular" name="slider-regular" value="10" class="slider" type="range" data-options="{'persistTooltip': false, tooltipContent: [''], attributes: [{ name: 'id', value: 'slider-id-1' }, { name: 'data-automation-id', value: 'slider-automation-id-1' }]}"/>
     </div>
   </div>
 </div>

--- a/app/views/components/spinbox/example-index.html
+++ b/app/views/components/spinbox/example-index.html
@@ -8,5 +8,10 @@
 </div>
 
 <script>
-  $('#regular-spinbox').spinbox();
+  $('#regular-spinbox').spinbox({
+    attributes: [
+      { name: 'id', value: 'spinbox-id-1' },
+      { name: 'data-automation-id', value: 'spinbox-automation-id-1' }
+    ]
+  });
 </script>

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -68,14 +68,14 @@ This list is a list of elements that have clickable items that need to be handle
 - [x] Progress
 - [x] Radar
 - [x] Radios
-- [ ] Rating
+- [x] Rating (not needed id can be directly applied)
 - [x] Scatterplot
 - [x] Searchfield
 - [ ] Signin
 - [x] Skiplink (not needed id can be directly applied)
-- [ ] Slider
+- [x] Slider
 - [x] Sparkline
-- [ ] Spinbox
+- [x] Spinbox
 - [ ] Splitter
 - [x] Stepchart
 - [ ] Swaplist

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,7 +38,7 @@
 - `[Notification]` Added `attributes` setting to set automation ids's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Radar/Sparkline]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Radios/Progress/Treemap]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
-- `[Rating/Slider/Spinbox/Slider]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
+- `[Rating/Slider/Spinbox]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Textarea]` Added `attributes` setting to set automation ids's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Treemap]` Added ability to show a tooltip. ([#2794](https://github.com/infor-design/enterprise/issues/2794))
 - `[Tabs]` Added `attributes` setting to the `add()` method's options argument for setting automation id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@
 - `[Notification]` Added `attributes` setting to set automation ids's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Radar/Sparkline]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Radios/Progress/Treemap]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
+- `[Rating/Slider/Spinbox/Slider]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Textarea]` Added `attributes` setting to set automation ids's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Treemap]` Added ability to show a tooltip. ([#2794](https://github.com/infor-design/enterprise/issues/2794))
 - `[Tabs]` Added `attributes` setting to the `add()` method's options argument for setting automation id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))

--- a/src/components/slider/readme.md
+++ b/src/components/slider/readme.md
@@ -76,6 +76,15 @@ This is an example of a slider that can only have values in increments of 10, wi
 </div>
 ```
 
+Another example of a slider where you can set/add `attributes` like id and automation id.
+
+```html
+    <div class="field">
+      <label for="slider-regular">Regular</label>
+      <input id="slider-regular" name="slider-regular" value="10" class="slider" type="range" data-options="{'persistTooltip': false, tooltipContent: [''], attributes: [{ name: 'id', value: 'slider-id-1' }, { name: 'data-automation-id', value: 'slider-automation-id-1' }]}"/>
+    </div>
+```
+
 ## Implementation Tips
 
 Only providing the HTML label and input with a `type="range"` attribute and `slider` CSS class are necessary if using the IDS Enterprise Components Suite.
@@ -99,6 +108,26 @@ The Slider is fairly complex to make accessible. But generally this can be accom
     - `aria-describedby` - When used in conjunction with a [tooltip control](./tooltip), this attribute will be appended to the handle automatically, but in this case the `aria-label` attribute should be removed.
 
 ## Testability
+
+The slider can have custom id's/automation id's that can be used for scripting. To add them, use the option `attributes` to set an id on the generated slider. This can take either an object or an array if doing several id's, and you can configure the automation id name. For example:
+
+```js
+  attributes: { name: 'id', value: args => `message-id-${args.id}` }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: { name: 'data-automation-id', value: 'my-unique-id' }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: [{ name: 'id', value: 'my-unique-id' }, { name: 'data-automation-id', value: 'my-unique-id' }]
+```
+
+Providing the data, this will add an ID added to each slider wrapper with `-wrapper`, slider hitarea with `-hitarea`, slider range with `-range`, slider handle with `-handle`, slider ticks and ticks complete with `-tick-{idx}`, and the hidden slider element appended.
 
 - Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
 

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -23,7 +23,8 @@ const SLIDER_DEFAULTS = {
   ticks: [],
   tooltipContent: undefined,
   tooltipPosition: 'top',
-  persistTooltip: false
+  persistTooltip: false,
+  attributes: null
 };
 
 /**
@@ -40,6 +41,7 @@ const SLIDER_DEFAULTS = {
  * @param {undefined|Array} [settings.tooltipContent] Special customizable tooltip content.
  * @param {string} [settings.tooltipPosition = 'top'] Option to control the position of tooltip. ['top' , 'bottom']
  * @param {boolean} [settings.persistTooltip = false] If true the tooltip will stay visible.
+ * @param {string} [settings.attributes=null] Add extra attributes like id's to the element. e.g. `attributes: { name: 'id', value: 'my-unique-id' }`
  */
 function Slider(element, settings) {
   this.element = $(element);
@@ -360,6 +362,17 @@ Slider.prototype = {
       this.readonly();
     } else if (this.element.prop('disabled') === true) {
       this.disable();
+    }
+
+    utils.addAttributes(this.element, this, this.settings.attributes);
+    utils.addAttributes(this.wrapper, this, this.settings.attributes, 'wrapper');
+    utils.addAttributes(this.hitarea, this, this.settings.attributes, 'hitarea');
+    utils.addAttributes(this.range, this, this.settings.attributes, 'range');
+    utils.addAttributes(...this.handles, this, this.settings.attributes, 'handle');
+
+    for (let i = 0, l = this.ticks.length; i < l; i++) {
+      const ticks = $(this.ticks[i].element);
+      utils.addAttributes(ticks, this, this.settings.attributes, `tick-${i + 1}`);
     }
 
     return self;

--- a/src/components/spinbox/readme.md
+++ b/src/components/spinbox/readme.md
@@ -42,6 +42,26 @@ Touch and mobile keyboard are supported.
 
 ## Testability
 
+The spinbox can have custom id's/automation id's that can be used for scripting. To add them, use the option `attributes` to set an id on the generated spinbox. This can take either an object or an array if doing several id's, and you can configure the automation id name. For example:
+
+```js
+  attributes: { name: 'id', value: args => `message-id-${args.id}` }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: { name: 'data-automation-id', value: 'my-unique-id' }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: [{ name: 'id', value: 'my-unique-id' }, { name: 'data-automation-id', value: 'my-unique-id' }]
+```
+
+Providing the data, this will add an ID added to each spinbox wrapper with `-wrapper`, spinbox with `-spinbox`, spinbox button + with `-btn-up`, and spinbox button - with `-btn-down` appended.
+
 - Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
 
 ## Keyboard Shortcuts

--- a/src/components/spinbox/spinbox.js
+++ b/src/components/spinbox/spinbox.js
@@ -16,7 +16,8 @@ const SPINBOX_DEFAULTS = {
   min: -2147483647,
   max: 2147483647,
   step: null,
-  maskOptions: null
+  maskOptions: null,
+  attributes: null
 };
 
 /**
@@ -29,6 +30,7 @@ const SPINBOX_DEFAULTS = {
  * @param {Number} [settings.min = -2147483647] if defined, provides a minimum numeric limit
  * @param {Number} [settings.max = 2147483647]  if defined, provides a maximum numeric limit
  * @param {Number} [settings.maskOptions = null]  if defined this is passed to the internal mask component
+ * @param {string} [settings.attributes = null] Add extra attributes like id's to the element. e.g. `attributes: { name: 'id', value: 'my-unique-id' }`
  * @param {null|Number} [settings.step = null]  if defined, increases or decreases the spinbox value
  *  by a specific interval whenever the control buttons are used.
  *  the spinbox value after the spinbox has lost focus.
@@ -253,6 +255,11 @@ Spinbox.prototype = {
     if (this.element.attr('readonly')) {
       this.readonly();
     }
+
+    utils.addAttributes(this.element.parent(), this, this.settings.attributes, 'wrapper');
+    utils.addAttributes(this.element, this, this.settings.attributes, 'spinbox');
+    utils.addAttributes(this.buttons.down, this, this.settings.attributes, 'btn-down');
+    utils.addAttributes(this.buttons.up, this, this.settings.attributes, 'btn-up');
 
     return this;
   },

--- a/test/components/rating/rating.e2e-spec.js
+++ b/test/components/rating/rating.e2e-spec.js
@@ -24,4 +24,26 @@ describe('Rating example-index tests', () => {
       expect(await browser.imageComparison.checkScreen('rating')).toEqual(0);
     });
   }
+
+  it('Should be able to set ids/automation ids', async () => {
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.id('rating-id-1')).getAttribute('id')).toEqual('rating-id-1');
+    expect(await element(by.id('rating-id-1')).getAttribute('data-automation-id')).toEqual('rating-automation-id-1');
+
+    expect(await element(by.id('one-star-id1')).getAttribute('id')).toEqual('one-star-id1');
+    expect(await element(by.id('one-star-id1')).getAttribute('data-automation-id')).toEqual('one-star-automation-id1');
+
+    expect(await element(by.id('two-star-id1')).getAttribute('id')).toEqual('two-star-id1');
+    expect(await element(by.id('two-star-id1')).getAttribute('data-automation-id')).toEqual('two-star-automation-id1');
+
+    expect(await element(by.id('three-star-id1')).getAttribute('id')).toEqual('three-star-id1');
+    expect(await element(by.id('three-star-id1')).getAttribute('data-automation-id')).toEqual('three-star-automation-id1');
+
+    expect(await element(by.id('four-star-id1')).getAttribute('id')).toEqual('four-star-id1');
+    expect(await element(by.id('four-star-id1')).getAttribute('data-automation-id')).toEqual('four-star-automation-id1');
+
+    expect(await element(by.id('five-star-id1')).getAttribute('id')).toEqual('five-star-id1');
+    expect(await element(by.id('five-star-id1')).getAttribute('data-automation-id')).toEqual('five-star-automation-id1');
+  });
 });

--- a/test/components/slider/slider.e2e-spec.js
+++ b/test/components/slider/slider.e2e-spec.js
@@ -24,6 +24,31 @@ describe('Slider example-index tests', () => { //eslint-disable-line
       expect(await browser.imageComparison.checkScreen('slider')).toEqual(0);
     });
   }
+
+  it('Should be able to set ids/automation ids', async () => {
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.id('slider-id-1')).getAttribute('id')).toEqual('slider-id-1');
+    expect(await element(by.id('slider-id-1')).getAttribute('data-automation-id')).toEqual('slider-automation-id-1');
+
+    expect(await element(by.id('slider-id-1-wrapper')).getAttribute('id')).toEqual('slider-id-1-wrapper');
+    expect(await element(by.id('slider-id-1-wrapper')).getAttribute('data-automation-id')).toEqual('slider-automation-id-1-wrapper');
+
+    expect(await element(by.id('slider-id-1-hitarea')).getAttribute('id')).toEqual('slider-id-1-hitarea');
+    expect(await element(by.id('slider-id-1-hitarea')).getAttribute('data-automation-id')).toEqual('slider-automation-id-1-hitarea');
+
+    expect(await element(by.id('slider-id-1-range')).getAttribute('id')).toEqual('slider-id-1-range');
+    expect(await element(by.id('slider-id-1-range')).getAttribute('data-automation-id')).toEqual('slider-automation-id-1-range');
+
+    expect(await element(by.id('slider-id-1-handle')).getAttribute('id')).toEqual('slider-id-1-handle');
+    expect(await element(by.id('slider-id-1-handle')).getAttribute('data-automation-id')).toEqual('slider-automation-id-1-handle');
+
+    expect(await element(by.id('slider-id-1-tick-1')).getAttribute('id')).toEqual('slider-id-1-tick-1');
+    expect(await element(by.id('slider-id-1-tick-1')).getAttribute('data-automation-id')).toEqual('slider-automation-id-1-tick-1');
+
+    expect(await element(by.id('slider-id-1-tick-2')).getAttribute('id')).toEqual('slider-id-1-tick-2');
+    expect(await element(by.id('slider-id-1-tick-2')).getAttribute('data-automation-id')).toEqual('slider-automation-id-1-tick-2');
+  });
 });
 
 describe('Slider Vertical tests', () => { //eslint-disable-line

--- a/test/components/spinbox/spinbox-settings.func-spec.js
+++ b/test/components/spinbox/spinbox-settings.func-spec.js
@@ -36,7 +36,8 @@ describe('Spinbox settings', () => {
       min: 0,
       max: 10,
       step: null,
-      maskOptions: null
+      maskOptions: null,
+      attributes: null
     };
 
     settings.min = 0; // example initializes with data-options
@@ -51,7 +52,8 @@ describe('Spinbox settings', () => {
       min: 10,
       max: 20,
       step: null,
-      maskOptions: null
+      maskOptions: null,
+      attributes: null
     };
 
     spinboxApi.updated();
@@ -82,7 +84,8 @@ describe('Spinbox settings', () => {
       min: 0,
       max: 10,
       step: null,
-      maskOptions: null
+      maskOptions: null,
+      attributes: null
     };
 
     expect(spinboxApi.settings).toEqual(settings);

--- a/test/components/spinbox/spinbox-settings.func-spec.js
+++ b/test/components/spinbox/spinbox-settings.func-spec.js
@@ -69,7 +69,8 @@ describe('Spinbox settings', () => {
       min: 10,
       max: 20,
       step: null,
-      maskOptions: null
+      maskOptions: null,
+      attributes: null
     };
     spinboxApi.updated(settings);
     spinboxApi.settings.min = 10;

--- a/test/components/spinbox/spinbox.e2e-spec.js
+++ b/test/components/spinbox/spinbox.e2e-spec.js
@@ -37,6 +37,22 @@ describe('Spinbox example-index tests', () => {
     });
   }
 
+  it('Should be able to set ids/automation ids', async () => {
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.id('spinbox-id-1-wrapper')).getAttribute('id')).toEqual('spinbox-id-1-wrapper');
+    expect(await element(by.id('spinbox-id-1-wrapper')).getAttribute('data-automation-id')).toEqual('spinbox-automation-id-1-wrapper');
+
+    expect(await element(by.id('spinbox-id-1-spinbox')).getAttribute('id')).toEqual('spinbox-id-1-spinbox');
+    expect(await element(by.id('spinbox-id-1-spinbox')).getAttribute('data-automation-id')).toEqual('spinbox-automation-id-1-spinbox');
+
+    expect(await element(by.id('spinbox-id-1-btn-up')).getAttribute('id')).toEqual('spinbox-id-1-btn-up');
+    expect(await element(by.id('spinbox-id-1-btn-up')).getAttribute('data-automation-id')).toEqual('spinbox-automation-id-1-btn-up');
+
+    expect(await element(by.id('spinbox-id-1-btn-down')).getAttribute('id')).toEqual('spinbox-id-1-btn-down');
+    expect(await element(by.id('spinbox-id-1-btn-down')).getAttribute('data-automation-id')).toEqual('spinbox-automation-id-1-btn-down');
+  });
+
   it('Should be set with down arrow', async () => {
     await spinboxEl.sendKeys(protractor.Key.ARROW_DOWN);
     await browser.driver


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adds the attributes (ids & automation ids) for rating, slider, and spinbox. Also includes e2e and docs.


**Related github/jira issue (required)**:

Partial #4498 

**Steps necessary to review your pull request (required)**:

- Pull this branch, build, and run the app

1.) Rating
- Go to http://localhost:4000/components/rating/example-index
- Open developers tool and inspect the element
- `rating` and `one - five star` elements should have ids and automation ids

2.) Slider
- Go to http://localhost:4000/components/slider/example-index
- Open developers tool and inspect the element
- `slider`, `slider wrapper`, `slider hitarea`, `slider range`, `slider handle`, and `slider ticks` should all have ids and automation ids

3.) Spinbox
- Go to http://localhost:4000/components/spinbox/example-index
- Open developers tool and inspect the element
- `spinbox`, `spinbox wrapper`, and `spinbox controls` should all have ids and automation ids

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
