### PR TITLE
4498 - Add automation id for completion chart and targeted-achievement charts

### DIFF
--- a/app/views/components/completion-chart/example-variations.html
+++ b/app/views/components/completion-chart/example-variations.html
@@ -24,7 +24,11 @@ $('body').on('initialized', function () {
       completed: {text: 'Spent', value: 50000, format: '$,.0f'},
       remaining: {text: 'Pending', value: 10000, format: '$,.0f'},
       total: {value: 95000, format: '$,.0f'},
-    }]
+    }],
+    attributes: [
+      { name: 'id', value: 'completion-chart-example1' },
+      { name: 'data-automation-id', value: 'automation-id-completion-chart-example1' }
+    ]
   }];
 
   var dataset2 = [{
@@ -75,7 +79,11 @@ $('body').on('initialized', function () {
       info: {text: '/100'},
       completed: {value: 84},
       targetline: {text: 'target', value: '87%'},
-    }]
+    }],
+    attributes: [
+      { name: 'id', value: 'completion-chart-example7' },
+      { name: 'data-automation-id', value: 'automation-id-completion-chart-example7' }
+    ]
   }];
 
   var api1 = $('#example-1').chart({dataset: dataset1, type: 'completion-target'}).data('chart');

--- a/app/views/components/targeted-achievement/example-index.html
+++ b/app/views/components/targeted-achievement/example-index.html
@@ -16,7 +16,11 @@ $('body').on('initialized', function () {
       completed: {text: '50K of 250K', value: 50000, format: '.2s', color: 'primary'},
       remaining: {value: 20000, format: '.2s', text: ' To Target'},
       total: {value: 250000, format: '.2s'},
-    }]
+    }],
+    attributes: [
+      { name: 'id', value: 'targeted-achievement-example1' },
+      { name: 'data-automation-id', value: 'automation-id-targeted-achievement-example1' }
+    ]
   }];
 
   var api1 = $('#example-1').chart({dataset: dataset1, type: 'targeted-achievement'}).data('chart');

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -25,7 +25,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [x] Column
 - [x] Column Grouped
 - [x] Column Stacked
-- [ ] Completion Chart
+- [x] Completion Chart
 - [x] Contextmenu
 - [x] Contextualactionpanel
 - [ ] Datagrid
@@ -86,7 +86,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [x] Tabs Multi
 - [x] Tabs Vertical
 - [x] Tag (not needed id can be directly applied)
-- [ ] Targeted Achievement
+- [x] Targeted Achievement
 - [x] Textarea
 - [ ] Timeline
 - [ ] Timepicker

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[Calendar/Monthview/WeekView/CalendarToolbar]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Circlepager]` Added `attributes` setting to set automation ids's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Column/Column Grouped/Column Stacked/Positive Negative]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
+- `[CompletionChart/TargetedAchievement]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[ContextualActionPanel]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Datagrid]` Fixed an issue with a custom toolbar, where buttons would click twice. ([#4471](https://github.com/infor-design/enterprise/issues/4471))
 - `[Datepicker]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))

--- a/src/components/completion-chart/completion-chart.js
+++ b/src/components/completion-chart/completion-chart.js
@@ -228,6 +228,10 @@ CompletionChart.prototype = {
           value: $('.info .value', this.element),
           text: $('.info .text', this.element)
         },
+        plainInfo: {
+          value: $('>.value', this.element),
+          text: $('>.text', this.element)
+        },
         completed: {
           bar: $('.completed.bar', this.element),
           value: $('.completed .value', this.element),
@@ -249,6 +253,31 @@ CompletionChart.prototype = {
         },
         percentText: $('.chart-percent-text', this.element)
       };
