### PR TITLE
Stepped interval spinbox doesn't work properly for double digits

### DIFF
--- a/src/components/spinbox/spinbox.js
+++ b/src/components/spinbox/spinbox.js
@@ -130,7 +130,7 @@ Spinbox.prototype = {
     }
 
     if (this.element.attr('step')) {
-      this.settings.max = this.element.attr('step');
+      this.settings.step = this.element.attr('step');
     } else if (this.settings.step) {
       this.element.attr('step', this.settings.step);
     }

--- a/test/components/spinbox/spinbox-settings.func-spec.js
+++ b/test/components/spinbox/spinbox-settings.func-spec.js
@@ -1,12 +1,14 @@
 import { Spinbox } from '../../../src/components/spinbox/spinbox';
 
 const spinboxHTML = require('../../../app/views/components/spinbox/example-index.html');
+const steppedIntervalSpinboxHTML = require('../../../app/views/components/spinbox/example-stepped-intervals.html');
 const svg = require('../../../src/components/icons/svg.html');
 
 let spinboxEl;
 let svgEl;
 let spinboxApi;
 const spinboxId = '#regular-spinbox';
+const steppedIntervalSpinboxId = '#stepped-spinbox';
 
 describe('Spinbox settings', () => {
   beforeEach(() => {
@@ -85,6 +87,40 @@ describe('Spinbox settings', () => {
       min: 0,
       max: 10,
       step: null,
+      maskOptions: null,
+      attributes: null
+    };
+
+    expect(spinboxApi.settings).toEqual(settings);
+  });
+});
+
+describe('Spinbox Stepped Intervals', () => {
+  beforeEach(() => {
+    spinboxEl = null;
+    svgEl = null;
+    spinboxApi = null;
+
+    document.body.insertAdjacentHTML('afterbegin', svg);
+    document.body.insertAdjacentHTML('afterbegin', steppedIntervalSpinboxHTML);
+
+    spinboxEl = document.body.querySelector(steppedIntervalSpinboxId);
+    svgEl = document.body.querySelector('.svg-icons');
+    spinboxApi = new Spinbox(spinboxEl);
+  });
+
+  afterEach(() => {
+    spinboxApi.destroy();
+    spinboxEl.parentNode.removeChild(spinboxEl);
+    svgEl.parentNode.removeChild(svgEl);
+  });
+
+  it('should parse attributes and set the settings on init', () => {
+    const settings = {
+      autocorrectOnBlur: true,
+      min: '-99',
+      max: '99',
+      step: '3',
       maskOptions: null,
       attributes: null
     };

--- a/test/components/spinbox/spinbox.e2e-spec.js
+++ b/test/components/spinbox/spinbox.e2e-spec.js
@@ -121,3 +121,22 @@ describe('Spinbox Range Tests tests', () => {
     expect(await element(by.id('limited-spinbox-2')).getAttribute('value')).toEqual('200');
   });
 });
+
+describe('Spinbox Stepped Interval tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/spinbox/example-stepped-intervals.html');
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.id('stepped-spinbox'))), config.waitsFor);
+  });
+
+  it('should be able to input a double digit number when a step is defined', async () => {
+    const spinBoxElement = element(by.id('stepped-spinbox'));
+
+    await spinBoxElement.clear();
+    await spinBoxElement.sendKeys('21');
+    await spinBoxElement.sendKeys(protractor.Key.TAB);
+    await browser.driver.sleep(config.sleepShort);
+
+    expect(await spinBoxElement.getAttribute('value')).toEqual('21');
+  });
+});


### PR DESCRIPTION
**Explain the details for making this change. What existing problem does the pull request solve?**
When setting the [step] attribute, the spinbox would no longer allow double digits. 

Related github/jira issue (required):
Fixes #4762 

**Steps necessary to review your pull request (required)**:

1. Go to 'example-stepped-intervals' under the spinbox component at https://master-enterprise.demo.design.infor.com/components/spinbox/example-stepped-intervals.html
2. Click on the spin up button until the number is in the double digits
3. Click or tab out of the spinbox
4. Notice that only one digit remains in the spinbox
5. Try typing multiple digits into the spinbox
6. Notice that only one digit is allowed

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

