### PR TITLE
4702 - Fix hyperlinks not clickable in readonly state

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `[Dropdown]` Fixed a bug where the tooltips are invoked for each dropdown item. This was slow with a lot of items. ([#4672](https://github.com/infor-design/enterprise/issues/4672))
 - `[Dropdown]` Fixed a bug where mouseup was used rather than click to open the list and this was inconsistent. ([#4638](https://github.com/infor-design/enterprise/issues/4638))
 - `[Editor]` Fixed an issue where the dirty indicator was not reset when the contents contain `<br>` tags. ([#4624](https://github.com/infor-design/enterprise/issues/4624))
+- `[Editor]` Fixed a bug where hyperlinks were not clickable in readonly state. ([#4702](https://github.com/infor-design/enterprise/issues/4702))
 - `[Homepage]` Fixed a bug where the border behaves differently and does not change back correctly when hovering in editable mode. ([#4640](https://github.com/infor-design/enterprise/issues/4640))
 - `[Homepage]` Added support for small size (260x260) widgets and six columns. ([#4663](https://github.com/infor-design/enterprise/issues/4663))
 - `[Homepage]` Fixed an issue where the animation was not working on widget removed. ([#4686](https://github.com/infor-design/enterprise/issues/4686))

--- a/src/components/editor/_editor.scss
+++ b/src/components/editor/_editor.scss
@@ -103,7 +103,7 @@
 
     .editor,
     .editor-source {
-      border-color: transparent $editor-focus-border-color $editor-focus-border-color;
+      border-color: $editor-focus-border-color $editor-focus-border-color;
       box-shadow: $focus-box-shadow;
 
       &.error {

--- a/src/components/editor/_editor.scss
+++ b/src/components/editor/_editor.scss
@@ -22,10 +22,6 @@
 
   &.is-readonly {
     .editor {
-      a {
-        pointer-events: none;
-      }
-
       > * {
         color: $input-readonly-color !important;
       }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes hyperlinks were not clickable when the editor is in readonly state.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/4702

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/editor/test-readonly.html
- Hyperlink should be clickable

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
