### PR TITLE
4718 - Fix the cursor overlapped the icon when selecting the field

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v4.38.0 Fixes
 
-- `[Example]` Placeholder remove me. ([#9999](https://github.com/infor-design/enterprise/issues/999))
+- `[Input]` Fixed a bug where the cursor overlapped the icon in right aligned lookup and input fields when selecting the field. ([#4718](https://github.com/infor-design/enterprise/issues/4718))
 
 ## v4.37.0
 

--- a/src/components/dropdown/_dropdown-uplift.scss
+++ b/src/components/dropdown/_dropdown-uplift.scss
@@ -99,6 +99,20 @@ div.multiselect {
       top: auto;
     }
   }
+
+  &.text-align-reverse {
+    input.dropdown-search {
+      &.text-align-reverse {
+        padding-right: 19px !important;
+      }
+    }
+
+    &.search-mode {
+      input.dropdown-search {
+        padding-right: 20px !important;
+      }
+    }
+  }
 }
 
 // Adjust Short Field Dropdowns

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -631,6 +631,30 @@ div.multiselect {
       margin-left: 14px;
     }
   }
+
+  &.text-align-reverse {
+    li {
+      padding: 0 10px;
+    }
+
+    &.dropdown-list {
+      > .trigger {
+        width: auto;
+      }
+    }
+
+    input.dropdown-search {
+      &.text-align-reverse {
+        padding-right: 16px !important;
+      }
+    }
+
+    &.search-mode {
+      input.dropdown-search {
+        padding-right: 19px !important;
+      }
+    }
+  }
 }
 
 .dropdown-search {

--- a/src/components/lookup/_lookup.scss
+++ b/src/components/lookup/_lookup.scss
@@ -270,7 +270,7 @@
   }
 
   .lookup {
-    padding-right: 18px;
+    padding-right: 25px;
   }
 }
 

--- a/src/components/timepicker/_timepicker.scss
+++ b/src/components/timepicker/_timepicker.scss
@@ -134,7 +134,7 @@
 .field-short,
 .form-layout-compact .field {
   .timepicker {
-    padding-right: 18px;
+    padding-right: 23px;
 
     + .icon,
     + .tooltip-description + .icon {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes the cursor overlapped the icon in right-aligned lookup and input fields when selecting the field. 

I also noticed issues in timepicker and dropdown field. This PR also covered the fixes for these issues.
- No spacing in between the text and icon in Timepicker field.
- UI Issues in dropdown once open. (Misalignment, dropdown list cutoff, etc.)

**Related GitHub/Jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/4718

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/input/test-short-fields-right-aligned.html

Firstly, test the main issue (Lookup field)
- Select the lookup input field to see that the cursor shouldn't overlap with the icon.

Secondly, test the timepicker field
- Go to the bottom of the page
- Click the timepicker field.
- You'll see that there should be spacing in between of cursor and the icon.
- Open the timepicker and select any date.
- Should have at least some spacing.

Lastly, test the dropdown field
- Click the dropdown `dropdown-md` field.
- The dropdown list should not cut off in a `dropdown short` field.
- Try to search in the dropdown.
- UI should behave the same as expected to be.

Please test and play around in uplift mode.

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the changelog.

<!-- After submitting your PR, please check back to make sure tests pass on the GitHub actions. -->
