### PR TITLE
4898 - Fix missing clear button

### DIFF
--- a/app/views/components/tabs-module/example-category-searchfield-go-button-home.html
+++ b/app/views/components/tabs-module/example-category-searchfield-go-button-home.html
@@ -71,7 +71,8 @@
       'goButtonAction': goButtonAction,
       'showGoButton': true,
       'categories': [ 'Books', 'Movies', 'Music', 'Video Games' ],
-      'showCategoryText': true
+      'showCategoryText': true,
+      'clearable': true
     });
 
   </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[General]` We Updated jQuery to use 3.6.0. ([#1690](https://github.com/infor-design/enterprise/issues/1690))
 - `[Modal]` Fixed a bug where fullsize responsive setting doesn't work on android phones in landscape mode. ([#4451](https://github.com/infor-design/enterprise/issues/4451))
+- `[Tabs Module]` Fixed a bug where clear button was missing when clearable setting is activated in tabs module searchfield. ([#4898](https://github.com/infor-design/enterprise/issues/4898))
 
 ## v4.38.0
 

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -318,6 +318,20 @@
         }
       }
     }
+
+    button.close {
+      right: 35px;
+      top: 4px;
+
+      @media (min-width: $breakpoint-phone-to-tablet) {
+        right: 45px;
+      }
+
+      svg.close {
+        left: 0;
+        top: 0 !important;
+      }
+    }
   }
 
   //Call to action button


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes missing clear button if the search field has categories in tabs module. 

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/4898

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/tabs-module/example-category-searchfield-go-button-home.html
- Type anything in searchfield to show the `x` button
- It should show the clear button
- Click the `x` button
- It should clear the search field
- Test also on a classic theme and on mobile viewport/phone device

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
