### PR TITLE
4746 - Fix regression in calendar linking legend checks to labels

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### v4.37.0 Fixes
 
+- `[Calendar]` Fixed a regression where clicking Legend checkboxes was no longer possible. ([#4746](https://github.com/infor-design/enterprise/issues/4746))
 - `[Tabs]` Fixed a bug where the info icon were not aligned correctly in the tab, and info message were not visible. ([#4711](https://github.com/infor-design/enterprise/issues/4711))
 - `[Toolbar Searchfield]` Fixed a bug where the toolbar searchfield were unable to focused when tabbing through the page. ([#4683](https://github.com/infor-design/enterprise/issues/4683))
 - `[Toolbar Searchfield]` Fixed a bug where the search bar were showing extra outline when focused. ([#4682](https://github.com/infor-design/enterprise/issues/4682))

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -219,7 +219,11 @@ Calendar.prototype = {
       const eventTypeMarkup = `<input type="checkbox" class="checkbox ${eventType.color}07" name="${eventType.id}" id="${eventType.id}" ${eventType.checked ? 'checked="true"' : ''} ${eventType.disabled ? 'disabled="true"' : ''} />
         <label for="${eventType.id}" class="checkbox-label">${eventType.translationKey ? Locale.translate(eventType.translationKey, { locale: this.locale.name, language: this.language }) : eventType.label}</label><br/>`;
       this.eventTypeContainer.insertAdjacentHTML('beforeend', eventTypeMarkup);
+
+      // Add attributes to the checkbox, copy the ID to its label's [for] attribute.
+      const checkboxEl = $(this.eventTypeContainer).find(`#${eventType.id}`);
       utils.addAttributes($(this.eventTypeContainer).find(`#${eventType.id}`), this, this.settings.attributes, `legend-${eventType.id}`, true);
+      checkboxEl.next('label').attr('for', checkboxEl[0].id);
     }
     return this;
   },

--- a/test/components/calendar/calendar.e2e-spec.js
+++ b/test/components/calendar/calendar.e2e-spec.js
@@ -57,6 +57,8 @@ describe('Calendar index tests', () => {
   it('Should be able to set id/automation id', async () => {
     expect(await element(by.id('calendar-id-legend-dto')).getAttribute('id')).toEqual('calendar-id-legend-dto');
     expect(await element(by.id('calendar-id-legend-dto')).getAttribute('data-automation-id')).toEqual('calendar-automation-id-legend-dto');
+    expect(await element(by.css('#calendar-id-legend-dto + label')).getAttribute('for')).toEqual('calendar-id-legend-dto');
+
     expect(await element(by.id('calendar-id-legend-admin')).getAttribute('id')).toEqual('calendar-id-legend-admin');
     expect(await element(by.id('calendar-id-legend-admin')).getAttribute('data-automation-id')).toEqual('calendar-automation-id-legend-admin');
     expect(await element(by.id('calendar-id-legend-team')).getAttribute('id')).toEqual('calendar-id-legend-team');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a small regression in the Calendar's legend area, where checkboxes were no longer linked correctly to their labels because of differing automated ids.  The issue is now fixed.

**Related github/jira issue (required)**:
Closes #4746

**Steps necessary to review your pull request (required)**:
- Pull/Build/Run
- Open http://localhost:4000/components/calendar/example-index.html
- Try checking/unchecking any of the legend labels.  This should work now.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

@jbrcna