### PR TITLE
954 - Add fix for multiselect selection

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[Datagrid]` Fixed an issue where updateRow will not correctly sync and merge data. ([#4674](https://github.com/infor-design/enterprise/issues/4674))
 - `[Datagrid]` Fixed a bug where the error icon overlapped to the calendar icon when a row has been selected and hovered. ([#4670](https://github.com/infor-design/enterprise/issues/4670))
 - `[Datagrid]` Fixed a bug where the datagrid header checkbox had the wrong aria-checked state when only some rows are selected. ([#4491](https://github.com/infor-design/enterprise/issues/4491))
+- `[Datagrid]` Fixed a bug where multiselect would loose selection across pages when using selectRowsAcrossPages. ([#954](https://github.com/infor-design/enterprise-ng/issues/954))
 - `[Dropdown]` Fixed a bug where the tooltips are invoked for each dropdown item. This was slow with a lot of items. ([#4672](https://github.com/infor-design/enterprise/issues/4672))
 - `[Dropdown]` Fixed a bug where mouseup was used rather than click to open the list and this was inconsistent. ([#4638](https://github.com/infor-design/enterprise/issues/4638))
 - `[Editor]` Fixed an issue where the dirty indicator was not reset when the contents contain `<br>` tags. ([#4624](https://github.com/infor-design/enterprise/issues/4624))

--- a/src/components/lookup/lookup.js
+++ b/src/components/lookup/lookup.js
@@ -55,6 +55,9 @@ function addSuffixToAttributes(parentAttrs = [], childAttrs = [], suffix) {
  * @param {function} [settings.click] Provide a special function to run when the dialog opens to customize the interaction entirely.
  * @param {string} [settings.clickArguments={}] If a click method is defined, this flexible object can be passed
  * into the click method, and augmented with parameters specific to the implementation.
+ * @param {function} [settings.clear] Provide a special function to run when the clear x is pressed
+ * @param {string} [settings.clearArguments={}] If a clear method is defined, this flexible object can be passed
+ * into the clear method, and augmented with parameters specific to the implementation.
  * @param {string} [settings.field='id'] Field name to return from the dataset or can be a function which returns a string on logic
  * @param {string} [settings.title] Dialog title to show, or befault shows  field label + "Lookup"
  * @param {string} [settings.icon] Swap out the lookup id for any other icon in the icon set by name
@@ -207,6 +210,12 @@ Lookup.prototype = {
       lookup.searchfield({
         clearable: true,
         attributes: this.settings.attributes
+      });
+    }
+
+    if (this.settings.clearable && this.settings.clear) {
+      lookup.on('cleared', (e) => {
+        this.settings.clear(e, this, this.settings.clearArguments);
       });
     }
 
@@ -752,11 +761,12 @@ Lookup.prototype = {
       if (adjust) {
         const self = this;
         self.modal.element.find('.contextual-toolbar .selection-count').text(`${selectedIds.length} ${Locale.translate('Selected')}`);
+        this.grid.syncSelectedUI();
       }
     } else {
       // For Single Record Select
       const selectedIds = [];
-      selectedIds[0] = selectedId;
+      selectedIds.push(selectedId);
       let isFound = false;
 
       for (let i = 0; i < selectedIds.length; i++) {
@@ -784,6 +794,7 @@ Lookup.prototype = {
       if (adjust) {
         const self = this;
         self.modal.element.find('.contextual-toolbar .selection-count').text(`${selectedIds.length} ${Locale.translate('Selected')}`);
+        this.grid.syncSelectedUI();
       }
       return;
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

FIxes a bug submitted by @kvchaudhari that solves an issue doing selection in multiselect across pages

**Related github/jira issue (required)**:
Fixes infor-design/enterprise-ng#954

**Steps necessary to review your pull request (required)**:
1. pull this branch and build and copy over to an NG project
1 . Go to ids-enterprise-ng-demo/lookup
1. Go to "Products (Async Results) Multi Select" lookup -> Now there is no record selected in lookup.
1. Now click on browse button and open lookup pop up.
1. Go to page 2 and select only one record and click on apply button.
1. Now again open that popup and select one record from page 1 -> expect 2 records selected
1. Test out http://localhost:4000/components/lookup particularly http://localhost:4000/components/lookup/example-multiselect-paging-serverside.html 

**Included in this Pull Request**:
- [x] A note to the change log.
