### PR TITLE
4485 - Add setting for selection on enter edit mode with datagrid

### DIFF
--- a/app/views/components/datagrid/test-editable-select-on-edit.html
+++ b/app/views/components/datagrid/test-editable-select-on-edit.html
@@ -1,0 +1,190 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <div role="toolbar" class="toolbar">
+
+      <div class="title">
+        Data Grid Header Title
+        <span class="datagrid-result-count">(N Results)</span>
+      </div>
+
+      <div class="buttonset">
+          <button type="button" id="toggle-row-status" class="btn">
+            <span>Add Row Status</span>
+          </button>
+          <button type="button" id="validate" class="btn-menu">
+            <span>Validate</span>
+          </button>
+          <ul class="popupmenu">
+            <li><a href="#" data-action="specific-row-error">Specific Row Error</a></li>
+            <li><a href="#" data-action="all-cells-in-row">All Cells in Row</a></li>
+            <li><a href="#" data-action="all-rows-and-cells">All Rows and Cells</a></li>
+            <li class="separator"></li>
+            <li><a href="#" data-action="clear-specific-row-error">Clear Specific Row Error</a></li>
+            <!-- <li><a href="#" data-action="clear-all-cells-in-row">Clear All Cells in Row</a></li> -->
+            <li><a href="#" data-action="clear-all-rows-and-cells">Clear All Rows and Cells</a></li>
+          </ul>
+        <button class="btn-icon" type="button" id="add-btn">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-add"></use>
+          </svg>
+          <span class="audible">Add</span>
+        </button>
+      </div>
+
+      <div class="more">
+        <button class="btn-actions" type="button">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-more"></use>
+          </svg>
+          <span class="audible">More Actions</span>
+        </button>
+        <ul class="popupmenu">
+          <li class="single-selectable-section"></li>
+          <li class="heading">Row Height</li>
+          <li class="is-selectable"><a data-option="row-extra-small" href="#" data-translate="text">ExtraSmall</a></li>
+          <li class="is-selectable"><a data-option="row-small" href="#" data-translate="text">Small</a></li>
+          <li class="is-selectable"><a data-option="row-medium" href="#" data-translate="text">Medium</a></li>
+          <li class="is-selectable is-checked"><a data-option="row-large" href="#" data-translate="text">Large</a></li>
+        </ul>
+
+      </div>
+    </div>
+
+    <div class="contextual-toolbar toolbar is-hidden">
+      <div class="title selection-count">1 Selected</div>
+      <div class="buttonset">
+        <button class="btn-icon" type="button" id="remove-btn">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-delete"></use>
+          </svg>
+          <span class="audible">Remove</span>
+        </button>
+      </div>
+    </div>
+
+    <div id="datagrid"></div>
+  </div>
+</div>
+
+<script>
+  var gridApi = null;
+
+  $('body').one('initialized', function () {
+    var grid,
+      columns = [],
+      data = [];
+
+    var isDisabled = function(row, cell, value, item) {
+      return (row % 2 === 0);
+    }
+
+    // Some Sample Data
+    data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity: '<svg/onload=alert(1)>', quantity: 1, price: 210.99, status: 'OK', orderDate: '00000000', portable: false, action: 1, description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning'});
+    data.push({ id: 2, productId: 2241202, productName: 'console.log', activity: 'Inspect and Repair', quantity: 2, price: 210.991, status: '', orderDate: '', portable: false, action: 1, description: 'The kit has an air blow gun that can be used for cleaning'});
+    data.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity: '', portable: true, quantity: null, price: 120.992, status: null, orderDate: new Date(2014, 6, 3), action: 2});
+    data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity: 'Assemble Paint', portable: true, quantity: 3, price: null, status: 'OK', orderDate: new Date(2015, 3, 3), action: 3, description: 'Compressor comes with with air tool kit'});
+    data.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 1});
+    data.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity: 'Inspect and Repair', portable: false, quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 2});
+    data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity: 'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 2});
+
+    //Define Columns for the Grid.
+    // columns.push({ id: 'rowStatus', sortable: false, resizable: false, formatter: Formatters.Status, align: 'center'});
+    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
+    columns.push({ id: 'id', name: 'Row Id', field: 'id', formatter: Formatters.Readonly});
+    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input});
+    columns.push({ id: 'activity', name: 'Activity', field: 'activity', required: true, editor: Editors.Input, validate: 'required'});  //maxLength: 2
+    columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', align: 'right', editor: Editors.Input, mask: '###', isEditable: isDisabled});
+    columns.push({ id: 'portable', name: 'Portable', field: 'portable', align: 'center', formatter: Formatters.Checkbox, editor: Editors.Checkbox});
+    columns.push({ id: 'price', name: 'Price', field: 'price', align: 'right', formatter: Formatters.Decimal, validate: 'required', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input});
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date , validate: 'required date', width: 120});
+    columns.push({ id: 'action', name: 'Action', field: 'action', formatter: Formatters.Dropdown, editor: Editors.Dropdown, validate: 'required', isEditable: isDisabled,
+    options: [{id: '', label: '', value: -1}, {id: 'oh1', label: 'On Hold', value: 1}, {id: 'sh1', label: 'Shipped', value: 2} , {id: 'ac1', label: 'Action', value: 3}, {id: 'pen', label: 'Pending', value: 4}, {id: 'bk1', label: 'Backorder', value: 5}, {id: 'can', label: 'Cancelled', value: 6}, {id: 'pro', label: 'Processing', value: 7}]
+    });
+
+    //Init and get the api for the grid
+    grid = $('#datagrid').datagrid({
+      columns: columns,
+      dataset: data,
+      editable: true,
+      selectOnEdit: false,
+      showNewRowIndicator: false,
+      clickToSelect: false,
+      selectable: 'multiple',
+      toolbar: {title: 'Data Grid Header Title', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: true,  collapsibleFilter: true},
+      paging: true,
+      pagesize: 5,
+      pagesizes: [2, 5, 6]
+    }).on('cellchange', function (e, args) {
+      console.log('cellchange', args);
+    }).on('rowadd', function (e, args) {
+      console.log(e, args);
+    }).on('rowremove', function (e, args) {
+      console.log(e, args);
+    }).on('dblclick', function (e, args) {
+      console.log('dblclick', args);
+    });
+
+    gridApi = $('#datagrid').data('datagrid');
+
+    //Example row status
+    $('#toggle-row-status').on('click', function () {
+      var btn = $(this).find('span');
+      var status = {
+        add: 'Add Row Status',
+        remove: 'Remove Row Status'
+      };
+      if (btn.text() === status.add) {
+        btn.text(status.remove);
+        gridApi.rowStatus(0, 'error', 'Error');
+        gridApi.rowStatus(0, 'error', 'Error 2');
+        gridApi.rowStatus(0, 'error', 'Error 3');
+        gridApi.rowStatus(1, 'alert', 'Alert');
+        gridApi.rowStatus(2, 'info', 'Info');
+        gridApi.rowStatus(3, 'in-progress', 'inProgress');
+        gridApi.rowStatus(4, 'success', 'Confirm');
+        gridApi.rowStatus(6, 'new', 'new');
+        gridApi.rowStatus(6, 'error', 'This row has errors');
+      } else {
+        btn.text(status.add);
+        gridApi.resetRowStatus();
+      }
+    });
+
+    window.data = data;
+  });
+
+  var newId = 8;
+  //Add Code for Add and icon-delete
+  $('#add-btn').on('click', function () {
+    gridApi.addRow({ id: newId++, productId: 2642206, productName: 'New Product'});
+    console.log(gridApi.settings.dataset[1]);
+  });
+
+  //Add Code for Add and icon-delete
+  $('#remove-btn').on('click', function () {
+    gridApi.removeSelected();
+  });
+
+  //A few other ways
+  $('#validate').on('selected', function (e, args) {
+    var action = args.attr('data-action');
+
+    if (action === 'specific-row-error') {
+      gridApi.showRowError(2, 'This row has a custom error message.', 'error');
+    }
+    if (action === 'all-cells-in-row') {
+      gridApi.validateRow(2);
+    }
+    if (action === 'all-rows-and-cells') {
+      gridApi.validateAll();
+    }
+    if (action === 'clear-specific-row-error') {
+      gridApi.clearRowError(2);
+    }
+    if (action === 'clear-all-rows-and-cells') {
+      gridApi.clearAllErrors();
+    }
+  });
+
+</script>

