### PR TITLE
4486 - Fix parent for addnode method with tree

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### v4.36.0 Fixes
 
 - `[Column Chart]` Fixed an alignment issue with the labes in grouped column charts. ([#4645](https://github.com/infor-design/enterprise/issues/4645))
+- `[Tree]` Fixed an issue where the parent value was get deleted after use `addNode()` method. ([#4486](https://github.com/infor-design/enterprise/issues/4486))
 
 ## v4.35.0
 

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -2077,6 +2077,10 @@ Tree.prototype = {
         nodeData.node = li.find(`ul li a#${nodeData.id}`);
       }
     } else {
+      if (typeof nodeData.tempidsparent !== 'undefined') {
+        nodeData.parent = nodeData.tempidsparent;
+        delete nodeData.tempidsparent;
+      }
       li = $(li);
       this.addChildNodes(nodeData, li);
       nodeData.node = li.children('a').first();
@@ -2123,6 +2127,9 @@ Tree.prototype = {
       this.decorateNode(li.querySelector('a'));
     }
 
+    if (typeof nodeData.parent !== 'undefined') {
+      nodeData.tempidsparent = nodeData.parent;
+    }
     nodeData.parent = '';
     this.addNode(nodeData, $(ul), location);
   },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the parent value was get deleted after use `addNode()` method with Tree.

**Related github/jira issue (required)**:
Closes #4486

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/tree/test-add-node-with-parent-option.html
- Open developer tools
- Run in console as below:
- `var tree = $('#tree').data('tree');`
- `tree.addNode({id: 'newTestNode', text: 'New Test Node', parent: 'leadership'});`
- `tree.findById('newTestNode');`
- Check the return data for `parent` key/value should not be blank

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
