### PR TITLE
4656 - Added a fix for locale losing a digit

### DIFF
--- a/app/views/components/locale/test-format-big-negative.html
+++ b/app/views/components/locale/test-format-big-negative.html
@@ -1,0 +1,39 @@
+<div class="row">
+  <div class="six columns">
+    <h2>Format Big Negative Number</h2>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="six columns">
+    <div class="field">
+      <label for="test-input">Numeric Input</label>
+      <input id="test-input" type="number" value="-922589489099.38" class="new-mask" data-options='{ "process": "number", "patternOptions": { "allowLeadingZeros": true, "allowThousandsSeparator": false, "allowDecimal": true, "allowNegative": true, "integerLimit": 29, "decimalLimit": 2 } }' placeholder="-#######.00" step="0.01"/>
+    </div>
+    <div class="field">
+      <button id="format" class="btn-secondary">Format</button>
+    </div>
+    <div class="field">
+      <label for="test-format-value">Formatted Value</label>
+      <input id="test-format-value" type="number" readonly class="new-mask" data-options='{ "process": "number", "patternOptions": { "allowLeadingZeros": true, "allowThousandsSeparator": false, "allowDecimal": true, "allowNegative": true, "integerLimit": 29, "decimalLimit": 2 } }' placeholder="-#######.00" step="0.01"/>
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').on('initialized', function() {
+    $('#format').on('click', function(e) {
+      var value = document.getElementById('test-input').value;
+
+      document.getElementById('test-format-value').value = Locale.formatNumber(value, {
+        style: "decimal",
+        round: true,
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+        group: "",
+        decimal: "."
+      });
+    });
+
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[App Menu]` Removed the close button animation on the hamburger button when app menus open. ([#4756](https://github.com/infor-design/enterprise/issues/4756))
 - `[Dropdown]` Fixed an issue where some elements did not correctly get an id in the dropdow n. ([#4742](https://github.com/infor-design/enterprise/issues/4742))
 - `[Calendar]` Fixed a regression where clicking Legend checkboxes was no longer possible. ([#4746](https://github.com/infor-design/enterprise/issues/4746))
+- `[Locale]` Fixed an issue where if the 11th digit is a zero the formatNumbers and truncateDecimals function will loose a digit. ([#4656](https://github.com/infor-design/enterprise/issues/4656))
 - `[Tabs]` Fixed a bug where the info icon were not aligned correctly in the tab, and info message were not visible. ([#4711](https://github.com/infor-design/enterprise/issues/4711))
 - `[Toolbar Searchfield]` Fixed a bug where the toolbar searchfield were unable to focused when tabbing through the page. ([#4683](https://github.com/infor-design/enterprise/issues/4683))
 - `[Toolbar Searchfield]` Fixed a bug where the search bar were showing extra outline when focused. ([#4682](https://github.com/infor-design/enterprise/issues/4682))

--- a/src/utils/number.js
+++ b/src/utils/number.js
@@ -61,8 +61,11 @@ numberUtils.toFixed = function toFixed(number, decimals = 2) {
     firstPart = (parseInt(firstPart, 10) + 1).toString();
   }
 
-  if (lastPart) {
+  if (lastPart && lastPart.substr(0, 1) !== '0') {
     parsedNum = firstPart + parsedNum;
+  }
+  if (lastPart && lastPart.substr(0, 1) === '0') {
+    parsedNum = `${firstPart}0${parsedNum}`;
   }
   return parsedNum;
 };

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -1147,6 +1147,15 @@ describe('Locale API', () => {
       minimumFractionDigits: 6,
       maximumFractionDigits: 6
     })).toEqual('123,456,789,012.123460');
+
+    expect(Locale.formatNumber('-922589489099.38', {
+      style: 'decimal',
+      round: true,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+      group: '',
+      decimal: '.'
+    })).toEqual('-922589489099.38');
   });
 
   it('Should handle AM/PM', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixed a bug with big numbers where if the 11th digit is a zero in the middle of the number it will get lost due to incorrect logic in the toFixed routines.

**Related github/jira issue (required)**:
Fixes #4656

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/locale/test-format-big-negative.html
- click the button
- the number should be the same in the lower field

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