--- a/app/views/components/datagrid/test-editable-spinbox.html
+++ b/app/views/components/datagrid/test-editable-spinbox.html
@@ -30,8 +30,8 @@
         //Define Columns for the Grid.
         columns.push({ id: 'productId', name: 'Product Id', field: 'productId'});
         columns.push({ id: 'productName', name: 'Product Name', field: 'productName', editor: Editors.Input});
-        columns.push({ id: 'spinBox1', name: 'Spinbox Max (50)', field: 'quantity', formatter: Formatters.Spinbox, editor: Editors.Spinbox, editorOptions: {min: -99, max: 99, step: 3}, width: 150});
-        columns.push({ id: 'spinBox2', name: 'Spinbox', field: 'price', formatter: Formatters.Spinbox, editor: Editors.Spinbox, editorOptions: {min: 0, max: 50}, width: 150});
+        columns.push({ id: 'spinBox1', name: 'Spinbox Max (50)', field: 'quantity', formatter: Formatters.Spinbox, editor: Editors.Spinbox, editorOptions: {min: 0, max: 50}, width: 150});
+        columns.push({ id: 'spinBox2', name: 'Spinbox (step-3)', field: 'price', formatter: Formatters.Spinbox, editor: Editors.Spinbox, editorOptions: {step: 3}, width: 150});
         columns.push({ id: 'buffer', name: '', field: ''});
 
         //Init and get the api for the grid

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[Column Chart]` Fixed a minor alignment issue in the xAxis labels ([#4460](https://github.com/infor-design/enterprise/issues/4460))
 - `[Datagrid]` Fix a bug where changing selectable on the fly did not change the select behavior. ([#4575](https://github.com/infor-design/enterprise/issues/4575))
 - `[Datagrid]` Fixed an issue where the click event was not fire for hyperlinks keyword search results. ([#4550](https://github.com/infor-design/enterprise/issues/4550))
+- `[Datagrid]` Added api setting for selection on enter edit mode. ([#4485](https://github.com/infor-design/enterprise/issues/4485))
 - `[Datagrid]` Fixed a bug where the plus-minus icon were misaligned together with focus state on all row heights. ([#4480](https://github.com/infor-design/enterprise/issues/4480))
 - `[Dropdown]` Fixed a bug where the last option icon changes when searching/filtering in dropdown search field. ([#4474](https://github.com/infor-design/enterprise/issues/4474))
 - `[Editor/Fontpicker]` Fixed a bug where the label relationship were not valid in the editor role. Adding aria-labelledby will fix the association for both editor and the label. Also, added an audible label in fontpicker. ([#4454](https://github.com/infor-design/enterprise/issues/4454))

--- a/src/components/datagrid/datagrid.editors.js
+++ b/src/components/datagrid/datagrid.editors.js
@@ -85,7 +85,7 @@ function addStandardInputFeatures(input, row, cell, value, container, column, e,
 }
 
 /**
-*  A object containing all the supported Editors
+*  A object containing all the supported Editors.
 * @private
 */
 const editors = {

--- a/src/components/datagrid/datagrid.editors.js
+++ b/src/components/datagrid/datagrid.editors.js
@@ -120,7 +120,10 @@ const editors = {
     };
 
     this.focus = function () {
-      this.input.focus().select();
+      this.input.focus();
+      if (api.settings.selectOnEdit) {
+        this.input.select();
+      }
     };
 
     this.destroy = function () {
@@ -136,7 +139,7 @@ const editors = {
     this.init();
   },
 
-  Textarea(row, cell, value, container, column) {
+  Textarea(row, cell, value, container, column, e, api) {
     this.name = 'textarea';
     this.originalValue = value;
 
@@ -153,8 +156,8 @@ const editors = {
       }
       this.api = this.input.data('autogrow-start-height', autogrowStartHeight).textarea(column.editorOptions).data('textarea');
 
-      this.input.on('click.textareaeditor', (e) => {
-        e.stopPropagation();
+      this.input.on('click.textareaeditor', (evt) => {
+        evt.stopPropagation();
       });
 
       if (column.maxLength) {
@@ -175,7 +178,10 @@ const editors = {
     };
 
     this.focus = function () {
-      this.input.focus().select();
+      this.input.focus();
+      if (api.settings.selectOnEdit) {
+        this.input.select();
+      }
     };
 
     this.destroy = function () {
@@ -345,7 +351,10 @@ const editors = {
       this.input.trigger('openlist');
       const rowNodes = grid.rowNodes(row);
       rowNodes.removeClass('is-hover-row');
-      this.input.focus().select();
+      this.input.focus();
+      if (grid.settings.selectOnEdit) {
+        this.input.select();
+      }
 
       this.input.off('listclosed').on('listclosed', () => {
         grid.commitCellEdit(self.input);
@@ -490,6 +499,21 @@ const editors = {
         this.input[0].parentNode.querySelector('div.dropdown').focus();
       }
 
+      // Unselect dropdown search, and move cursor at end
+      if (!grid.settings.selectOnEdit) {
+        const ddSearch = $('#dropdown-search')[0];
+        if (ddSearch) {
+          if (typeof ddSearch.selectionStart === 'number') {
+            ddSearch.selectionEnd = ddSearch.value.length;
+            ddSearch.selectionStart = ddSearch.selectionEnd;
+          } else if (typeof ddSearch.createTextRange !== 'undefined') {
+            const range = ddSearch.createTextRange();
+            range.collapse(false);
+            range.select();
+          }
+        }
+      }
+
       this.input.off('listclosed').on('listclosed', (e, type) => {
         grid.commitCellEdit(self.input);
 
@@ -537,7 +561,10 @@ const editors = {
     this.focus = function () {
       const self = this;
 
-      this.input.select().focus();
+      this.input.focus();
+      if (grid.settings.selectOnEdit) {
+        this.input.select();
+      }
 
       // Check if isClick or cell touch and just open the list
       if (event.type === 'click' && $(event.target).is('.icon')) {
@@ -725,7 +752,10 @@ const editors = {
     this.focus = function () {
       const self = this;
 
-      this.input.select().focus();
+      this.input.focus();
+      if (grid.settings.selectOnEdit) {
+        this.input.select();
+      }
 
       // Check if isClick or cell touch and just open the list
       if (event.type === 'click' && $(event.target).is('.icon')) {
@@ -811,7 +841,10 @@ const editors = {
 
       // Using keyboard
       if (event.type === 'keydown') {
-        self.input.select().focus();
+        self.input.focus();
+        if (grid.settings.selectOnEdit) {
+          self.input.select();
+        }
         td.on('keydown.editorlookup', (e) => {
           if (e.keyCode === 40) {
             e.preventDefault();
@@ -825,7 +858,10 @@ const editors = {
         if ($(event.target).is('svg')) {
           api.openDialog(event);
         } else {
-          self.input.select().focus();
+          self.input.focus();
+          if (grid.settings.selectOnEdit) {
+            self.input.select();
+          }
           td.on('touchcancel.editorlookup touchend.editorlookup', '.trigger', () => {
             api.openDialog();
           });
@@ -882,7 +918,10 @@ const editors = {
 
     this.focus = function () {
       grid.quickEditMode = true;
-      this.input.select().focus();
+      this.input.focus();
+      if (grid.settings.selectOnEdit) {
+        this.input.select();
+      }
     };
 
     this.destroy = function () {
@@ -896,13 +935,14 @@ const editors = {
   },
 
   Spinbox(ow, cell, value, container, column, event, grid) {
+    const self = this;
     this.name = 'spinbox';
     this.originalValue = value;
     this.useValue = true; // use the data set value not cell value
 
     this.init = function () {
       if (column.inlineEditor) {
-        this.input = container.find('input');
+        self.input = container.find('input');
         return;
       }
 
@@ -912,25 +952,28 @@ const editors = {
         <span class="spinbox-control up">+</span></span>`;
 
       DOM.append(container, markup, '<label><span><input>');
