### PR TITLE
4610 - Fix alignment with field options

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[Datagrid]` Fixed a bug where the plus-minus icon were misaligned together with focus state on all row heights. ([#4480](https://github.com/infor-design/enterprise/issues/4480))
 - `[Dropdown]` Fixed a bug where the last option icon changes when searching/filtering in dropdown search field. ([#4474](https://github.com/infor-design/enterprise/issues/4474))
 - `[Editor/Fontpicker]` Fixed a bug where the label relationship were not valid in the editor role. Adding aria-labelledby will fix the association for both editor and the label. Also, added an audible label in fontpicker. ([#4454](https://github.com/infor-design/enterprise/issues/4454))
+- `[Field Options]` Fixed an issue where the action button was misaligned for safari. ([#4610](https://github.com/infor-design/enterprise/issues/4610))
 - `[FileUploadAdvanced]` Fixed an issue where abort method was not working properly to remove the file block when upload fails. ([#938](https://github.com/infor-design/enterprise-ng/issues/938))
 - `[Lookup]` Fixed some layout issues when using the editable and clearable options on the filter row. ([#4527](https://github.com/infor-design/enterprise/issues/4527))
 - `[Tree]` Fixed an issue where the character entity references were render differently for parent and child levels. ([#4512](https://github.com/infor-design/enterprise/issues/4512))

--- a/src/components/field-options/_field-options-uplift.scss
+++ b/src/components/field-options/_field-options-uplift.scss
@@ -48,6 +48,7 @@
     left: -12px;
   }
 
+  .field-options ~ .close ~ .icon ~ .btn-actions,
   input[type='text'][readonly]:not(.fileupload) ~ .btn-actions {
     top: 0;
   }
@@ -111,7 +112,7 @@
   margin-left: -8px;
 
   + .btn-actions {
-    left: -10px !important;
+    left: -11px !important;
   }
 }
 
@@ -174,7 +175,7 @@
   .field-short.is-fieldoptions,
   .form-layout-compact .field.is-fieldoptions {
     .btn-actions:not(.is-checkbox) {
-      top: 5px !important;
+      top: 1px !important;
       width: 28px;
 
       .icon {
@@ -188,19 +189,17 @@
     }
 
     .spinbox-wrapper .btn-actions {
+      top: 5px !important;
       width: 28px !important;
     }
 
     .colorpicker-container ~ .btn-actions {
-      top: -5px !important;
+      top: -8px !important;
     }
 
+    [data-clearable='true'] + .icon.close ~ .btn-actions,
     input[type='text'][readonly]:not(.fileupload) ~ .btn-actions {
-      top: 4px !important;
-    }
-
-    [data-clearable='true'] + .icon.close ~ .btn-actions {
-      top: 5px !important;
+      top: 1px !important;
     }
 
     .searchfield-wrapper.has-focus:not(.toolbar-searchfield-wrapper) > .icon:not(.close):not(.icon-error),
@@ -209,12 +208,43 @@
     }
 
     .textarea ~ .btn-actions:not(.is-checkbox) {
-      top: calc(50% - 0) !important;
+      top: calc(50% - 0px) !important;
     }
   }
 
   .form-layout-compact .compound-field .field.is-fieldoptions:first-child input[type='text'] ~ .btn-actions:not(.is-checkbox) {
     top: 4px !important;
+  }
+
+  &.is-mac {
+    .field-short.is-fieldoptions,
+    .form-layout-compact .field.is-fieldoptions {
+      .btn-actions:not(.is-checkbox) {
+        top: 5px !important;
+      }
+
+      .field-options.dropdown ~ .btn-actions,
+      .field-options.multiselect ~ .btn-actions {
+        top: 3px !important;
+      }
+
+      .field-options ~ .close ~ .icon ~ .btn-actions {
+        top: 5px !important;
+      }
+
+      .colorpicker-container ~ .btn-actions {
+        top: -4px !important;
+      }
+
+      [data-clearable='true'] + .icon.close ~ .btn-actions,
+      input[type='text'][readonly]:not(.fileupload) ~ .btn-actions {
+        top: 5px !important;
+      }
+
+      .textarea ~ .btn-actions:not(.is-checkbox) {
+        top: calc(50% - 0px) !important;
+      }
+    }
   }
 }
 
@@ -314,6 +344,30 @@
       ~ .btn-actions {
         left: -9px;
       }
+    }
+  }
+
+  .field.is-fieldoptions {
+    .colorpicker-container {
+      ~ .btn-actions {
+        top: 1px;
+      }
+    }
+
+    .field-options ~ .close,
+    input[type='text'][readonly]:not(.fileupload) {
+      ~ .btn-actions {
+        top: 0;
+      }
+    }
+  }
+
+  .field-short.is-fieldoptions,
+  .form-layout-compact .field.is-fieldoptions {
+    .field-options ~ .close ~ .btn-actions,
+    input[type='text'][readonly]:not(.fileupload) ~ .btn-actions,
+    .colorpicker-container ~ .btn-actions {
+      top: 1px;
     }
   }
 }

--- a/src/components/field-options/_field-options.scss
+++ b/src/components/field-options/_field-options.scss
@@ -276,6 +276,10 @@
     }
   }
 
+  .field-options ~ .close ~ .icon ~ .btn-actions {
+    top: -1px;
+  }
+
   // Clearable Inputs that are not Searchfields
   [data-clearable='true'] {
     ~ .btn-actions {
@@ -326,6 +330,7 @@
     }
   }
 
+  .field-options ~ .close ~ .icon ~ .btn-actions,
   input[type='text'][readonly]:not(.fileupload) ~ .btn-actions {
     top: 1px;
   }
@@ -581,7 +586,7 @@
 
     .colorpicker-container {
       ~ .btn-actions {
-        top: -13px;
+        top: -12px;
       }
     }
 
@@ -610,7 +615,7 @@
   .form-layout-compact .field.is-fieldoptions {
     .field-options {
       ~ .btn-actions:not(.is-checkbox) {
-        top: 2px;
+        top: 0;
       }
 
       &.dropdown ~ .btn-actions,
@@ -624,21 +629,23 @@
       }
     }
 
+    .spinbox-wrapper .btn-actions {
+      top: 5px !important;
+    }
+
+    .colorpicker-container ~ .btn-actions {
+      top: -8px;
+    }
+
+    .searchfield-wrapper .btn-actions,
+    [data-clearable='true'] + .icon.close ~ .btn-actions,
     input[type='text'][readonly]:not(.fileupload) ~ .btn-actions {
-      top: 2px !important;
+      top: 0 !important;
     }
 
     &.field-checkbox .btn-actions .icon:not(.icon-dropdown) {
       margin-left: 1px;
       margin-top: -2px;
-    }
-
-    [data-clearable='true'] + .icon.close ~ .btn-actions {
-      top: 2px !important;
-    }
-
-    .searchfield-wrapper .btn-actions {
-      top: 2px !important;
     }
   }
 
@@ -661,12 +668,6 @@
     &.multiselect {
       ~ .btn-actions {
         top: 1px;
-      }
-    }
-
-    &.searchfield {
-      ~ .btn-actions {
-        left: -6px;
       }
     }
   }
@@ -702,6 +703,17 @@
 
   .field-short.is-fieldoptions,
   .form-layout-compact .field.is-fieldoptions {
+    .field-options ~ .btn-actions:not(.is-checkbox) {
+      top: 2px;
+    }
+
+    .field-options ~ .close,
+    input[type='text'][readonly]:not(.fileupload) {
+      ~ .btn-actions {
+        top: 2px !important;
+      }
+    }
+
     .lookup-wrapper .btn-actions {
       left: -3px;
     }
@@ -735,7 +747,7 @@
   .field.is-fieldoptions {
     .colorpicker-container {
       ~ .btn-actions {
-        top: -1px;
+        top: 0;
       }
     }
 
@@ -757,6 +769,19 @@
     .data.field-options {
       ~ .btn-actions {
         left: -10px;
+      }
+    }
+  }
+
+  .form-layout-compact {
+    .field.is-fieldoptions {
+      .colorpicker-container ~ .btn-actions,
+      input[type='text'] ~ .btn-actions:not(.is-checkbox) {
+        top: 1px;
+      }
+
+      .spinbox-wrapper .btn-actions {
+        top: 5px !important;
       }
     }
   }
@@ -857,6 +882,11 @@
         margin-left: -9px;
       }
     }
+  }
+
+  .field-short.is-fieldoptions .spinbox-wrapper .btn-actions,
+  .form-layout-compact .field.is-fieldoptions .spinbox-wrapper .btn-actions {
+    top: 5px;
   }
 }
 

--- a/src/components/field-options/field-options.js
+++ b/src/components/field-options/field-options.js
@@ -174,7 +174,7 @@ FieldOptions.prototype = {
           returns = 2;
         }
       } else if (isRadio) {
-        returns = ((height - this.trigger.height()) / 2) * -1;
+        returns = (((height - 10) - this.trigger.height()) / 2) * -1;
       }
       return returns;
     };


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the action button was misaligned for safari with Field Options.

**Related github/jira issue (required)**:
Closes #4610

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Use safari mac
- Navigate to: http://localhost:4000/components/field-options/example-index.html?theme=uplift&variant=dark&colors=0066D4
- Try field options in each field
- See action button should not misalign
- Also in compact mode

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
