### PR TITLE
4814 - Fix editor alignment issues

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v4.38.0 Fixes
 
-- `[Example]` Placeholder remove me. ([#9999](https://github.com/infor-design/enterprise/issues/999))
+- `[Datagrid]` Fixed alignment issue when editing. ([#4814](https://github.com/infor-design/enterprise/issues/4814))
 
 ## v4.37.0
 
@@ -12,7 +12,7 @@
 
 - `[FileUpload]` Added the ability to drag files onto the file upload field like in 3.x versions. ([#4723](https://github.com/infor-design/enterprise/issues/4723))
 - `[Datagrid]` Added the ability to edit columns formatted with tags and badges with an Input editor. ([#4637](https://github.com/infor-design/enterprise/issues/4637))
-- `[Datagrid]` Added the ability to pass a locale numberFormat to the TargetedAchievement formatter and also set the defaut to two decimals. ([#4802](https://github.com/infor-design/enterprise/issues/4802))
+- `[Datagrid]` Added the ability to pass a locale numberFormat to the TargetedAchievement formatter and also set the default to two decimals. ([#4802](https://github.com/infor-design/enterprise/issues/4802))
 - `[Dropdown]` Added basic virtual scrolling to dropdown for if you have thousands of items. Only basic dropdown functionality will work with this setting but it improved performance on larger dropdown lists. ([#4708](https://github.com/infor-design/enterprise/issues/4708))
 
 ### v4.37.0 Fixes

--- a/src/components/datagrid/_datagrid-uplift.scss
+++ b/src/components/datagrid/_datagrid-uplift.scss
@@ -168,8 +168,8 @@
   tbody tr td.is-editing {
     input {
       height: 22px !important;
-      margin-left: -17px;
-      margin-top: -4px;
+      margin-left: 0;
+      margin-top: 1px;
     }
 
     .datepicker {

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -2291,6 +2291,8 @@ $datagrid-small-row-height: 25px;
         position: relative;
 
         .icon-error {
+          background-color: transparent;
+          box-shadow: none;
           left: 100%;
           margin-left: -30px;
           position: absolute;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes some alignment issues related to editing datagrid.

**Related github/jira issue (required)**:
Fixes #4814

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-editable.html
- go to vibrant mode
- switch to medium row height
- edit a field -> alignment should be ok
- click ... then add -> do this twice so one row has readonly column in the last column
- click validate all cells
- see that the icon doesnt have a shadow around it anymore

**Included in this Pull Request**:
- [x] A note to the change log.
