### PR TITLE
4838 - Fix accordion events

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### v4.38.0 Fixes
 
 - `[Application Menu]` Fixed visibility of expander icon on classic theme. ([#4874](https://github.com/infor-design/enterprise/issues/4874))
+- `[Accordion]` Fixed an issue where the afterexpand and aftercollapse events fired before the states are set.  ([#4838](https://github.com/infor-design/enterprise/issues/4838))
 - `[Breadcrumb]` Fixed unnecessary scrollbar in safari on a flex toolbar. ([#4839](https://github.com/infor-design/enterprise/issues/4839))
 - `[Datagrid]` Added the ability to use shift click to select in mixed selection mode. ([#4748](https://github.com/infor-design/enterprise/issues/4748))
 - `[Datagrid]` Fixed alignment issue when editing. ([#4814](https://github.com/infor-design/enterprise/issues/4814))

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -854,11 +854,11 @@ Accordion.prototype = {
         if (e) {
           e.stopPropagation();
         }
-        pane.triggerHandler('afterexpand', [a]);
-        self.element.trigger('afterexpand', [a]);
         $.when(...expandDfds, ...collapseDfds).done(() => {
           dfd.resolve();
         });
+        pane.triggerHandler('afterexpand', [a]);
+        self.element.trigger('afterexpand', [a]);
       }
 
       if (pane.hasClass('no-transition')) {
@@ -961,10 +961,11 @@ Accordion.prototype = {
       if (e) {
         e.stopPropagation();
       }
-      pane.triggerHandler('aftercollapse', [a]);
-      self.element.trigger('aftercollapse', [a]);
+
       header.add(pane).removeClass('is-expanded');
       a.attr('aria-expanded', 'false');
+      pane.triggerHandler('aftercollapse', [a]);
+      self.element.trigger('aftercollapse', [a]);
       dfd.resolve();
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The the afterexpand and aftercollapse events fired before the states are set. Have a look @EdwardCoyle not sure why they might be like that?

**Related github/jira issue (required)**:
Fixes #4838

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/accordion/example-accordion-panels.html
- paste the folling in the console
```
  const $accordions = $('div.accordion ');
  function listOpenHeaders() {
    const states = $(this).children('.accordion-header').map((i, header) => {
      return {
        text: $(header).text().trim(),
        expanded: $(this).data('accordion').isExpanded(header)
      }
    }).toArray();
    console.log(states);
  }
  $accordions.on({
    afterexpand: listOpenHeaders,
    aftercollapse: listOpenHeaders
  });
```
- expand and collapse the first pane and check the result has the correct value for expanded in the array..

**Included in this Pull Request**:
- [x] A note to the change log.
