### PR TITLE
4766  - Add better fix to closing datagrid menu

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1611,10 +1611,9 @@ Datagrid.prototype = {
       if (popupmenu) {
         popupmenu.close(true, true);
       } else {
-        filterBtn.off('beforeopen.datagrid-filter').on('beforeopen.datagrid-filter', () => {
-          const menu = filterBtn.next('.popupmenu-wrapper');
-          utils.fixSVGIcons(menu);
+        filterBtn.off('beforeopen.datagrid-filter').on('beforeopen.datagrid-filter', (e, menu, api) => {
           self.hideTooltip();
+          activeMenu = api;
         }).popupmenu(popupOpts)
           .off('selected.datagrid-filter')
           .on('selected.datagrid-filter', () => {
@@ -1651,10 +1650,6 @@ Datagrid.prototype = {
               data.destroy();
             }
             activeMenu = null;
-          })
-          .off('open.datagrid-filter')
-          .on('open.datagrid-filter', function () {
-            activeMenu = $(this).data('popupmenu');
           });
       }
       return false;

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -1743,11 +1743,12 @@ PopupMenu.prototype = {
      * @event beforeopen
      * @memberof PopupMenu
      * @property {object} event - The jquery event object
-     * @property {object} this menu instance
+     * @property {object} this The menu instance
+     * @property {object} api The menu api
      */
     let canOpen = true;
     if (!this.element.hasClass('autocomplete')) {
-      canOpen = this.element.triggerHandler('beforeopen', [this.menu]);
+      canOpen = this.element.triggerHandler('beforeopen', [this.menu, this]);
       if (canOpen === false) {
         return;
       }
@@ -2021,7 +2022,7 @@ PopupMenu.prototype = {
       submenu = submenu.children('.popupmenu');
     }
 
-    let canOpen = this.element.triggerHandler('beforeopen', [submenu]);
+    let canOpen = this.element.triggerHandler('beforeopen', [submenu, this]);
     if (canOpen === false) {
       return;
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Added a new fix to #4766 because open fires on a delay of 300ms it was possible to make it fail if you clicked into the input quickly.

**Related github/jira issue (required)**:
Fixes #4766

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-compact-mode.html
- click on the filter button in the order date column
- VERY quickly click into the input -> menu should still close