### PR TITLE
4498 - Add automation id for editor and hierarchy

### DIFF
--- a/app/views/components/editor/example-index.html
+++ b/app/views/components/editor/example-index.html
@@ -8,7 +8,7 @@
 
     <div class="field">
       <span class="label">Comments</span>
-      <div class="editor" id="editor1" role="textbox" aria-multiline="true" aria-label="Comments">
+      <div class="editor" id="editor1" role="textbox" aria-multiline="true" aria-label="Comments" data-options="{attributes: [{name: 'id', value: 'example1'}, {name: 'data-automation-id', value: 'automation-id-example1'}]}">
         <p>Embrace <a href="http://en.wikipedia.org/wiki/e-commerce" class="hyperlink">e-commerce action-items</a>, reintermediate, ecologies paradigms wireless share life-hacks create innovative harness. Evolve solutions rich-clientAPIs synergies harness relationships virtual vertical facilitate end-to-end, wireless, evolve synergistic synergies.</p>
         <p>Cross-platform, evolve, ROI scale cultivate eyeballs addelivery, e-services content cross-platform leverage extensible viral incentivize integrateAJAX-enabled sticky evolve magnetic cultivate leverage; cutting-edge. Innovate, end-to-end podcasting, whiteboard streamline e-business social; compelling, "cross-media exploit infomediaries innovative integrate integrateAJAX-enabled." Killer interactive reinvent, cultivate widgets leverage morph.</p>
       </div>

--- a/app/views/components/hierarchy/example-context-menu-with-details.html
+++ b/app/views/components/hierarchy/example-context-menu-with-details.html
@@ -1,5 +1,20 @@
 <figure class="hierarchy" id="hierarchy"></figure>
 <script>
