### PR TITLE
4740 - Improve detection of non-focusable elements in Modals

### DIFF
--- a/app/views/components/modal/test-focusable-elements.html
+++ b/app/views/components/modal/test-focusable-elements.html
@@ -1,0 +1,78 @@
+<div class="row">
+	<div class="twelve columns">
+
+		<button class="btn-secondary" type="button" id="add-context">Show Modal</button><br/><br/>
+
+		<!-- Modal Example -->
+		<div id="modal-add-context" class="hidden">
+			<div class="field">
+				<label for="testtab">Test Tab Index -1</label>
+				<input type="text" id="testtab" name="testtab" tabindex="-1"/>
+			</div>
+
+			<div class="field">
+				<label for="testdisabled">Test Disabled</label>
+				<input type="text" id="testdisabled" name="testdisabled" disabled="true"/>
+			</div>
+
+      <div class="field">
+        <label for="problem">Problem</label>
+        <input type="text" id="problem" name="problem"/>
+      </div>
+
+      <div class="field">
+        <label for="location" class="label">Location</label>
+        <select id="location" name="location" class="dropdown">
+          <option value="N">North</option>
+          <option value="S">South</option>
+          <option value="E">East</option>
+          <option value="W">West</option>
+        </select>
+      </div>
+
+			<div class="field">
+				<label for="notes-max">Notes (maxlength)</label>
+				<textarea id="notes-max" class="textarea" maxlength="90" name="notes-max">Line One</textarea>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<script>
+var modals = {
+    'add-context': {
+      'title': 'Add Context',
+      'id': 'my-id',
+      'content': $('#modal-add-context')
+    }
+  },
+
+  setModal = function (opt) {
+    opt = $.extend({
+      buttons: [{
+        text: 'Cancel',
+      //  id: 'modal-button-1',
+        click: function(e, modal) {
+          modal.close();
+        }
+      }, {
+        text: 'Save',
+      //  id: 'modal-button-2',
+        click: function(e, modal) {
+          modal.close();
+        },
+        validate: false,
+        isDefault: true
+      }]
+    }, opt);
+
+    $('body').modal(opt);
+  };
+
+  $('#add-context').on('click', function () {
+		$(this).focus();
+    setModal(modals[this.id]);
+  });
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[App Menu]` Removed the close button animation on the hamburger button when app menus open. ([#4756](https://github.com/infor-design/enterprise/issues/4756))
 - `[Dropdown]` Fixed an issue where some elements did not correctly get an id in the dropdow n. ([#4742](https://github.com/infor-design/enterprise/issues/4742))
 - `[Calendar]` Fixed a regression where clicking Legend checkboxes was no longer possible. ([#4746](https://github.com/infor-design/enterprise/issues/4746))
+- `[Modal]` Improved detection of non-focusable elements when a Modal is configured to auto focus one of its inner components. ([#4740](https://github.com/infor-design/enterprise/issues/4740))
 - `[Tabs]` Fixed a bug where the info icon were not aligned correctly in the tab, and info message were not visible. ([#4711](https://github.com/infor-design/enterprise/issues/4711))
 - `[Toolbar Searchfield]` Fixed a bug where the toolbar searchfield were unable to focused when tabbing through the page. ([#4683](https://github.com/infor-design/enterprise/issues/4683))
 - `[Toolbar Searchfield]` Fixed a bug where the search bar were showing extra outline when focused. ([#4682](https://github.com/infor-design/enterprise/issues/4682))

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -627,19 +627,17 @@ DOM.convertToHTMLElement = function convertToHTMLElement(item) {
  */
 DOM.focusableElems = function focusableElems(el, additionalSelectors = [], ignoreSelectors = []) {
   const focusableElemSelector = [
-    'button',
-    '[href]',
-    'input',
-    'select',
-    'textarea',
+    'button:not([disabled]):not([tabindex="-1"])',
+    '[href]:not([disabled]):not([tabindex="-1"])',
+    'input:not([disabled]):not([tabindex="-1"])',
+    'textarea:not([disabled]):not([tabindex="-1"])',
     '[focusable]:not([focusable="false"])',
     '[tabindex]:not([tabindex="-1"])',
     '[contenteditable]',
     'iframe'
   ].concat(additionalSelectors).filter(item => ignoreSelectors.indexOf(item) === -1);
-  const elems = el.querySelectorAll(focusableElemSelector.join(', '));
-  const arrElems = utils.getArrayFromList(elems);
-  return arrElems.filter((elem) => {
+  const elems = [...el.querySelectorAll(focusableElemSelector.join(', '))];
+  return elems.filter((elem) => {
     if (elem.tagName.toLowerCase() === 'use') {
       return false;
     }

--- a/test/components/modal/modal.e2e-spec.js
+++ b/test/components/modal/modal.e2e-spec.js
@@ -488,3 +488,20 @@ describe('Modal with external components tests', () => {
     expect(focusedElemText).toEqual('Close');
   });
 });
+
+describe('Modal focusable elements tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/modal/test-focusable-elements?layout=nofrills');
+    const buttonEl = await element(by.id('add-context'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(buttonEl), config.waitsFor);
+    await buttonEl.click();
+    await browser.driver.sleep(config.sleep);
+  });
+
+  it('Should focus the first available input field', async () => {
+    const focusedElemId = await browser.driver.switchTo().activeElement().getAttribute('id');
+
+    expect(focusedElemId).toEqual('problem');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR makes some adjustments to the current method for retrieving focusable elements within a component, to better account for elements with `tabindex="-1"` and `disabled` attributes.

**Related github/jira issue (required)**:
Closes #4740

**Steps necessary to review your pull request (required)**:
- Pull, build, run
- Open http://localhost:4000/components/modal/test-focusable-elements
- Click "Show Modal"
- When the modal opens, the third input field down labelled "Problem" should be focused.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
