### PR TITLE
4808 - Add fix for checkbox position (4.37.x)

### DIFF
--- a/app/views/components/checkboxes/test-tables.html
+++ b/app/views/components/checkboxes/test-tables.html
@@ -1,0 +1,28 @@
+<div class="row">
+  <div class="six columns">
+    <div class="field">
+    	<table>
+    		<tbody>
+    			<tr>
+    				<td>
+    					<input id="check1" type="checkbox" class="checkbox"/>
+    					<label for="check1">First</label>
+    				</td>
+    			</tr>
+    			<tr>
+    				<td>
+    					<input id="check2" type="checkbox" class="checkbox"/>
+    					<label for="check2">Second</label>
+    				</td>
+    			</tr>
+    			<tr>
+    				<td>
+    					<input id="check3" type="checkbox" class="checkbox"/>
+    					<label for="check3">Third</label>
+    				</td>
+    			</tr>
+    		</tbody>
+    	</table>
+    </div>
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Bar Chart]` Fixed an issue where the data was passing wrong for grouped type custom tooltip. ([#4548](https://github.com/infor-design/enterprise/issues/4548))
 - `[Busy Indicator]` Fixed an error was showing when called `close()` method too soon after `activate()`. ([#980](https://github.com/infor-design/enterprise-ng/issues/980))
 - `[Calendar]` Fixed a regression where clicking Legend checkboxes was no longer possible. ([#4746](https://github.com/infor-design/enterprise/issues/4746))
+- `[Checkboxes]` Fixed a bug where if checkboxes are in a specific relative layout the checkboxes may click the wrong one. ([#4808](https://github.com/infor-design/enterprise/issues/4808))
 - `[Column Chart]` Fixed an issue where the data was passing wrong for grouped type custom tooltip. ([#4548](https://github.com/infor-design/enterprise/issues/4548))
 - `[Datagrid]` Fixed an issue where the filter border on readonly lookups was not displayed in high contrast mode. ([#4724](https://github.com/infor-design/enterprise/issues/4724))
 - `[Datagrid]` Added missing aria row group role to the datagrid. ([#4479](https://github.com/infor-design/enterprise/issues/4479))

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -76,11 +76,13 @@
 
 input.checkbox,
 span.checkbox > input {
+  height: 14px;
   left: 0;
   opacity: 0;
   position: absolute;
   top: 0;
-  width: 16px;// use fixed, to prevent page jump on click
+  width: 16px;
+  z-index: -1;
 
   &.error {
     + label {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixed a regression when checkboxes are in certain layouts clicking will click the wrong one.

**Related github/jira issue (required)**:
Fixes #4808

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/checkboxes/test-tables.html
- click first checkbox (should work and not click the last one)
- retest https://github.com/infor-design/enterprise/pull/3764 
- go to http://localhost:4000/components/checkboxes/example-index.html
- Open Chrome Dev Tools
- Inside the element inspector, locate the <form id="test-form"> element in the document.
- Set an element style on the span with "margin-top: 1000px" to get the checkboxes off the screen.
- Inside the console, type: `document.getElementById("checkbox1").focus()`
- The page should scroll to the first checkbox and show it focused with the blurred blue border.

**Included in this Pull Request**:
- [x] A note to the change log.