+  // Get suffix text for automation attributes
+  function getSuffix(d) {
+    var suffix = '-' + d.id;
+    suffix += '-' + d.Name || '';
+    return suffix.toString().toLowerCase().replace(/\s/g, '-');
+  }
+
+  // Set automation attributes
+  function setAutomationAttributes(d) {
+    d.attributes = [
+      { name: 'id', value: 'example1'+ getSuffix(d) },
+      { name: 'data-automation-id', value: 'automation-id-example1'+ getSuffix(d) }
+    ];
+  };
+
   $.getJSON('{{basepath}}api/orgstructure', function(data) {
     const legendData = [
       { 'value' : 'FT', 'label' : 'Full Time'     },
@@ -7,6 +22,10 @@
       { 'value' : 'C',  'label' : 'Contractor'    },
       { 'value' : 'O',  'label' : 'Open Position' }
     ];
+
+    // Add automation attributes, first and first-child node
+    setAutomationAttributes(data[0]);
+    setAutomationAttributes(data[0].children[0]);
 
     $('#hierarchy').hierarchy({
       templateId: 'hierarchyChartTemplate',

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -32,7 +32,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [ ] Datepicker
 - [x] Donut
 - [ ] Dropdown
-- [ ] Editor
+- [x] Editor
 - [x] Emptymessage
 - [x] Error Page
 - [x] Expandablearea
@@ -42,7 +42,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [x] Fileupload
 - [x] Fileupload Advanced
 - [ ] Header
-- [ ] Hierarchy
+- [x] Hierarchy
 - [ ] Homepage
 - [x] Hyperlinks (not needed id can be directly applied)
 - [x] Icons (not needed id can be directly applied)

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -53,6 +53,7 @@ const EDITOR_PARENT_ELEMENTS = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockq
 * @param {boolean} [settings.useSourceFormatter = false] true will format the html content in source mode.
 * @param {boolean} [settings.formatterTabsize = 4] number of spaces can use for indentation.
 * @param {boolean} [settings.rows = null] Number of rows that will be shown in each part of the editor. Set like textarea rows attributes to adjust the height of the editor without css. Example: `{ editor: 10, source: 20 }`
+* @param {string|array} [settings.attributes = null] Add extra attributes like id's to the chart elements. For example `attributes: { name: 'id', value: 'my-unique-id' }`
 */
 const EDITOR_DEFAULTS = {
   buttons: {
@@ -115,7 +116,8 @@ const EDITOR_DEFAULTS = {
         y: 0
       }
     }
-  }
+  },
+  attributes: null
 };
 
 function Editor(element, settings) {
@@ -447,7 +449,15 @@ Editor.prototype = {
       }
     }
 
-    const toolbar = `<div class="${toolbarCssClasses}" data-init="false" id="editor-toolbar-${this.id}">
+    // Add automation attributes to each buttons
+    let btnAttributes = '';
+    if (this.settings.attributes) {
+      btnAttributes = this.getAutomationAttributes('-editor-toolbar');
+      btnAttributes = JSON.stringify(btnAttributes);
+      btnAttributes = ` data-options='{"attributes": ${btnAttributes}}'`;
+    }
+
+    const toolbar = `<div class="${toolbarCssClasses}" data-init="false" id="editor-toolbar-${this.id}"${btnAttributes}>
       <div class="${sectionCss}buttonset">
         ${buttonsHTML}
       </div>
@@ -464,6 +474,16 @@ Editor.prototype = {
     // Invoke Fontpicker, if applicable
     const fpElement = this.toolbar.find('[data-action="fontStyle"]').first();
     if (fpElement && fpElement.length) {
+      // Set suffix for fontpicker automation attributes
+      if (this.settings.attributes) {
+        const fpAttributes = this.getAutomationAttributes('-editor-fontpicker');
+        if (typeof this.settings.fontpickerSettings.popupmenuSettings === 'object') {
+          this.settings.fontpickerSettings.popupmenuSettings.attributes = fpAttributes;
+        } else if (!this.settings.fontpickerSettings.popupmenuSettings) {
+          this.settings.fontpickerSettings.popupmenuSettings = { attributes: fpAttributes };
+        }
+      }
+
       fpElement.fontpicker(this.settings.fontpickerSettings);
       this.fontPickerElem = fpElement;
     }
@@ -518,6 +538,30 @@ Editor.prototype = {
     });
 
     return this;
+  },
+
+  /**
+   * Get append suffix with automation attributes
+   * @private
+   * @param {string} suffix to use
+   * @returns {object|array} attributes with suffix
+   */
+  getAutomationAttributes(suffix) {
+    const s = this.settings;
+    let attributes = s.attributes;
+    if (s.attributes && typeof suffix === 'string' && suffix !== '') {
+      if (Array.isArray(s.attributes)) {
+        attributes = [];
+        s.attributes.forEach((item) => {
+          const value = typeof item.value === 'function' ? item.value(this) : item.value;
+          attributes.push({ name: item.name, value: (value + suffix) });
+        });
+      } else {
+        const value = typeof s.attributes.value === 'function' ? s.attributes.value(this) : s.attributes.value;
+        attributes = { name: s.attributes.name, value: (value + suffix) };
+      }
+    }
+    return attributes;
   },
 
   /**
@@ -1067,7 +1111,9 @@ Editor.prototype = {
 
       if (action) {
         self.execAction(action, e);
-        btn.focus();
+        if (btn && !self.isBtnOverflowedItem(btn)) {
+          btn.focus();
+        }
       }
 
       if (env.browser.name === 'ie' || env.browser.isEdge()) {
@@ -1141,6 +1187,17 @@ Editor.prototype = {
           }
         }, 10);
       })
+      .off('beforeclose')
+      .on('beforeclose', function () {
+        const action = $(this).is('.editor-modal-image') ? 'image' : 'anchor';
+        if (self.toolbar) {
+          const btn = self.toolbar.find(`[data-action="${action}"]`);
+          const modalApi = $(this).data('modal');
+          if (btn && modalApi) {
+            modalApi.settings.noRefocus = self.isBtnOverflowedItem(btn);
+          }
+        }
+      })
       .off('close')
       .on('close', function (e, isCancelled) {
         self.restoreSelection(self.savedSelection);
@@ -1192,8 +1249,18 @@ Editor.prototype = {
     if (isTargetCustom) {
       targetOptions += `<option value="${s.anchor.target}">${s.anchor.target}</option>`;
     }
+
+    let modalAttributes;
+    let ddAttributes = '';
+    // Set automation attributes settings for dropdown
+    if (s.attributes) {
+      modalAttributes = this.getAutomationAttributes('-editor-modal');
+      ddAttributes = JSON.stringify(modalAttributes);
+      ddAttributes = ` data-options='{"attributes": ${ddAttributes}}'`;
+    }
+
     // TODO: Rename to link when you get strings
-    return $(`<div class="modal editor-modal-url" id="modal-url-${this.id}"></div>`)
+    const output = $(`<div class="modal editor-modal-url" id="modal-url-${this.id}"></div>`)
       .html(`<div class="modal-content">
         <div class="modal-header">
           <h1 class="modal-title">${Locale.translate('InsertAnchor')}</h1>
@@ -1213,7 +1280,7 @@ Editor.prototype = {
           </div>
           <div class="field">
             <label for="em-target-${this.id}" class="label"> ${Locale.translate('Target')}</label>
-            <select id="em-target-${this.id}" name="em-target-${this.id}" class="dropdown">
+            <select id="em-target-${this.id}" name="em-target-${this.id}" class="dropdown"${ddAttributes}>
               ${targetOptions}
             </select>
           </div>
@@ -1222,7 +1289,17 @@ Editor.prototype = {
             <button type="button" class="btn-modal-primary"> ${Locale.translate('Insert')}</button>
           </div>
         </div>
-      </div>`).appendTo('body');
+      </div>`);
+
+    // Add automation attributes
+    if (s.attributes) {
+      const inputs = [].slice.call(output[0].querySelectorAll('[type="text"]'));
+      const buttons = [].slice.call(output[0].querySelectorAll('button'));
+      inputs.forEach((input, i) => utils.addAttributes($(input), this, modalAttributes, `input${i}`));
+      buttons.forEach((btn, i) => utils.addAttributes($(btn), this, modalAttributes, `button${i}`));
+    }
+
+    return output.appendTo('body');
   },
 
   /**
@@ -1237,7 +1314,8 @@ Editor.prototype = {
     if (imageModal.length > 0) {
       return imageModal;
     }
-    return $(`<div class="modal editor-modal-image" id="modal-image-${this.id}"></div>'`)
+
+    const output = $(`<div class="modal editor-modal-image" id="modal-image-${this.id}"></div>'`)
       .html(`<div class="modal-content">
         <div class="modal-header">
           <h1 class="modal-title">${Locale.translate('InsertImage')}</h1>
@@ -1254,7 +1332,17 @@ Editor.prototype = {
               ${Locale.translate('Insert')}</button>
           </div>
         </div>
-      </div>`).appendTo('body');
+      </div>`);
+
+    // Add automation attributes
+    if (this.settings.attributes) {
+      const modalAttributes = this.getAutomationAttributes('-editor-modal');
+      const inputs = [].slice.call(output[0].querySelectorAll('[type="text"]'));
+      const buttons = [].slice.call(output[0].querySelectorAll('button'));
+      inputs.forEach((input, i) => utils.addAttributes($(input), this, modalAttributes, `input${i}`));
+      buttons.forEach((btn, i) => utils.addAttributes($(btn), this, modalAttributes, `button${i}`));
+    }
+    return output.appendTo('body');
   },
 
   bindAnchorPreview() {
@@ -2211,7 +2299,10 @@ Editor.prototype = {
          * @property {string} content Additional argument
          */
         this.element.triggerHandler('afterpreviewmode', content);
-        this.toolbar?.find('[data-action="source"]').focus();
+        const btn = this.toolbar?.find('[data-action="source"]');
+        if (btn && !this.isBtnOverflowedItem(btn)) {
+          btn.focus();
+        }
       }, 0);
     };
 
