### PR TITLE
4268 - Add fix for safari

### DIFF
--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -5014,6 +5014,22 @@ html[dir='rtl'] {
   a.btn-icon.row-btn {
     top: -4px;
   }
+
+  .datagrid-summary-row td {
+    bottom: 35px;
+  }
+
+  .medium-rowheight .datagrid-summary-row td {
+    bottom: 30px;
+  }
+
+  .small-rowheight .datagrid-summary-row td {
+    bottom: 26px;
+  }
+
+  .extra-small-rowheight .datagrid-summary-row td {
+    bottom: 25px;
+  }
 }
 
 // All IE hacks


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

#4268 wasnt working on safari correctly so this is an additional fix.

**Related github/jira issue (required)**:
Fixes #4268

**Steps necessary to review your pull request (required)**:
- open http://localhost:4000/components/datagrid/example-summary-row.html in safari
- try all 4 row sizes and scroll down and ensure the bottom row is properly placed
