### PR TITLE
4538 - Fix misalignment tab items in uplift theme

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,13 +1,5 @@
 # What's New with Enterprise
 
-## v4.35.0
-
-### v4.35.0 Features
-
-## v4.35.0 Fixes
-
-- `[Tabs Module]` Fixed a bug where tab items were not centered correctly in uplift theme. ([#4538](https://github.com/infor-design/enterprise/issues/4538))
-
 ## v4.34.0
 
 ### v4.34.0 Features
@@ -86,6 +78,7 @@
 - `[Listview]` Fixed a bug where readonly and non-selectable listview should not have hover state. ([#4452](https://github.com/infor-design/enterprise/issues/4452))
 - `[Lookup]` Fixed a bug where the filter header together with the checkbox column is not properly align. ([#3774](https://github.com/infor-design/enterprise/issues/3774))
 - `[Splitter]` Added missing audible labels in splitter collapse button and splitter handle. ([#4404](https://github.com/infor-design/enterprise/issues/4404))
+- `[Tabs Module]` Fixed a bug where tab items were not centered correctly in uplift theme. ([#4538](https://github.com/infor-design/enterprise/issues/4538))
 - `[Treemap]` Fixed a bug where small slices may show a "tip" below the chart. ([#2794](https://github.com/infor-design/enterprise/issues/2794))
 
 ## v4.33.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # What's New with Enterprise
 
+## v4.35.0
+
+### v4.35.0 Features
+
+## v4.35.0 Fixes
+
+- `[Tabs Module]` Fixed a bug where tab items were not centered correctly in uplift theme. ([#4538](https://github.com/infor-design/enterprise/issues/4538))
+
 ## v4.34.0
 
 ### v4.34.0 Features

--- a/src/components/tabs-module/_tabs-module-uplift.scss
+++ b/src/components/tabs-module/_tabs-module-uplift.scss
@@ -4,16 +4,17 @@
 .tab-container.module-tabs {
   .tab {
     > a {
-      padding: 5px 6px 9px;
+      padding: 7px 6px;
     }
 
     &.dismissible {
       a {
-        padding: 5px 35px 9px 6px;
+        padding: 7px 35px 7px 6px;
       }
 
       .icon {
         height: 11px;
+        margin-top: 1px;
       }
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes alignment of tab items in uplift theme.

**Related github/jira issue (required)**:

 Closes https://github.com/infor-design/enterprise/issues/4538

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Navigate to http://localhost:4000/components/tabs-module/example-index.html?theme=uplift&variant=light&colors=0066D4
- Check the tab items
- Tab items (text) should centered correctly

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
