### PR TITLE
980 - Fix an error was showing when close too soon with busy indicator

### DIFF
--- a/app/views/components/busyindicator/test-activate-close.html
+++ b/app/views/components/busyindicator/test-activate-close.html
@@ -1,0 +1,65 @@
+<div class="row">
+  <div class="six columns">
+    <h2>Busy Indicator Test: Activate and Close</h2>
+    <p>Fixed an error was showing when called `close()` method too soon after `activate()`. (Github issue <a href="https://github.com/infor-design/enterprise-ng/issues/980">#980</a>)</p>
+    <p></p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="six columns">
+
+    <form id="busy-form" class="busy" action="#" method="POST">
+      <div class="field">
+        <label for="busy-field-name">Name</label>
+        <input id="busy-field-name" name="busy-field-name" />
+      </div>
+      <div class="field">
+        <label for="busy-field-address">Address</label>
+        <input id="busy-field-address" name="busy-field-address" />
+      </div>
+      <div class="field">
+        <label for="busy-field-cats">Number of Cats</label>
+        <input id="busy-field-cats" name="busy-field-cats" />
+      </div>
+      <div class="field">
+        <button type="reset" id="reset" class="btn-secondary">Clear</button>
+        <button type="submit" id="submit" class="btn-primary">Submit to activate Busy Indicator</button>
+      </div>
+    </form>
+
+  </div>
+</div>
+
+<script>
+  $('body').on('initialized', function() {
+
+    var busyApi = $('#busy-form').data('busyindicator');
+    var delay = 1;
+
+    $('#submit').click(function(e) {
+      e.preventDefault();
+      if (busyApi) {
+        // Activate busyindicator
+        busyApi.activate();
+        showToast('Activated');
+
+        setTimeout(function() {
+          // Close busyindicator
+          busyApi.close();
+          showToast('Closed');
+        }, delay);
+      }
+    });
+
+    // Show toast
+    function showToast (option) {
+      $('body').toast({
+        title: 'Busyindicator',
+        message: option
+      });
+      console.log('Busyindicator: '+ option);
+    }
+
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - `[App Menu]` Fixed a regression bug  where the searchfield icon duplicated and were not properly aligned with the searchfield. ([#4737](https://github.com/infor-design/enterprise/issues/4737))
 - `[App Menu]` Removed the close button animation on the hamburger button when app menus open. ([#4756](https://github.com/infor-design/enterprise/issues/4756))
+- `[Busy Indicator]` Fixed an error was showing when called `close()` method too soon after `activate()`. ([#980](https://github.com/infor-design/enterprise-ng/issues/980))
 - `[Calendar]` Fixed a regression where clicking Legend checkboxes was no longer possible. ([#4746](https://github.com/infor-design/enterprise/issues/4746))
 - `[Datagrid]` Fixed an issue where the filter border on readonly lookups was not displayed in high contrast mode. ([#4724](https://github.com/infor-design/enterprise/issues/4724))
 - `[Dropdown]` Fixed an issue where some elements did not correctly get an id in the dropdown. ([#4742](https://github.com/infor-design/enterprise/issues/4742))

--- a/src/components/busyindicator/busyindicator.js
+++ b/src/components/busyindicator/busyindicator.js
@@ -363,7 +363,10 @@ BusyIndicator.prototype = {
       this.scrollParent = $(this.getScrollParent(elem));
       const sElem = this.scrollParent[0];
       const height = sElem ? sElem.offsetHeight : 0;
-      const elComputedPos = window.getComputedStyle(this.overlay[0], null).getPropertyValue('position');
+      let elComputedPos;
+      if (this.overlay && this.overlay[0]) {
+        elComputedPos = window.getComputedStyle(this.overlay[0], null).getPropertyValue('position');
+      }
       const isOverlayAbsolute = elComputedPos === 'absolute';
       if ((height && this.container && (height <= elem.offsetHeight))) {
         const winHeight = window.innerHeight || document.documentElement.clientHeight;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed an error was showing when called `close()` method too soon after `activate()` with Busy Indicator.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#980

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/busyindicator/test-activate-close.html
- Open developer tools
- Click on button `Submit to activate Busy Indicator`
- See in console should not be any error


Test on angular side:
- Pull this branch and build/run the demo app
- Pull and build NG branch ([master](https://github.com/infor-design/enterprise-ng))
- Copy and replace "dist" folder from `enterprise` to `⁨enterprise-ng⁩/node_modules⁩/ids-enterprise`
- Edit file `enterprise-ng/src/app/busyindicator/form.demo.ts`
- Change delay time from 10000 to 10 at (Line [#38](https://github.com/infor-design/enterprise-ng/blob/188f7c35a1dc5abbda24414898d3a0a7dee9a705/src/app/busyindicator/form.demo.ts#L38))
- Run app and Navigate to: http://localhost:4200/ids-enterprise-ng-demo/busyindicator
- Open developer tools
- Click on button `Timer`
- See in console should not be any error

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
