### PR TITLE
1813 - Fix splitter drags the wrong direction in rtl (4.37.x)

### DIFF
--- a/app/views/components/splitter/example-splitter-right-custom-width.html
+++ b/app/views/components/splitter/example-splitter-right-custom-width.html
@@ -7,7 +7,7 @@
 
   <nav class="sidebar scrollable" style="width: calc(20% + 10px);">
     <div class="content">
-      <div id="splitter" class="splitter"data-options="{'side':'right', 'save':false}"></div>
+      <div id="splitter" class="splitter" data-options="{'side':'right', 'save':false}"></div>
     </div>
   </nav>
 </div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@
 - `[Module Tabs]` Fixed a bug related to automatic linking of Application Menu trigger tabs in Angular environments ([#4736](https://github.com/infor-design/enterprise/issues/4736))
 - `[ProcessIndicator]` Fixed a layout issue on the index page and added a rejected icon. ([#4770](https://github.com/infor-design/enterprise/issues/4770))
 - `[Rating]` Fixed an issue where the rating was not clear on toggle. ([#4571](https://github.com/infor-design/enterprise/issues/4571))
+- `[Splitter]` Fixed the splitter was dragging to wrong direction in RTL. ([#1813](https://github.com/infor-design/enterprise/issues/1813))
 - `[Swaplist]` Fixed an issue where the user attributes need to be override existing attributes. ([#4694](https://github.com/infor-design/enterprise/issues/4694))
 - `[Tabs]` Fixed a bug where the info icon were not aligned correctly in the tab, and info message were not visible. ([#4711](https://github.com/infor-design/enterprise/issues/4711))
 - `[Tabs]` Fixed a bug where the tab key would move through tabs rather than moving to the tab content. ([#4745](https://github.com/infor-design/enterprise/issues/4745))

--- a/src/components/splitter/splitter.js
+++ b/src/components/splitter/splitter.js
@@ -68,7 +68,7 @@ Splitter.prototype = {
     const parent = splitter.parent();
     const direction = s.axis === 'x' ? 'left' : 'top';
     const thisSide = parent.is('.content') ? parent.parent() : parent;
-    const dragHandle = $(`<div class="splitter-drag-handle">${$.createIcon('drag')}</div>`);
+    let dragHandle = splitter.find('.splitter-drag-handle');
     let defaultOffset = 299;
     let w = parent.width();
     let parentHeight;
@@ -83,8 +83,10 @@ Splitter.prototype = {
     this.isSplitterRightSide = splitter.is('.splitter-right') || (s.axis === 'x' && s.side === 'right');
     this.isSplitterHorizontal = splitter.is('.splitter-horizontal') || s.axis === 'y';
     s.uniqueId = utils.uniqueId(this.element, 'splitter');
-    dragHandle.appendTo(splitter);
-    dragHandle.prepend(`<span class="audible">${Locale.translate('SplitterDragHandle')}</span>`);
+    if (!dragHandle.length) {
+      dragHandle = $(`<div class="splitter-drag-handle"><span class="audible">${Locale.translate('SplitterDragHandle')}</span>${$.createIcon('drag')}</div>`);
+      dragHandle.appendTo(splitter);
+    }
 
     const handleCollapseButton = () => {
       let savedOffset = 0;
@@ -447,6 +449,9 @@ Splitter.prototype = {
    */
   unbind() {
     this.element.off(`updated.${COMPONENT_NAME}`);
+    if (this.splitterCollapseButton) {
+      this.splitterCollapseButton.remove();
+    }
     return this;
   },
 
@@ -458,13 +463,10 @@ Splitter.prototype = {
   updated(settings) {
     if (typeof settings !== 'undefined') {
       this.settings = utils.mergeSettings(this.element, settings, SPLITTER_DEFAULTS);
-
-      return this
-        .destroy()
-        .init();
     }
-
-    return this;
+    return this
+      .unbind()
+      .init();
   },
 
   /**
@@ -473,9 +475,6 @@ Splitter.prototype = {
   */
   destroy() {
     this.unbind();
-    if (this.splitterCollapseButton) {
-      this.splitterCollapseButton.remove();
-    }
     $.removeData(this.element[0], COMPONENT_NAME);
     return this;
   },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the splitter was dragging to wrong direction in RTL.

**Related github/jira issue (required)**:
Closes #1813

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Use `Incognito Window`
- Navigate to: http://localhost:4000/components/splitter/example-index.html?locale=ar-SA
- Dragging the splitter, should go in correct side

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
