### PR TITLE
4693 - Fix to datagrid so that applyFilter refreshes the clear checkbox

### DIFF
--- a/app/views/components/datagrid/test-lookup-filter.html
+++ b/app/views/components/datagrid/test-lookup-filter.html
@@ -104,7 +104,11 @@
           filterable: true,
           dataset: data,
           toolbar: {keywordFilter: true, results: true}
-        });
+        }).on('filtered', function (e, args) {
+          console.log(e, args);
+        }).data('datagrid');
+
+        grid.applyFilter([{ columnId: 'productId', operator: 'contains', value: '2241202' }], 'filtered');
     });
   });
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[Datagrid]` Fixed an issue where updateRow will not correctly sync and merge data. ([#4674](https://github.com/infor-design/enterprise/issues/4674))
 - `[Datagrid]` Fixed a bug where the error icon overlapped to the calendar icon when a row has been selected and hovered. ([#4670](https://github.com/infor-design/enterprise/issues/4670))
 - `[Datagrid]` Fixed a bug where the datagrid header checkbox had the wrong aria-checked state when only some rows are selected. ([#4491](https://github.com/infor-design/enterprise/issues/4491))
+- `[Datagrid]` Made a fix that when calling applyFilter the lookup checkbox did not update. ([#4693](https://github.com/infor-design/enterprise/issues/4693))
 - `[Dropdown]` Fixed a bug where the tooltips are invoked for each dropdown item. This was slow with a lot of items. ([#4672](https://github.com/infor-design/enterprise/issues/4672))
 - `[Dropdown]` Fixed a bug where mouseup was used rather than click to open the list and this was inconsistent. ([#4638](https://github.com/infor-design/enterprise/issues/4638))
 - `[Editor]` Fixed an issue where the dirty indicator was not reset when the contents contain `<br>` tags. ([#4624](https://github.com/infor-design/enterprise/issues/4624))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -2538,6 +2538,11 @@ Datagrid.prototype = {
 
       input.val(conditions[i].value);
 
+      // Enable clear button
+      if (input.is('.lookup') && input.parent().find('svg.close').length === 1 && conditions[i].value) {
+        input.parent().find('svg.close').removeClass('is-empty');
+      }
+
       if (input.is('select')) {
         const firstVal = conditions[i].value instanceof Array ?
           conditions[i].value[0] : conditions[i].value;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When calling the applyFilter api the lookup filter did not refresh the clear button.

**Related github/jira issue (required)**:
Fixes #4693 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-lookup-filter
- it calls applyFilter in the example so the x should be enabled
- try the following in the console tto make sure you can also reset it
```
$('#datagrid').data('datagrid').applyFilter([{ columnId: 'productId', operator: 'contains', value: '' }]);
// Reload Page
grid.applyFilter([])
```

**Included in this Pull Request**:
- [x] A note to the change log.
