### PR TITLE
4519 - Fix toast live region announcement

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Modal]` Fixed a bug where fullsize responsive setting doesn't work on android phones in landscape mode. ([#4451](https://github.com/infor-design/enterprise/issues/4451))
 - `[Rating]` Fixed color of unclick rating star. ([#4853](https://github.com/infor-design/enterprise/issues/4853))
 - `[Tabs Module]` Fixed a bug where clear button was missing when clearable setting is activated in tabs module searchfield. ([#4898](https://github.com/infor-design/enterprise/issues/4898))
+- `[Toast]` Fixed a bug where the first toast in the page is not announced to screen readers. ([#4519](https://github.com/infor-design/enterprise/issues/4519))
 - `[Tooltip]` Fixed a bug in tooltip that prevented linking id-based tooltip content. ([#4827](https://github.com/infor-design/enterprise/issues/4827))
 
 ## v4.38.1

--- a/src/components/circlepager/circlepager.js
+++ b/src/components/circlepager/circlepager.js
@@ -354,7 +354,7 @@ CirclePager.prototype = {
     this.show();
   },
 
-  /** 
+  /**
    * Add attributes for control buttons
    * @private
    * @returns {void}

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -79,8 +79,10 @@ Toast.prototype = {
     let container = $(`#toast-container${this.uniqueId}`);
     const toast = $(`
       <div class="toast">
-        <span class="toast-title">${xssUtils.stripHTML(s.title)}</span>
-        <span class="toast-message">${message}</span>
+        <span aria-relevant="additions text" aria-live="polite">
+          <span class="toast-title">${xssUtils.stripHTML(s.title)}</span>
+          <span class="toast-message">${message}</span>
+        </span>
       </div>`);
     const closeBtn = $(`
       <button type="button" class="btn-icon btn-close" title="${Locale.translate('Close')}" aria-hidden="true">
@@ -91,7 +93,7 @@ Toast.prototype = {
     const progress = $('<div class="toast-progress"></div>');
 
     if (!container.length) {
-      container = $(`<div id="toast-container${this.uniqueId}" class="toast-container" aria-relevant="additions" aria-live="polite"></div>`).appendTo('body');
+      container = $(`<div id="toast-container${this.uniqueId}" class="toast-container"></div>`).appendTo('body');
     }
 
     container
@@ -438,6 +440,7 @@ Toast.prototype = {
   remove(toast, id) {
     const removeCallback = () => {
       toast.remove();
+
       const canDestroy = !$(`#toast-container${this.uniqueId} .toast`).length;
       if (canDestroy) {
         this.destroy();
@@ -451,6 +454,7 @@ Toast.prototype = {
       return;
     }
 
+    toast.attr('aria-live', '').attr('aria-relevent', '').hide();
     toast.addClass('effect-scale-hide');
 
     const closeTimer = new RenderLoopItem({


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes an issue with toasts not being announced by the screen readers when in a live region. To solve this i moved the region to the item itself using technique 4 of https://codepen.io/vloux/pen/exYQKR

In addition found that it is announced and removal too and fixed that

**Related github/jira issue (required)**:
Fixes #4519 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/toast/example-index.html
- enable Chrome Vox
- tab to the button - wait for it to read out entirely (since its set to polite it wont "talk over") other bits the screen reader is using
- hit enter -> should read the announcement in the toast
- wait for it to end and close -> should not hear it a second time
- hit enter -> should read the announcement in the toast -> just as it finishes hit enter again -> should read a second announcement
- wait for it both end and close -> should not hear a double message

**Included in this Pull Request**:
- [x] A note to the change log.