### PR TITLE
958 - Fix readonly function

### DIFF
--- a/app/views/components/rating/example-readonly.html
+++ b/app/views/components/rating/example-readonly.html
@@ -3,7 +3,7 @@
   <div class="twelve columns">
     <div class="field">
 
-      <div class="rating is-readonly">
+      <div class="rating is-readonly" id="rating">
         <fieldset>
           <legend class="audible">Rate Your Experience</legend>
           <input type="radio" class="is-filled" name="rating-name" id="one-star-id1"/>
@@ -47,6 +47,9 @@
           </label>
         </fieldset>
       </div>
+
+      <br />
+      <button class="btn-secondary" type="button" id="toggle-readonly">Make Enabled</button>
     </div>
 
   </div>
@@ -56,5 +59,15 @@
   $(document).ready(function(){
     var ratingCtrl = $('.rating').rating().data('rating');
     ratingCtrl.val(4.3);
+
+    $('#toggle-readonly').on('click', function () {
+      if ($('.rating').hasClass('is-readonly')) {
+        ratingCtrl.enable();
+        $(this).text('Make Readonly');
+      } else {
+        ratingCtrl.readonly();
+        $(this).text('Make Enabled');
+      }
+    });
   });
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Locale]` Don't attempt to set d3 locale if d3 is not being used ([#4668](https://github.com/infor-design/enterprise/issues/4486))
 - `[Modal]` Fixed a bug where the autofocus was not working on anchor tag inside of the modal and moving the first button as a default focus if there's no `isDefault` property set up.
 - `[Pager]` Fixed a bug that automation id's are not added when the attachToBody is used. ([#4692](https://github.com/infor-design/enterprise/issues/4692))
+- `[Rating]` Fixed a bug with the readonly function, it did not toggle the readonly state correctly. ([#958](https://github.com/infor-design/enterprise-ng/issues/958))
 - `[Tabs]` Added support for a "More Actions" button to exist beside horizontal/header tabs. ([#4532](https://github.com/infor-design/enterprise/issues/4532))
 - `[Tree]` Fixed an issue where the parent value was get deleted after use `addNode()` method. ([#4486](https://github.com/infor-design/enterprise/issues/4486))
 

--- a/src/components/rating/rating.js
+++ b/src/components/rating/rating.js
@@ -137,9 +137,8 @@ Rating.prototype = {
   */
   readonly() {
     const elem = $(this.element);
-    if (elem.hasClass('is-readonly')) {
-      elem.find('input').attr('disabled', '');
-    }
+    elem.addClass('is-readonly');
+    elem.find('input').attr('disabled', '');
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes a bug in the readonly function that prevent toggling the state back and forth from working correctly.

**Related github/jira issue (required)**:
Fixes infor-design/enterprise-ng#958

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/rating/example-readonly.html
- it is initially readonly and you cant click the rating
- hit the toggle - now you can click the rating
- hit the toggle again - now you can't click the rating (this part was fixed)

**Included in this Pull Request**:
- [x] A note to the change log.
