### PR TITLE
4746 - Re-link calendar events to legend clicks

### DIFF
--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -600,7 +600,7 @@ Calendar.prototype = {
     for (let i = 0; i < checkboxes.length; i++) {
       const input = checkboxes[i];
       if (!input.checked) {
-        types.push(input.getAttribute('id'));
+        types.push(input.getAttribute('name'));
       }
     }
     return types;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This is a follow up fix to PR #4747, after it was discovered that clicking on a legend checkbox was still not linked to showing/hiding events.  This PR changes the method of linking legend items to events to use the `name` attribute, instead of `id`s which are now variable.

**Related github/jira issue (required)**:
Closes #4746 

**Steps necessary to review your pull request (required)**:
- Pull, run, build
- Open http://localhost:4000/components/calendar/example-index.html
- Choose any date and add a new event.  Be aware of the event type you pick.
- After adding the event, toggle the event type's checkbox.  It should hide/show the event as expected.
