### PR TITLE
4933 - removed unnecessary css top property calls to fix select look up component alignment

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Message]` Added automation id's to the message's modal main area dialog as well with `modal` prefix. ([#4871](https://github.com/infor-design/enterprise/issues/4871))
 - `[Modal]` Fixed a bug where fullsize responsive setting doesn't work on android phones in landscape mode. ([#4451](https://github.com/infor-design/enterprise/issues/4451))
 - `[Rating]` Fixed color of unclick rating star. ([#4853](https://github.com/infor-design/enterprise/issues/4853))
+- `Searchfields` Fixed reset X icon search alignment issue ([#4933](https://github.com/infor-design/enterprise/issues/4933))
 - `[Tabs Module]` Fixed a bug where clear button was missing when clearable setting is activated in tabs module searchfield. ([#4898](https://github.com/infor-design/enterprise/issues/4898))
 - `[Tooltip]` Fixed a bug in tooltip that prevented linking id-based tooltip content. ([#4827](https://github.com/infor-design/enterprise/issues/4827))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@
 - `[Message]` Added automation id's to the message's modal main area dialog as well with `modal` prefix. ([#4871](https://github.com/infor-design/enterprise/issues/4871))
 - `[Modal]` Fixed a bug where fullsize responsive setting doesn't work on android phones in landscape mode. ([#4451](https://github.com/infor-design/enterprise/issues/4451))
 - `[Rating]` Fixed color of unclick rating star. ([#4853](https://github.com/infor-design/enterprise/issues/4853))
-- `Searchfields` Fixed reset X icon search alignment issue ([#4933](https://github.com/infor-design/enterprise/issues/4933))
+- `[Searchfields]` Fixed reset X icon search alignment issue ([#4933](https://github.com/infor-design/enterprise/issues/4933))
 - `[Tabs Module]` Fixed a bug where clear button was missing when clearable setting is activated in tabs module searchfield. ([#4898](https://github.com/infor-design/enterprise/issues/4898))
 - `[Tooltip]` Fixed a bug in tooltip that prevented linking id-based tooltip content. ([#4827](https://github.com/infor-design/enterprise/issues/4827))
 

--- a/src/components/searchfield/_searchfield-new.scss
+++ b/src/components/searchfield/_searchfield-new.scss
@@ -9,7 +9,6 @@
 
 .searchfield-wrapper {
   > .icon {
-
     &.close {
       height: 12px;
       right: 9px;

--- a/src/components/searchfield/_searchfield-new.scss
+++ b/src/components/searchfield/_searchfield-new.scss
@@ -50,9 +50,6 @@
       padding-top: 6px;
     }
 
-    .icon.close {
-      top: 12px;
-    }
   }
 
   &:not(.is-open) {
@@ -61,19 +58,6 @@
     }
   }
 
-  &.has-text .icon.close {
-    top: 11px;
-  }
-}
-
-.toolbar-searchfield-wrapper {
-  &.searchfield-wrapper {
-    &.non-collapsible {
-      svg.icon {
-        top: 11px;
-      }
-    }
-  }
 }
 
 // Firefox needs some help

--- a/src/components/searchfield/_searchfield-new.scss
+++ b/src/components/searchfield/_searchfield-new.scss
@@ -9,12 +9,10 @@
 
 .searchfield-wrapper {
   > .icon {
-    top: 12px;
 
     &.close {
       height: 12px;
       right: 9px;
-      top: 13px;
     }
   }
 

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -225,7 +225,6 @@ $toolbarsearchfield-category-empty-width: 51px;
     .icon {
       color: $searchfield-text-color;
       height: 14px;
-      //top: 10px;
     }
 
     &:not(.non-collapsible) {

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -123,10 +123,6 @@ $toolbarsearchfield-category-empty-width: 51px;
     top: 11px;
   }
 
-  .icon.close {
-    top: 10px;
-  }
-
   .btn {
     background-color: rgba(0, 0, 0, 0);
     border-radius: 2px 0 0 2px;
@@ -229,7 +225,7 @@ $toolbarsearchfield-category-empty-width: 51px;
     .icon {
       color: $searchfield-text-color;
       height: 14px;
-      top: 10px;
+      //top: 10px;
     }
 
     &:not(.non-collapsible) {

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -402,6 +402,16 @@ $toolbarsearchfield-category-empty-width: 51px;
       display: none;
     }
   }
+
+  .btn-icon {
+    &:focus {
+      .close.icon {
+        display: block;
+        left: 4px;
+        top: 0.5px;
+      }
+    }
+  }
 }
 
 .azure07 .active input {

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -32,7 +32,6 @@
     color: $trigger-icon-fill-color;
     height: 14px;
     position: absolute;
-    top: 10px;
 
     &:not(.close):not(.icon-error) {
       left: 8px;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Removed scss/css top from the **<svg class="close icon" focusable="false" aria-hidden="true" role="presentation">** DOM element to reposition it properly inside the input field. 

**Related github/jira issue (required)**:
Fixes https://github.com/infor-design/enterprise/issues/4933

**Steps necessary to review your pull request (required)**:
Include:
- Open up a browser window and navigate to the following URL 
(http://localhost:4000/components/lookup/example-index.html)
- Open up the modal window by clicking on the magnifying glass on the right side of the input field.
- Once opened you can type inside the search input, the X icon should now appear and be completely functional. 
- Browser testing Images below. The OS and version details are included in the screenshots as follow 
(Windows os_version=8 1 browser=Edge browser_version=89 0)
<img width="1261" alt="FireFox_86_local" src="https://user-images.githubusercontent.com/5215954/111363683-b5cf9b00-8666-11eb-81e7-82562b29ec51.png">
<img width="1851" alt="os=android os_version=11 0" src="https://user-images.githubusercontent.com/5215954/111363695-b700c800-8666-11eb-8f51-15a13e6f95ac.png">
<img width="1846" alt="os=iOS os_version=13 0" src="https://user-images.githubusercontent.com/5215954/111363706-b8ca8b80-8666-11eb-86db-387aebba9510.png">
<img width="1840" alt="os=Windows os_version=10 browser=Chrome browser_version=89 0" src="https://user-images.githubusercontent.com/5215954/111363714-bb2ce580-8666-11eb-9383-88b11cc81def.png">
<img width="1846" alt="os=Windows os_version=10 browser=Edge browser_version=89 0" src="https://user-images.githubusercontent.com/5215954/111363716-bc5e1280-8666-11eb-875e-c4740bdcefe7.png">
<img width="1840" alt="os=Windows os_version=10 browser=Firefox browser_version=86 0" src="https://user-images.githubusercontent.com/5215954/111363717-bcf6a900-8666-11eb-8daf-c77185c8185b.png">
<img width="1840" alt="os=Windows os_version=10 browser=Opera browser_version=74 0" src="https://user-images.githubusercontent.com/5215954/111363720-bcf6a900-8666-11eb-9f02-851d6b2d63b4.png">
<img width="1257" alt="safari_14_local" src="https://user-images.githubusercontent.com/5215954/111363723-bd8f3f80-8666-11eb-9a4e-4f814dbb0633.png">

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
