### PR TITLE
4474 - Fix the last option icon changes when filtering

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[Column Chart]` Fixed a minor alignment issue in the xAxis labels ([#4460](https://github.com/infor-design/enterprise/issues/4460))
 - `[Datagrid]` Fix a bug where changing selectable on the fly did not change the select behavior. ([#4575](https://github.com/infor-design/enterprise/issues/4575))
 - `[Datagrid]` Fixed a bug where the plus-minus icon were misaligned together with focus state on all row heights. ([#4480](https://github.com/infor-design/enterprise/issues/4480))
+- `[Dropdown]` Fixed a bug where the last option icon changes when searching/filtering in dropdown search field. ([#4474](https://github.com/infor-design/enterprise/issues/4474))
 - `[Editor/Fontpicker]` Fixed a bug where the label relationship were not valid in the editor role. Adding aria-labelledby will fix the association for both editor and the label. Also, added an audible label in fontpicker. ([#4454](https://github.com/infor-design/enterprise/issues/4454))
 - `[Lookup]` Fixed some layout issues when using the editable and clearable options on the filter row. ([#4527](https://github.com/infor-design/enterprise/issues/4527))
 - `[Tree]` Fixed an issue where the character entity references were render differently for parent and child levels. ([#4512](https://github.com/infor-design/enterprise/issues/4512))

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1665,6 +1665,10 @@ Dropdown.prototype = {
         return;
       }
 
+      if (this.list.find('ul li.hidden').length === 0) {
+        this.list.find(' > svg.listoption-icon').changeIcon('icon-empty-circle');
+      }
+
       filter();
     }, self.settings.delay);
   },

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1666,7 +1666,7 @@ Dropdown.prototype = {
       }
 
       if (this.list.find('ul li.hidden').length === 0) {
-        this.list.find(' > svg.listoption-icon').changeIcon('icon-empty-circle');
+        this.list.find(' > svg.listoption-icon:not(.swatch)').changeIcon('icon-empty-circle');
       }
 
       filter();

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1262,10 +1262,6 @@ Dropdown.prototype = {
 
     term = '';
     this.position();
-
-    if (hasIcons && this.list.find('svg').length > 2) {
-      this.list.find('svg').last().changeIcon('icon-empty-circle');
-    }
   },
 
   /**
@@ -1321,10 +1317,6 @@ Dropdown.prototype = {
 
     lis.removeClass('hidden');
     this.position();
-
-    if (hasIcons && this.list.find('svg').length > 2) {
-      this.list.find('svg').last().changeIcon('icon-empty-circle');
-    }
 
     if (this.list.find('svg').length === 2) {
       this.list.find('svg').last().remove();

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -736,3 +736,30 @@ describe('Dropdown selectValue() tests', () => {
     });
   }
 });
+
+describe('Dropdown with icons tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/dropdown/example-icons');
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should not change the last option icon when filtering', async () => {
+    const dropdownEl = await element(by.css('select#example-icon + .dropdown-wrapper .dropdown'));
+
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(dropdownEl), config.waitsFor);
+    await browser.driver.sleep(config.sleep);
+    await dropdownEl.click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('ul[role="listbox"]'))), config.waitsFor);
+    await browser.driver.sleep(config.sleep);
+
+    const searchEl = await element(by.css('.dropdown-search'));
+    await searchEl.clear().sendKeys(protractor.Key.BACK_SPACE);
+
+    expect(await element(by.css('#list-option-4 svg use[href="#icon-notes"]')).getAttribute('href')).toEqual('#icon-notes');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes the last option icon when filtering in dropdown search field. Removing the script that changes the last icon to `icon-empty-circle`.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/4474

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/dropdown/example-icons
- In first element, click on the dropdown and remove the text in the search field
- It should not change the last icon to `icon-empty-circle`
- It should add `icon-empty-circle` in search field only (Updated)

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