+    };
+
+    // Add automation attributes
+    const setAutomationAttributes = function () {
+      const attr = chartData.attributes;
+      if (attr) {
+        const addAttributes = (elem, suffix) => utils.addAttributes(elem, chartData, chartData.attributes, suffix);
+        addAttributes(c.name, 'name');
+        addAttributes(c.info.value, 'info-value');
+        addAttributes(c.info.text, 'info-text');
+        addAttributes(c.plainInfo.value, 'info-value');
+        addAttributes(c.plainInfo.text, 'info-text');
+        addAttributes(c.completed.bar, 'completed-bar');
+        addAttributes(c.completed.value, 'completed-value');
+        addAttributes(c.completed.text, 'completed-text');
+        addAttributes(c.remaining.bar, 'remaining-bar');
+        addAttributes(c.remaining.value, 'remaining-value');
+        addAttributes(c.remaining.text, 'remaining-text');
+        addAttributes(c.targetline.bar, 'targetline-bar');
+        addAttributes(c.targetline.value, 'targetline-value');
+        addAttributes(c.targetline.text, 'targetline-text');
+        addAttributes(c.total.bar, 'total-bar');
+        addAttributes(c.total.value, 'total-value');
+        addAttributes(c.percentText, 'percent-text');
+      }
     };
 
     const setJsonData = function (ds) {
@@ -400,6 +429,7 @@ CompletionChart.prototype = {
     DOM.append(this.element, html.label + html.body.prop('outerHTML'), '<a><use><svg><div><span><br>');
 
     cacheElements();
+    setAutomationAttributes();
     setJsonData();
     updateBars();
 

--- a/src/components/completion-chart/readme.md
+++ b/src/components/completion-chart/readme.md
@@ -49,7 +49,28 @@ Accessibility work is needed on this component.
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+You can add custom id's/automation id's to the completion chart that can be used for scripting using the `attributes` data attribute. This data attribute can be either an object or an array for setting multiple values such as an automation-id or other attributes. For example:
+
+Setting the id/automation id with a string value or function. The function will give you the data as a parameter for making things more dynamic.
+
+```js
+var dataset1 = [{
+  data: [{
+    name: { text: 'Available Credit' },
+    completed: { text: 'Spent', value: 50000, format: '$,.0f' },
+    remaining: { text: 'Pending', value: 10000, format: '$,.0f' },
+    total: { value: 95000, format: '$,.0f' },
+  }],
+  attributes: [
+    { name: 'id', value: 'completion-chart-example1' },
+    { name: 'data-automation-id', value: 'automation-id-completion-chart-example1' }
+  ]
+}];
+```
+
+Providing the data this will add an ID added to each name with `-name`, info-value with `-info-value`, info-text with `-info-text`, completed-bar with `-completed-bar`, completed-value with `-completed-value`, completed-text with `-completed-text`, remaining-bar with `-remaining-bar`, remaining-value with `-remaining-value`, remaining-text with `-remaining-text`, targetline-bar with `-targetline-bar`, targetline-value with `-targetline-value`, targetline-text with `-targetline-text`, total-bar with `-total-bar` and total-value with `-total-value` appended after it.
+
+- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for general information.
 
 ## Keyboard Shortcuts
 

--- a/src/components/targeted-achievement/readme.md
+++ b/src/components/targeted-achievement/readme.md
@@ -56,7 +56,28 @@ api.data('chart').updated({ dataset: dataset2 });
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+You can add custom id's/automation id's to the targeted achievement chart that can be used for scripting using the `attributes` data attribute. This data attribute can be either an object or an array for setting multiple values such as an automation-id or other attributes. For example:
+
+Setting the id/automation id with a string value or function. The function will give you the data as a parameter for making things more dynamic.
+
+```js
+var dataset1 = [{
+  data: [{
+    name: { text: 'Label A' },
+    completed: { text: '50K of 250K', value: 50000, format: '.2s', color: 'primary' },
+    remaining: { value: 20000, format: '.2s', text: ' To Target' },
+    total: { value: 250000, format: '.2s' },
+  }],
+  attributes: [
+    { name: 'id', value: 'targeted-achievement-example1' },
+    { name: 'data-automation-id', value: 'automation-id-targeted-achievement-example1' }
+  ]
+}];
+```
+
+Providing the data this will add an ID added to each name with `-name`, completed-bar with `-completed-bar`, completed-value with `-completed-value`, completed-text with `-completed-text`, remaining-bar with `-remaining-bar`, remaining-value with `-remaining-value`, remaining-text with `-remaining-text`, total-bar with `-total-bar`, total-value with `-total-value`, and percent-text with `-percent-text` appended after it.
+
+- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for general information.
 
 ## Keyboard Shortcuts
 

--- a/test/components/completion-chart/completion-chart.e2e-spec.js
+++ b/test/components/completion-chart/completion-chart.e2e-spec.js
@@ -14,6 +14,58 @@ describe('Completion Chart variations tests', () => {
     await utils.checkForErrors();
   });
 
+  it('Should be able to set id/automation id example one', async () => {
+    expect(await element(by.id('completion-chart-example1-name')).getAttribute('id')).toEqual('completion-chart-example1-name');
+    expect(await element(by.id('completion-chart-example1-name')).getAttribute('data-automation-id')).toEqual('automation-id-completion-chart-example1-name');
+
+    expect(await element(by.id('completion-chart-example1-total-value')).getAttribute('id')).toEqual('completion-chart-example1-total-value');
+    expect(await element(by.id('completion-chart-example1-total-value')).getAttribute('data-automation-id')).toEqual('automation-id-completion-chart-example1-total-value');
+
+    expect(await element(by.id('completion-chart-example1-total-bar')).getAttribute('id')).toEqual('completion-chart-example1-total-bar');
+    expect(await element(by.id('completion-chart-example1-total-bar')).getAttribute('data-automation-id')).toEqual('automation-id-completion-chart-example1-total-bar');
+
+    expect(await element(by.id('completion-chart-example1-remaining-bar')).getAttribute('id')).toEqual('completion-chart-example1-remaining-bar');
+    expect(await element(by.id('completion-chart-example1-remaining-bar')).getAttribute('data-automation-id')).toEqual('automation-id-completion-chart-example1-remaining-bar');
+    expect(await element(by.id('completion-chart-example1-remaining-value')).getAttribute('id')).toEqual('completion-chart-example1-remaining-value');
+    expect(await element(by.id('completion-chart-example1-remaining-value')).getAttribute('data-automation-id')).toEqual('automation-id-completion-chart-example1-remaining-value');
+    expect(await element(by.id('completion-chart-example1-remaining-text')).getAttribute('id')).toEqual('completion-chart-example1-remaining-text');
+    expect(await element(by.id('completion-chart-example1-remaining-text')).getAttribute('data-automation-id')).toEqual('automation-id-completion-chart-example1-remaining-text');
+
+    expect(await element(by.id('completion-chart-example1-completed-bar')).getAttribute('id')).toEqual('completion-chart-example1-completed-bar');
+    expect(await element(by.id('completion-chart-example1-completed-bar')).getAttribute('data-automation-id')).toEqual('automation-id-completion-chart-example1-completed-bar');
+    expect(await element(by.id('completion-chart-example1-completed-value')).getAttribute('id')).toEqual('completion-chart-example1-completed-value');
+    expect(await element(by.id('completion-chart-example1-completed-value')).getAttribute('data-automation-id')).toEqual('automation-id-completion-chart-example1-completed-value');
+    expect(await element(by.id('completion-chart-example1-completed-text')).getAttribute('id')).toEqual('completion-chart-example1-completed-text');
+    expect(await element(by.id('completion-chart-example1-completed-text')).getAttribute('data-automation-id')).toEqual('automation-id-completion-chart-example1-completed-text');
+  });
+
+  it('Should be able to set id/automation id example seven', async () => {
+    expect(await element(by.id('completion-chart-example7-info-value')).getAttribute('id')).toEqual('completion-chart-example7-info-value');
+    expect(await element(by.id('completion-chart-example7-info-value')).getAttribute('data-automation-id')).toEqual('automation-id-completion-chart-example7-info-value');
+    expect(await element(by.id('completion-chart-example7-info-text')).getAttribute('id')).toEqual('completion-chart-example7-info-text');
+    expect(await element(by.id('completion-chart-example7-info-text')).getAttribute('data-automation-id')).toEqual('automation-id-completion-chart-example7-info-text');
+
+    expect(await element(by.id('completion-chart-example7-total-bar')).getAttribute('id')).toEqual('completion-chart-example7-total-bar');
+    expect(await element(by.id('completion-chart-example7-total-bar')).getAttribute('data-automation-id')).toEqual('automation-id-completion-chart-example7-total-bar');
+
+    expect(await element(by.id('completion-chart-example7-remaining-bar')).getAttribute('id')).toEqual('completion-chart-example7-remaining-bar');
+    expect(await element(by.id('completion-chart-example7-remaining-bar')).getAttribute('data-automation-id')).toEqual('automation-id-completion-chart-example7-remaining-bar');
+
+    expect(await element(by.id('completion-chart-example7-completed-bar')).getAttribute('id')).toEqual('completion-chart-example7-completed-bar');
+    expect(await element(by.id('completion-chart-example7-completed-bar')).getAttribute('data-automation-id')).toEqual('automation-id-completion-chart-example7-completed-bar');
+    expect(await element(by.id('completion-chart-example7-completed-value')).getAttribute('id')).toEqual('completion-chart-example7-completed-value');
+    expect(await element(by.id('completion-chart-example7-completed-value')).getAttribute('data-automation-id')).toEqual('automation-id-completion-chart-example7-completed-value');
+    expect(await element(by.id('completion-chart-example7-completed-text')).getAttribute('id')).toEqual('completion-chart-example7-completed-text');
+    expect(await element(by.id('completion-chart-example7-completed-text')).getAttribute('data-automation-id')).toEqual('automation-id-completion-chart-example7-completed-text');
+
+    expect(await element(by.id('completion-chart-example7-targetline-bar')).getAttribute('id')).toEqual('completion-chart-example7-targetline-bar');
+    expect(await element(by.id('completion-chart-example7-targetline-bar')).getAttribute('data-automation-id')).toEqual('automation-id-completion-chart-example7-targetline-bar');
+    expect(await element(by.id('completion-chart-example7-targetline-value')).getAttribute('id')).toEqual('completion-chart-example7-targetline-value');
+    expect(await element(by.id('completion-chart-example7-targetline-value')).getAttribute('data-automation-id')).toEqual('automation-id-completion-chart-example7-targetline-value');
+    expect(await element(by.id('completion-chart-example7-targetline-text')).getAttribute('id')).toEqual('completion-chart-example7-targetline-text');
+    expect(await element(by.id('completion-chart-example7-targetline-text')).getAttribute('data-automation-id')).toEqual('automation-id-completion-chart-example7-targetline-text');
+  });
+
   if (utils.isChrome() && utils.isCI()) {
     it('Should not visual regress', async () => {
       const containerEl = await element(by.css('div[role=main]'));

--- a/test/components/targeted-achievement/targeted-achievement.e2e-spec.js
+++ b/test/components/targeted-achievement/targeted-achievement.e2e-spec.js
@@ -14,6 +14,25 @@ describe('Targeted Achievement example-index tests', () => {
     await utils.checkForErrors();
   });
 
+  it('Should be able to set id/automation id example one', async () => {
+    expect(await element(by.id('targeted-achievement-example1-name')).getAttribute('id')).toEqual('targeted-achievement-example1-name');
+    expect(await element(by.id('targeted-achievement-example1-name')).getAttribute('data-automation-id')).toEqual('automation-id-targeted-achievement-example1-name');
+
+    expect(await element(by.id('targeted-achievement-example1-total-value')).getAttribute('id')).toEqual('targeted-achievement-example1-total-value');
+    expect(await element(by.id('targeted-achievement-example1-total-value')).getAttribute('data-automation-id')).toEqual('automation-id-targeted-achievement-example1-total-value');
+
+    expect(await element(by.id('targeted-achievement-example1-total-bar')).getAttribute('id')).toEqual('targeted-achievement-example1-total-bar');
+    expect(await element(by.id('targeted-achievement-example1-total-bar')).getAttribute('data-automation-id')).toEqual('automation-id-targeted-achievement-example1-total-bar');
+
+    expect(await element(by.id('targeted-achievement-example1-remaining-bar')).getAttribute('id')).toEqual('targeted-achievement-example1-remaining-bar');
+    expect(await element(by.id('targeted-achievement-example1-remaining-bar')).getAttribute('data-automation-id')).toEqual('automation-id-targeted-achievement-example1-remaining-bar');
+
+    expect(await element(by.id('targeted-achievement-example1-completed-bar')).getAttribute('id')).toEqual('targeted-achievement-example1-completed-bar');
+    expect(await element(by.id('targeted-achievement-example1-completed-bar')).getAttribute('data-automation-id')).toEqual('automation-id-targeted-achievement-example1-completed-bar');
+    expect(await element(by.id('targeted-achievement-example1-completed-text')).getAttribute('id')).toEqual('targeted-achievement-example1-completed-text');
+    expect(await element(by.id('targeted-achievement-example1-completed-text')).getAttribute('data-automation-id')).toEqual('automation-id-targeted-achievement-example1-completed-text');
+  });
+
   if (utils.isChrome() && utils.isCI()) {
     it('Should not visual regress', async () => {
       const containerEl = await element(by.css('div[role=main]'));


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adds the attributes/automation id/ id functionality for Completion Chart and Targeted Achievement Charts.

**Related github/jira issue (required)**:
related to #4498

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app

Bullet
- Navigate to: http://localhost:4000/components/completion-chart/example-variations.html
- Check for `id` and `data-automation-id` attributes, get from the settings
- For 1st chart see (name, total-value, total-bar, remaining-bar, remaining-value, remaining-text, completed-bar, completed-value and completed-text)
- For 7th chart see (info-value, info-text, total-bar, remaining-bar, completed-bar, completed-value, completed-text, targetline-bar, targetline-value and targetline-text)
- Review the text in the docs

Targeted Achievement
- Navigate to: http://localhost:4000/components/targeted-achievement/example-index.html
- Check for `id` and `data-automation-id` attributes, get from the settings (name, total-value, total-bar, remaining-bar, completed-bar and completed-text for 1st chart)
- Review the text in the docs

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
