### PR TITLE
4491 - Fix mixed selection aria state

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Datagrid]` Fixed a bug where filterWhenTyping did not work on lookup filter columns. ([#4678](https://github.com/infor-design/enterprise/issues/4678))
 - `[Datagrid]` Fixed an issue where updateRow will not correctly sync and merge data. ([#4674](https://github.com/infor-design/enterprise/issues/4674))
 - `[Datagrid]` Fixed a bug where the error icon overlapped to the calendar icon when a row has been selected and hovered. ([#4670](https://github.com/infor-design/enterprise/issues/4670))
+- `[Datagrid]` Fixed a bug where the datagrid header checkbox had the wrong aria-checked state when only some rows are selected. ([#4491](https://github.com/infor-design/enterprise/issues/4491))
 - `[Homepage]` Fixed a bug where the border behaves differently and does not change back correctly when hovering in editable mode. ([#4640](https://github.com/infor-design/enterprise/issues/4640))
 - `[Locale]` Don't attempt to set d3 locale if d3 is not being used ([#4668](https://github.com/infor-design/enterprise/issues/4486))
 - `[Tree]` Fixed an issue where the parent value was get deleted after use `addNode()` method. ([#4486](https://github.com/infor-design/enterprise/issues/4486))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7655,17 +7655,20 @@ Datagrid.prototype = {
     // Sync the header checkbox
     if (selectedRowsLength > 0) {
       headerCheckbox.data('selected', 'partial')
-        .addClass('is-checked is-partial');
+        .addClass('is-checked is-partial')
+        .attr('aria-checked', 'mixed');
     }
 
     if (selectedRowsLength === rowsLength) {
       headerCheckbox.data('selected', 'all')
-        .addClass('is-checked').removeClass('is-partial');
+        .addClass('is-checked').removeClass('is-partial')
+        .attr('aria-checked', 'true');
     }
 
     if (selectedRowsLength === 0) {
       headerCheckbox.data('selected', 'none')
-        .removeClass('is-checked is-partial');
+        .removeClass('is-checked is-partial')
+        .attr('aria-checked', 'false');
     }
   },
 

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -1281,6 +1281,12 @@ describe('Datagrid multiselect tests', () => {
     expect(await element.all(by.css('.datagrid-row.is-selected')).count()).toEqual(2);
   });
 
+  it('Should have aria selected mixed when partly selected', async () => {
+    await element(by.css('#datagrid .datagrid-wrapper tbody tr:nth-child(1) td:nth-child(2)')).click();
+
+    expect(await element(by.css('.datagrid-checkbox.is-partial')).getAttribute('aria-checked')).toEqual('mixed');
+  });
+
   it('Should handle removing selected rows ', async () => {
     expect(await element.all(by.css('.datagrid-row')).count()).toEqual(7);
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When the rows selected are only some of the available rows the aria-checked state was wrong. This fixes that issue

**Related github/jira issue (required)**:
Fixes #4491

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-multiselect.html
- select one (not all rows)
- inspect the header checkbox dom and the `aria-checked` state should be `mixed`
- unselect all and the `aria-checked` state should be `false`
- select all and the `aria-checked` state should be `true`

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
