### PR TITLE
NG#915 - Fix issue where closing About after closing nested Modal was impossible

### DIFF
--- a/app/views/components/about/test-nested.html
+++ b/app/views/components/about/test-nested.html
@@ -1,0 +1,34 @@
+<div class="row">
+  <div class="twelve columns">
+    <button type="button" class="btn-secondary" id="about-trigger">Show About Screen</button>
+  </div>
+</div>
+
+<script>
+  $('#about-trigger').on('click', function () {
+    // Show About Screen
+    $('body').about({
+      appName: 'IDS Enterprise',
+      productName: 'Controls',
+      showCloseBtn: true,
+      version: '4.0.0',
+      content: '<p><button id="modal-trigger" class="btn-primary">Open Nested Modal</button></p>',
+      attributes: [
+        { name: 'id', value: 'about-modal' },
+        { name: 'data-automation-id', value: 'about-modal' }
+      ],
+    });
+
+    // Show Nested Modal
+    $('#modal-trigger').on('click', function () {
+      $('body').modal({
+        content: '<p>Here\'s another Modal!</p>',
+        showCloseBtn: true,
+        attributes: [
+          { name: 'id', value: 'nested-modal' },
+          { name: 'data-automation-id', value: 'nested-modal' }
+        ]
+      });
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### v4.35.0 Fixes
 
+- `[About]` Made it possible to close About dialogs that previously had open, nested Modals present. ([NG#915](https://github.com/infor-design/enterprise-ng/issues/915))
 - `[Button]` Fixed the tooltip in action button to be not visible when there's no title attribute. ([#4473](https://github.com/infor-design/enterprise/issues/4473))
 - `[Badges]` Fixed alignment issues in uplift theme. ([#4578](https://github.com/infor-design/enterprise/issues/4578))
 - `[Column Chart]` Fixed a minor alignment issue in the xAxis labels ([#4460](https://github.com/infor-design/enterprise/issues/4460))

--- a/src/components/about/about.js
+++ b/src/components/about/about.js
@@ -142,7 +142,15 @@ About.prototype = {
     $('.modal-body', this.modal)[0].tabIndex = 0;
 
     this.modal.appendTo('body');
-    this.modal.modal({ trigger: this.isBody ? 'immediate' : 'click', attributes: this.settings.attributes });
+    this.modal.modal({
+      trigger: this.isBody ? 'immediate' : 'click',
+      attributes: this.settings.attributes
+    });
+
+    // Link the About API to the Modal API
+    const modalAPI = this.modal.data('modal');
+    modalAPI.aboutAPI = this;
+
     return this;
   },
 
@@ -240,6 +248,7 @@ About.prototype = {
       const modalApi = this.modal.data('modal');
       if (modalApi) {
         modalApi.element.off('beforeopen.about');
+        modalApi.aboutAPI = null;
         modalApi.destroy();
       }
     }

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -110,19 +110,6 @@ Modal.prototype = {
 
   /**
    * @private
-   */
-  get aboutAPI() {
-    let api;
-    if (this.trigger && this.trigger.length) {
-      api = this.trigger.data('about');
-    } else if (this.mainContent && this.mainContent.length && this.mainContent.is('body')) {
-      api = this.mainContent.data('about');
-    }
-    return api;
-  },
-
-  /**
-   * @private
    * @returns {boolean} whether or not the Modal is a Contextual Action Panel (CAP)
    */
   get isCAP() {

--- a/test/components/about/about.e2e-spec.js
+++ b/test/components/about/about.e2e-spec.js
@@ -114,3 +114,37 @@ describe('About Event tests', () => {
     await utils.checkForErrors();
   });
 });
+
+describe('About Nested Tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/about/test-nested');
+  });
+
+  it('Should be able to use both close buttons', async () => {
+    // Open About
+    await element(by.id('about-trigger')).click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('about-modal'))), config.waitsFor);
+
+    // Open Nested Modal
+    await element(by.id('modal-trigger')).click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('nested-modal'))), config.waitsFor);
+
+    expect(await element(by.id('nested-modal')).isDisplayed()).toBeTruthy();
+
+    // Close Nested Modal
+    await element(by.id('nested-modal-btn-close')).click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.invisibilityOf(await element(by.id('nested-modal'))), config.waitsFor);
+
+    // Close About
+    await element(by.id('about-modal-btn-close')).click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.invisibilityOf(await element(by.id('about-modal'))), config.waitsFor);
+
+    expect(await element(by.id('about-modal')).isPresent()).toBeFalsy();
+
+    await utils.checkForErrors();
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes an issue where the About dialog was unable to be closed by click, after a nested modal had previously been closed.  

**Related github/jira issue (required)**:
- Related to infor-design/enterprise-ng#915
- Depended on by infor-design/enterprise-ng#937 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the demoapp
- Open http://localhost:4000/components/about/test-nested.html
- Click "Open About Screen"
- Inside the About dialog, click the "Open Nested Modal" button
- Click the "X" button inside the nested modal to close it
- Click the "X" button inside the About dialog.  It should close the About dialog as expected.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.