### PR TITLE
BusyIndicator: Is showing below the datagrid #4953

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### v4.39.0 Fixes
 
+- `[BusyIndicator]` Fixed a bug that caused the busy-indicator to show below the busy indicator container. ([#4953](https://github.com/infor-design/enterprise/issues/4953))
 - `[Datagrid]` Fixed a bug where filter dropdown menus did not close when focusing a filter input. ([#4766](https://github.com/infor-design/enterprise/issues/4766))
 - `[Datagrid]` Fixed an error seen clicking items if using a flex toolbar for the datagrid toolbar. ([#4941](https://github.com/infor-design/enterprise/issues/4941))
 - `[Datepicker]` Updated validation.js to check if date picker contains a time value ([#4888](https://github.com/infor-design/enterprise/issues/4888))
@@ -13,7 +14,6 @@
 - `[Rating]` Fixed color of unclick rating star. ([#4853](https://github.com/infor-design/enterprise/issues/4853))
 - `[Tabs Module]` Fixed a bug where clear button was missing when clearable setting is activated in tabs module searchfield. ([#4898](https://github.com/infor-design/enterprise/issues/4898))
 - `[Tooltip]` Fixed a bug in tooltip that prevented linking id-based tooltip content. ([#4827](https://github.com/infor-design/enterprise/issues/4827))
-- `[BusyIndicator]` Fixed a bug that caused the busy-indicator to show below the busy indicator container. ([#4953](https://github.com/infor-design/enterprise/issues/4953))
 
 ## v4.38.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@
 - `[Rating]` Fixed color of unclick rating star. ([#4853](https://github.com/infor-design/enterprise/issues/4853))
 - `[Tabs Module]` Fixed a bug where clear button was missing when clearable setting is activated in tabs module searchfield. ([#4898](https://github.com/infor-design/enterprise/issues/4898))
 - `[Tooltip]` Fixed a bug in tooltip that prevented linking id-based tooltip content. ([#4827](https://github.com/infor-design/enterprise/issues/4827))
-- `[BusyIndicator]` Fixed a bug that caused the busy-indicator to show below the scroll container. ([#4953](https://github.com/infor-design/enterprise/issues/4953))
+- `[BusyIndicator]` Fixed a bug that caused the busy-indicator to show below the busy indicator container. ([#4953](https://github.com/infor-design/enterprise/issues/4953))
 
 ## v4.38.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[Rating]` Fixed color of unclick rating star. ([#4853](https://github.com/infor-design/enterprise/issues/4853))
 - `[Tabs Module]` Fixed a bug where clear button was missing when clearable setting is activated in tabs module searchfield. ([#4898](https://github.com/infor-design/enterprise/issues/4898))
 - `[Tooltip]` Fixed a bug in tooltip that prevented linking id-based tooltip content. ([#4827](https://github.com/infor-design/enterprise/issues/4827))
+- `[BusyIndicator]` Fixed a bug that caused the busy-indicator to show below the scroll container. ([#4953](https://github.com/infor-design/enterprise/issues/4953))
 
 ## v4.38.0
 

--- a/src/components/busyindicator/busyindicator.js
+++ b/src/components/busyindicator/busyindicator.js
@@ -370,7 +370,7 @@ BusyIndicator.prototype = {
       const isOverlayAbsolute = elComputedPos === 'absolute';
       if ((height && this.container && (height <= elem.offsetHeight))) {
         const winHeight = window.innerHeight || document.documentElement.clientHeight;
-        const isHeight = el => ((el.scrollHeight > el.clientHeight) && el.clientHeight < (winHeight - 60));
+        const isHeight = el => ((el.scrollHeight >= el.clientHeight) && el.clientHeight < (winHeight - 60));
         const loc = ((height / 2) - 58);
         const setTop = () => {
           if (isOverlayAbsolute && this.element.is(sElem)) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
changed calculation of when to place the busy indicator over the content

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
closes #4953 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
