### PR TITLE
4888 - Incorrect validation message for invalid value issue

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### v4.39.0 Fixes
 
+- `[Datepicker]` Updated validation.js to check if date picker contains a time value ([#4888](https://github.com/infor-design/enterprise/issues/4888))
 - `[General]` We Updated jQuery to use 3.6.0. ([#1690](https://github.com/infor-design/enterprise/issues/1690))
 - `[Message]` Added automation id's to the message's modal main area dialog as well with `modal` prefix. ([#4871](https://github.com/infor-design/enterprise/issues/4871))
 - `[Modal]` Fixed a bug where fullsize responsive setting doesn't work on android phones in landscape mode. ([#4451](https://github.com/infor-design/enterprise/issues/4451))

--- a/src/components/locale/cultures/en-US.js
+++ b/src/components/locale/cultures/en-US.js
@@ -235,6 +235,7 @@ Soho.Locale.addCulture('en-US', {
     Italic: { id: 'Italic', value: 'Italic', comment: 'Make Text Italic' },
     InvalidDate: { id: 'InvalidDate', value: 'Invalid Date', comment: 'validation message for wrong date format (short)' },
     InvalidTime: { id: 'InvalidTime', value: 'Invalid Time', comment: 'validation message for wrong time format' },
+    InvalidDateTime: { id: 'InvalidDateTime', value: 'Invalid Date or Time', comment: 'validation message for wrong date and time format' },
     Inventory: { id: 'Inventory', value: 'Inventory', comment: 'Icon button tooltop for Inventory Action' },
     InRange: { id: 'InRange', value: 'In Range', comment: 'In Range in icons for filtering' },
     IsEmpty: { id: 'IsEmpty', value: 'Is Empty', comment: 'Is Empty in icons for filtering' },

--- a/src/components/validation/validation.js
+++ b/src/components/validation/validation.js
@@ -105,9 +105,7 @@ function ValidationRules() {
     // date: Validate date, datetime (24hr or 12hr am/pm)
     date: {
       check(value, field, gridInfo) {
-        const dateTimeClass = field[0].classList.contains('datetime');
-
-        this.message = Locale.translate(dateTimeClass ? 'InvalidDateTime' : 'InvalidDate');
+        this.message = Locale.translate('InvalidDate');
 
         if (gridInfo && gridInfo.column) {
           const gridValue = gridInfo.column.formatter(gridInfo.row, gridInfo.cell, value, gridInfo.column, true);
@@ -125,6 +123,10 @@ function ValidationRules() {
         let dtApi = null;
         if (field && field.data('datepicker')) {
           dtApi = field.data('datepicker');
+          console.log(dtApi.settings.showTime)
+          if(dtApi.settings.showTime){
+            this.message = Locale.translate('InvalidDateTime');
+          }
           dateFormat = dtApi.pattern;
         }
         if (gridInfo && gridInfo.column) {

--- a/src/components/validation/validation.js
+++ b/src/components/validation/validation.js
@@ -1,5 +1,5 @@
 import { Locale } from '../locale/locale';
-
+console.log('validation.js')
 // The validation rules object.
 // This contains all base rules for validation that come bundled as part of Soho.
 // These rules can be extended.
@@ -106,7 +106,10 @@ function ValidationRules() {
     // date: Validate date, datetime (24hr or 12hr am/pm)
     date: {
       check(value, field, gridInfo) {
-        this.message = Locale.translate('InvalidDate');
+
+        let dateTimeClass = field[0].classList.contains('datetime')
+
+        dateTimeClass ? this.message = 'Invalid Date or Time' : this.message = Locale.translate('InvalidDate')
 
         if (gridInfo && gridInfo.column) {
           const gridValue = gridInfo.column.formatter(gridInfo.row, gridInfo.cell, value, gridInfo.column, true);
@@ -116,6 +119,7 @@ function ValidationRules() {
         }
 
         if (value instanceof Date) {
+          console.log(this.message)
           return value && value.getTime && !isNaN(value.getTime());
         }
 

--- a/src/components/validation/validation.js
+++ b/src/components/validation/validation.js
@@ -1,5 +1,4 @@
 import { Locale } from '../locale/locale';
-console.log('validation.js')
 // The validation rules object.
 // This contains all base rules for validation that come bundled as part of Soho.
 // These rules can be extended.
@@ -119,7 +118,6 @@ function ValidationRules() {
         }
 
         if (value instanceof Date) {
-          console.log(this.message)
           return value && value.getTime && !isNaN(value.getTime());
         }
 

--- a/src/components/validation/validation.js
+++ b/src/components/validation/validation.js
@@ -108,7 +108,7 @@ function ValidationRules() {
 
         let dateTimeClass = field[0].classList.contains('datetime')
 
-        dateTimeClass ? this.message = 'Invalid Date or Time' : this.message = Locale.translate('InvalidDate')
+        dateTimeClass ? this.message = Locale.translate('InvalidDateTime') : this.message = Locale.translate('InvalidDate')
 
         if (gridInfo && gridInfo.column) {
           const gridValue = gridInfo.column.formatter(gridInfo.row, gridInfo.cell, value, gridInfo.column, true);

--- a/src/components/validation/validation.js
+++ b/src/components/validation/validation.js
@@ -105,10 +105,9 @@ function ValidationRules() {
     // date: Validate date, datetime (24hr or 12hr am/pm)
     date: {
       check(value, field, gridInfo) {
+        const dateTimeClass = field[0].classList.contains('datetime');
 
-        let dateTimeClass = field[0].classList.contains('datetime')
-
-        dateTimeClass ? this.message = Locale.translate('InvalidDateTime') : this.message = Locale.translate('InvalidDate')
+        dateTimeClass ? this.message = Locale.translate('InvalidDateTime') : this.message = Locale.translate('InvalidDate');
 
         if (gridInfo && gridInfo.column) {
           const gridValue = gridInfo.column.formatter(gridInfo.row, gridInfo.cell, value, gridInfo.column, true);

--- a/src/components/validation/validation.js
+++ b/src/components/validation/validation.js
@@ -123,8 +123,7 @@ function ValidationRules() {
         let dtApi = null;
         if (field && field.data('datepicker')) {
           dtApi = field.data('datepicker');
-          console.log(dtApi.settings.showTime)
-          if(dtApi.settings.showTime){
+          if (dtApi.settings.showTime) {
             this.message = Locale.translate('InvalidDateTime');
           }
           dateFormat = dtApi.pattern;

--- a/src/components/validation/validation.js
+++ b/src/components/validation/validation.js
@@ -107,7 +107,7 @@ function ValidationRules() {
       check(value, field, gridInfo) {
         const dateTimeClass = field[0].classList.contains('datetime');
 
-        dateTimeClass ? this.message = Locale.translate('InvalidDateTime') : this.message = Locale.translate('InvalidDate');
+        this.message = Locale.translate(dateTimeClass ? 'InvalidDateTime' : 'InvalidDate');
 
         if (gridInfo && gridInfo.column) {
           const gridValue = gridInfo.column.formatter(gridInfo.row, gridInfo.cell, value, gridInfo.column, true);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

In the validation.js there is a date object that contains a **check** method. This method does not take into account if the date picker has a time value or not. On line 127 I have added a conditional statement that checks if the **dtApi.settings.showTime** returns true, based on this condition the message inside of the **Locale.translate** will change based on the given Date picker.

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise/issues/4888

**Steps necessary to review your pull request (required)**:
Include:
- Navigate to the each of the date picker competent pages, one will have a date value and the other will have a date time value. 
**Date Value:**
http://localhost:4000/components/datepicker/example-index.html
**Date Time value:**
http://localhost:4000/components/datepicker/example-timeformat?theme=uplift&variant=light
- If you add a value to the date picker that is not a valid date/date time you will see the appropriate error messages.  
<img width="865" alt="Screen Shot 2021-03-12 at 9 57 49 AM" src="https://user-images.githubusercontent.com/5215954/110957245-6fea9e00-8319-11eb-8174-0803ca2fdbd6.png">
<img width="863" alt="Screen Shot 2021-03-12 at 9 49 29 AM" src="https://user-images.githubusercontent.com/5215954/110957032-3b76e200-8319-11eb-911c-163520d8d52f.png">


- test scenarios


**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
