### PR TITLE
4941 - Add fix for flex datagrid toolbar error

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### v4.39.0 Fixes
 
+- `[Datagrid]` Fixed an error seen clicking items if using a flex toolbar for the datagrid toolbar. ([#4941](https://github.com/infor-design/enterprise/issues/4941))
 - `[General]` We Updated jQuery to use 3.6.0. ([#1690](https://github.com/infor-design/enterprise/issues/1690))
 - `[Message]` Added automation id's to the message's modal main area dialog as well with `modal` prefix. ([#4871](https://github.com/infor-design/enterprise/issues/4871))
 - `[Modal]` Fixed a bug where fullsize responsive setting doesn't work on android phones in landscape mode. ([#4451](https://github.com/infor-design/enterprise/issues/4451))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -6888,7 +6888,7 @@ Datagrid.prototype = {
     }
 
     const selectHandler = (e, args, args2) => {
-      const action = args.attr ? args.attr('data-option') : args2.attr('data-option');
+      const action = args?.attr ? args?.attr('data-option') : args2?.attr('data-option');
       if (!action) {
         return;
       }

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -699,6 +699,8 @@ const Locale = {  // eslint-disable-line
       ret = ret.replace('zz', shortName);
     }
 
+    // Replace Left to Right Mark
+    ret = ret.replace(/&lrm;|\u200E/gi, ' ');
     return ret.trim();
   },
 

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -1455,12 +1455,12 @@ describe('Locale API', () => {
     Locale.set('zh-Hant');
 
     expect(Locale.formatDate(new Date(2020, 6, 22, 20, 11, 12), { date: 'datetime' })).toEqual('2020/7/22 下午8:11');
-    expect(['2020/7/22 下午8:11', '2020/7/22 下午9:11 EST']).toContain(Locale.formatDate(new Date(2020, 6, 22, 21, 11, 12), { date: 'timezone' }));
+    expect(['2020/7/22 下午8:11', '2020/7/22 下午9:11 EST', '2020/7/22 下午9:11 EDT']).toContain(Locale.formatDate(new Date(2020, 6, 22, 21, 11, 12), { date: 'timezone' }));
 
     Locale.set('zh-TW');
 
     expect(Locale.formatDate(new Date(2020, 6, 22, 20, 11, 12), { date: 'datetime' })).toEqual('2020/7/22 下午8:11');
-    expect(['2020/7/22 下午8:11', '2020/7/22 下午9:11 EST']).toContain(Locale.formatDate(new Date(2020, 6, 22, 21, 11, 12), { date: 'timezone' }));
+    expect(['2020/7/22 下午8:11', '2020/7/22 下午9:11 EST', '2020/7/22 下午9:11 EDT']).toContain(Locale.formatDate(new Date(2020, 6, 22, 21, 11, 12), { date: 'timezone' }));
   });
 
   it('Should be able to display dates into another timezone including short timezone name', () => {

--- a/test/components/message/message.e2e-spec.js
+++ b/test/components/message/message.e2e-spec.js
@@ -115,7 +115,7 @@ describe('Message visual regression tests', () => {
       await browser.driver.sleep(config.sleep);
       const container = await element(by.id('maincontent'));
       await element(by.id('show-message')).click();
-      await browser.driver.sleep(config.sleep);
+      await browser.driver.sleep(config.sleepLonger);
 
       expect(await browser.imageComparison.checkElement(container, 'message-open-list')).toEqual(0);
     });
@@ -125,7 +125,7 @@ describe('Message visual regression tests', () => {
       await browser.driver.sleep(config.sleep);
       const container = await element(by.id('maincontent'));
       await element(by.id('show-application-error')).click();
-      await browser.driver.sleep(config.sleep);
+      await browser.driver.sleep(config.sleepLonger);
 
       expect(await browser.imageComparison.checkElement(container, 'message-open')).toEqual(0);
     });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When using a flex toolbar for the datagrid toolbar it was throwing an error clicking toolbar buttons. This is the fix.

**Related github/jira issue (required)**:
Fixes #4941

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-custom-toolbar-flex.html
- click the toolbar button -> check the console should be no error
- try the functions in the .. menu that are not examples only and ensure they work (personalize, row heights ect)

**Included in this Pull Request**:
- [x] A note to the change log.
