### PR TITLE
4672 - Fix performance with tooltips

### DIFF
--- a/app/views/components/dropdown/test-8000-items.html
+++ b/app/views/components/dropdown/test-8000-items.html
@@ -1,0 +1,25 @@
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="field">
+      <label for="big-dropdown">Test Dropdown with tooltips and 8000 items</label>
+      <select id="big-dropdown" name="big-dropdown" class="dropdown">
+      </select>
+    </div>
+
+  </div>
+</div>
+
+<script>
+  var ele = $('#big-dropdown');
+  var markup = '';
+  for(var i =0; i < 8000; i++) {
+    var date = new Date();
+    date.setDate(date.getDate() + i);
+
+    markup += `<option value="option${i}" title="${date}">${date}</option>`;
+  }
+  ele.append(markup).dropdown();
+
+  $('body').initialize();
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@
 - `[Column Chart]` Fixed an alignment issue with the labes in grouped column charts. ([#4645](https://github.com/infor-design/enterprise/issues/4645))
 - `[Datagrid]` Fixed an issue where updateRow will not correctly sync and merge data. ([#4674](https://github.com/infor-design/enterprise/issues/4674))
 - `[Datagrid]` Fixed a bug where the error icon overlapped to the calendar icon when a row has been selected and hovered. ([#4670](https://github.com/infor-design/enterprise/issues/4670))
+- `[Dropdown]` Fixed a bug where the tooltips are invoked for each dropdown item. This was slow with a lot of items. ([#4672](https://github.com/infor-design/enterprise/issues/4672))
+- `[Dropdown]` Fixed a bug where mouseup was used rather than click to open the list and this was inconsistent. ([#4638](https://github.com/infor-design/enterprise/issues/4638))
 - `[Homepage]` Fixed a bug where the border behaves differently and does not change back correctly when hovering in editable mode. ([#4640](https://github.com/infor-design/enterprise/issues/4640))
 - `[Locale]` Don't attempt to set d3 locale if d3 is not being used ([#4668](https://github.com/infor-design/enterprise/issues/4486))
 - `[Tree]` Fixed an issue where the parent value was get deleted after use `addNode()` method. ([#4486](https://github.com/infor-design/enterprise/issues/4486))


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

CRM gave us an example with 8000 dropdown items with tooltips. The main issue preventing this from working well was the tooltips being initialized. Instead I made it a delegated event.

Also fixed a click issue thats related and fixed a few selectors to make it a bit faster. Decided we should not patch this as needs a bigger testing effort

**Related github/jira issue (required)**:
Fixes #4672
Fixes #4638

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/dropdown/test-8000-items.html
- opening the page should not be too slow
- open the list -> this is much faster than before
- go to http://localhost:4000/components/dropdown/example-index
- click down on the label and then drag down to the dropdown and then release -> this should not open the list
- smoke test dropdown and multiselect examples

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
