### PR TITLE
938 - Fix abort method with fileupload advanced

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[Datagrid]` Fixed a bug where the plus-minus icon were misaligned together with focus state on all row heights. ([#4480](https://github.com/infor-design/enterprise/issues/4480))
 - `[Dropdown]` Fixed a bug where the last option icon changes when searching/filtering in dropdown search field. ([#4474](https://github.com/infor-design/enterprise/issues/4474))
 - `[Editor/Fontpicker]` Fixed a bug where the label relationship were not valid in the editor role. Adding aria-labelledby will fix the association for both editor and the label. Also, added an audible label in fontpicker. ([#4454](https://github.com/infor-design/enterprise/issues/4454))
+- `[FileUploadAdvanced]` Fixed an issue where abort method was not working properly to remove the file block when upload fails. ([#938](https://github.com/infor-design/enterprise-ng/issues/938))
 - `[Lookup]` Fixed some layout issues when using the editable and clearable options on the filter row. ([#4527](https://github.com/infor-design/enterprise/issues/4527))
 - `[Tree]` Fixed an issue where the character entity references were render differently for parent and child levels. ([#4512](https://github.com/infor-design/enterprise/issues/4512))
 

--- a/src/components/fileupload-advanced/fileupload-advanced.js
+++ b/src/components/fileupload-advanced/fileupload-advanced.js
@@ -389,7 +389,9 @@ FileUploadAdvanced.prototype = {
         * @property {object} file - aborted
         */
         this.element.triggerHandler('fileaborted', [file]);
-        jqxhr.abort();
+        if (jqxhr && typeof jqxhr.abort === 'function') {
+          jqxhr.abort();
+        }
         btnCancel.off('click.fileuploadadvanced');
         container.remove();
       });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed abort method was not working properly to remove the file block when upload fails with fileupload advanced.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#938

**Steps necessary to review your pull request (required)**:
- Pull and build this branch
- Pull and build NG branch ([938-fileupload-advanced-ngsend](https://github.com/infor-design/enterprise-ng/tree/938-fileupload-advanced-ngsend))
- Copy and replace "dist" folder from `enterprise` to `⁨enterprise-ng⁩/node_modules⁩/ids-enterprise`
- Navigate to http://localhost:4200/ids-enterprise-ng-demo/fileupload-advanced
- Open developer tools
- Use last field on the page labeled as: `Send Method`
- Upload a file
- Should get an alert, click `OK` on alert
- Should show error on console
- Click on `(x)` button on file block
- Should remove the file block, and see console should log

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
