### PR TITLE
4692 - Correct the id's when using attachToBody

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,7 +19,7 @@
 - `[Editor]` Fixed an issue where the dirty indicator was not reset when the contents contain `<br>` tags. ([#4624](https://github.com/infor-design/enterprise/issues/4624))
 - `[Homepage]` Fixed a bug where the border behaves differently and does not change back correctly when hovering in editable mode. ([#4640](https://github.com/infor-design/enterprise/issues/4640))
 - `[Locale]` Don't attempt to set d3 locale if d3 is not being used ([#4668](https://github.com/infor-design/enterprise/issues/4486))
-- `[Homepage]` Fixed a bug where the border behaves differently and does not change back correctly when hovering in editable mode. ([#4640](https://github.com/infor-design/enterprise/issues/4640))
+- `[Pager]` Fixed a bug that automation id's are not added when the attachToBody is used. ([#4692](https://github.com/infor-design/enterprise/issues/4692))
 - `[Tabs]` Added support for a "More Actions" button to exist beside horizontal/header tabs. ([#4532](https://github.com/infor-design/enterprise/issues/4532))
 - `[Tree]` Fixed an issue where the parent value was get deleted after use `addNode()` method. ([#4486](https://github.com/infor-design/enterprise/issues/4486))
 

--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -1218,6 +1218,16 @@ Pager.prototype = {
       const value = link.text();
       utils.addAttributes(link, self, self.settings.attributes, `pagesize-opt-${value}`);
     });
+
+    // Append if using attach to body
+    const menu = this.pagerBar.find('.btn-menu')?.data('popupmenu')?.menu;
+    if (menu) {
+      menu.find('li').each(function () {
+        const link = $(this).find('a');
+        const value = link.text();
+        utils.addAttributes(link, self, self.settings.attributes, `pagesize-opt-${value}`);
+      });
+    }
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The pager - automation id feature did not attach ID's to the menu if the attachToBody option was used. This corrects that.

**Related github/jira issue (required)**:
Fixes #4692

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/pager/example-standalone.html
- click "show page size selector"
- click "Attach page size menu to body"
- Open the page size menu
- inspect the dom on the menu on the menu items, they should have id's the same as they do when "Attach page size menu to body" is checked 
 
**Included in this Pull Request**:
- [x] A note to the change log.
