### PR TITLE
4498 - Add the `attributes` setting to Lookup, add docs/tests/examples

### DIFF
--- a/app/views/components/lookup/example-index.html
+++ b/app/views/components/lookup/example-index.html
@@ -69,7 +69,13 @@
           collapsibleFilter: false,
           fullWidth: true
         }
-      }
+      },
+      attributes: [
+        {
+          name: 'data-automation-id',
+          value: 'my-lookup'
+        }
+      ]
     });
 
     $('#product-mask').mask({

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -51,7 +51,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [x] Line
 - [ ] Listbuilder
 - [x] Listview
-- [ ] Lookup
+- [x] Lookup
 - [ ] Masthead
 - [x] Message
 - [x] Modal

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@
 - `[Listview]` Added a new setting `allowDeselect` which will make it such that if you select an item you cant deselect, you can only select another item. ([#4376](https://github.com/infor-design/enterprise/issues/4376))
 - `[Locale]` Added a new set of translations from the translation team. ([#4501](https://github.com/infor-design/enterprise/issues/4501))
 - `[Locale/Charts]` The numbers inside charts are now formatted using the current locale's, number settings. This can be disabled/changed in some charts by passing in a localeInfo object to override the default settings. ([#4437](https://github.com/infor-design/enterprise/issues/4437))
+- `[Lookup]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Listview]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Message]` Added `attributes` setting to set automation id's and id's. ([#4277](https://github.com/infor-design/enterprise/issues/4277))
 - `[Modal]` Added `attributes` setting to set automation id's and id's. ([#4277](https://github.com/infor-design/enterprise/issues/4277))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,7 +32,6 @@
 - `[Listview]` Added a new setting `allowDeselect` which will make it such that if you select an item you cant deselect, you can only select another item. ([#4376](https://github.com/infor-design/enterprise/issues/4376))
 - `[Locale]` Added a new set of translations from the translation team. ([#4501](https://github.com/infor-design/enterprise/issues/4501))
 - `[Locale/Charts]` The numbers inside charts are now formatted using the current locale's, number settings. This can be disabled/changed in some charts by passing in a localeInfo object to override the default settings. ([#4437](https://github.com/infor-design/enterprise/issues/4437))
-- `[Lookup]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Listview]` Added `attributes` setting to set automation id's and id's. ([#4498](https://github.com/infor-design/enterprise/issues/4498))
 - `[Message]` Added `attributes` setting to set automation id's and id's. ([#4277](https://github.com/infor-design/enterprise/issues/4277))
 - `[Modal]` Added `attributes` setting to set automation id's and id's. ([#4277](https://github.com/infor-design/enterprise/issues/4277))

--- a/src/components/lookup/lookup.js
+++ b/src/components/lookup/lookup.js
@@ -18,14 +18,21 @@ let LOOKUP_GRID_ID = 'lookup-datagrid';
 // This helper appends suffixes representing those components to each attribute.
 function addSuffixToAttributes(parentAttrs = [], childAttrs = [], suffix) {
   let attrs = [];
+  if (!parentAttrs?.length && !childAttrs?.length) {
+    return attrs;
+  }
 
   // If no child attributes exist, just pass the parents on with the prefix
-  if (!childAttrs.length) {
+  if (!childAttrs?.length) {
     attrs = parentAttrs.map(obj => ({
       name: obj.name,
       value: `${obj.value}-${suffix}`
     }));
     return attrs;
+  }
+
+  if (!parentAttrs.length) {
+    return childAttrs;
   }
 
   // If child attributes exist, only append the ones from the parent

--- a/src/components/lookup/readme.md
+++ b/src/components/lookup/readme.md
@@ -85,7 +85,34 @@ grid = $('#product-lookup').lookup({
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+You can add custom id's/automation id's to the Lookup that can be used for scripting using the `attributes` setting. This setting takes either an object or an array for setting multiple values such as an automation-id or other attributes.
+For example:
+
+```js
+  attributes: { name: 'id', value: args => `background-color` }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: { name: 'data-automation-id', value: 'my-unique-id' }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: [{ name: 'id', value: 'my-unique-id' }, { name: 'data-automation-id', value: 'my-unique-id' }]
+```
+
+When using the attributes setting, the following elements are appended:
+- the input field, with `-input`.
+- the trigger icon, with `-trigger`.
+- the modal component is passed the same `attributes` setting, but all attribute values are suffixed with `-modal`.
+- the datagrid component is passed the same `attributes` setting, but all attribute values are suffixed with `-datagrid`.
+
+Additionally, if any of the Lookup's content is manually defined -- such as the Datagrid, inner-Searchfield, or Toolbar, you should label those with automation id's manually.
+
+Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
 
 ## Upgrading from 3.X
 

--- a/src/components/lookup/readme.md
+++ b/src/components/lookup/readme.md
@@ -105,6 +105,7 @@ Setting the id/automation id with a string value:
 ```
 
 When using the attributes setting, the following elements are appended:
+
 - the input field, with `-input`.
 - the trigger icon, with `-trigger`.
 - the modal component is passed the same `attributes` setting, but all attribute values are suffixed with `-modal`.

--- a/test/components/lookup/lookup.e2e-spec.js
+++ b/test/components/lookup/lookup.e2e-spec.js
@@ -92,7 +92,7 @@ describe('Lookup example tests', () => {
     expect(await lookupEl.getAttribute('value')).toEqual('2142201');
   });
 
-  fit('should generate automation id\'s', async () => {
+  it('should generate automation id\'s', async () => {
     expect(await element(by.id('product-lookup')).getAttribute('data-automation-id')).toEqual('my-lookup-input');
     expect(await element(by.css('#product-lookup + .trigger')).getAttribute('data-automation-id')).toEqual('my-lookup-trigger');
 

--- a/test/components/lookup/lookup.e2e-spec.js
+++ b/test/components/lookup/lookup.e2e-spec.js
@@ -92,6 +92,16 @@ describe('Lookup example tests', () => {
     expect(await lookupEl.getAttribute('value')).toEqual('2142201');
   });
 
+  fit('should generate automation id\'s', async () => {
+    expect(await element(by.id('product-lookup')).getAttribute('data-automation-id')).toEqual('my-lookup-input');
+    expect(await element(by.css('#product-lookup + .trigger')).getAttribute('data-automation-id')).toEqual('my-lookup-trigger');
+
+    await element.all(by.className('trigger')).first().click();
+    await browser.driver.wait(protractor.ExpectedConditions.visibilityOf(element(by.id('lookup-datagrid'))), config.waitsFor);
+
+    expect(await element(by.css('.modal.lookup-modal')).getAttribute('data-automation-id')).toEqual('my-lookup-modal');
+  });
+
   if (utils.isChrome() && utils.isCI()) {
     it('Should not visual regress', async () => {
       const buttonEl = await element.all(by.className('trigger')).first();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds the `attributes` setting to the Lookup component for custom/automation ids

**Related github/jira issue (required)**:
- related to #4498 
- depends on #4552 (needs to be tested with datagrid `attributes` API but should work)

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the demoapp
- Open http://localhost:4000/components/lookup/example-index.html
- Inspect the first Lookup field's input and trigger icon.  Both should have `data-automation-id`
- Open the lookup by clicking the trigger icon.  When it opens:
  - The Modal should have any auto-generated attributes set on their respective elements (`.modal` container, its trigger button, any inner modal buttons, close button, etc)
  - The Datagrid should have any auto-generated attributes set on their respective elements (column headers, etc)

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
