### PR TITLE
4498 - Add automation id for tree and processindicator

### DIFF
--- a/app/views/components/processindicator/example-index.html
+++ b/app/views/components/processindicator/example-index.html
@@ -2,21 +2,21 @@
 <div class="row">
   <div class="four columns">
 
-    <div class="process-indicator">
+    <div class="process-indicator" id="pi1" data-automation-id="automation-pi1">
       <div class="display">
-        <span class="indicator darkest"></span>
-        <span class="separator darkest"></span>
-        <span class="indicator darker"></span>
-        <span class="separator darker"></span>
-        <span class="indicator lighter"></span>
-        <span class="separator lighter"></span>
-        <span class="indicator lightest"></span>
-        <span class="separator lightest"></span>
-        <span class="indicator current processing"></span>
-        <span class="separator"></span>
-        <span class="indicator"></span>
-        <span class="separator"></span>
-        <span class="indicator"></span>
+        <span class="indicator darkest" id="pi1-i0" data-automation-id="automation-pi1-i0"></span>
+        <span class="separator darkest" id="pi1-s0" data-automation-id="automation-pi1-s0"></span>
+        <span class="indicator darker" id="pi1-i1" data-automation-id="automation-pi1-i1"></span>
+        <span class="separator darker" id="pi1-s1" data-automation-id="automation-pi1-s1"></span>
+        <span class="indicator lighter" id="pi1-i2" data-automation-id="automation-pi1-i2"></span>
+        <span class="separator lighter" id="pi1-s2" data-automation-id="automation-pi1-s2"></span>
+        <span class="indicator lightest" id="pi1-i3" data-automation-id="automation-pi1-i3"></span>
+        <span class="separator lightest" id="pi1-s3" data-automation-id="automation-pi1-s3"></span>
+        <span class="indicator current processing" id="pi1-i4" data-automation-id="automation-pi1-i4"></span>
+        <span class="separator" id="pi1-s4" data-automation-id="automation-pi1-s4"></span>
+        <span class="indicator" id="pi1-i5" data-automation-id="automation-pi1-i5"></span>
+        <span class="separator" id="pi1-s5" data-automation-id="automation-pi1-s5"></span>
+        <span class="indicator" id="pi1-i6" data-automation-id="automation-pi1-i6"></span>
       </div>
       <div class="heading">
         Processing 3 Items

--- a/app/views/components/tree/example-ajax.html
+++ b/app/views/components/tree/example-ajax.html
@@ -36,32 +36,68 @@
 
   sampleDataNoID = [{
     "text": "Node One",
-    "extra": "test 1"
+    "extra": "test 1",
+    "attributes": [{
+      "name": "id",
+      "value": "tree-ajax-exp1-node1"
+    }, {
+      "name": "data-automation-id",
+      "value": "automation-id-tree-ajax-exp1-node1"
+    }]
   }, {
     "text": "Node Two",
     "open": false,
     "children": [],
-    "extra": "test 2"
+    "extra": "test 2",
+    "attributes": [{
+      "name": "id",
+      "value": "tree-ajax-exp1-node2"
+    }, {
+      "name": "data-automation-id",
+      "value": "automation-id-tree-ajax-exp1-node2"
+    }]
   }, {
     "text": "Node Three",
     "open": false,
     "children": null,
-    "extra": "test 3"
+    "extra": "test 3",
+    "attributes": [{
+      "name": "id",
+      "value": "tree-ajax-exp1-node3"
+    }, {
+      "name": "data-automation-id",
+      "value": "automation-id-tree-ajax-exp1-node3"
+    }]
   }];
 
 
