### PR TITLE
4693 - Add fix for safari

### DIFF
--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -5052,6 +5052,10 @@ html[dir='rtl'] {
   .extra-small-rowheight .datagrid-summary-row td {
     bottom: 25px;
   }
+
+  .datagrid-header .datagrid-filter-wrapper .lookup-wrapper .searchfield-wrapper.has-close-icon-button .icon {
+    top: -2px;
+  }
 }
 
 // All IE hacks


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adds an additional fix on #4693 for safari.

<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->

**Related github/jira issue (required)**:
Fixes #4683

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-lookup-filter-click-clear in safari
- click the lookup search and the X will show -> the x alignment should be ok

