### PR TITLE
4498 - Add attributes/ids to Flex Toolbar, enable `attributes` setting in Button/Popupmenu APIs

### DIFF
--- a/app/views/components/button/example-menubutton.html
+++ b/app/views/components/button/example-menubutton.html
@@ -2,7 +2,7 @@
 <div class="row">
   <div class="twelve columns">
 
-      <button type="button" id="test" class="btn-menu">
+      <button type="button" id="test" class="btn-menu" data-options="{ 'attributes': [ { 'name': 'data-automation-id', 'value': 'menu-button' } ] }">
         <span>Add Item</span>
       </button>
       <ul class="popupmenu is-selectable has-icons">

--- a/app/views/components/contextmenu/example-index.html
+++ b/app/views/components/contextmenu/example-index.html
@@ -3,12 +3,12 @@
 
     <div class="field">
       <label for="input-menu">Label</label>
-      <input type="text" data-options="{trigger:'rightClick'}" data-popupmenu="action-popupmenu" value="Right Click Me" id="input-menu"/>
+      <input type="text" data-options="{ trigger:'rightClick', 'attributes': [ { 'name': 'data-automation-id', 'value': 'action-popupmenu' } ] }" data-popupmenu="action-popupmenu" value="Right Click Me" id="input-menu"/>
     </div>
 
     <div class="field">
       <label for="input-menu2">Label2</label>
-      <input type="text"  data-options="{trigger:'rightClick'}" data-popupmenu="action-popupmenu" value="Right Click Me" id="input-menu2"/>
+      <input type="text"  data-options="{ trigger:'rightClick' }" data-popupmenu="action-popupmenu" value="Right Click Me" id="input-menu2"/>
     </div>
 
     <ul id="action-popupmenu" class="popupmenu">

--- a/app/views/components/contextmenu/example-page-rightclick.html
+++ b/app/views/components/contextmenu/example-page-rightclick.html
@@ -54,6 +54,9 @@
 <script id="test-script">
   $('body').popupmenu({
     menu: 'action-popupmenu',
-    trigger: 'rightClick'
+    trigger: 'rightClick',
+    attributes: [
+      { name: 'data-automation-id', value: 'contextmenu' }
+    ]
   });
 </script>

--- a/app/views/components/popupmenu/example-ajax.html
+++ b/app/views/components/popupmenu/example-ajax.html
@@ -55,6 +55,12 @@
 
   $('#targetButton').popupmenu({
     beforeOpen: popupmenuTestBeforeOpen,
-    menu: 'popup-menu'
+    menu: 'popup-menu',
+    attributes: [
+      {
+        name: 'data-automation-id',
+        value: 'test'
+      }
+    ]
   });
 </script>

--- a/app/views/components/popupmenu/example-index.html
+++ b/app/views/components/popupmenu/example-index.html
@@ -2,7 +2,7 @@
   <div class="twelve columns">
 
     <div class="field">
-      <button id="popupmenu-trigger" class="btn-menu">
+      <button id="popupmenu-trigger" class="btn-menu" data-init="false">
         <span>Normal Menu</span>
         <svg role="presentation" aria-hidden="true" focusable="false" class="icon icon-dropdown">
           <use href="#icon-dropdown"></use>
@@ -18,8 +18,8 @@
   </div>
 </div>
 
