### PR TITLE
4387 - Fix for slow autocomplete ajax xalls

### DIFF
--- a/app/views/components/toolbar/example-index.html
+++ b/app/views/components/toolbar/example-index.html
@@ -1,15 +1,15 @@
 <div class="row">
   <div class="twelve columns">
 
-    <div id="regular-toolbar-example" class="toolbar" role="toolbar">
+    <div id="regular-toolbar-example" class="toolbar" role="toolbar" data-options="{ 'attributes': [ { 'name': 'data-automation-id', 'value': 'my-toolbar' } ] }">
       <div class="title">
         Toolbar Title
       </div>
       <div class="buttonset">
 
         <div class="searchfield-wrapper toolbar-searchfield-wrapper">
-          <label class="audible" for="regular-toolbar-searchfield">Toolbar Searchfield</label>
-          <input class="searchfield" placeholder="keyword" id="regular-toolbar-searchfield" name="regular-toolbar-searchfield" />
+          <label class="audible" for="test-sf">Toolbar Searchfield</label>
+          <input class="searchfield" placeholder="keyword" id="test-sf" />
         </div>
 
         <button id="btn-row" class="btn" type="button">

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -93,6 +93,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [x] Toast
 - [x] Toolbarsearchfield
 - [x] Toolbar Flex
+- [x] Toolbar
 - [ ] Tooltip
 - [ ] Tree
 - [x] Treemap

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -52,7 +52,8 @@
 
 ### v4.34.0 Fixes
 
