### PR TITLE
4853 - Fixed color of unclick rating star

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[General]` We Updated jQuery to use 3.6.0. ([#1690](https://github.com/infor-design/enterprise/issues/1690))
 - `[Modal]` Fixed a bug where fullsize responsive setting doesn't work on android phones in landscape mode. ([#4451](https://github.com/infor-design/enterprise/issues/4451))
+- `[Rating]` Fixed color of unclick rating star. ([#4853](https://github.com/infor-design/enterprise/issues/4853))
 
 ## v4.38.0
 

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -75,7 +75,6 @@
 .rating input:checked + label > svg.icon,
 .rating .is-half + label > svg.icon {
   @include opacity(1);
-  
 }
 
 // Compact Mode

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -30,7 +30,7 @@
 
   // Rating Icons - Svg
   svg.icon {
-    // color: $rating-bg-color;
+    //color: $rating-bg-color;
     display: inline-block;
     height: 22px;
     position: relative;
@@ -75,8 +75,7 @@
 .rating input:checked + label > svg.icon,
 .rating .is-half + label > svg.icon {
   @include opacity(1);
-
-  color: $rating-bg-color;
+  
 }
 
 // Compact Mode

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -30,7 +30,6 @@
 
   // Rating Icons - Svg
   svg.icon {
-    //color: $rating-bg-color;
     display: inline-block;
     height: 22px;
     position: relative;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
There was an extra call to a scss property (color: $rating-bg-color;) in _rating.scss line 79 that was overriding the color of the stars on there off state. Color on off state should be a dark gray / black color not orange. 

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise/issues/4853

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/rating/example-index.html
- click the first star once to make it selected
- click the first star once to make it unselected - the border should not be the yellow color

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
