### PR TITLE
4798 - Fix wrong metadata for resize, reorder and remove card with homepage (4.37.x)

### DIFF
--- a/app/views/components/homepage/example-editable.html
+++ b/app/views/components/homepage/example-editable.html
@@ -64,6 +64,5 @@
     .on('removecard', function(event, card, data){ console.log("Homepage: removecard event: ", [card, data])});
   $('.widget')
     .on('resizecard', function(event, card, data){ console.log("Widget: resizecard event: ", [card, data])})
-    .on('reordercard', function(event, card, data){ console.log("Widget: reordercard event: ", [card, data])})
-    .on('removecard', function(event, card, data){ console.log("Widget: removecard event: ", [card, data])});
+    .on('reordercard', function(event, card, data){ console.log("Widget: reordercard event: ", [card, data])});
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `[Datagrid]` Added missing aria row group role to the datagrid. ([#4479](https://github.com/infor-design/enterprise/issues/4479))
 - `[Dropdown]` Fixed an issue where some elements did not correctly get an id in the dropdown. ([#4742](https://github.com/infor-design/enterprise/issues/4742))
 - `[Dropdown]` Fixed a bug where you could click the label and focus a disabled dropdown. ([#4739](https://github.com/infor-design/enterprise/issues/4739))
+- `[Homepage]` Fixed the wrong metadata was sending for resize, reorder and remove card events. ([#4798](https://github.com/infor-design/enterprise/issues/4798))
 - `[Locale]` Fixed an issue where if the 11th digit is a zero the formatNumbers and truncateDecimals function will loose a digit. ([#4656](https://github.com/infor-design/enterprise/issues/4656))
 - `[Modal]` Improved detection of non-focusable elements when a Modal is configured to auto focus one of its inner components. ([#4740](https://github.com/infor-design/enterprise/issues/4740))
 - `[Module Tabs]` Fixed a bug related to automatic linking of Application Menu trigger tabs in Angular environments ([#4736](https://github.com/infor-design/enterprise/issues/4736))

--- a/src/components/homepage/homepage.js
+++ b/src/components/homepage/homepage.js
@@ -213,26 +213,22 @@ Homepage.prototype = {
           const header = card.children('.widget-header');
           removeButton.insertBefore(header)
             .on('click.card-remove', () => {
+              const removeCard = () => {
+                card.remove();
+                homepage.refresh(false);
+                setTimeout(() => {
+                  homepage.element.triggerHandler('removecard', [card, homepage.state]);
+                }, 0);
+              };
               if (this.settings && typeof this.settings.onBeforeRemoveCard === 'function') {
                 const result = this.settings.onBeforeRemoveCard(card);
                 if (result && result.then && typeof result.then === 'function') { // A promise is returned
-                  result.then(() => {
-                    card.triggerHandler('removecard', [card, homepage.state]);
-                    card.remove();
-                    homepage.refresh(false);
-                    homepage.element.triggerHandler('removecard', [card, homepage.state]);
-                  });
+                  result.then(() => removeCard());
                 } else if (result) { // Boolean is returned instead of a promise
-                  card.triggerHandler('removecard', [card, homepage.state]);
-                  card.remove();
-                  homepage.refresh(false);
-                  homepage.element.triggerHandler('removecard', [card, homepage.state]);
+                  removeCard();
                 }
               } else {
-                card.triggerHandler('removecard', [card, homepage.state]);
-                card.remove();
-                homepage.refresh(false);
-                homepage.element.triggerHandler('removecard', [card, homepage.state]);
+                removeCard();
               }
             });
         }
@@ -279,8 +275,10 @@ Homepage.prototype = {
                   $('.ui-resizable-handle').remove();
                   card.css({ opacity: 1, width: '' });
                   homepage.refresh(false);
-                  card.triggerHandler('resizecard', [card, homepage.state]);
-                  homepage.element.triggerHandler('resizecard', [card, homepage.state]);
+                  setTimeout(() => {
+                    card.triggerHandler('resizecard', [card, homepage.state]);
+                    homepage.element.triggerHandler('resizecard', [card, homepage.state]);
+                  }, 0);
                 });
             });
           const southHandle = $('<div>').addClass('ui-resizable-handle ui-resizable-s')
@@ -315,8 +313,10 @@ Homepage.prototype = {
                   $('.ui-resizable-handle').remove();
                   card.css({ opacity: 1, height: '' });
                   homepage.refresh(false);
-                  card.triggerHandler('resizecard', [card, homepage.state]);
-                  homepage.element.triggerHandler('resizecard', [card, homepage.state]);
+                  setTimeout(() => {
+                    card.triggerHandler('resizecard', [card, homepage.state]);
+                    homepage.element.triggerHandler('resizecard', [card, homepage.state]);
+                  }, 0);
                 });
             });
           if (card.has('.ui-resizable-handle').length === 0) {
@@ -373,8 +373,10 @@ Homepage.prototype = {
             card.removeClass('is-dragging');
             homepage.guide.remove();
             homepage.refresh(false);
-            card.triggerHandler('reordercard', [card, homepage.state]);
-            homepage.element.triggerHandler('reordercard', [card, homepage.state]);
+            setTimeout(() => {
+              card.triggerHandler('reordercard', [card, homepage.state]);
+              homepage.element.triggerHandler('reordercard', [card, homepage.state]);
+            }, 0);
           }
         });
     } else {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the wrong metadata was sending for resize, reorder and remove card events with Homepage.

**Related github/jira issue (required)**:
Closes #4798

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/homepage/example-editable.html
- Open developer tools
- Move Widget A (top left) to position of Widget B (top right)
- See the logs in console, should have updated data
- Resize or Remove card
- See the logs in console, should have updated data

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