@@ -2247,7 +2338,10 @@ Editor.prototype = {
        * @property {string} content Additional argument
        */
       this.element.triggerHandler('aftersourcemode', content);
-      this.toolbar?.find('[data-action="visual"]').focus();
+      const btn = this.toolbar?.find('[data-action="visual"]');
+      if (btn && !this.isBtnOverflowedItem(btn)) {
+        btn.focus();
+      }
     };
 
     // Check the false value
@@ -2284,6 +2378,25 @@ Editor.prototype = {
         }
       });
     }
+  },
+
+  /**
+   * Check button is overflowed item or not.
+   * @private
+   * @param  {jQuery} btn button to check
+   * @returns {boolean} true if button is overflowed item
+   */
+  isBtnOverflowedItem(btn) {
+    const toolbarApi = this.toolbar.data('toolbar') || this.toolbar.data('toolbar-flex');
+    let found = false;
+    if (toolbarApi) {
+      toolbarApi.overflowedItems.forEach((item) => {
+        if (btn.is(item.element)) {
+          found = true;
+        }
+      });
+    }
+    return found;
   },
 
   /**

--- a/src/components/editor/readme.md
+++ b/src/components/editor/readme.md
@@ -43,7 +43,22 @@ To save and get the data from the `contenteditable` element, you should simply s
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+You can add custom id's/automation id's to the rich text editor that can be used for scripting using the `attributes` data attribute. This data attribute can be either an object or an array for setting multiple values such as an automation-id or other attributes. For example:
+
+Setting the id/automation id with a string value or function. The function will give you the data as a parameter for making things more dynamic.
+
+```js
+{
+  attributes: [
+    { name: 'id', value: 'example1' },
+    { name: 'data-automation-id', value: 'automation-id-example1' }
+  ]
+}
+```
+
+Providing the data this will add an ID added to each button with `-editor-toolbar-button-{index}`, fontpicker options with `-editor-fontpicker-option-{index}`, colors in color-picker with `-editor-toolbar-colorpicker-{btnIndex}-{colorIndex}`, modal input with `-editor-modal-input{inputIndex}`, modal dropdown options with -`editor-modal-option-{itemIndex}` and modal button with `-editor-modal-button{btnIndex}` appended after it.
+
+- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for general information.
 
 ## Keyboard Shortcuts
 

--- a/src/components/hierarchy/readme.md
+++ b/src/components/hierarchy/readme.md
@@ -53,7 +53,39 @@ Required template HTML markup:
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+You can add custom id's/automation id's to the hierarchy that can be used for scripting using the `attributes` data attribute. This data attribute can be either an object or an array for setting multiple values such as an automation-id or other attributes. For example:
+
+Setting the id/automation id with a string value or function. The function will give you the data as a parameter for making things more dynamic.
+
+```js
+var dataset = [{
+  "id": "1",
+  "Name": "Jonathan Cargill",
+  "Position": "Director",
+  "EmploymentType": "FT",
+  "Picture": "/images/21.jpg",
+  "attributes": [
+    { "name": "id", "value": "example1-1-jonathan-cargill" },
+    { "name": "data-automation-id", "value": "automation-id-example1-1-jonathan-cargill" }
+  ]
+  "children": [
+    {
+      "id": "1_3",
+      "Name": "Kaylee Edwards",
+      "Position": "Records Manager",
+      "EmploymentType": "FT",
+      "Picture": "/images/11.jpg",
+      "attributes": [
+        { "name": "id", "value": "example1-1_3-kaylee-edwards" },
+        { "name": "data-automation-id", "value": "automation-id-example1-1_3-kaylee-edwards" }
+      ]
+    }
+  }];
+```
+
+Providing the data this will add an ID added to each leaf with `-hierarchy-leaf`, toggle button with `-hierarchy-btn-toggle`, actions button with `-hierarchy-popupmenu-trigger` and action button options with `-hierarchy-popupmenu-option-{index}` appended after it.
+
+- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for general information.
 
 ## Upgrading from 3.X
 

--- a/test/components/editor/editor.e2e-spec.js
+++ b/test/components/editor/editor.e2e-spec.js
@@ -124,6 +124,33 @@ describe('Editor example-index tests', () => {
     expect(await element(by.css('.editor')).getAttribute('innerHTML')).toEqual('<h3>test test</h3>');
     expect(await element(by.css('.fontpicker')).getText()).toEqual('Header 1');
   });
+
+  it('Should be able to set id/automation id example', async () => {
+    expect(await element(by.id('example1-editor-fontpicker-option-0')).getAttribute('id')).toEqual('example1-editor-fontpicker-option-0');
+    expect(await element(by.id('example1-editor-fontpicker-option-0')).getAttribute('data-automation-id')).toEqual('automation-id-example1-editor-fontpicker-option-0');
+
+    expect(await element(by.id('example1-editor-toolbar-button-1')).getAttribute('id')).toEqual('example1-editor-toolbar-button-1');
+    expect(await element(by.id('example1-editor-toolbar-button-1')).getAttribute('data-automation-id')).toEqual('automation-id-example1-editor-toolbar-button-1');
+
+    await element(by.css('.btn-editor[data-action="foreColor"]')).click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.css('.popupmenu.colorpicker.is-open'))), config.waitsFor);
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.id('example1-editor-toolbar-colorpicker-5-slate10')).getAttribute('id')).toEqual('example1-editor-toolbar-colorpicker-5-slate10');
+    expect(await element(by.id('example1-editor-toolbar-colorpicker-5-slate10')).getAttribute('data-automation-id')).toEqual('automation-id-example1-editor-toolbar-colorpicker-5-slate10');
+
+    await element(by.css('.btn-editor[data-action="anchor"]')).click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.css('.editor-modal-url.is-visible'))), config.waitsFor);
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.id('em-url-editor-1-id')).getAttribute('id')).toEqual('em-url-editor-1-id');
+    expect(await element(by.id('em-url-editor-1-id')).getAttribute('data-automation-id')).toEqual('automation-id-example1-editor-modal-input0');
+
+    expect(await element(by.id('example1-editor-modal-button0')).getAttribute('id')).toEqual('example1-editor-modal-button0');
+    expect(await element(by.id('example1-editor-modal-button0')).getAttribute('data-automation-id')).toEqual('automation-id-example1-editor-modal-button0');
+  });
 });
 
 describe('Editor visual regression tests', () => {

--- a/test/components/hierarchy/hierarchy.e2e-spec.js
+++ b/test/components/hierarchy/hierarchy.e2e-spec.js
@@ -35,3 +35,39 @@ describe('Hierarchy index tests', () => {
     });
   }
 });
+
+describe('Hierarchy context menu tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/hierarchy/example-context-menu-with-details?layout=nofrills');
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should be able to set id/automation id example', async () => {
+    expect(await element(by.id('1')).getAttribute('id')).toEqual('1');
+    expect(await element(by.id('1')).getAttribute('data-automation-id')).toEqual('automation-id-example1-1-jonathan-cargill-hierarchy-leaf');
+
+    expect(await element(by.id('1_3')).getAttribute('id')).toEqual('1_3');
+    expect(await element(by.id('1_3')).getAttribute('data-automation-id')).toEqual('automation-id-example1-1_3-kaylee-edwards-hierarchy-leaf');
+
+    expect(await element(by.id('example1-1_3-kaylee-edwards-hierarchy-btn-toggle')).getAttribute('id')).toEqual('example1-1_3-kaylee-edwards-hierarchy-btn-toggle');
+    expect(await element(by.id('example1-1_3-kaylee-edwards-hierarchy-btn-toggle')).getAttribute('data-automation-id')).toEqual('automation-id-example1-1_3-kaylee-edwards-hierarchy-btn-toggle');
+
+    expect(await element(by.id('btn-1_3')).getAttribute('id')).toEqual('btn-1_3');
+    expect(await element(by.id('btn-1_3')).getAttribute('data-automation-id')).toEqual('automation-id-example1-1_3-kaylee-edwards-hierarchy-popupmenu-trigger');
+
+    await element(by.id('btn-1_3')).click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.css('.popupmenu.is-open'))), config.waitsFor);
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.id('example1-1_3-kaylee-edwards-hierarchy-popupmenu-option-0')).getAttribute('id')).toEqual('example1-1_3-kaylee-edwards-hierarchy-popupmenu-option-0');
+    expect(await element(by.id('example1-1_3-kaylee-edwards-hierarchy-popupmenu-option-0')).getAttribute('data-automation-id')).toEqual('automation-id-example1-1_3-kaylee-edwards-hierarchy-popupmenu-option-0');
+    expect(await element(by.id('example1-1_3-kaylee-edwards-hierarchy-popupmenu-option-1')).getAttribute('id')).toEqual('example1-1_3-kaylee-edwards-hierarchy-popupmenu-option-1');
+    expect(await element(by.id('example1-1_3-kaylee-edwards-hierarchy-popupmenu-option-1')).getAttribute('data-automation-id')).toEqual('automation-id-example1-1_3-kaylee-edwards-hierarchy-popupmenu-option-1');
+    expect(await element(by.id('example1-1_3-kaylee-edwards-hierarchy-popupmenu-option-2')).getAttribute('id')).toEqual('example1-1_3-kaylee-edwards-hierarchy-popupmenu-option-2');
+    expect(await element(by.id('example1-1_3-kaylee-edwards-hierarchy-popupmenu-option-2')).getAttribute('data-automation-id')).toEqual('automation-id-example1-1_3-kaylee-edwards-hierarchy-popupmenu-option-2');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adds the attributes/automation id/ id functionality for Editor and Hierarchy.

**Related github/jira issue (required)**:
related to #4498

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app

Editor
- Navigate to: http://localhost:4000/components/editor/example-index.html
- Check for `id` and `data-automation-id` attributes, get from the settings (for each button, fontpicker options, colors in color-picker, url/image modal input, modal dropdown options and modal buttons)
- Review the text in the docs

Hierarchy
- Navigate to: http://localhost:4000/components/hierarchy/example-context-menu-with-details.html
- Check for `id` and `data-automation-id` attributes, get from the settings (for each leaf, toggle-button, actions-button and action button options)
- Review the text in the docs

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
