### PR TITLE
4655 - Fix selectable text for touch devices with listview

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,7 +27,7 @@
 - `[Homepage]` Added support for small size (260x260) widgets and six columns. ([#4663](https://github.com/infor-design/enterprise/issues/4663))
 - `[Homepage]` Fixed an issue where the animation was not working on widget removed. ([#4686](https://github.com/infor-design/enterprise/issues/4686))
 - `[Homepage]` Fixed a bug where the border behaves differently and does not change back correctly when hovering in editable mode. ([#4640](https://github.com/infor-design/enterprise/issues/4640))
-- `[Listview]` Fixed an issue where the contextmenu was not open on longpress for iOS device. ([#4655](https://github.com/infor-design/enterprise/issues/4655))
+- `[Listview]` Fixed an issue where the contextmenu was not open on longpress and text as not selectable for iOS device. ([#4655](https://github.com/infor-design/enterprise/issues/4655))
 - `[Locale]` Don't attempt to set d3 locale if d3 is not being used ([#4668](https://github.com/infor-design/enterprise/issues/4486))
 - `[Modal]` Fixed a bug where the autofocus was not working on anchor tag inside of the modal and moving the first button as a default focus if there's no `isDefault` property set up.
 - `[Pager]` Fixed a bug that automation id's are not added when the attachToBody is used. ([#4692](https://github.com/infor-design/enterprise/issues/4692))

--- a/src/components/listview/_listview.scss
+++ b/src/components/listview/_listview.scss
@@ -375,6 +375,10 @@
     }
   }
 
+  .is-touch {
+    @include unselectable;
+  }
+
   .is-disabled {
     @include unselectable;
 

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -3,6 +3,7 @@ import * as debug from '../../utils/debug';
 import { deprecateMethod } from '../../utils/deprecated';
 import { utils } from '../../utils/utils';
 import { DOM } from '../../utils/dom';
+import { Environment as env } from '../../utils/environment';
 import { stringUtils as str } from '../../utils/string';
 import { Tmpl } from '../tmpl/tmpl';
 import { ListFilter } from '../listfilter/listfilter';
@@ -371,6 +372,11 @@ ListView.prototype = {
       const item = $(this);
 
       item.attr('role', 'option');
+
+      // Add css class `is-touch` for touch devices
+      if (env.features.touch) {
+        item.addClass('is-touch');
+      }
 
       // Add user-defined attributes
       if (self.settings.attributes) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed selectable text for touch devices with Listview.

**Related github/jira issue (required)**:
Closes #4655

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Use iPhone11
- Navigate to: http://localhost:4000/components/listview/example-contextmenu.html
- Long press on a list row
- Context menu should open
- Text for list view row should not be selectable on touch devices

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
