### PR TITLE
4146 - Fix Colorpicker not selecting when multiple present on page

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[Button]` Fixed the tooltip in action button to be not visible when there's no title attribute. ([#4473](https://github.com/infor-design/enterprise/issues/4473))
 - `[Badges]` Fixed alignment issues in uplift theme. ([#4578](https://github.com/infor-design/enterprise/issues/4578))
 - `[Column Chart]` Fixed a minor alignment issue in the xAxis labels ([#4460](https://github.com/infor-design/enterprise/issues/4460))
+- `[Colorpicker]` Fixed an issue where values were not being selecting when multiple colopickers are present. ([#4146](https://github.com/infor-design/enterprise/issues/4146))
 - `[Datagrid]` Fix a bug where changing selectable on the fly did not change the select behavior. ([#4575](https://github.com/infor-design/enterprise/issues/4575))
 - `[Datagrid]` Fixed an issue where the click event was not fire for hyperlinks keyword search results. ([#4550](https://github.com/infor-design/enterprise/issues/4550))
 - `[Datagrid]` Fixed a bug where the plus-minus icon were misaligned together with focus state on all row heights. ([#4480](https://github.com/infor-design/enterprise/issues/4480))

--- a/src/components/colorpicker/colorpicker.js
+++ b/src/components/colorpicker/colorpicker.js
@@ -402,6 +402,8 @@ ColorPicker.prototype = {
           this.setColor(item.data('value'), item.data('label'));
         }
 
+        this.itemLabel = item.data('label');
+
         // Editor colorpicker
         let cpEditorNotVisible = false;
         if (this.element.is('.colorpicker-editor-button')) {
@@ -592,7 +594,10 @@ ColorPicker.prototype = {
           });
           /* eslint-disable no-loop-func */
         }
-        a.addClass(`is-selected${checkmarkClass}`);
+
+        if (colorText === this.itemLabel) {
+          a.addClass(`is-selected${checkmarkClass}`);
+        }
       }
 
       colorValue = s.uppercase ? colorValue.toUpperCase() : colorValue.toLowerCase();

--- a/src/components/colorpicker/colorpicker.js
+++ b/src/components/colorpicker/colorpicker.js
@@ -556,6 +556,9 @@ ColorPicker.prototype = {
     const checkThemes = s.themes[themeVariant].checkmark;
     let checkmarkClass = '';
 
+    // Remove previously opened colorpicker first
+    $('#colorpicker-menu').remove();
+
     for (let i = 0, l = s.colors.length; i < l; i++) {
       const li = $('<li></li>');
       const a = $('<a href="#"><span class="swatch"></span></a>').appendTo(li);

--- a/src/components/colorpicker/colorpicker.js
+++ b/src/components/colorpicker/colorpicker.js
@@ -450,7 +450,7 @@ ColorPicker.prototype = {
     let colorLabel = label;
 
     // Make sure there is always a hash
-    if (hex.substr(0, 1) !== '#' && hex !== '') {
+    if (hex.toString().substr(0, 1) !== '#' && hex !== '') {
       colorHex = `#${colorHex}`;
     }
 
@@ -598,10 +598,11 @@ ColorPicker.prototype = {
         swatch[0].style.backgroundColor = `#${colorValue}`;
       }
       swatch.addClass(isBorder ? 'is-border' : '');
-      a.data('label', colorText)
-        .data('value', colorValue)
-        .attr('title', `${colorText} #${colorValue}`)
-        .tooltip();
+
+      a[0].setAttribute('data-label', colorText);
+      a[0].setAttribute('data-value', colorValue);
+      a[0].setAttribute('data-title', `${colorText} #${colorValue}`);
+      a.tooltip();
 
       utils.addAttributes(a, this, this.settings.attributes, colorText);
 

--- a/src/components/colorpicker/colorpicker.js
+++ b/src/components/colorpicker/colorpicker.js
@@ -601,7 +601,7 @@ ColorPicker.prototype = {
 
       a[0].setAttribute('data-label', colorText);
       a[0].setAttribute('data-value', colorValue);
-      a[0].setAttribute('data-title', `${colorText} #${colorValue}`);
+      a[0].setAttribute('title', `${colorText} #${colorValue}`);
       a.tooltip();
 
       utils.addAttributes(a, this, this.settings.attributes, colorText);

--- a/src/components/colorpicker/colorpicker.js
+++ b/src/components/colorpicker/colorpicker.js
@@ -595,7 +595,7 @@ ColorPicker.prototype = {
           /* eslint-disable no-loop-func */
         }
 
-        if (colorText === this.itemLabel) {
+        if (colorText === this.itemLabel || this.itemLabel === undefined) {
           a.addClass(`is-selected${checkmarkClass}`);
         }
       }

--- a/src/components/colorpicker/colorpicker.js
+++ b/src/components/colorpicker/colorpicker.js
@@ -398,11 +398,11 @@ ColorPicker.prototype = {
         this.element.trigger('listclosed', 'select');
       })
       .on('selected.colorpicker', (e, item) => {
-        if (!this.isEditor) {
-          this.setColor(item.data('value'), item.data('label'));
-        }
-
         this.itemLabel = item.data('label');
+
+        if (!this.isEditor) {
+          this.setColor(item.data('value'), this.itemLabel);
+        }
 
         // Editor colorpicker
         let cpEditorNotVisible = false;

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -656,6 +656,7 @@ Tooltip.prototype = {
   show(newSettings, ajaxReturn) {
     const self = this;
 
+    console.log('show tooltip');
     // Don't open if this is an Actions Button with an open popupmenu
     if (this.popupmenuAPI && this.popupmenuAPI.isOpen) {
       return;

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -656,7 +656,6 @@ Tooltip.prototype = {
   show(newSettings, ajaxReturn) {
     const self = this;
 
-    console.log('show tooltip');
     // Don't open if this is an Actions Button with an open popupmenu
     if (this.popupmenuAPI && this.popupmenuAPI.isOpen) {
       return;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes an issue where toggling a colorpicker while another one was open the colorpicker would not select a color. Also fixes a separate issue where custom colors and their default counterparts were both getting the `is-selected` class.

**Related github/jira issue (required)**:
closes #4146 

**Steps necessary to review your pull request (required)**:
- Pull and run branch
- Go to http://localhost:4000/components/colorpicker/example-custom-labels.html
- Open the bottom colorpicker
- While it's open, click on the trigger button in the top one 
- The colorpicker should close
- Open the top colorpicker and you should still be able to select a color

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
