### PR TITLE
4827 - Add fix for linking tooltips to id content

### DIFF
--- a/app/views/components/tooltip/example-icon-in-tooltip.html
+++ b/app/views/components/tooltip/example-icon-in-tooltip.html
@@ -9,7 +9,7 @@
 <div class="row">
   <div class="twelve columns">
 
-    <button class="btn-secondary" type="button" title="#tooltip-id">
+    <button class="btn-secondary" type="button" id="tooltip-btn" title="#tooltip-id">
       <span>Add Comment</span>
     </button>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `[Message]` Added automation id's to the message's modal main area dialog as well with `modal` prefix. ([#4871](https://github.com/infor-design/enterprise/issues/4871))
 - `[Modal]` Fixed a bug where fullsize responsive setting doesn't work on android phones in landscape mode. ([#4451](https://github.com/infor-design/enterprise/issues/4451))
 - `[Rating]` Fixed color of unclick rating star. ([#4853](https://github.com/infor-design/enterprise/issues/4853))
+- `[Tooltip]` Fixed a bug in tooltip that prevented linking id-based tooltip content. ([#4827](https://github.com/infor-design/enterprise/issues/4827))
 
 ## v4.38.0
 

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -471,15 +471,16 @@ Tooltip.prototype = {
       // If it matches an element already on the page, grab that element's content
       // and store the reference only.
       // Adding a condition if it's really uses the ID attribute.
-      const idAttr = this.element[0].id;
-      if (content.indexOf('#') === 0 && (this.settings.popover ? true : idAttr === content.split('#').pop())) {
+      if (content.indexOf('#') === 0) {
         const contentCheck = $(`${content}`);
         if (contentCheck.length) {
           this.content = contentCheck;
           doRender();
           return true;
         }
-        return false;
+        this.content = content;
+        doRender();
+        return true;
       }
 
     // functions

--- a/test/components/message/message.e2e-spec.js
+++ b/test/components/message/message.e2e-spec.js
@@ -115,7 +115,7 @@ describe('Message visual regression tests', () => {
       await browser.driver.sleep(config.sleep);
       const container = await element(by.id('maincontent'));
       await element(by.id('show-message')).click();
-      await browser.driver.sleep(config.sleep);
+      await browser.driver.sleep(config.sleepLonger);
 
       expect(await browser.imageComparison.checkElement(container, 'message-open-list')).toEqual(0);
     });
@@ -125,7 +125,7 @@ describe('Message visual regression tests', () => {
       await browser.driver.sleep(config.sleep);
       const container = await element(by.id('maincontent'));
       await element(by.id('show-application-error')).click();
-      await browser.driver.sleep(config.sleep);
+      await browser.driver.sleep(config.sleepLonger);
 
       expect(await browser.imageComparison.checkElement(container, 'message-open')).toEqual(0);
     });

--- a/test/components/tooltip/tooltip.e2e-spec.js
+++ b/test/components/tooltip/tooltip.e2e-spec.js
@@ -115,3 +115,38 @@ describe('Tooltip (personalizable) tests', () => {
     });
   }
 });
+
+describe('Tooltips icons page tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/tooltip/example-icon-in-tooltip?theme=classic&layout=nofrills');
+  });
+
+  it('should display tooltip with icon', async () => {
+    await browser.actions()
+      .mouseMove(await element(by.id('tooltip-btn')))
+      .perform();
+
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('tooltip'))), config.waitsFor);
+
+    expect(await element(by.css('#tooltip .tooltip-content')).getAttribute('innerHTML')).toContain('<use href="#icon-compose"></use>');
+  });
+});
+
+describe('Tooltips with pound sign', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/tooltip/test-tooltip-starts-with-pound-sign?theme=classic&layout=nofrills');
+  });
+
+  it('should display tooltip with #content', async () => {
+    await browser.actions()
+      .mouseMove(await element(by.id('tooltip-btn')))
+      .perform();
+
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('tooltip'))), config.waitsFor);
+
+    expect(await element(by.css('#tooltip .tooltip-content')).getAttribute('innerHTML')).toEqual('#Tooltips Provide Additional Information');
+  });
+});
+


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

We found that the example showing a tooltip with an icon broke. This fixes the issue. It was caused by a change to the code that links content by ID.

**Related github/jira issue (required)**:
Fixes #4827

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/tooltip/example-icon-in-tooltip.html
- hover the button -> should see a icon in the content
- go to http://localhost:4000/components/tooltip/test-tooltip-starts-with-pound-sign.html
- hover the button -> should see a # in the content

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