-- `[Breadcrumb]` Fixed an issue were css only breadcrumbs were missing styles. ([#4501](https://github.com/infor-design/enterprise/issues/4501))
+- `[Autocomplet]` Fixed an issue where a slow and incomplete ajax request would cause the dropdown to briefly show wrong contents. ([#4387](https://github.com/infor-design/enterprise/issues/4387))
+- `[Breadcrumb]` Fixed an issue where css only breadcrumbs were missing styles. ([#4501](https://github.com/infor-design/enterprise/issues/4501))
 - `[Datepicker]` Fixed an issue where range highlight was not aligning for Mac/Safari. ([#4352](https://github.com/infor-design/enterprise/issues/4352))
 - `[Datagrid]` Fixed an issue with a custom toolbar, where buttons would click twice. ([#4471](https://github.com/infor-design/enterprise/issues/4471))
 - `[Datagrid]` Fixed an issue where the special characters (é, à, ü, û, ...) export to csv was not generated them correctly. ([#4347](https://github.com/infor-design/enterprise/issues/4347))
@@ -145,7 +146,7 @@
 - `[Accordion]` Fixed a bug in the vibrant theme where nested header text was not showing because the width was pushing it to the next line. ([#4145](https://github.com/infor-design/enterprise/issues/4145))
 - `[Application Menu]` Fixed too much spacing level when there's an icon in accordion header in uplift theme. ([#4202](http://localhost:4000/components/applicationmenu/test-six-levels-icons.html?theme=uplift&variant=light&colors=0066D4))
 - `[Contextual Action Panel]` Made the close button work in cases where subcomponents are open inside the CAP. ([#4112](https://github.com/infor-design/enterprise/issues/4112))
-- `[Colorpicker]` The sizes were inconsistent with other components in width so we adjusted them. ([#4310](https://github.com/infor-design/enterprise/issues/4310))
+- `[Colorpicker]` The sizes where inconsistent with other components in width so we adjusted them. ([#4310](https://github.com/infor-design/enterprise/issues/4310))
 - `[Datagrid]` Fixed an issue where the selectedRows array contents continued to multiply each time running `selectAllRows`. ([#4195](https://github.com/infor-design/enterprise/issues/4195))
 - `[Datagrid]` Fixed an issue where the dynamic tooltip was not working properly. ([#4260](https://github.com/infor-design/enterprise/issues/4260))
 - `[Datagrid]` Fixed an issue where the check box filter was not working. ([#4271](https://github.com/infor-design/enterprise/issues/4271))
@@ -167,7 +168,7 @@
 - `[Tabs]` Added detection for width/height/style changes on a Tabs component, which now triggers a resize event. ([ng#860](https://github.com/infor-design/enterprise-ng/issues/860))
 - `[Tabs]` Fixed a small error by removing a - 1 involved with testing. ([#4093](https://github.com/infor-design/enterprise/issues/4093))
 - `[Tabs]` Fixed a bug where using `#` in a Tab title was not possible. ([#4179](https://github.com/infor-design/enterprise/issues/4179))
-- `[Tabs Header]` Fixed a bug where the add icon were too small and the page form layout has a big space on top of it. ([#4289](https://github.com/infor-design/enterprise/issues/4289))
+- `[Tabs Header]` Fixed a bug where the add icon was too small and the page form layout has a big space on top of it. ([#4289](https://github.com/infor-design/enterprise/issues/4289))
 - `[Toolbar Flex]` Fixed a bug where in some cases a un-needed scrollbar would appear. [[#4325](https://github.com/infor-design/enterprise/issues/4325)]
 - `[Toolbar Searchfield]` Fixed a bug where the searchfield doesn't perfectly align together with flex toolbar. [[#4226](https://github.com/infor-design/enterprise/issues/4226)]
 - `[Tree]` Fixed an issue where the return focus state was not working properly after closing the context menu. ([#4252](https://github.com/infor-design/enterprise/issues/4252))
@@ -221,11 +222,11 @@
 - `[Blockgrid]` Fixed a bug where first/last pager buttons would show and be disabled by default (buttons are now hidden by default). ([ng#836](https://github.com/infor-design/enterprise-ng/issues/836))
 - `[Buttons]` Reverted an inner Css rule change that set 'btn' classes to contains vs starts with. ([#4120](https://github.com/infor-design/enterprise/issues/4120))
 - `[Datagrid]` Fixed an issue when hiding columns after loading a datagrid up with grouped headers and frozen columns. ([#4218](https://github.com/infor-design/enterprise/issues/4218))
-- `[Datagrid]` Fixed an issue where the rows were not render properly when use method `updateDataset()` for treegrid. ([#4213](https://github.com/infor-design/enterprise/issues/4213))
+- `[Datagrid]` Fixed an issue where the rows where not rendering properly when use method `updateDataset()` for treegrid. ([#4213](https://github.com/infor-design/enterprise/issues/4213))
 - `[Datagrid]` Fixed an issue where the tooltip for tree grid was not working properly. ([#827](https://github.com/infor-design/enterprise-ng/issues/827))
 - `[Datagrid]` Fixed an issue where the keyword search was not working for server side paging. ([#3977](https://github.com/infor-design/enterprise/issues/3977))
 - `[Datagrid]` Fixed a bug that nested datagrid columns could not be clicked. ([#4197](https://github.com/infor-design/enterprise/issues/4197))
-- `[Datagrid]` Fixed an issue where the 'value' and 'oldValue' on cell change event were showing escaped. ([#4028](https://github.com/infor-design/enterprise/issues/4028))
+- `[Datagrid]` Fixed an issue where the 'value' and 'oldValue' on cell change event where showing escaped. ([#4028](https://github.com/infor-design/enterprise/issues/4028))
 - `[Datagrid]` Fixed an issue where the keyword search was not working for group headers. ([#4068](https://github.com/infor-design/enterprise/issues/4068))
 - `[Datagrid]` Fixed an issue where the column filter results were inconsistent for tree grid. ([#4031](https://github.com/infor-design/enterprise/issues/4031))
 - `[Datagrid]` Fixed an issue where the data was not exporting to excel when using the groupable setting. ([#4081](https://github.com/infor-design/enterprise/issues/4081))
@@ -297,7 +298,6 @@
 - `[Custom Builds]` The build script can now produce an ES Module version of the components that can be imported by your application. ([#3771](https://github.com/infor-design/enterprise/issues/3771))
 - `[Datagrid]` Added a setting disableRowDeselection that if enabled does not allow selected rows to be toggled to deselected. ([#3791](https://github.com/infor-design/enterprise/issues/3791))
 - `[Datagrid]` Added an additional row size extra-small. This row size may need a bit of further fleshing out. All of the previous row sizes have been renamed but using the old settings are supported but deprecated. The new sizes are Extra Small, Small, Medium, Large (Normal). ([#3755](https://github.com/infor-design/enterprise/issues/3755))
-- `[Demoapp]` Added the ability to set runtime flags for persisting settings that were previously only possible to set via URL query parameters. ([n/a])
 - `[Demoapp]` Added the ability to set runtime flags for persisting settings that were previously only possible to set via URL query parameters. ([n/a])
 - `[Icons]` Changed the tree node icon to be more meaningful in uplift theme. Added a print-preview icon. This replaces the update-preview icon which has confusing meaning but was not removed.
 - `[Searchfield]` Added the ability to clear the searchfield by calling a public clear() function. ([#3810](https://github.com/infor-design/enterprise/issues/3810))
@@ -598,7 +598,7 @@
 - `[Contextual Action Panel]` Fixed close icon button in getting cut off on mobile view ([#3586](https://github.com/infor-design/enterprise/issues/3586))
 - `[Datagrid]` Fixed an issue where lookup editor was removing all characters following and including the '|' pipe character. ([#3556](https://github.com/infor-design/enterprise/issues/3556))
 - `[Datagrid]` Fixed an issue where date range filter was unable to filter data. ([#3503](https://github.com/infor-design/enterprise/issues/3503))
-- `[Datagrid]` Fixed a bug were datagrid tree would have very big text in the tree nodes on IOS. ([#3347](https://github.com/infor-design/enterprise/issues/3347))
+- `[Datagrid]` Fixed a bug where datagrid tree would have very big text in the tree nodes on IOS. ([#3347](https://github.com/infor-design/enterprise/issues/3347))
 - `[Datagrid]` Fixed a focus trap issue when using actionable mode, tab will now move up and down rows. ([#2399](https://github.com/infor-design/enterprise/issues/2399))
 - `[Datagrid]` Fixed a bug when setting the UI indicator with `setSortIndicator` then it would take two clicks to sort the inverse direction. ([#3391](https://github.com/infor-design/enterprise/issues/3391))
 - `[Datagrid]` Fixed an issue where date range filter was not working. ([#3337](https://github.com/infor-design/enterprise/issues/3337))

--- a/src/components/autocomplete/autocomplete.js
+++ b/src/components/autocomplete/autocomplete.js
@@ -641,6 +641,9 @@ Autocomplete.prototype = {
     clearTimeout(this.loadingTimeout);
 
     function done(searchTerm, response, deferredStatus) {
+      if (self.lastTerm !== searchTerm) {
+        return dfd.reject(searchTerm);
+      }
       self.element.triggerHandler('complete'); // For Busy Indicator
 
       /**
@@ -759,6 +762,7 @@ Autocomplete.prototype = {
         // Attempt to resolve source as a URL string.  Do an AJAX get with the URL
         const sourceURL = self.settings.source.toString();
         const request = $.getJSON(sourceURL + buffer);
+        this.lastTerm = buffer;
 
         request.done((data) => {
           done(buffer, data, true);

--- a/src/components/toolbar/readme.md
+++ b/src/components/toolbar/readme.md
@@ -74,7 +74,46 @@ If you want to have no action button (button with three dots) visible in the too
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+You can add custom id's/automation id's to the Toolbar that can be used for scripting using the `attributes` setting. This setting takes either an object or an array for setting multiple values such as an automation-id or other attributes.
+For example:
+
+```js
+  attributes: { name: 'id', value: args => `background-color` }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: { name: 'data-automation-id', value: 'my-unique-id' }
+```
+
+Setting the id/automation id with a string value:
+
+```js
+  attributes: [
+    { name: 'id', value: 'my-unique-id' },
+    { name: 'data-automation-id', value: 'my-unique-id' }
+  ]
+```
+
+These attributes can be added programmatically using the Toolbar API:
+
+```js
+  $('#my-toolbar').toolbar({
+    attributes: [
+      { name: 'data-automation-id', value: 'my-toolbar' }
+    ]
+  });
+```
+
+When passing attributes in this manner, the following elements within the Toolbar are appended with a `data-automation-id` attribute:
+
+- The main toolbar element with `my-toolbar`.
+- All toolbar buttons, with `my-toolbar-button-{0}` where `{0}` is the toolbar button's index.
+- One exception to the button rule is the More Actions button, which will be `my-toolbar-actionbutton`. The attributes setting is passed into the [Popupmenu API]('./popupmenu#testability') using this suffix.  All action button menu items are labeled at the Popupmenu API level.
+- If a [Searchfield]('./searchfield') is present, it will be labeled with `my-toolbar-searchfield`.
+
+Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
 
 ## Keyboard Shortcuts
 

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -241,8 +241,8 @@ Toolbar.prototype = {
     }
 
     const menuItems = [];
-    this.items.not(this.more).not('.ignore-in-menu').filter(menuItemFilter).each(function (i) {
-      menuItems.push(self.buildMoreActionsMenuItem($(this), i));
+    this.items.not(this.more).not('.ignore-in-menu').filter(menuItemFilter).each(function () {
+      menuItems.push(self.buildMoreActionsMenuItem($(this)));
     });
 
     menuItems.reverse();
@@ -259,10 +259,13 @@ Toolbar.prototype = {
     // use the toolbar's with an `actionbutton` suffix
     let moreMenuAttrs = this.settings.moreMenuSettings?.attributes;
     if (!moreMenuAttrs?.length) {
-      moreMenuAttrs = this.settings.attributes?.map(attr => ({
-        name: attr.name,
-        value: typeof attr.value === 'function' ? attr.value : `${attr.value}-actionbutton`
-      }));
+      moreMenuAttrs = this.settings.attributes?.map((attr) => {
+        const value = (typeof attr.value === 'function') ? attr.value : `${attr.value}-actionbutton`;
+        return {
+          name: attr.name,
+          value
+        };
+      });
     }
     if (!moreMenuAttrs?.length) {
       moreMenuAttrs = null;
@@ -344,11 +347,10 @@ Toolbar.prototype = {
    * allow events/properties to propagate when the More Actions item is acted upon.
    * @private
    * @param {jQuery[]} item the source item from the toolbar.
-   * @param {number} [index] an optional index value
    * @returns {jQuery[]} a jQuery-wrapped <li> representing a More Actions menu
    *  implementation of the toolbar item.
    */
-  buildMoreActionsMenuItem(item, index) {
+  buildMoreActionsMenuItem(item) {
     const isSplitButton = false;
     let popupLi;
 
@@ -456,9 +458,27 @@ Toolbar.prototype = {
       }
     }
 
+    const index = this.items.not(this.more).not('.searchfield').index(item);
     if (item.is('.btn-menu')) {
+      // Automatically apply attributes to menu buttons if attributes are set on the toolbar,
+      // but the menubutton doesn't have them.
+      // If no more menu attributes are directly added through settings,
+      // use the toolbar's with an `actionbutton` suffix
+      let menuBtnAttrs = this.settings.attributes?.map((attr) => {
+        const value = (typeof attr.value === 'function') ? attr.value : `${attr.value}-menubutton-${index}`;
+        return {
+          name: attr.name,
+          value
+        };
+      });
+      if (!menuBtnAttrs?.length) {
+        menuBtnAttrs = null;
+      }
+
       if (!item.data('popupmenu')) {
-        item.popupmenu();
+        item.popupmenu({
+          attributes: menuBtnAttrs
+        });
       } else if (!a.children('.icon.arrow').length) {
         a.append($.createIcon({
           classes: 'icon arrow icon-dropdown',


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When the autocomplete ajax calls are slow and you do a second request the dropdown will open with both requests. This fixes the issue

**Related github/jira issue (required)**:
Fixes #4387

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/autocomplete/example-index.html
- once the page loads open chrome tools and go to the network tab and set the speed to 3g
- type "a" and wait for the request to start
- quickly backspace and type "c"
- only the "c's" should show in the dropdown (last request)

**Included in this Pull Request**:
- [x] A note to the change log.
