### PR TITLE
4674 - Fix to update row

### DIFF
--- a/app/views/components/message/example-index.html
+++ b/app/views/components/message/example-index.html
@@ -32,6 +32,8 @@
             },
             isDefault: true
         }]
+      }).on('beforeopen', function() {
+        console.log('beforeopen fired');
       });
     });
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,10 +9,10 @@
 ### v4.36.0 Fixes
 
 - `[Column Chart]` Fixed an alignment issue with the labes in grouped column charts. ([#4645](https://github.com/infor-design/enterprise/issues/4645))
+- `[Datagrid]` Fixed an issue where updateRow will not correctly sync and merge data. ([#4674](https://github.com/infor-design/enterprise/issues/4674))
 - `[Homepage]` Fixed a bug where the border behaves differently and does not change back correctly when hovering in editable mode. ([#4640](https://github.com/infor-design/enterprise/issues/4640))
-- `[Column Chart]` Fixed an alignment issue with the labels in grouped column charts. ([#4645](https://github.com/infor-design/enterprise/issues/4645))
-- `[Tree]` Fixed an issue where the parent value was get deleted after use `addNode()` method. ([#4486](https://github.com/infor-design/enterprise/issues/4486))
 - `[Locale]` Don't attempt to set d3 locale if d3 is not being used ([#4668](https://github.com/infor-design/enterprise/issues/4486))
+- `[Tree]` Fixed an issue where the parent value was get deleted after use `addNode()` method. ([#4486](https://github.com/infor-design/enterprise/issues/4486))
 
 ## v4.35.0
 

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1848,6 +1848,11 @@ $datagrid-small-row-height: 25px;
         .is-readonly {
           background-color: transparent !important;
         }
+
+        .icon {
+          background-color: $datagrid-cell-bg-color !important;
+          box-shadow: none !important;
+        }
       }
     }
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5016,10 +5016,7 @@ Datagrid.prototype = {
       this.updateCellNode(idx, j, this.fieldValue(rowData, col.field), true);
     }
 
-    this.settings.dataset[idx] = {
-      ...this.settings.dataset[idx],
-      ...data
-    };
+    this.settings.dataset[idx] = utils.extend(true, this.settings.dataset[idx], data);
   },
 
   /**

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -1113,29 +1113,6 @@ describe('Datepicker Range Tests', () => {
     expect(await element.all(by.css('.range-selection')).last().getText()).toEqual('28');
   });
 
-  it('Should be able to select with disabled not included', async () => {
-    const datepickerEl = await element(by.id('range-disablenotincluded'));
-
-    expect(datepickerEl.getAttribute('value')).toEqual('2/5/2018 - 2/28/2018');
-    await datepickerEl.sendKeys(protractor.Key.ARROW_DOWN);
-    await browser.driver.sleep(config.sleepShort);
-    await browser.driver
-      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.css('.monthview-popup.is-open'))), config.waitsFor);
-
-    await element.all(by.cssContainingText('.monthview-table td', '5')).first().click();
-    await element.all(by.cssContainingText('.monthview-table td', '10')).first().click();
-
-    expect(datepickerEl.getAttribute('value')).toEqual('2/5/2018 - 2/10/2018');
-
-    await datepickerEl.sendKeys(protractor.Key.ARROW_DOWN);
-    await browser.driver
-      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.css('.monthview-popup.is-open'))), config.waitsFor);
-
-    expect(await element.all(by.css('.range-selection')).count()).toEqual(4);
-    expect(await element.all(by.css('.is-disabled')).first().getText()).toEqual('7');
-    expect(await element.all(by.css('.is-disabled')).get(1).getText()).toEqual('9');
-  });
-
   it('Should be able to select with disabled included', async () => {
     const datepickerEl = await element(by.id('range-disableincluded'));
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The fix to https://github.com/infor-design/enterprise/issues/4476 used spread to merge the updated data with the dataset. This dropped some information. Changed this to a deep copy merge.

**Related github/jira issue (required)**:
Fixes #4674
Relates to #4476

**Steps necessary to review your pull request (required)**:
- test http://localhost:4000/components//datagrid/example-row-reorder.html -> fixed an issue with a grey background around the icon
- build this branch and copy it over to the latest master in enterprise-NG
- run and go to http://localhost:4200/ids-enterprise-ng-demo/datagrid-rowreorder -> try to reorder a row more than once and it should work again. note that this example has an updateRow in the rowreorder event. Before this fix this failed
- retest https://github.com/infor-design/enterprise/issues/4476#issuecomment-719606349

**Included in this Pull Request**:
- [x] A note to the change log.
