### PR TITLE
4806 - Fix editing in datagrid (4.37.x)

### DIFF
--- a/app/views/components/datagrid/test-custom-number-formats.html
+++ b/app/views/components/datagrid/test-custom-number-formats.html
@@ -20,6 +20,7 @@
       columns.push({ id: 'quantity', name: 'Integer', field: 'quantity', formatter: Formatters.Integer});
       columns.push({ id: 'quantity', name: 'Decimal', field: 'quantity', formatter: Formatters.Decimal});
       columns.push({ id: 'quantity', name: 'Decimal (NL)', field: 'quantityStr', formatter: Formatters.Decimal});
+      columns.push({ id: 'quantity', name: 'Change Group', field: 'quantityStr', formatter: Formatters.Decimal, numberFormat: { decimal: ',', group: '.'}, mask: '#.###,00' , editor: Editors.Input});
 
       //Init and get the api for the grid
       grid = $('#datagrid').datagrid({

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise
 
+## v4.38.0
+
+### v4.38.0 Fixes
+
+- `[Example]` Placeholder remove me. ([#9999](https://github.com/infor-design/enterprise/issues/999))
+
 ## v4.37.0
 
 ### v4.37.0 Features
@@ -18,6 +24,7 @@
 - `[Column Chart]` Fixed an issue where the data was passing wrong for grouped type custom tooltip. ([#4548](https://github.com/infor-design/enterprise/issues/4548))
 - `[Datagrid]` Fixed an issue where the filter border on readonly lookups was not displayed in high contrast mode. ([#4724](https://github.com/infor-design/enterprise/issues/4724))
 - `[Datagrid]` Added missing aria row group role to the datagrid. ([#4479](https://github.com/infor-design/enterprise/issues/4479))
+- `[Datagrid]` Fixed a bug where when setting a group and decimal out of the current locale then editing would not work. ([#4806](https://github.com/infor-design/enterprise/issues/4806))
 - `[Dropdown]` Fixed an issue where some elements did not correctly get an id in the dropdown. ([#4742](https://github.com/infor-design/enterprise/issues/4742))
 - `[Dropdown]` Fixed a bug where you could click the label and focus a disabled dropdown. ([#4739](https://github.com/infor-design/enterprise/issues/4739))
 - `[Locale]` Fixed an issue where if the 11th digit is a zero the formatNumbers and truncateDecimals function will loose a digit. ([#4656](https://github.com/infor-design/enterprise/issues/4656))

--- a/src/components/datagrid/datagrid.editors.js
+++ b/src/components/datagrid/datagrid.editors.js
@@ -116,6 +116,10 @@ const editors = {
         thisValue = this.input.val().trim().replace(/(\s%?|%)$/g, '');
         return Locale.parseNumber(thisValue) / 100;
       }
+
+      if (column.numberFormat) {
+        return Locale.parseNumber(this.input.val(), column.numberFormat);
+      }
       return this.input.val();
     };
 

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -1641,10 +1641,10 @@ const Locale = {  // eslint-disable-line
       numString = numString.toString();
     }
 
-    const group = numSettings ? numSettings.group : ',';
-    const decimal = numSettings ? numSettings.decimal : '.';
-    const percentSign = numSettings ? numSettings.percentSign : '%';
-    const currencySign = localeData.currencySign || '$';
+    const group = options && options.group ? options.group : numSettings ? numSettings.group : ',';
+    const decimal = options && options.decimal ? options.decimal : numSettings ? numSettings.decimal : '.';
+    const percentSign = options && options.percentSign ? options.percentSign : numSettings ? numSettings.percentSign : '%';
+    const currencySign = options && options.currencySign ? options.currencySign : localeData.currencySign || '$';
 
     const exp = (group === ' ') ? new RegExp(/\s/g) : new RegExp(`\\${group}`, 'g');
     numString = numString.replace(exp, '');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

If a user sets the number format to something with different decimal character that the locale then editing will mess up the values in a decimal formatter.

**Related github/jira issue (required)**:
Fixes #4806

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-custom-number-formats.html
- edit the last column -> its using a comma as a decimal place which is different than the locale
- this should work
- click in a cell in the last column and then click out -> it should not change the value

**Included in this Pull Request**:
- [x] A note to the change log.