-<script>
-  $('.popupmenu').popupmenu({
+<script id="test-script">
+  $('#popupmenu-trigger').popupmenu({
     attributes: [
       {
         name: 'id',

--- a/app/views/components/toolbar-flex/example-index.html
+++ b/app/views/components/toolbar-flex/example-index.html
@@ -8,7 +8,7 @@
   <div class="twelve columns">
 
     <!-- BEGIN Toolbar with All Buttons (Buttonset Favoring) -->
-    <div class="flex-toolbar">
+    <div class="flex-toolbar" data-options="{ 'attributes': [ { 'name': 'data-automation-id', 'value': 'my-toolbar' } ] }">
       <div class="toolbar-section title">
         <h2>Incredibly Long Toolbar (Favor's Buttonset)</h2>
       </div>
@@ -18,7 +18,7 @@
           <span>Text Button</span>
         </button>
 
-        <button class="btn-menu">
+        <button class="btn-menu" data-options="{ 'attributes': [ { 'name': 'data-automation-id', 'value': 'my-menubutton' } ] }">
           <span>Menu Button</span>
         </button>
         <ul class="popupmenu">
@@ -78,7 +78,7 @@
   <div class="twelve columns">
 
     <!-- BEGIN Toolbar with All Buttons (Title Favoring) -->
-    <div class="flex-toolbar">
+    <div class="flex-toolbar" data-options="{ 'attributes': [ { 'name': 'data-automation-id', 'value': 'flex-toolbar-title' } ] }">
       <div class="toolbar-section title favor">
         <h2>Incredibly Long Toolbar (Favor's Title)</h2>
       </div>
@@ -148,7 +148,7 @@
   <div class="twelve columns">
 
     <!-- BEGIN Toolbar similar to Header Toolbar -->
-    <div class="flex-toolbar">
+    <div class="flex-toolbar" data-options="{ 'attributes': [ { 'name': 'data-automation-id', 'value': 'flex-toolbar-header' } ] }">
       <div class="toolbar-section">
         <button class="btn-icon application-menu-trigger" type="button">
           <span class="audible">Show navigation</span>
@@ -183,7 +183,7 @@
   <div class="twelve columns">
 
     <!-- BEGIN Toolbar with Title Eyebrow -->
-    <div class="flex-toolbar">
+    <div class="flex-toolbar" data-options="{ 'attributes': [ { 'name': 'data-automation-id', 'value': 'flex-toolbar-eyebrow' } ] }">
       <div class="toolbar-section">
         <button class="btn-icon" type="button">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/toolbar-flex/example-more-actions-default-behavior.html
+++ b/app/views/components/toolbar-flex/example-more-actions-default-behavior.html
@@ -2,7 +2,7 @@
   <div class="twelve columns">
 
     <!-- BEGIN Toolbar with All Buttons (Buttonset Favoring) -->
-    <div class="flex-toolbar">
+    <div class="flex-toolbar" data-options="{ 'attributes': [ { 'name': 'data-automation-id', 'value': 'my-toolbar' } ] }">
       <div class="toolbar-section title">
         <h2>Incredibly Long Toolbar (Favor's Buttonset)</h2>
       </div>

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -16,7 +16,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [x] Breadcrumb
 - [x] Bullet
 - [x] Busyindicator
-- [ ] Button
+- [x] Button
 - [x] Calendar
 - [x] Calendar Toolbar
 - [x] Checkboxes (not needed id can be directly applied)
@@ -62,7 +62,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [x] Pie
 - [ ] Popdown
 - [x] Popover
-- [ ] Popupmenu
+- [x] Popupmenu
 - [x] Positive Negative
 - [ ] Processindicator
 - [x] Progress
@@ -92,7 +92,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [ ] Timepicker
 - [x] Toast
 - [x] Toolbar (deprecated for toolbar flex)
-- [ ] Toolbar Flex
+- [x] Toolbar Flex
 - [ ] Toolbarsearchfield
 - [ ] Tooltip
 - [ ] Tree

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[Bar/Bar Grouped/Bar Stacked]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Breadcrumb]` Added `attributes` setting to Breadcrumb Items for setting automation id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Bullet/Stepchart]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
+- `[Button]` Added `attributes` setting to Button API for automation id's and id's ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Calendar/Monthview/WeekView/CalendarToolbar]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Circlepager]` Added `attributes` setting to set automation ids's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Column/Column Grouped/Column Stacked/Positive Negative]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
@@ -36,6 +37,8 @@
 - `[Message]` Added `attributes` setting to set automation id's and id's. ([#4277](https://github.com/infor-design/enterprise/issues/4277))
 - `[Modal]` Added `attributes` setting to set automation id's and id's. ([#4277](https://github.com/infor-design/enterprise/issues/4277))
 - `[Pager/Wizard]` Added `attributes` setting to set automation id's and id's. ([#4277](https://github.com/infor-design/enterprise/issues/4277))
+- `[Pager]` Added `attributes` setting to set automation id's and id's. ([#4277](https://github.com/infor-design/enterprise/issues/4277))
+- `[Popupmenu]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Locale/Charts]` The numbers inside charts are now formatted using the current locale's, number settings. This can be disabled/changed in some charts by passing in a localeInfo object to override the default settings. ([#4437](https://github.com/infor-design/enterprise/issues/4437))
 - `[Notification]` Added `attributes` setting to set automation ids's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Radar/Sparkline]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
@@ -44,6 +47,7 @@
 - `[Textarea]` Added `attributes` setting to set automation ids's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Treemap]` Added ability to show a tooltip. ([#2794](https://github.com/infor-design/enterprise/issues/2794))
 - `[Tabs]` Added `attributes` setting to the `add()` method's options argument for setting automation id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
+- `[Toolbar Flex]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Radios/Progress/Treemap]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 
 ### v4.34.0 Fixes

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -53,7 +53,8 @@ const BUTTON_DEFAULTS = {
   hideMenuArrow: null,
   replaceText: false,
   ripple: true,
-  validate: false
+  validate: false,
+  attributes: null
 };
 
 function Button(element, settings) {
@@ -213,6 +214,8 @@ Button.prototype = {
    * @returns {void}
    */
   render() {
+    this.renderAttributes();
+
     const elemClasses = this.element[0].classList;
     // Style = "primary/secondary/tertiary" hierarchy/context
     if (buttonStyles.indexOf(this.settings.style) > 0) {
@@ -403,6 +406,16 @@ Button.prototype = {
     // Hide Focus API
     if (!this.element.data('hidefocus')) {
       this.element.hideFocus();
+    }
+  },
+
+  /**
+   * Handle attributes from settings, if applicable
+   * @returns {void}
+   */
+  renderAttributes() {
+    if (Array.isArray(this.settings.attributes)) {
+      utils.addAttributes(this.element, this, this.settings.attributes);
     }
   },
 

--- a/src/components/button/readme.md
+++ b/src/components/button/readme.md
@@ -100,7 +100,28 @@ Once the proper markup is in place calling `$(elem).button()` will correctly ini
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+In most cases, special attributes or automation ids should be added directly to the button markup:
+
+```html
+<button id="my-button" data-automation-id="my-button" class="btn-primary">
+  <span>My Button</span>
+</button>
+```
+
+It's also possible to use the Javascript IDS Button API to add attributes programmatically.  This is helpful when composing more complex components using the button as a trigger:
+
+```js
+$('#my-button').button({
+  attributes: [
+    {
+      name: 'data-automation-id',
+      value: 'my-button'
+    }
+  ]
+})
+```
+
+Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
 
 ## Keyboard Shortcuts
 

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -690,14 +690,27 @@ PopupMenu.prototype = {
     contextElement[0].setAttribute('role', 'menu');
     contextElement[0].setAttribute('aria-labelledby', this.element.attr('id'));
 
+    // Calculates a nested index
+    function getTreeIndex(li) {
+      const $li = $(li);
+      const parentLis = $li.parents('li');
+      const indexes = [];
+
+      $li.add(parentLis).each((i, thisLi) => {
+        indexes.push($(thisLi).parent().children('li:not(.heading):not(.separator)').index(thisLi));
+      });
+
+      return indexes.join('-');
+    }
+
     lis.each((i, li) => {
       const a = $(li).children('a')[0]; // TODO: do this better when we have the infrastructure
       const $a = $(a);
       const $li = $(li);
-      let span = $(a).children('span')[0];
-      let submenu = $(li).children('ul')[0];
-      const icon = $(li).find('.icon:not(.close):not(.icon-dropdown):not(.image-user-status .icon)');
-      const submenuWrapper = $(li).children('.wrapper')[0];
+      let span = $a.children('span')[0];
+      let submenu = $li.children('ul')[0];
+      const icon = $li.find('.icon:not(.close):not(.icon-dropdown):not(.image-user-status .icon)');
+      const submenuWrapper = $li.children('.wrapper')[0];
 
       li.setAttribute('role', 'none');
 
@@ -707,7 +720,7 @@ PopupMenu.prototype = {
 
         // Add user-defined attributes to the anchor
         if (self.settings.attributes) {
-          utils.addAttributes($a, self, self.settings.attributes, `option-${i}`);
+          utils.addAttributes($a, self, self.settings.attributes, `option-${getTreeIndex(li)}`);
         }
 
         // disabled menu items, by prop and by className

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -69,7 +69,8 @@ const POPUPMENU_DEFAULTS = {
   },
   predefined: $(),
   duplicateMenu: null,
-  stretchToWidestMenuItem: false
+  stretchToWidestMenuItem: false,
+  attributes: null,
 };
 
 function PopupMenu(element, settings) {
@@ -160,13 +161,6 @@ PopupMenu.prototype = {
     // Set a reference collection for containing "pre-defined" menu items that should never
     // be replaced during an AJAX call.
     this.predefinedItems = $().add(this.settings.predefined);
-
-    // Add test automation ids
-    utils.addAttributes(this.element, this, this.settings.attributes);
-    const options = this.element.find('li a');
-    [...options].forEach((opt, i) => {
-      utils.addAttributes($(opt), this, this.settings.attributes, `option-${i}`);
-    });
   },
 
   /**
@@ -275,6 +269,12 @@ PopupMenu.prototype = {
     // and simply acting like a button.
     if (this.menu.length === 0) {
       return;
+    }
+
+    // Add attributes to both the trigger element and the menu `<ul>`
+    if (this.settings.attributes) {
+      utils.addAttributes(this.element, this, this.settings.attributes, 'trigger');
+      utils.addAttributes(this.menu, this, this.settings.attributes, 'menu');
     }
 
     // if the menu is deeply rooted inside the markup, detach it and append it to the <body> tag
@@ -692,6 +692,8 @@ PopupMenu.prototype = {
 
     lis.each((i, li) => {
       const a = $(li).children('a')[0]; // TODO: do this better when we have the infrastructure
+      const $a = $(a);
+      const $li = $(li);
       let span = $(a).children('span')[0];
       let submenu = $(li).children('ul')[0];
       const icon = $(li).find('.icon:not(.close):not(.icon-dropdown):not(.image-user-status .icon)');
@@ -703,10 +705,12 @@ PopupMenu.prototype = {
         a.setAttribute('role', (self.settings.ariaListbox ? 'option' : 'menuitem'));
         a.setAttribute('tabindex', '-1');
 
-        // disabled menu items, by prop and by className
-        const $a = $(a);
-        const $li = $(li);
+        // Add user-defined attributes to the anchor
+        if (self.settings.attributes) {
+          utils.addAttributes($a, self, self.settings.attributes, `option-${i}`);
+        }
 
+        // disabled menu items, by prop and by className
         if ($li.hasClass('is-disabled') || (a.getAttribute('disabled') === 'true' || a.getAttribute('disabled') === 'disabled')) {
           $li.addClass('is-disabled');
           a.setAttribute('aria-disabled', 'true');

--- a/src/components/popupmenu/readme.md
+++ b/src/components/popupmenu/readme.md
@@ -147,7 +147,76 @@ Or it can be attached on the fly in the page.
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+You can add custom attributes/automation id's that can be used for scripting to the Popupmenu.  It's possible to add `data-automation-id` attributes (or other attributes) directly to a Popupmenu's trigger, list and anchors:
+
+```html
+<button id="trigger" class="btn" data-automation-id="my-popupmenu-trigger">
+  <span>Open Menu</span>
+</button>
+<ul class="popupmenu" data-automation-id="my-popupmenu-menu">
+  <li><a id="item-one" data-automation-id="my-popupmenu-option-0" href="#">Item One</a></li>
+  <li><a id="item-two" data-automation-id="my-popupmenu-option-1" href="#">Item Two</a></li>
+  <li><a id="item-three" data-automation-id="my-popupmenu-option-2" href="#">Item Three</a></li>
+</ul>
+```
+
+It's also possible to pass an `attributes` setting via Javascript.  For example, programmatically creating the use case above could be done using this example:
+
+```js
+$('#trigger').popupmenu({
+  'attributes': [
+    {
+      name: 'data-automation-id',
+      value: 'my-popupmenu'
+    }
+  ]
+})
+```
+
+In this case, the strings `-trigger`, `-menu`, and `-option-(x)` are all appended to the Popupmenu automatically.  The menu options are appended with a unique number based on their numeric index within that list of items.
+
+The numeric indexes also take into account nesting of menu items.  For each level of nesting, another number representing an item's location is appended.  For example, a nested menu invoked with the above JS code might look like this after it's fully rendered:
+
+```html
+<button id="trigger" class="btn" data-automation-id="my-popupmenu-trigger">
+  <span>Open Menu</span>
+</button>
+
+<!-- ... -->
+
+<div class="popupmenu-wrapper">
+  <ul class="popupmenu" data-automation-id="my-popupmenu-menu">
+    <li class="popupmenu-item">
+      <a id="item-one" data-automation-id="my-popupmenu-option-0" href="#">Item One</a>
+    </li>
+    <li class="popupmenu-item">
+      <a id="item-two" data-automation-id="my-popupmenu-option-1" href="#">Item Two</a>
+    </li>
+    <li class="popupmenu-item submenu">
+      <a id="item-three" data-automation-id="my-popupmenu-option-2" href="#">Item Three</a>
+      <div class="wrapper">
+        <ul class="popupmenu">
+          <li class="popupmenu-item">
+            <a id="subitem-one" href="#" data-automation-id="my-popupmenu-option-2-0">Sub-item One</a>
+          </li>
+          <li class="popupmenu-item">
+            <a id="subitem-two" href="#" data-automation-id="my-popupmenu-option-2-1">Sub-item Two</a>
+          </li>
+          <li class="separator"></li>
+          <li class="popupmenu-item">
+            <a id="subitem-three" href="#" data-automation-id="my-popupmenu-option-2-2">Sub-item Three</a>
+          </li>
+        </ul>
+      </div>
+    </li>
+    <li class="popupmenu-item">
+      <a id="item-four" data-automation-id="my-popupmenu-option-3" href="#">Item Four</a>
+    </li>
+  </ul>
+</div>
+```
+
+Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
 
 ## Keyboard Shortcuts
 

--- a/src/components/toolbar-flex/readme.md
+++ b/src/components/toolbar-flex/readme.md
@@ -277,4 +277,110 @@ When there are too many buttons, inputs, or other items present on the toolbar t
 
 ## Testability
 
+You can add custom id's/automation id's to the Flex Toolbar that can be used for scripting using the `attributes` setting. This setting takes either an object or an array for setting multiple values such as an automation-id or other attributes.
+For example:
+
+```js
+  attributes: { name: 'id', value: args => `background-color` }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: { name: 'data-automation-id', value: 'my-unique-id' }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: [
+    { name: 'id', value: 'my-unique-id' },
+    { name: 'data-automation-id', value: 'my-unique-id' }
+  ]
+```
+
+These attributes can be added programmatically using the Flex Toolbar API:
+
+```js
+  $('#my-flex-toolbar').toolbarflex({
+    attributes: [
+      { name: 'data-automation-id', value: 'my-toolbar' }
+    ]
+  });
+```
+
+Setting attributes in this manner labels all the following elements:
+
+- the root level Toolbar element gets an attribute of `my-toolbar`
+- all Toolbar Items will get a string that looks like `my-toolbar-${type}-${index}-${extra}`, depending on their composition.
+
+For example, a standard button might appear as:
+
+```html
+<button class="btn" data-automation-id="my-toolbar-button-0">
+  <span>Text Button</span>
+</button>
+```
+
+A menu button might look like the following example. Internally, the extraneous "trigger" text is appended to this element because Flex Toolbar is aware that this is a [MenuButton]('./menubutton'), and defers to that component to apply attributes.  The Flex Toolbar concatenates the attribute value internally:
+
+```html
+<button class="btn-menu" data-automation-id="my-toolbar-menubutton-1-trigger">
+  <span>Menu Button</span>
+</button>
+<!-- ... -->
+<div class="popupmenu-wrapper">
+  <ul class="popupmenu" data-automation-id="my-toolbar-menubutton-1-menu">
+    <li class="popupmenu-item">
+      <a href="#" data-automation-id="my-toolbar-menubutton-1-option-0">Item One</a>
+    </li>
+    <li class="popupmenu-item">
+      <a href="#" data-automation-id="my-toolbar-menubutton-1-option-1">Item Two</a>
+    </li>
+    <li class="popupmenu-item submenu">
+      <a href="#" data-automation-id="my-toolbar-menubutton-1-option-2">Item Three</a>
+    </il>
+  </ul>
+</div>
+```
+
+A "More Actions" button -- being a type of Menu Button itself -- will contain similarly-named attributes with different values on it's "overflowed" version of a Flex Toolbar Menu Button:
+
+```html
+<button class="btn-actions" data-automation-id="my-toolbar-actionbutton-5-trigger">
+  <svg class="icon" role="presentation">
+    <use href="#icon-more"></use>
+  </svg>
+  <span class="audible">More Actions</span>
+</button>
+<!-- ... -->
+<div class="popupmenu-wrapper">
+  <ul class="popupmenu" data-automation-id="my-toolbar-actionbutton-5-menu">
+    <li class="popupmenu-item">
+      <a href="#" data-automation-id="my-toolbar-actionbutton-5-option-0">Text Button</a>
+    </li>
+    <li class="popupmenu-item submenu">
+      <a href="#" data-automation-id="my-toolbar-actionbutton-5-option-1">Menu Button</a>
+      <div class="wrapper">
+        <ul class="popupmenu">
+          <li class="popupmenu-item">
+            <a href="#" data-automation-id="my-toolbar-actionbutton-5-option-1-0">Item One</a>
+          </li>
+          <li class="popupmenu-item">
+            <a href="#" data-automation-id="my-toolbar-actionbutton-5-option-1-1">Item Two</a>
+          </li>
+          <li class="popupmenu-item">
+            <a href="#" data-automation-id="my-toolbar-actionbutton-5-option-1-2">Item Three</a>
+          </li>
+        </ul>
+      </div>
+    </li>
+  </ul>
+</div>
+```
+
+For other component types, such as [Colorpicker]('./colorpicker'), [Searchfield]('./searchfield'), etc., attribute values are similarly passed down.  This provides a way for a developer to simply implement a single ID on the Toolbar API that will be respected for all components the Toolbar contains.
+
+If you only need to test a specific Flex Toolbar Item, and not the entire component (for example, one button out of five), please either set attributes directly on those elements, or use their respective component API's `attributes` setting, if applicable.
+
 Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.

--- a/src/components/toolbar-flex/toolbar-flex.js
+++ b/src/components/toolbar-flex/toolbar-flex.js
@@ -16,6 +16,7 @@ const COMPONENT_NAME = 'toolbar-flex';
  */
 const TOOLBAR_FLEX_DEFAULTS = {
   allowTabs: false,
+  attributes: null,
   beforeMoreMenuOpen: null,
   moreMenuSettings: {},
 };
@@ -69,7 +70,8 @@ ToolbarFlex.prototype = {
       $(item).toolbarflexitem({
         toolbarAPI: this,
         componentSettings: itemComponentSettings,
-        allowTabs: this.settings.allowTabs
+        allowTabs: this.settings.allowTabs,
+        attributes: this.settings.attributes,
       });
       return $(item).data('toolbarflexitem');
     });
@@ -107,6 +109,11 @@ ToolbarFlex.prototype = {
    */
   render() {
     this.element.setAttribute('role', 'toolbar');
+
+    if (Array.isArray(this.settings.attributes)) {
+      utils.addAttributes($(this.element), this, this.settings.attributes);
+    }
+
     this.items.forEach((item) => {
       item.render();
     });

--- a/test/components/button/button-api.func-spec.js
+++ b/test/components/button/button-api.func-spec.js
@@ -117,6 +117,17 @@ describe('Button API', () => {
       done();
     }, 1000);
   });
+
+  it('can have custom attributes', () => {
+    buttonAPI.updated({
+      attributes: [{
+        name: 'data-automation-id',
+        value: 'my-button'
+      }]
+    });
+
+    expect(buttonEl.getAttribute('data-automation-id')).toEqual('my-button');
+  });
 });
 
 // Secondary Button HTML with visible text and an icon

--- a/test/components/popupmenu/popupmenu.e2e-spec.js
+++ b/test/components/popupmenu/popupmenu.e2e-spec.js
@@ -8,7 +8,7 @@ const axePageObjects = requireHelper('axe-page-objects');
 
 jasmine.getEnv().addReporter(browserStackErrorReporter);
 
-fdescribe('Contextmenu index tests', () => {
+describe('Contextmenu index tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/contextmenu/example-index');
   });
@@ -64,7 +64,7 @@ fdescribe('Contextmenu index tests', () => {
   });
 });
 
-fdescribe('Popupmenu example-selectable tests', () => {
+describe('Popupmenu example-selectable tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/popupmenu/example-selectable?layout=nofrills');
   });
@@ -169,7 +169,7 @@ fdescribe('Popupmenu example-selectable tests', () => {
 });
 
 // NOTE: tests for infor-design/enterprise#2458
-fdescribe('Popupmenu missing submenu tests', () => {
+describe('Popupmenu missing submenu tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/popupmenu/test-malformed-popupmenu?layout=nofrills');
   });
@@ -193,7 +193,7 @@ fdescribe('Popupmenu missing submenu tests', () => {
   });
 });
 
-fdescribe('Popupmenu example-selectable-multiple tests', () => {
+describe('Popupmenu example-selectable-multiple tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/popupmenu/example-selectable-multiple?layout=nofrills');
   });
@@ -253,7 +253,7 @@ fdescribe('Popupmenu example-selectable-multiple tests', () => {
   }
 });
 
-fdescribe('Contextmenu created dynamically tests', () => {
+describe('Contextmenu created dynamically tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-contextmenu-dynamic');
   });
@@ -282,7 +282,7 @@ fdescribe('Contextmenu created dynamically tests', () => {
   });
 });
 
-fdescribe('Contextmenu immediate tests', () => {
+describe('Contextmenu immediate tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/tree/example-context-menu');
   });
@@ -316,7 +316,7 @@ fdescribe('Contextmenu immediate tests', () => {
   });
 });
 
-fdescribe('Contextmenu Placement Tests', () => {
+describe('Contextmenu Placement Tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/contextmenu/example-page-rightclick');
   });

--- a/test/components/popupmenu/popupmenu.e2e-spec.js
+++ b/test/components/popupmenu/popupmenu.e2e-spec.js
@@ -8,7 +8,7 @@ const axePageObjects = requireHelper('axe-page-objects');
 
 jasmine.getEnv().addReporter(browserStackErrorReporter);
 
-describe('Contextmenu index tests', () => {
+fdescribe('Contextmenu index tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/contextmenu/example-index');
   });
@@ -55,21 +55,16 @@ describe('Contextmenu index tests', () => {
   it('Should be able to set id/automation id', async () => {
     await browser.driver.sleep(config.sleep);
 
-    expect(await element(by.id('popupmenu-id')).getAttribute('id')).toEqual('popupmenu-id');
-    expect(await element(by.id('popupmenu-id')).getAttribute('data-automation-id')).toEqual('popupmenu-automation-id');
+    expect(await element(by.id('input-menu')).getAttribute('data-automation-id')).toEqual('action-popupmenu-trigger');
+    expect(await element(by.id('action-popupmenu')).getAttribute('data-automation-id')).toEqual('action-popupmenu-menu');
 
-    expect(await element(by.id('popupmenu-id-option-0')).getAttribute('id')).toEqual('popupmenu-id-option-0');
-    expect(await element(by.id('popupmenu-id-option-0')).getAttribute('data-automation-id')).toEqual('popupmenu-automation-id-option-0');
-
-    expect(await element(by.id('popupmenu-id-option-1')).getAttribute('id')).toEqual('popupmenu-id-option-1');
-    expect(await element(by.id('popupmenu-id-option-1')).getAttribute('data-automation-id')).toEqual('popupmenu-automation-id-option-1');
-
-    expect(await element(by.id('popupmenu-id-option-2')).getAttribute('id')).toEqual('popupmenu-id-option-2');
-    expect(await element(by.id('popupmenu-id-option-2')).getAttribute('data-automation-id')).toEqual('popupmenu-automation-id-option-2');
+    expect(await element(by.id('cut')).getAttribute('data-automation-id')).toEqual('action-popupmenu-option-0');
+    expect(await element(by.id('copy')).getAttribute('data-automation-id')).toEqual('action-popupmenu-option-1');
+    expect(await element(by.id('paste')).getAttribute('data-automation-id')).toEqual('action-popupmenu-option-2');
   });
 });
 
-describe('Popupmenu example-selectable tests', () => {
+fdescribe('Popupmenu example-selectable tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/popupmenu/example-selectable?layout=nofrills');
   });
@@ -174,7 +169,7 @@ describe('Popupmenu example-selectable tests', () => {
 });
 
 // NOTE: tests for infor-design/enterprise#2458
-describe('Popupmenu missing submenu tests', () => {
+fdescribe('Popupmenu missing submenu tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/popupmenu/test-malformed-popupmenu?layout=nofrills');
   });
@@ -198,7 +193,7 @@ describe('Popupmenu missing submenu tests', () => {
   });
 });
 
-describe('Popupmenu example-selectable-multiple tests', () => {
+fdescribe('Popupmenu example-selectable-multiple tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/popupmenu/example-selectable-multiple?layout=nofrills');
   });
@@ -258,7 +253,7 @@ describe('Popupmenu example-selectable-multiple tests', () => {
   }
 });
 
-describe('Contextmenu created dynamically tests', () => {
+fdescribe('Contextmenu created dynamically tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-contextmenu-dynamic');
   });
@@ -287,7 +282,7 @@ describe('Contextmenu created dynamically tests', () => {
   });
 });
 
-describe('Contextmenu immediate tests', () => {
+fdescribe('Contextmenu immediate tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/tree/example-context-menu');
   });
@@ -321,7 +316,7 @@ describe('Contextmenu immediate tests', () => {
   });
 });
 
-describe('Contextmenu Placement Tests', () => {
+fdescribe('Contextmenu Placement Tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/contextmenu/example-page-rightclick');
   });

--- a/test/components/popupmenu/popupmenu.func-spec.js
+++ b/test/components/popupmenu/popupmenu.func-spec.js
@@ -380,18 +380,24 @@ describe('Popupmenu (settings)', () => {
     popupmenuButtonEl = null;
     svgEl = null;
     popupmenuObj = null;
-    document.body.insertAdjacentHTML('afterbegin', popupmenuHTML);
+    document.body.insertAdjacentHTML('afterbegin', popupmenuContextMenuHTML);
     document.body.insertAdjacentHTML('afterbegin', svg);
-    popupmenuButtonEl = document.body.querySelector('#popupmenu-trigger');
     svgEl = document.body.querySelector('.svg-icons');
   });
 
   afterEach(() => {
-    popupmenuButtonEl.parentNode.removeChild(popupmenuButtonEl);
-    svgEl.parentNode.removeChild(svgEl);
+    if (popupmenuObj) {
+      popupmenuObj.destroy();
+    }
+    cleanup([
+      '.svg-icons',
+      '.row',
+      '.popupmenu-wrapper'
+    ]);
   });
 
   it('should place the menu underneath the `body` element with `attachToBody` set', () => {
+    popupmenuButtonEl = document.body.querySelector('#input-menu');
     popupmenuObj = new PopupMenu(popupmenuButtonEl, {
       attachToBody: true
     });
@@ -401,27 +407,48 @@ describe('Popupmenu (settings)', () => {
 
     // Menu markup should move back to immediately after the button when destroyed.
     popupmenuObj.destroy();
-    const popupmenuEl = document.body.querySelector('#popupmenu-trigger + .popupmenu');
+    const popupmenuEl = document.body.querySelector('#input-menu + .popupmenu');
 
     expect(popupmenuEl).toBeDefined();
   });
 
   it('should remove the menu `<ul>` from the DOM when destroyed with `removeOnDestroy` set', () => {
+    popupmenuButtonEl = document.body.querySelector('#input-menu');
     popupmenuObj = new PopupMenu(popupmenuButtonEl, {
       removeOnDestroy: true
     });
-    let popupmenuEl = document.body.querySelector('#popupmenu-trigger + .popupmenu-wrapper > .popupmenu');
+    let popupmenuEl = document.body.querySelector('#input-menu + .popupmenu-wrapper > .popupmenu');
 
     // When invoked, references should exist
     expect(popupmenuEl).toBeDefined();
     expect(popupmenuObj.menu).toBeDefined();
 
     popupmenuObj.destroy();
-    popupmenuEl = document.body.querySelector('#popupmenu-trigger + .popupmenu');
+    popupmenuEl = document.body.querySelector('#input-menu + .popupmenu');
 
     // When destroyed with the setting, references should be gone
     expect(popupmenuEl).toBe(null);
     expect(popupmenuObj.menu).not.toBeDefined();
+  });
+
+  it('can append custom attributes via setting', () => {
+    popupmenuButtonEl = document.body.querySelector('#input-menu');
+    popupmenuObj = new PopupMenu(popupmenuButtonEl, {
+      attributes: [{
+        name: 'data-automation-id',
+        value: 'action-popupmenu'
+      }]
+    });
+    const popupmenuEl = document.body.querySelector('.popupmenu-wrapper > .popupmenu');
+    const firstItemEl = popupmenuEl.querySelector('li:first-child a');
+    const lastSubItemEl = popupmenuEl.querySelector('li.submenu li:last-child a');
+
+    expect(popupmenuButtonEl.getAttribute('data-automation-id')).toEqual('action-popupmenu-trigger');
+    expect(popupmenuEl.getAttribute('data-automation-id')).toEqual('action-popupmenu-menu');
+    expect(firstItemEl.getAttribute('data-automation-id')).toEqual('action-popupmenu-option-0');
+
+    // Account for menu nesting
+    expect(lastSubItemEl.getAttribute('data-automation-id')).toEqual('action-popupmenu-option-3-2');
   });
 });
 
@@ -439,9 +466,14 @@ describe('Popupmenu toData() API', () => {
     });
 
     afterEach(() => {
-      popupmenuObj.destroy();
-      popupmenuButtonEl.parentNode.removeChild(popupmenuButtonEl);
-      svgEl.parentNode.removeChild(svgEl);
+      if (popupmenuObj) {
+        popupmenuObj.destroy();
+      }
+      cleanup([
+        '.svg-icons',
+        '.row',
+        '.popupmenu-wrapper'
+      ]);
     });
 
     it('Should convert the main Popupmenu example into an object representation', () => {

--- a/test/components/toolbar-flex/toolbar-flex-api.func-spec.js
+++ b/test/components/toolbar-flex/toolbar-flex-api.func-spec.js
@@ -349,3 +349,63 @@ describe('Flex Toolbar', () => { //eslint-disable-line
     });
   });
 });
+
+describe('Flex Toolbar (with extra attributes)', () => {
+  beforeEach(() => {
+    toolbarEl = null;
+    toolbarAPI = null;
+    rowEl = null;
+
+    document.body.insertAdjacentHTML('afterbegin', svg);
+    document.body.insertAdjacentHTML('afterbegin', toolbarFavorButtonsetHTML);
+
+    rowEl = document.body.querySelector('.row');
+    toolbarEl = document.body.querySelector('.flex-toolbar');
+    toolbarAPI = new ToolbarFlex(toolbarEl, {
+      attributes: [
+        {
+          name: 'data-automation-id',
+          value: 'my-toolbar'
+        }
+      ]
+    });
+  });
+
+  afterEach(() => {
+    toolbarAPI.destroy();
+    cleanup([
+      '.svg-icons',
+      '.row',
+      '.popupmenu-wrapper'
+    ]);
+  });
+
+  it('can have automation ids', () => {
+    const firstItem = toolbarAPI.items[0];
+
+    // Toolbar elements get the attribute
+    expect(toolbarEl.getAttribute('data-automation-id')).toEqual('my-toolbar');
+    expect(firstItem.element.getAttribute('data-automation-id')).toEqual('my-toolbar-button-0');
+
+    // MenuButton and its controlled elements get the attribute
+    const menuButtonItem = toolbarAPI.items[1];
+    const menuEl = menuButtonItem.componentAPI.menu[0];
+    const menuFirstItemEl = menuEl.querySelector('li:first-child a');
+
+    expect(menuButtonItem.element.getAttribute('data-automation-id')).toEqual('my-toolbar-menubutton-1-trigger');
+    expect(menuEl.getAttribute('data-automation-id')).toEqual('my-toolbar-menubutton-1-menu');
+    expect(menuFirstItemEl.getAttribute('data-automation-id')).toEqual('my-toolbar-menubutton-1-option-0');
+
+    // "More Actions" button should render with a copy of the MenuButton's items,
+    // but they will have unique `data-automation-id` attributes specific for the overflowed MenuButton items
+    const actionButtonItem = toolbarAPI.items[5];
+    const actionMenuEl = actionButtonItem.componentAPI.menu[0];
+    const actionMenuFirstItemEl = actionMenuEl.querySelector('li:first-child a');
+    const actionMenuButtonFirstItemEl = actionMenuEl.querySelector('li.submenu li:first-child a');
+
+    expect(actionButtonItem.element.getAttribute('data-automation-id')).toEqual('my-toolbar-actionbutton-5-trigger');
+    expect(actionMenuEl.getAttribute('data-automation-id')).toEqual('my-toolbar-actionbutton-5-menu');
+    expect(actionMenuFirstItemEl.getAttribute('data-automation-id')).toEqual('my-toolbar-actionbutton-5-option-0');
+    expect(actionMenuButtonFirstItemEl.getAttribute('data-automation-id')).toEqual('my-toolbar-actionbutton-5-option-1-0');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds:
- the ability to pass automation ids and other custom attributes to the Flex Toolbar and its Items via the `attributes` setting
- the `attributes` setting in the Button and Popupmenu APIs (couldn't just do this with markup so I had to add the APIs -- added tests/examples/docs for these where there weren't any)

**Related github/jira issue (required)**:
related to #4498 

**Steps necessary to review your pull request (required)**:
Pull this branch, build, run the app:

_Context Menu:_
- Open http://localhost:4000/components/contextmenu/example-index.html - The automation ids should work here but I had to change the logic slightly - the first input field, menu `<ul>`, and all anchors should get automation ids.  double-check the sub items.
- Open http://localhost:4000/components/contextmenu/example-page-rightclick.html - The body tag, menu `<ul>` and all anchors should get automation ids.

_Popupmenu:_
- Open http://localhost:4000/components/popupmenu/example-ajax.html.  Ensure that automation ids are added to the trigger button, the menu, all the menu items and sub-items.

_Flex Toolbar:_
- Open http://localhost:4000/components/toolbar-flex/example-index.html.
- Ensure the toolbar items all have automation ids (buttons, menubutton, actionbutton -- searchfield isn't done yet but will get attributes once the setting works)
- Shrink the page width to be small, then open the More Actions menu on the first toolbar.  Under the "Menu Button" item, ensure the automation ids for the menu items are not the same as the ones underneath the actual Toolbar Menu Button.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
