### PR TITLE
4742 - Add additional automation ID's

### DIFF
--- a/app/views/components/dropdown/example-no-search.html
+++ b/app/views/components/dropdown/example-no-search.html
@@ -17,7 +17,7 @@
 
     <div class="field">
       <label for="nosearch-dropdown">No-Search Dropdown</label>
-      <select id="nosearch-dropdown" class="dropdown" data-options="{noSearch: true}">
+      <select id="nosearch-dropdown" class="dropdown" data-init="false">
         <option value="">&nbsp;</option>
         <option value="1">One</option>
         <option value="2">Two</option>
@@ -51,5 +51,19 @@
       'title': 'Change Event Fired',
       'message': 'Value changed to <span class="text-strong">' + $(this).val() + '</span> '
     });
+  });
+
+  $('#nosearch-dropdown').dropdown({
+    noSearch: true,
+    attributes: [
+      {
+        name: 'id',
+        value: 'custom-nosearch-id-1'
+      },
+      {
+        name: 'data-automation-id',
+        value: 'custom-automation-nosearch-id'
+      }
+    ]
   });
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### v4.37.0 Fixes
 
+- `[Dropdown]` Fixed an issue where some elements did not correctly get an id in the dropdow n. ([#4742](https://github.com/infor-design/enterprise/issues/4742))
 - `[Tabs]` Fixed a bug where the info icon were not aligned correctly in the tab, and info message were not visible. ([#4711](https://github.com/infor-design/enterprise/issues/4711))
 - `[Toolbar Searchfield]` Fixed a bug where the toolbar searchfield were unable to focused when tabbing through the page. ([#4683](https://github.com/infor-design/enterprise/issues/4683))
 - `[Toolbar Searchfield]` Fixed a bug where the search bar were showing extra outline when focused. ([#4682](https://github.com/infor-design/enterprise/issues/4682))

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -55,6 +55,7 @@ const reloadSourceStyles = ['none', 'open', 'typeahead'];
 * @param {string} [settings.allTextString]  Custom text string for `All` text header use in MultiSelect.
 * @param {string} [settings.selectedTextString]  Custom text string for `Selected` text header use in MultiSelect.
 * @param {boolean} [settings.selectAllFilterOnly = true] if true, when using the optional "Select All" checkbox, the Multiselect will only select items that are in the current filter.  If false, or if there is no filter present, all items will be selected.
+* @param {string|array} [settings.attributes = null] Add extra attributes like id's to the chart elements. For example `attributes: { name: 'id', value: 'my-unique-id' }`
 */
 const DROPDOWN_DEFAULTS = {
   closeOnSelect: true,
@@ -81,7 +82,8 @@ const DROPDOWN_DEFAULTS = {
   tagListMaxHeight: 120,
   allTextString: null,
   selectedTextString: null,
-  selectAllFilterOnly: true
+  selectAllFilterOnly: true,
+  attributes: null
 };
 
 function Dropdown(element, settings) {
@@ -265,6 +267,10 @@ Dropdown.prototype = {
         role: 'button',
         'aria-haspopup': 'listbox'
       });
+
+    if (this.settings.attributes) {
+      utils.addAttributes(this.pseudoElem, this, this.settings.attributes, 'dropdown', true);
+    }
 
     // Pass disabled/readonly from the original element, if applicable
     // "disabled" is a stronger setting than "readonly" - should take precedent.
@@ -1857,18 +1863,21 @@ Dropdown.prototype = {
       .attr('aria-expanded', 'true')
       .addClass('is-open');
 
-    // Add test automation ids
-    utils.addAttributes(this.list.find('label'), this, this.settings.attributes, 'label');
-    utils.addAttributes(this.list.find('input'), this, this.settings.attributes, 'input');
-    this.list.find('label').attr('for', this.list.find('input').attr('id'));
-    utils.addAttributes(this.list.find('.trigger'), this, this.settings.attributes, 'trigger');
-    utils.addAttributes(this.list.find('ul'), this, this.settings.attributes, 'listbox');
-    const options = this.list.find('.dropdown-option a');
-
     if (self.settings.attributes) {
+      // Add test automation ids
+      utils.addAttributes(this.list.find('input'), this, this.settings.attributes, 'search', true);
+      this.list.find('label').attr('for', this.list.find('input').attr('id'));
+      utils.addAttributes(this.list.find('label'), this, this.settings.attributes, 'search-label');
+
+      utils.addAttributes(this.list.find('.trigger'), this, this.settings.attributes, 'trigger', true);
+      utils.addAttributes(this.list.find('ul'), this, this.settings.attributes, 'listbox', true);
+      utils.addAttributes(this.list, this, this.settings.attributes, 'list');
+
+      const options = this.list.find('.dropdown-option a');
+
       options.each(function (i) {
         const opt = $(this);
-        utils.addAttributes(opt, self, self.settings.attributes, `option-${i}`);
+        utils.addAttributes(opt, self, self.settings.attributes, `option-${i}`, true);
       });
     }
 

--- a/test/components/dropdown/dropdown-updates-events.func-spec.js
+++ b/test/components/dropdown/dropdown-updates-events.func-spec.js
@@ -47,7 +47,8 @@ describe('Dropdown updates, events', () => {
       allTextString: null,
       selectedTextString: null,
       tagListMaxHeight: 120,
-      selectAllFilterOnly: true
+      selectAllFilterOnly: true,
+      attributes: null
     };
 
     expect(dropdownObj.settings).toEqual(settings);
@@ -76,7 +77,8 @@ describe('Dropdown updates, events', () => {
       allTextString: null,
       selectedTextString: null,
       tagListMaxHeight: 120,
-      selectAllFilterOnly: true
+      selectAllFilterOnly: true,
+      attributes: null
     };
 
     dropdownObj.updated();
@@ -109,7 +111,8 @@ describe('Dropdown updates, events', () => {
       allTextString: null,
       selectedTextString: null,
       tagListMaxHeight: 120,
-      selectAllFilterOnly: true
+      selectAllFilterOnly: true,
+      attributes: null
     };
     dropdownObj.updated(settings);
 
@@ -148,7 +151,8 @@ describe('Dropdown updates, events', () => {
       allTextString: null,
       selectedTextString: null,
       tagListMaxHeight: 120,
-      selectAllFilterOnly: true
+      selectAllFilterOnly: true,
+      attributes: null
     };
 
     const spyEvent = spyOnEvent('.dropdown', 'has-updated');

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -105,7 +105,7 @@ describe('Dropdown example-index tests', () => {
       await browser.driver
         .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('ul[role="listbox"]'))), config.waitsFor);
       await browser.driver.sleep(config.sleep);
-      const dropdownSearchEl = await element(by.id('dropdown-search'));
+      const dropdownSearchEl = await element(by.id('custom-dropdown-id-1-search'));
       await dropdownSearchEl.click();
       await dropdownSearchEl.sendKeys(protractor.Key.ARROW_DOWN);
       await dropdownSearchEl.sendKeys(protractor.Key.ARROW_DOWN);
@@ -124,7 +124,7 @@ describe('Dropdown example-index tests', () => {
       await dropdownEl.click();
       await browser.driver
         .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('ul[role="listbox"]'))), config.waitsFor);
-      const dropdownSearchEl = await element(by.id('dropdown-search'));
+      const dropdownSearchEl = await element(by.id('custom-dropdown-id-1-search'));
       await dropdownSearchEl.click();
       await dropdownSearchEl.sendKeys(protractor.Key.ARROW_DOWN);
       await dropdownSearchEl.sendKeys(protractor.Key.ARROW_DOWN);
@@ -162,9 +162,9 @@ describe('Dropdown example-index tests', () => {
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('ul[role="listbox"]'))), config.waitsFor);
     await browser.driver.sleep(config.sleep);
-    const dropdownSearchEl = element(by.id('dropdown-search'));
+    const dropdownSearchEl = element(by.id('custom-dropdown-id-1-search'));
     await dropdownSearchEl.click();
-    await element(by.id('dropdown-search')).clear().sendKeys('Colorado');
+    await element(by.id('custom-dropdown-id-1-search')).clear().sendKeys('Colorado');
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('.is-focused .dropdown-highlight'))), config.waitsFor);
 
@@ -183,7 +183,7 @@ describe('Dropdown example-index tests', () => {
       // Wait for the list to open
       await browser.driver
         .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('ul[role="listbox"]'))), config.waitsFor);
-      const dropdownSearchEl = element(by.id('dropdown-search'));
+      const dropdownSearchEl = element(by.id('custom-dropdown-id-1-search'));
 
       await dropdownSearchEl.click();
       await dropdownSearchEl.sendKeys(' Jersey');
@@ -193,7 +193,7 @@ describe('Dropdown example-index tests', () => {
         .wait(protractor.ExpectedConditions.presenceOf(await element(by.css('ul[role="listbox"]'))), config.waitsFor);
 
       // SearchInput should display "New Jersey" and not just " Jersey"
-      expect(await element(by.id('dropdown-search')).getAttribute('value')).toEqual('New Jersey');
+      expect(await element(by.id('custom-dropdown-id-1-search')).getAttribute('value')).toEqual('New Jersey');
     });
 
     it('Should close an open list and tab to the next element without re-opening', async () => {
@@ -227,7 +227,7 @@ describe('Dropdown example-index tests', () => {
       await browser.driver.sleep(100);
 
       // First key press causes the menu to close
-      await element(by.css('#dropdown-search')).sendKeys(protractor.Key.ESCAPE);
+      await element(by.css('#custom-dropdown-id-1-search')).sendKeys(protractor.Key.ESCAPE);
 
       // Wait for the menu to disappear
       // NOTE: Need to fix this once setTimeouts are removed (Github #794)
@@ -252,8 +252,15 @@ describe('Dropdown example-index tests', () => {
       expect(await element(by.id('custom-dropdown-id-1')).getAttribute('id')).toEqual('custom-dropdown-id-1');
       expect(await element(by.id('custom-dropdown-id-1')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id');
 
-      expect(await element(by.id('dropdown-search')).getAttribute('id')).toEqual('dropdown-search');
-      expect(await element(by.id('dropdown-search')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-input');
+      expect(await element(by.id('custom-dropdown-id-1-search')).getAttribute('id')).toEqual('custom-dropdown-id-1-search');
+      expect(await element(by.id('custom-dropdown-id-1-search')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-search');
+
+      expect(await element(by.id('custom-dropdown-id-1-search-label')).getAttribute('for')).toEqual('custom-dropdown-id-1-search');
+      expect(await element(by.id('custom-dropdown-id-1-search-label')).getAttribute('id')).toEqual('custom-dropdown-id-1-search-label');
+      expect(await element(by.id('custom-dropdown-id-1-search-label')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-search-label');
+
+      expect(await element(by.id('custom-dropdown-id-1-dropdown')).getAttribute('id')).toEqual('custom-dropdown-id-1-dropdown');
+      expect(await element(by.id('custom-dropdown-id-1-dropdown')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-dropdown');
 
       expect(await element(by.id('custom-dropdown-id-1-trigger')).getAttribute('id')).toEqual('custom-dropdown-id-1-trigger');
       expect(await element(by.id('custom-dropdown-id-1-trigger')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-trigger');
@@ -261,17 +268,8 @@ describe('Dropdown example-index tests', () => {
       expect(await element(by.id('custom-dropdown-id-1-listbox')).getAttribute('id')).toEqual('custom-dropdown-id-1-listbox');
       expect(await element(by.id('custom-dropdown-id-1-listbox')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-listbox');
 
-      expect(await element(by.id('list-option-0')).getAttribute('id')).toEqual('list-option-0');
-      expect(await element(by.id('list-option-0')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-option-0');
-
-      expect(await element(by.id('list-option-1')).getAttribute('id')).toEqual('list-option-1');
-      expect(await element(by.id('list-option-1')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-option-1');
-
-      expect(await element(by.id('list-option-2')).getAttribute('id')).toEqual('list-option-2');
-      expect(await element(by.id('list-option-2')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-option-2');
-
-      expect(await element(by.id('list-option-3')).getAttribute('id')).toEqual('list-option-3');
-      expect(await element(by.id('list-option-3')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-option-3');
+      expect(await element(by.id('custom-dropdown-id-1-option-0')).getAttribute('id')).toEqual('custom-dropdown-id-1-option-0');
+      expect(await element(by.id('custom-dropdown-id-1-option-0')).getAttribute('data-automation-id')).toEqual('custom-automation-dropdown-id-option-0');
     });
   }
 
@@ -283,13 +281,13 @@ describe('Dropdown example-index tests', () => {
     await dropdownEl.click();
     await browser.driver.sleep(config.sleep);
 
-    expect(await element(by.id('dropdown-search')).isDisplayed()).toBeTruthy();
+    expect(await element(by.id('custom-dropdown-id-1-search')).isDisplayed()).toBeTruthy();
 
     await element(by.css('.btn-actions')).click();
 
     await browser.driver.sleep(config.sleep);
 
-    expect(await element(by.id('dropdown-search')).isPresent()).toBeFalsy();
+    expect(await element(by.id('custom-dropdown-id-1-search')).isPresent()).toBeFalsy();
     await browser.driver.sleep(config.sleep);
 
     dropdownEl = await element(by.css('div.dropdown'));
@@ -298,7 +296,7 @@ describe('Dropdown example-index tests', () => {
     await dropdownEl.click();
     await browser.driver.sleep(config.sleep);
 
-    expect(await element(by.id('dropdown-search')).isDisplayed()).toBeTruthy();
+    expect(await element(by.id('custom-dropdown-id-1-search')).isDisplayed()).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adds some fixes for automation ID's on dropdown. To be patched to 4.36. Mainly the problem was some id's are missing and some are not overriding with the setting.

**Related github/jira issue (required)**:
Fixes #4742

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/dropdown/example-index.html and open the list
- ensure the following have both an id and automation-id
```
select + div.dropdown-wrapper > div.dropdown`
.dropdown-list > ul
.dropdown-list > label
.dropdown-list > input
.dropdown-list > ul > li.dropdown-option > a
```
- go to http://localhost:4000/components/dropdown/example-no-search.html and open the list
- ensure `#dropdown-list > span.trigger` has an id and automation-id

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
