### PR TITLE
936 - Fix error were showing when use trackdirty with tabs 

### DIFF
--- a/app/views/components/tabs/example-index.html
+++ b/app/views/components/tabs/example-index.html
@@ -32,6 +32,11 @@
       </div>
       <div id="tabs-normal-opportunities" data-automation-id="tabs-panel-opportunities" class="tab-panel">
         <p>Bricks-and-clicks? Evolve ubiquitous matrix B2B 24/365 vertical 24/365 platforms standards-compliant global leverage dynamic 24/365 intuitive ROI seamless rss-capable. Cutting-edge grow morph web services leverage; ROI, unleash reinvent innovative podcasts citizen-media networking.</p>
+        <br/><br/>
+        <div class="field">
+          <label for="test-trackdirty">Dirty Tracking</label>
+          <input type="text" placeholder="Dirty Tracking" data-trackdirty="true" id="test-trackdirty" name="test-trackdirty"/>
+        </div>
       </div>
       <div id="tabs-normal-attachments" data-automation-id="tabs-panel-attachments" class="tab-panel">
         <p>Frictionless webservices, killer open-source innovate, best-of-breed, whiteboard interactive back-end optimize capture dynamic front-end. Initiatives ubiquitous 24/7 enhance channels B2B drive frictionless web-readiness generate recontextualize widgets applications. Sexy sticky matrix, user-centred, rich user-centric: peer-to-peer podcasting networking addelivery optimize streamline integrated proactive: granular morph.</p>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,7 +23,7 @@
 - `[Tabs]` Fixed a bug where the info icon were not aligned correctly in the tab, and info message were not visible. ([#4711](https://github.com/infor-design/enterprise/issues/4711))
 - `[Toolbar Searchfield]` Fixed a bug where the toolbar searchfield were unable to focused when tabbing through the page. ([#4683](https://github.com/infor-design/enterprise/issues/4683))
 - `[Toolbar Searchfield]` Fixed a bug where the search bar were showing extra outline when focused. ([#4682](https://github.com/infor-design/enterprise/issues/4682))
-- `[Track Dirty]` Fixed a bug where error were showing when use with tabs. ([#936](https://github.com/infor-design/enterprise-ng/issues/936))
+- `[Track Dirty]` Fixed an error that was showing when using dirty indicator within a tab component. ([#936](https://github.com/infor-design/enterprise-ng/issues/936))
 - `[Tree]` Fixed an issue where the character entity was stripped for addNode() method. ([#4694](https://github.com/infor-design/enterprise/issues/4694))
 
 ## v4.36.2

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `[Tabs]` Fixed a bug where the info icon were not aligned correctly in the tab, and info message were not visible. ([#4711](https://github.com/infor-design/enterprise/issues/4711))
 - `[Toolbar Searchfield]` Fixed a bug where the toolbar searchfield were unable to focused when tabbing through the page. ([#4683](https://github.com/infor-design/enterprise/issues/4683))
 - `[Toolbar Searchfield]` Fixed a bug where the search bar were showing extra outline when focused. ([#4682](https://github.com/infor-design/enterprise/issues/4682))
+- `[Track Dirty]` Fixed a bug where error were showing when use with tabs. ([#936](https://github.com/infor-design/enterprise-ng/issues/936))
 - `[Tree]` Fixed an issue where the character entity was stripped for addNode() method. ([#4694](https://github.com/infor-design/enterprise/issues/4694))
 
 ## v4.36.2

--- a/src/components/trackdirty/trackdirty.jquery.js
+++ b/src/components/trackdirty/trackdirty.jquery.js
@@ -8,7 +8,7 @@ import { Trackdirty, COMPONENT_NAME } from './trackdirty';
 $.fn.trackdirty = function (settings) {
   return this.each(function () {
     let instance = $.data(this, COMPONENT_NAME);
-    if (instance) {
+    if (instance && instance instanceof Trackdirty) {
       instance.updated(settings);
     } else {
       instance = $.data(this, COMPONENT_NAME, new Trackdirty(this, settings));


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed error were showing when use trackdirty with tabs.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#936

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/tabs/example-index.html
- Open developer tools
- See in console should not be any error
- Click on tab `Opportunities`
- Type something into `Dirty Tracking` input and blur
- Dirty indicator should show

Test on angular side:
- Pull this branch and build/run the demo app
- Pull and build NG branch ([master](https://github.com/infor-design/enterprise-ng))
- Copy and replace "dist" folder from `enterprise` to `⁨enterprise-ng⁩/node_modules⁩/ids-enterprise`
- Add `soho-trackdirty` attribute to any input as example below
`<input soho-trackdirty type="text" name="text-normal-opportunities" id="text-normal-opportunities" data-validate="required">`
- Run app and Navigate to: http://localhost:4000/components/tabs/example-index.html
- Open developer tools
- See in console should not be any error
- Go to the tab where edit the input for `soho-trackdirty`
- Type something into this input and blur
- Dirty indicator should show

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
