### PR TITLE
4694 - Fix stripped character entity with tree

### DIFF
--- a/app/views/components/tree/test-escape-node.html
+++ b/app/views/components/tree/test-escape-node.html
@@ -1,0 +1,24 @@
+<div class="row">
+  <div class="twelve columns">
+    <h2>Tree - Escaping</h2>
+    <p>&bull; Two tree nodes are created using addNode, both have a value of &lt;online1&gt;
+      <br>
+      &bull; The second node is then changed to &lt;online 2 after updateNode&gt; via updateNode
+    </p>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+    <ul role="tree" id="escapeTree" class="tree" data-init="false"></ul>
+  </div>
+</div>
+
+<script>
+  const tree = $('#escapeTree').tree().data('tree');
+
+  tree.addNode({text: '<online>', id: 'online1'});
+  tree.addNode({text: '<online>', id: 'online2'});
+
+  tree.updateNode({node: $('#online2'), text: '<online 2 after updateNode>'});
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `[Placeholder]` Placeholder item remove me. ([#xxx](https://github.com/infor-design/enterprise/issues/xxx))
 
+### v4.37.0 Fixes
+
+- `[Tree]` Fixed an issue where the character entity was stripped for addNode() method. ([#4694](https://github.com/infor-design/enterprise/issues/4694))
+
 ## v4.36.0
 
 ### v4.36.0 Features

--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -1951,7 +1951,8 @@ Tree.prototype = {
     }
 
     if (nodeData.text) {
-      a.textContent = xssUtils.unescapeHTML(nodeData.text);
+      a.textContent = /&#?[^\s].{1,9};/g.test(nodeData.text) ?
+        xssUtils.unescapeHTML(nodeData.text) : nodeData.text;
     }
 
     if (nodeData.disabled) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed character entity was stripped for addNode() method with Tree.

**Related github/jira issue (required)**:
Closes #4694

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app
Navigate to: http://localhost:4000/components/tree/test-escape-node.html
- See both node text should have less than(<) and more then(>) sign
- 1st node text should be `<online>`
- 2nd node text should be `<online 2 after updateNode>`

Navigate to: http://localhost:4000/components/tree/example-ajax.html
- See 1st node text (should have less than sign)
- Click on 2nd node to open folder
- See 1st node text in that folder (should have less than sign) too

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
