### PR TITLE
4613 - Fix broken date/time mask on sv-SE locale

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Editor/Fontpicker]` Fixed a bug where the label relationship were not valid in the editor role. Adding aria-labelledby will fix the association for both editor and the label. Also, added an audible label in fontpicker. ([#4454](https://github.com/infor-design/enterprise/issues/4454))
 - `[FileUploadAdvanced]` Fixed an issue where abort method was not working properly to remove the file block when upload fails. ([#938](https://github.com/infor-design/enterprise-ng/issues/938))
 - `[Lookup]` Fixed some layout issues when using the editable and clearable options on the filter row. ([#4527](https://github.com/infor-design/enterprise/issues/4527))
+- `[Mask]` Fixed broken date/time masks in the `sv-SE` locale. ([#4613](https://github.com/infor-design/enterprise/issues/4613))
 - `[Tree]` Fixed an issue where the character entity references were render differently for parent and child levels. ([#4512](https://github.com/infor-design/enterprise/issues/4512))
 
 ## v4.34.2

--- a/src/components/mask/masks.js
+++ b/src/components/mask/masks.js
@@ -429,6 +429,9 @@ function getSplitterRegex(splitterStr) {
     if (c === ' ') { // convert space characters into white space matcher
       c = '\\s';
     }
+    if (c === '-') { // escape dashes that might be part of date formats
+      c = '\\-';
+    }
     return c;
   });
   return new RegExp(`[(${fixedArr.join('|')})]+`);

--- a/test/components/mask/mask.e2e-spec.js
+++ b/test/components/mask/mask.e2e-spec.js
@@ -100,3 +100,21 @@ describe('Number Masks', () => {
     await (utils.checkForErrors());
   });
 });
+
+describe('Date Masks (custom formats)', () => {
+  it('correctly allows typing on sv-SE locale', async () => {
+    // Load the page
+    await utils.setPage('/components/datepicker/example-timeformat?locale=sv-SE');
+    const inputEl = await element(by.id('dp1'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(inputEl), config.waitsFor);
+    await browser.driver.sleep(config.sleepShort);
+
+    await inputEl.clear();
+    await inputEl.sendKeys('202002022200');
+
+    expect(await inputEl.getAttribute('value')).toEqual('2020-02-02 22:00');
+
+    await (utils.checkForErrors());
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR follows up the changes we made for #4079 to allow independently-editable date mask sections.  There was a bug in the way the new regex patterns handle date formats containing the `-` where the dash would incorrectly setup a range in the regex pattern and fail masking.  This is now fixed and tested.

**Related github/jira issue (required)**:
Closes #4613
Related to #4408

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run the demoapp
- Open http://localhost:4000/components/datepicker/example-timeformat?locale=sv-SE
- Type a valid date into the first input field.  It should correctly format as you type.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

@SofiK