-
+  var currentAutomationId = -1;
   //Can refer to the data set here
   $('#json-tree').tree({dataset: sampleDataNoID, source: function (req, response) {
     setTimeout(function () {
+      currentAutomationId++;
 
       var nodes = [{
         "id": "node2.1",
-        "text": "Node 2.1"
+        "text": "Node 2.1",
+        "attributes": [{
+          "name": "id",
+          "value": "tree-ajax-exp1-node21-" + currentAutomationId
+        }, {
+          "name": "data-automation-id",
+          "value": "automation-id-tree-ajax-exp1-node21-" + currentAutomationId
+        }]
       },{
         "id": "node2.2",
         "text": "Node 2.2",
-        "children": []
+        "children": [],
+        "attributes": [{
+          "name": "id",
+          "value": "tree-ajax-exp1-node22-" + currentAutomationId
+        }, {
+          "name": "data-automation-id",
+          "value": "automation-id-tree-ajax-exp1-node22-" + currentAutomationId
+        }]
       }];
 
       response(nodes);

--- a/app/views/components/tree/example-select-multiple.html
+++ b/app/views/components/tree/example-select-multiple.html
@@ -7,15 +7,15 @@
         <li>
             <a id="home" href="#">Home</a>
         </li>
-        <li><a id="about-us" href="#">About Us</a></li>
+        <li><a id="about-us" href="#" data-automation-attributes="{'attributes': [{'name': 'data-automation-id', 'value': 'tree-multiselect-exp1-about-us'}]}">About Us</a></li>
         <li class="is-open">
-            <a id="public-folder" href="#">Public Folders</a>
+            <a id="public-folder" href="#" data-automation-attributes="{'attributes': [{'name': 'data-automation-id', 'value': 'tree-multiselect-exp1-public-folder'}]}">Public Folders</a>
             <ul class="is-open root">
               <li class="is-open">
                   <a href="#" id="leadership">Leadership</a>
                   <ul class="is-open">
                     <li class="is-selected">
-                      <a id="shipment" href="#">Shipment</a>
+                      <a id="shipment" href="#" data-automation-attributes="{'attributes': [{'name': 'data-automation-id', 'value': 'tree-multiselect-exp1-shipment'}]}">Shipment</a>
                     </li>
                     <li>
                       <a id="network" href="#" class="is-disabled">Network</a>
@@ -157,7 +157,7 @@
   var api = elem.data('tree');
 
   //Add view jquery object
-  api.addNode({text: 'New Item 5', parent: $('#leadership'), id: 'new5'});
+  api.addNode({text: 'New Item 5', parent: $('#leadership'), id: 'new5', attributes: [{name: 'data-automation-id', value: 'tree-multiselect-exp1-newitem5'}]});
 
   elem
     .on('selected', function (e, args) {

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -64,7 +64,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [x] Popover
 - [x] Popupmenu
 - [x] Positive Negative
-- [ ] Processindicator
+- [x] Processindicator
 - [x] Progress
 - [x] Radar
 - [x] Radios
@@ -94,7 +94,7 @@ This list is a list of elements that have clickable items that need to be handle
 - [x] Toolbarsearchfield
 - [x] Toolbar Flex
 - [ ] Tooltip
-- [ ] Tree
+- [x] Tree
 - [x] Treemap
 - [x] Week View
 - [x] Wizard

--- a/src/components/processindicator/readme.md
+++ b/src/components/processindicator/readme.md
@@ -34,4 +34,26 @@ Here is an example of a compact process indicator. There are several classes in 
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+If automation id's or other attributes are needed for the Process Indicator component, simply add them directly to the markup:
+
+ ```html
+ <div class="process-indicator compact" id="pi1" data-automation-id="automation-pi1">
+   <div class="display">
+     <span class="indicator lightest" id="pi1-i0" data-automation-id="automation-pi1-i0"></span>
+     <span class="separator lightest" id="pi1-s0" data-automation-id="automation-pi1-s0"></span>
+     <span class="indicator current more-info" id="pi1-i1" data-automation-id="automation-pi1-i1"></span>
+     <span class="separator" id="pi1-s1" data-automation-id="automation-pi1-s1"></span>
+     <span class="indicator" id="pi1-i2" data-automation-id="automation-pi1-i2"></span>
+     <span class="separator" id="pi1-s2" data-automation-id="automation-pi1-s2"></span>
+     <span class="indicator" id="pi1-i3" data-automation-id="automation-pi1-i3"></span>
+   </div>
+   <div class="heading">
+     Rejected - More Information Required
+   </div>
+   <div class="sub-heading">
+     Today
+   </div>
+ </div>
+ ```
+
+ Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.

--- a/src/components/processindicator/readme.md
+++ b/src/components/processindicator/readme.md
@@ -36,24 +36,24 @@ Here is an example of a compact process indicator. There are several classes in 
 
 If automation id's or other attributes are needed for the Process Indicator component, simply add them directly to the markup:
 
- ```html
- <div class="process-indicator compact" id="pi1" data-automation-id="automation-pi1">
-   <div class="display">
-     <span class="indicator lightest" id="pi1-i0" data-automation-id="automation-pi1-i0"></span>
-     <span class="separator lightest" id="pi1-s0" data-automation-id="automation-pi1-s0"></span>
-     <span class="indicator current more-info" id="pi1-i1" data-automation-id="automation-pi1-i1"></span>
-     <span class="separator" id="pi1-s1" data-automation-id="automation-pi1-s1"></span>
-     <span class="indicator" id="pi1-i2" data-automation-id="automation-pi1-i2"></span>
-     <span class="separator" id="pi1-s2" data-automation-id="automation-pi1-s2"></span>
-     <span class="indicator" id="pi1-i3" data-automation-id="automation-pi1-i3"></span>
-   </div>
-   <div class="heading">
-     Rejected - More Information Required
-   </div>
-   <div class="sub-heading">
-     Today
-   </div>
+```html
+<div class="process-indicator compact" id="pi1" data-automation-id="automation-pi1">
+ <div class="display">
+   <span class="indicator lightest" id="pi1-i0" data-automation-id="automation-pi1-i0"></span>
+   <span class="separator lightest" id="pi1-s0" data-automation-id="automation-pi1-s0"></span>
+   <span class="indicator current more-info" id="pi1-i1" data-automation-id="automation-pi1-i1"></span>
+   <span class="separator" id="pi1-s1" data-automation-id="automation-pi1-s1"></span>
+   <span class="indicator" id="pi1-i2" data-automation-id="automation-pi1-i2"></span>
+   <span class="separator" id="pi1-s2" data-automation-id="automation-pi1-s2"></span>
+   <span class="indicator" id="pi1-i3" data-automation-id="automation-pi1-i3"></span>
  </div>
- ```
+ <div class="heading">
+   Rejected - More Information Required
+ </div>
+ <div class="sub-heading">
+   Today
+ </div>
+</div>
+```
 
- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.

--- a/src/components/tree/readme.md
+++ b/src/components/tree/readme.md
@@ -40,33 +40,33 @@ demo:
 
 You can add custom id's/automation id's to the tree that can be used for scripting using the `attributes` data attribute. This data attribute can be either an object or an array for setting multiple values such as an automation-id or other attributes. For example:
 
- Setting the id/automation id with a string value or function. The function will give you the data as a parameter for making things more dynamic.
+Setting the id/automation id with a string value or function. The function will give you the data as a parameter for making things more dynamic.
 
- ```html
- <li><a id="about-us" href="#" data-automation-attributes="{'attributes': [{'name': 'data-automation-id', 'value': 'tree-multiselect-exp1-about-us'}]}">About Us</a></li>
- ```
+```html
+<li><a id="about-us" href="#" data-automation-attributes="{'attributes': [{'name': 'data-automation-id', 'value': 'tree-multiselect-exp1-about-us'}]}">About Us</a></li>
+```
 
- ```js
- var data = [{
-   "text": "Node One",
-   "extra": "test 1",
-   "attributes": [{
-     "name": "data-automation-id",
-     "value": "tree-ajax-exp1-node1"
-   }]
- }, {
-   "text": "Node Two",
-   "open": false,
-   "children": [],
-   "extra": "test 2",
-   "attributes": [{
-     "name": "data-automation-id",
-     "value": "tree-ajax-exp1-node2"
-   }]
- }];
- $('#json-tree').tree({dataset: data});
- ```
+```js
+var data = [{
+ "text": "Node One",
+ "extra": "test 1",
+ "attributes": [{
+   "name": "data-automation-id",
+   "value": "tree-ajax-exp1-node1"
+ }]
+}, {
+ "text": "Node Two",
+ "open": false,
+ "children": [],
+ "extra": "test 2",
+ "attributes": [{
+   "name": "data-automation-id",
+   "value": "tree-ajax-exp1-node2"
+ }]
+}];
+$('#json-tree').tree({dataset: data});
+```
 
- Providing the data this will add an ID added to each link with `-tree-link`, link-text with `-tree-link-text`, icon with `-tree-icon`, expand target icon with `-tree-icon-expand-target` and checkbox with `-tree-checkbox` appended after it.
+Providing the data this will add an ID added to each link with `-tree-link`, link-text with `-tree-link-text`, icon with `-tree-icon`, expand target icon with `-tree-icon-expand-target` and checkbox with `-tree-checkbox` appended after it.
 
- - Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for general information.
+- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for general information.

--- a/src/components/tree/readme.md
+++ b/src/components/tree/readme.md
@@ -38,4 +38,35 @@ demo:
 
 ## Testability
 
-- Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for further details.
+You can add custom id's/automation id's to the tree that can be used for scripting using the `attributes` data attribute. This data attribute can be either an object or an array for setting multiple values such as an automation-id or other attributes. For example:
+
+ Setting the id/automation id with a string value or function. The function will give you the data as a parameter for making things more dynamic.
+
+ ```html
+ <li><a id="about-us" href="#" data-automation-attributes="{'attributes': [{'name': 'data-automation-id', 'value': 'tree-multiselect-exp1-about-us'}]}">About Us</a></li>
+ ```
+
+ ```js
+ var data = [{
+   "text": "Node One",
+   "extra": "test 1",
+   "attributes": [{
+     "name": "data-automation-id",
+     "value": "tree-ajax-exp1-node1"
+   }]
+ }, {
+   "text": "Node Two",
+   "open": false,
+   "children": [],
+   "extra": "test 2",
+   "attributes": [{
+     "name": "data-automation-id",
+     "value": "tree-ajax-exp1-node2"
+   }]
+ }];
+ $('#json-tree').tree({dataset: data});
+ ```
+
+ Providing the data this will add an ID added to each link with `-tree-link`, link-text with `-tree-link-text`, icon with `-tree-icon`, expand target icon with `-tree-icon-expand-target` and checkbox with `-tree-checkbox` appended after it.
+
+ - Please refer to the [Application Testability Checklist](https://design.infor.com/resources/application-testability-checklist) for general information.

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -1145,6 +1145,7 @@ Tree.prototype = {
       if (data.selected) {
         self.selectNode(a, data.focus);
       }
+      self.addAutomationAttributes(a, data);
       if (a.is('.hide-focus')) {
         a.hideFocus();
       }
@@ -1884,9 +1885,36 @@ Tree.prototype = {
         entry = $.extend({}, jsonData, entry);
       }
 
+      const autoAttr = utils.parseSettings(nodeJQ, 'data-automation-attributes');
+      if (autoAttr.attributes && jsonData) {
+        utils.extend(jsonData, autoAttr);
+        this.addAutomationAttributes(nodeJQ, jsonData);
+      }
       nodeJQ.data('jsonData', entry);
     }
     return entry;
+  },
+
+  /**
+  * Add automation attributes to given link items.
+  * @param {jQuery} a The main link href node.
+  * @param {object} nodeData The node data.
+  * @returns {void}
+  */
+  addAutomationAttributes(a, nodeData) {
+    a = this.isjQuery(a) ? a : $(a);
+    if (a.length && nodeData.attributes) {
+      const textEl = a.find('.tree-text');
+      const iconTree = a.find('.icon-tree');
+      const iconExpandTarget = a.find('.icon-expand-target');
+      const checkbox = a.find('.tree-checkbox');
+
+      utils.addAttributes(a, this, nodeData.attributes, 'tree-link');
+      utils.addAttributes(textEl, this, nodeData.attributes, 'tree-link-text');
+      utils.addAttributes(iconTree, this, nodeData.attributes, 'tree-icon');
+      utils.addAttributes(iconExpandTarget, this, nodeData.attributes, 'tree-icon-expand-target');
+      utils.addAttributes(checkbox, this, nodeData.attributes, 'tree-checkbox');
+    }
   },
 
   /**
@@ -2064,6 +2092,7 @@ Tree.prototype = {
     }
 
     a.data('jsonData', nodeData);
+    this.addAutomationAttributes(a, nodeData);
     this.createSortable();
     return li;
   },

--- a/test/components/tree/tree.e2e-spec.js
+++ b/test/components/tree/tree.e2e-spec.js
@@ -110,6 +110,21 @@ describe('Tree Ajax data tests', () => {
 
     expect(await element.all(by.css('.tree li')).count()).toBe(5);
   });
+
+  it('Should be able to set id/automation id example', async () => {
+    expect(await element(by.id('tree-ajax-exp1-node1-tree-link')).getAttribute('id')).toEqual('tree-ajax-exp1-node1-tree-link');
+    expect(await element(by.id('tree-ajax-exp1-node1-tree-link')).getAttribute('data-automation-id')).toEqual('automation-id-tree-ajax-exp1-node1-tree-link');
+    expect(await element(by.id('tree-ajax-exp1-node1-tree-icon')).getAttribute('id')).toEqual('tree-ajax-exp1-node1-tree-icon');
+    expect(await element(by.id('tree-ajax-exp1-node1-tree-icon')).getAttribute('data-automation-id')).toEqual('automation-id-tree-ajax-exp1-node1-tree-icon');
+
+    await element.all(by.css('.tree li.folder a[role="treeitem"]')).first().click();
+    await browser.driver.sleep(2500);
+
+    expect(await element(by.id('node2.1')).getAttribute('id')).toEqual('node2.1');
+    expect(await element(by.id('node2.1')).getAttribute('data-automation-id')).toEqual('automation-id-tree-ajax-exp1-node21-0-tree-link');
+    expect(await element(by.id('tree-ajax-exp1-node21-0-tree-icon')).getAttribute('id')).toEqual('tree-ajax-exp1-node21-0-tree-icon');
+    expect(await element(by.id('tree-ajax-exp1-node21-0-tree-icon')).getAttribute('data-automation-id')).toEqual('automation-id-tree-ajax-exp1-node21-0-tree-icon');
+  });
 });
 
 describe('Tree context menu tests', () => {
@@ -223,6 +238,23 @@ describe('Tree select-multiple tests', () => {
     expect(await element.all(by.css('.tree li.folder')).get(0).getAttribute('class')).toContain('is-partial');
     expect(await element.all(by.css('.tree li.folder')).get(0).getAttribute('class')).not.toContain('is-selected');
     expect(await element.all(by.css('.tree li.folder')).get(0).all(by.css('a[role="treeitem"].is-disabled')).count()).toBe(1);
+  });
+
+  it('Should be able to set id/automation id example', async () => {
+    expect(await element(by.id('about-us')).getAttribute('id')).toEqual('about-us');
+    expect(await element(by.id('about-us')).getAttribute('data-automation-id')).toEqual('tree-multiselect-exp1-about-us-tree-link');
+    expect(await element(by.css('#about-us .icon-tree')).getAttribute('data-automation-id')).toEqual('tree-multiselect-exp1-about-us-tree-icon');
+    expect(await element(by.css('#about-us .tree-checkbox')).getAttribute('data-automation-id')).toEqual('tree-multiselect-exp1-about-us-tree-checkbox');
+
+    expect(await element(by.id('public-folder')).getAttribute('id')).toEqual('public-folder');
+    expect(await element(by.id('public-folder')).getAttribute('data-automation-id')).toEqual('tree-multiselect-exp1-public-folder-tree-link');
+    expect(await element(by.css('#public-folder .icon-tree')).getAttribute('data-automation-id')).toEqual('tree-multiselect-exp1-public-folder-tree-icon');
+    expect(await element(by.css('#public-folder .tree-checkbox')).getAttribute('data-automation-id')).toEqual('tree-multiselect-exp1-public-folder-tree-checkbox');
+
+    expect(await element(by.id('shipment')).getAttribute('id')).toEqual('shipment');
+    expect(await element(by.id('shipment')).getAttribute('data-automation-id')).toEqual('tree-multiselect-exp1-shipment-tree-link');
+    expect(await element(by.css('#shipment .icon-tree')).getAttribute('data-automation-id')).toEqual('tree-multiselect-exp1-shipment-tree-icon');
+    expect(await element(by.css('#shipment .tree-checkbox')).getAttribute('data-automation-id')).toEqual('tree-multiselect-exp1-shipment-tree-checkbox');
   });
 });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adds the attributes/automation id/ id functionality for Tree and Processindicator.

**Related github/jira issue (required)**:
related to #4498

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app

Tree
- Navigate to:
- http://localhost:4000/components/tree/example-ajax.html
- http://localhost:4000/components/tree/example-select-multiple.html
- Check for `id` and `data-automation-id` attributes, get from the settings (for link, icon and checkbox)
- Review the text in the docs

Processindicator
- Navigate to: http://localhost:4000/components/processindicator/example-index.html
- Check for `id` and `data-automation-id` attributes, added directly from the markup (first example)
- Review the text in the docs

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.

<!-- After submitting your PR, please check back to make sure tests pass on Travis. -->
