### PR TITLE
4541 - Fix incorrectly positioned widgets with homepage

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -64,6 +64,7 @@
 - `[Editor]` Fixed an issue where the color picker was not opening the popup for overflow menu and had name as undefined in list. ([#4398](https://github.com/infor-design/enterprise/issues/4398))
 - `[Favorites]` Removed the favorites component as its not really a component, info on it can be found under buttons in the toggle example. ([#4405](https://github.com/infor-design/enterprise/issues/4405))
 - `[Fieldset]` Fixed a bug where summary form data gets cut off on a smaller viewport. ([#3861](https://github.com/infor-design/enterprise/issues/3861))
+- `[Homepage]` Fixed an issue where the four column widgets were incorrectly positioned, left aligned on large screen. ([#4541](https://github.com/infor-design/enterprise/issues/4541))
 - `[MenuButton]` Removed the menubutton component sections as its not really a component, info on it can be found under buttons in the MenuButton examples. ([#4416](https://github.com/infor-design/enterprise/issues/4416))
 - `[Message]` Added support for lists in the message, also fixed a problem when doing so, with screen readers. ([#4400](https://github.com/infor-design/enterprise/issues/4400))
 - `[Message]` Added the `noRefocus` setting that will feed through to the modal. ([#4507](https://github.com/infor-design/enterprise/issues/4507))

--- a/src/components/homepage/homepage.js
+++ b/src/components/homepage/homepage.js
@@ -582,7 +582,7 @@ Homepage.prototype = {
       self.columns = 5;
       bp = bpXXL;
     }
-    if (xl && /4|5/g.test(self.columns)) {
+    if ((xl || xxl) && /4|5/g.test(self.columns)) {
       self.columns = 4;
       bp = bpXL;
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed four column widgets were incorrectly positioned, left aligned on large screen with Homepage.

**Related github/jira issue (required)**:
Closes #4541

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/homepage/example-four-column.html
- Widgets main container should be in center of screen

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
