### PR TITLE
4830 - Improve input error accessibility

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[Searchfield]` Fixed an accessibility issue where the X was not tabbable with the keyboard. To fix this added a tabbable setting which is on by default. If you want it off you can set it to false but you would pass accessibility testing. ([#4815](https://github.com/infor-design/enterprise/issues/4815))
 - `[Tabs]` Fixed an iOS bug that was preventing dismissible tabs to be dismissed by tap. ([#4763](https://github.com/infor-design/enterprise/issues/4763))
 - `[TabsModule]` Fixed positioning of the icon in tabs module. ([#4842](https://github.com/infor-design/enterprise/issues/4842))
+- `[Validation]` Fixed an issue where validation messages did not have the correct aria for accessibility. ([#4830](https://github.com/infor-design/enterprise/issues/4830))
 
 ## v4.37.0
 

--- a/src/components/validation/validator.js
+++ b/src/components/validation/validator.js
@@ -913,6 +913,7 @@ Validator.prototype = {
 
     let markup;
     let icon;
+    const messageId = `${(field.attr('id') || 'id')}-${rule.type}`;
 
     if (rule.type === 'error') {
       icon = `${validationType.type}-alert`;
@@ -922,7 +923,7 @@ Validator.prototype = {
 
     if (rule.type === 'icon') {
       markup = '' +
-        `<div class="custom-icon-message" data-rule-id="${rule.id || rule.message}">
+        `<div id="${messageId}" class="custom-icon-message" data-rule-id="${rule.id || rule.message}">
           ${$.createIcon({ classes: ['icon-custom'], icon: rule.icon })}
           <pre class="audible">
             ${Locale.translate(validationType.titleMessageID)}
@@ -931,7 +932,7 @@ Validator.prototype = {
         </div>`;
     } else {
       markup = '' +
-        `<div class="${validationType.type}-message" data-rule-id="${rule.id || rule.message}">
+        `<div id="${messageId}" class="${validationType.type}-message" data-rule-id="${rule.id || rule.message}">
           ${$.createIcon({ classes: [`icon-${validationType.type}`], icon })}
           <pre class="audible">
             ${Locale.translate(validationType.titleMessageID)}
@@ -960,6 +961,9 @@ Validator.prototype = {
     if (validationType.type === 'error') {
       field.parent().find('.icon-success').remove();
     }
+    // Add aria
+    field.attr('aria-describedby', messageId);
+    field.attr('aria-invalid', 'true');
 
     // Trigger an event
     field.triggerHandler(validationType.type, { field, message: rule.message });
@@ -1047,6 +1051,9 @@ Validator.prototype = {
     if (field.closest('.field-fileupload').length > 0) {
       field.closest('.field-fileupload').find(`input.${rule.type}`).removeClass(rule.type);
     }
+
+    // Remove Aria
+    field.removeAttr('aria-describedby').removeAttr('aria-invalid');
 
     // Remove tooltip style message and tooltip
     if (field.attr(`data-${rule.type}-type`) === 'tooltip') {

--- a/test/components/validation/validation.e2e-spec.js
+++ b/test/components/validation/validation.e2e-spec.js
@@ -27,6 +27,29 @@ describe('Validation example-index tests', () => {
     expect(await element(by.css('.icon-error')).isPresent()).toBe(true);
     expect(await emailEl.getAttribute('class')).toContain('error');
   });
+
+  it('Should have correct aria', async () => {
+    const emailEl = await element(by.id('email-address-ok'));
+    await emailEl.clear();
+
+    expect(await emailEl.getAttribute('value')).toEqual('');
+
+    await emailEl.sendKeys(protractor.Key.TAB);
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.id('email-address-ok-error')).getText()).toBe('Required');
+    expect(await emailEl.getAttribute('aria-describedby')).toEqual('email-address-ok-error');
+    expect(await emailEl.getAttribute('aria-invalid')).toEqual('true');
+
+    // Reset it
+    await emailEl.sendKeys('test@test.test');
+    await emailEl.sendKeys(protractor.Key.TAB);
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element.all(by.id('email-address-ok-error')).count()).toEqual(0);
+    expect(await emailEl.getAttribute('aria-describedby')).toBeFalsy();
+    expect(await emailEl.getAttribute('aria-invalid')).toBeFalsy();
+  });
 });
 
 describe('Validation short-field tests', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The input validation messages did not have correct aria. Added `aria-invalid` and `aria-describedby`.

**Related github/jira issue (required)**:
Fixes #4830

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/validation/example-index.html
- clear the email field and tab out
- the error message div will get an id
- the error input will get aria-invalid and aria-described by pointing at the div
- optionally try a screen reader
- try this on http://localhost:4000/components/validation/test-message-types.html as well

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
