### PR TITLE
4557 - Fix stripping of font-size

### DIFF
--- a/app/views/components/editor/example-preview.html
+++ b/app/views/components/editor/example-preview.html
@@ -17,6 +17,8 @@
         <p>Embrace <a href="http://en.wikipedia.org/wiki/e-commerce" class="hyperlink hide-focus">e-commerce action-items</a>, reintermediate, ecologies paradigms wireless share life-hacks create innovative harness. <b>Evolve solutions rich-clientAPIs</b> synergies harness relationships <i>virtual vertical facilitate end-to-end</i>, wireless, evolve synergistic synergies.</p>
         <p>Cross-platform, <font color="#de7223">evolve, ROI scale cultivate eyeballs</font> <font color="#56932e">addelivery</font>, e-services content cross-platform l<strike>everage extensible viral incentivize</strike> integrateAJAX-enabled sticky evolve magnetic cultivate leverage; cutting-edge.</p><blockquote>Innovate, end-to-end podcasting, whiteboard streamline e-business social; compelling, cross-media exploit infomediaries innovative integrate integrateAJAX-enabled.</blockquote>
         <p>Killer interactive reinvent, cultivate widgets leverage morph.</p><ul><li>Item One</li><li>Item Two</li><li>Item Three</li></ul>
+        <p><font size="+2">Supports Font Tag</font> </p>
+        <p style="font-size: 20px">Supports Font Size css</p>
       </div>
     </div>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,6 +57,7 @@
 - `[Dropdown]` Improved the behavior of the `noSearch` dropdown when using the keyboard. ([#4388](https://github.com/infor-design/enterprise/issues/4388))
 - `[Editor]` Fixed an issue where the focus was getting lost after pressing toolbar buttons. ([#4335](https://github.com/infor-design/enterprise/issues/4335))
 - `[Editor]` Fixed an issue where the color picker was not opening the popup for overflow menu and had name as undefined in list. ([#4398](https://github.com/infor-design/enterprise/issues/4398))
+- `[Editor]` Fixed an issue where font-size tags are stripped from the css. ([#4557](https://github.com/infor-design/enterprise/issues/4557))
 - `[Favorites]` Removed the favorites component as its not really a component, info on it can be found under buttons in the toggle example. ([#4405](https://github.com/infor-design/enterprise/issues/4405))
 - `[Fieldset]` Fixed a bug where summary form data gets cut off on a smaller viewport. ([#3861](https://github.com/infor-design/enterprise/issues/3861))
 - `[Homepage]` Fixed an issue where the four column widgets were incorrectly positioned, left aligned on large screen. ([#4541](https://github.com/infor-design/enterprise/issues/4541))

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -3194,7 +3194,7 @@ Editor.prototype = {
 
   // Strip styles
   stripStyles(s, styleStripper) {
-    const stylesToKeep = ['color', 'background', 'font-weight', 'font-style', 'text-decoration', 'text-align'];
+    const stylesToKeep = ['color', 'font-size', 'background', 'font-weight', 'font-style', 'text-decoration', 'text-align'];
     return s.replace(styleStripper, (m) => {
       m = m.replace(/( style=|("|\'))/gi, '');
       const attributes = m.split(';');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

LM uses font size css and font tag in the editor when they integrate with external tools. This was getting stripped out and causing end user confusion.

Removed this stripping.

**Related github/jira issue (required)**:
Fixes #4557

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/editor/example-preview.html
- notice i have a font size and font tag at the bottom in prevew
- go into edit mode
- should still show the  font size and font tag
- switch to preview
- should still show the  font size and font tag code
- switch back to edit mode
- should still show the  font size and font tag (before the font-size was stripped)


**Included in this Pull Request**:
- [x] A note to the change log.
