### PR TITLE
4488 - Add fix for keyword search highlighting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -59,6 +59,7 @@
 - `[Datagrid]` To allow for some script tools to work we now set draggable to true. ([#4490](https://github.com/infor-design/enterprise/issues/4490))
 - `[Datagrid]` Fixed an error on the filter box on the personalization dialog where it would error if there is a column with no name field. ([#4495](https://github.com/infor-design/enterprise/issues/4495))
 - `[Datagrid]` Fixed links when changing personalization as they would inherit the wrong color. ([#4481](https://github.com/infor-design/enterprise/issues/4481))
+- `[Datagrid]` Fixed a bug where seaching with the search on the toolbar would not highlight results. ([#4488](https://github.com/infor-design/enterprise/issues/4488))
 - `[Datepicker]` Changed the month/year picker to skip 10 years instead of one. ([#4388](https://github.com/infor-design/enterprise/issues/4388))
 - `[Editor]` Fixed an issue where the focus was getting lost after pressing toolbar buttons. ([#4335](https://github.com/infor-design/enterprise/issues/4335))
 - `[Editor]` Fixed an issue where the color picker was not opening the popup for overflow menu and had name as undefined in list. ([#4398](https://github.com/infor-design/enterprise/issues/4398))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -932,6 +932,12 @@ Datagrid.prototype = {
     this.cellNode(0, 0, true).attr('tabindex', '0');
     this.renderPager(pagerInfo, true);
     this.displayCounts();
+
+    // Highlight search results
+    if ((this.settings.paging && this.settings.source &&
+      pagerInfo?.filterExpr && pagerInfo.filterExpr[0]?.column === 'all')) {
+      this.highlightSearchRows(pagerInfo.filterExpr[0].value);
+    }
   },
 
   /**

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -3237,6 +3237,30 @@ describe('Datagrid icon buttons tests', () => {
   });
 });
 
+describe('Datagrid keyword search server side tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datagrid/test-keyword-search-serverside?layout=nofrills');
+
+    const datagridEl = await element(by.css('#datagrid tbody tr:nth-child(1)'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(datagridEl), config.waitsFor);
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should show highlights on server side keyword search', async () => {
+    await element(by.id('gridfilter')).click();
+    await element(by.id('gridfilter')).sendKeys('214');
+    await element(by.id('gridfilter')).sendKeys(protractor.Key.ENTER);
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.css('.datagrid-result-count')).getText()).toEqual('(781 results)');
+    expect(await element.all(by.css('.datagrid-cell-wrapper i')).count()).toEqual(10);
+  });
+});
+
 describe('Datagrid loaddata selected rows tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-loaddata-selected-rows');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When doing server side filtering with keyword search the highlight didnt show up. This fixes this issue.

**Related github/jira issue (required)**:
Fixes #4488

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-keyword-search-serverside?layout=nofrills
-  click into the search field in the toolbar
- type "214" and then enter
- the list should both filter down and show the highlights in bold

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
