### PR TITLE
4766 - Added fix to close the filter menu

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### v4.39.0 Fixes
 
+- `[Datagrid]` Fixed a bug where filter dropdown menus did not close when focusing a filter input. ([#4766](https://github.com/infor-design/enterprise/issues/4766))
 - `[General]` We Updated jQuery to use 3.6.0. ([#1690](https://github.com/infor-design/enterprise/issues/1690))
 - `[Message]` Added automation id's to the message's modal main area dialog as well with `modal` prefix. ([#4871](https://github.com/infor-design/enterprise/issues/4871))
 - `[Modal]` Fixed a bug where fullsize responsive setting doesn't work on android phones in landscape mode. ([#4451](https://github.com/infor-design/enterprise/issues/4451))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -3122,7 +3122,7 @@ $datagrid-small-row-height: 25px;
 
       &.timepicker,
       &.datepicker {
-        padding: 3px 24px 2px 5px;
+        padding: 1px 24px 2px 5px;
       }
 
       &.lookup.is-not-editable {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1600,6 +1600,7 @@ Datagrid.prototype = {
     if (this.settings.twoLineHeader) {
       this.element.addClass('has-two-line-header');
     }
+    let activeMenu = null;
 
     // Attach Keyboard support
     this.element.off('click.datagrid-filter').on('click.datagrid-filter', '.btn-filter', function () {
@@ -1649,6 +1650,11 @@ Datagrid.prototype = {
             if (data) {
               data.destroy();
             }
+            activeMenu = null;
+          })
+          .off('open.datagrid-filter')
+          .on('open.datagrid-filter', function () {
+            activeMenu = $(this).data('popupmenu');
           });
       }
       return false;
@@ -1667,6 +1673,11 @@ Datagrid.prototype = {
       }
       return true;
     });
+
+    this.element.off('focus.datagrid-filter-focus')
+      .on('focus.datagrid-filter-focus', '.datagrid-filter-wrapper input', () => {
+        activeMenu?.close();
+      });
 
     if (this.settings.filterWhenTyping) {
       this.element.off('keyup.datagrid-filter-input').on('keyup.datagrid-filter-input', '.datagrid-filter-wrapper input', (e) => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

In the datagrid filter row code. The filter type popup did not close when focusing an input. This PR solves this issue

**Related github/jira issue (required)**:
Fixes #4766

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-compact-mode.html
- open any filter dropdown
- click to focus any field -> dropdown menu should shut

**Included in this Pull Request**:
- [x] A note to the change log.