-      this.input = container.find('input');
+      self.input = container.find('input');
 
       if (!column.editorOptions) {
         column.editorOptions = {};
       }
 
-      this.input.spinbox(column.editorOptions);
+      self.input.spinbox(column.editorOptions);
     };
 
     this.val = function (v) {
       if (v) {
-        this.input.val(v);
+        self.input.val(v);
       }
-      return parseInt(this.input.val(), 10);
+      return parseInt(self.input.val(), 10);
     };
 
     this.focus = function () {
       grid.quickEditMode = true;
-      this.input.select().focus();
+      self.input.focus();
+      if (grid.settings.selectOnEdit) {
+        self.input.select();
+      }
     };
 
     this.destroy = function () {
@@ -940,12 +983,12 @@ const editors = {
 
       setTimeout(() => {
         grid.quickEditMode = false;
-        const textVal = this.val();
-        if (this.input && this.input.data('spinbox')) {
-          this.input.data('spinbox').destroy();
+        const textVal = self.val();
+        if (self.input && self.input.data('spinbox')) {
+          self.input.data('spinbox').destroy();
         }
-        if (this.input) {
-          this.input.remove();
+        if (self.input) {
+          self.input.remove();
         }
         container.text(textVal);
       }, 0);

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -62,6 +62,7 @@ const COMPONENT_NAME = 'datagrid';
  * @param {object}   [settings.saveUserSettings.filter=true]
  * @param {boolean}  [settings.focusAfterSort=false] If true will focus the active cell after sorting.
  * @param {boolean}  [settings.editable=false] Enable editing in the grid, requires column editors.
+ * @param {boolean}  [settings.selectOnEdit=true] if true, will select the cell text soon get to edit mode.
  * @param {Function}  [settings.isRowDisabled=null] Allows you to provide a function so you can set some rows to disabled base on data or row index.
  * @param {boolean}  [settings.isList=false] Makes the grid have readonly "list" styling
  * @param {string}   [settings.menuId=null]  ID of the menu to use for a row level right click context menu
@@ -165,6 +166,7 @@ const DATAGRID_DEFAULTS = {
   saveUserSettings: {},
   focusAfterSort: false, // If true will focus the active cell after sorting.
   editable: false,
+  selectOnEdit: true,
   isRowDisabled: null,
   isList: false, // Makes a readonly "list"
   menuId: null, // Id to the right click context menu

--- a/test/components/datagrid/datagrid-settings.func-spec.js
+++ b/test/components/datagrid/datagrid-settings.func-spec.js
@@ -56,6 +56,7 @@ describe('Datagrid Settings', () => { //eslint-disable-line
       saveUserSettings: {},
       focusAfterSort: false,
       editable: false,
+      selectOnEdit: true,
       isRowDisabled: null,
       isList: false,
       menuId: null,


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added setting for selection on enter edit mode with Datagrid.

**Related github/jira issue (required)**:
Closes #4485

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/test-editable-select-on-edit.html
- Click on any editable cell, text should `not` be selected
- Navigate to: http://localhost:4000/components/datagrid/test-cell-edit-callback.html
- Click on any editable cell, text should be selected

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
