### PR TITLE
4977 - Fix textarea options being ignored inside of accordion

### DIFF
--- a/app/views/components/accordion/test-textarea-inside-of-accordion.html
+++ b/app/views/components/accordion/test-textarea-inside-of-accordion.html
@@ -24,7 +24,7 @@
       </div>
 
       <div id="header-two" class="accordion-header">
-        <a href="#" id="sort-by" data-automation-id="accordion-a-sort-by"><span>Auto Grow with Max Length</span></a>
+        <a href="#" id="sort-by" data-automation-id="accordion-a-sort-by"><span>Auto Grow with Max Height</span></a>
         <button id="sort-by-expander" data-automation-id="accordion-btn-sort-by" class="btn">
           <svg class="chevron icon">
             <use href="#icon-caret-down"></use>

--- a/app/views/components/accordion/test-textarea-inside-of-accordion.html
+++ b/app/views/components/accordion/test-textarea-inside-of-accordion.html
@@ -1,0 +1,73 @@
+<div class="row">
+  <div class="six columns">
+
+    <div class="accordion" data-demo-set-links="true" data-options='{ "allowOnePane": false }'>
+      <div id="header-one" class="accordion-header">
+        <a href="#" id="auto-grow" data-automation-id="accordion-a-header-one">
+          <span>Auto Grow (Infinite)</span></a>
+        <button id="personal-expander" data-automation-id="accordion-btn-warehouse-location" class="btn">
+          <svg class="chevron icon">
+            <use href="#icon-caret-down"></use>
+          </svg>
+          <span class="audible">Expand</span>
+        </button>
+      </div>
+      <div class="accordion-pane">
+        <div class="accordion-content">
+          <textarea id="autogrow-infinite" data-options="{autoGrow: true}"
+            class="textarea input-full" name="autogrow">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec rutrum hendrerit nunc sed mollis. Quisque pharetra venenatis aliquam. Nullam egestas cursus odio eget viverra. Phasellus nec ipsum tincidunt, tincidunt nunc dapibus, mattis neque. Nulla sodales faucibus orci vitae scelerisque. Pellentesque consequat vulputate ligula. Nam nec diam sit amet leo  fringilla viverra in eget augue. Suspendisse porttitor odio bibendum nulla tristique congue a eget justo. Fusce eu elementum ex. Curabitur gravida lorem vitae purus aliquam, fringilla euismod justo sagittis. Mauris non sem massa. Etiam ut sem sit amet nunc mollis sagittis viverra non ipsum.
+            In convallis, sapien sollicitudin interdum lacinia, libero tellus convallis lacus, eu tincidunt quam elit interdum justo. Nulla in blandit enim. Pellentesque eget imperdiet nisi. Nullam porttitor velit orci. Proin vehicula quis dui ut posuere. Pellentesque sed eros a enim vestibulum condimentum. Vestibulum libero sem, aliquam quis metus placerat, porta accumsan erat. Praesent rutrum sapien sed mi dapibus tempor. Nulla varius pharetra nisl ultricies posuere. Sed finibus nulla at dui dignissim eleifend. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer vitae vulputate lectus, vel aliquet nisi. Mauris pharetra nunc erat, pellentesque congue est blandit ac. Suspendisse in tellus eget purus iaculis fringilla. Nullam fringilla lorem rutrum neque vestibulum, a pulvinar urna tincidunt. Donec arcu ex, malesuada eget posuere eget, rutrum eget quam.
+            Sed convallis placerat tellus, vel ullamcorper sem ornare ut. Ut vulputate ornare lorem, id dictum lectus eleifend quis. Suspendisse mattis, sapien non ullamcorper vulputate, ligula diam gravida urna, sit amet fringilla lorem enim sit amet neque. Integer iaculis porttitor nulla, eu consequat ex. Mauris massa orci, mollis at feugiat vitae, ornare in nisi. Mauris a elit lorem. Donec condimentum malesuada ligula, sed auctor lectus rhoncus at. Quisque commodo vehicula urna eget varius. Integer faucibus rutrum condimentum. Nunc eu tellus sit amet erat congue ultricies.
+          </textarea>
+        </div>
+      </div>
+
+      <div id="header-two" class="accordion-header">
+        <a href="#" id="sort-by" data-automation-id="accordion-a-sort-by"><span>Auto Grow with Max Length</span></a>
+        <button id="sort-by-expander" data-automation-id="accordion-btn-sort-by" class="btn">
+          <svg class="chevron icon">
+            <use href="#icon-caret-down"></use>
+          </svg>
+          <span class="audible">Expand</span>
+        </button>
+      </div>
+      <div class="accordion-pane">
+        <div class="accordion-content">
+          <textarea id="autogrow-with-max-length" data-options="{autoGrow: true, autoGrowMaxHeight: 350}"
+            class="textarea input-full" name="autogrow">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec rutrum hendrerit nunc sed mollis. Quisque pharetra venenatis aliquam. Nullam egestas cursus odio eget viverra. Phasellus nec ipsum tincidunt, tincidunt nunc dapibus, mattis neque. Nulla sodales faucibus orci vitae scelerisque. Pellentesque consequat vulputate ligula. Nam nec diam sit amet leo  fringilla viverra in eget augue. Suspendisse porttitor odio bibendum nulla tristique congue a eget justo. Fusce eu elementum ex. Curabitur gravida lorem vitae purus aliquam, fringilla euismod justo sagittis. Mauris non sem massa. Etiam ut sem sit amet nunc mollis sagittis viverra non ipsum.
+            In convallis, sapien sollicitudin interdum lacinia, libero tellus convallis lacus, eu tincidunt quam elit interdum justo. Nulla in blandit enim. Pellentesque eget imperdiet nisi. Nullam porttitor velit orci. Proin vehicula quis dui ut posuere. Pellentesque sed eros a enim vestibulum condimentum. Vestibulum libero sem, aliquam quis metus placerat, porta accumsan erat. Praesent rutrum sapien sed mi dapibus tempor. Nulla varius pharetra nisl ultricies posuere. Sed finibus nulla at dui dignissim eleifend. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer vitae vulputate lectus, vel aliquet nisi. Mauris pharetra nunc erat, pellentesque congue est blandit ac. Suspendisse in tellus eget purus iaculis fringilla. Nullam fringilla lorem rutrum neque vestibulum, a pulvinar urna tincidunt. Donec arcu ex, malesuada eget posuere eget, rutrum eget quam.
+            Sed convallis placerat tellus, vel ullamcorper sem ornare ut. Ut vulputate ornare lorem, id dictum lectus eleifend quis. Suspendisse mattis, sapien non ullamcorper vulputate, ligula diam gravida urna, sit amet fringilla lorem enim sit amet neque. Integer iaculis porttitor nulla, eu consequat ex. Mauris massa orci, mollis at feugiat vitae, ornare in nisi. Mauris a elit lorem. Donec condimentum malesuada ligula, sed auctor lectus rhoncus at. Quisque commodo vehicula urna eget varius. Integer faucibus rutrum condimentum. Nunc eu tellus sit amet erat congue ultricies.
+          </textarea>
+        </div>
+      </div>
+
+      <div id="header-four" class="accordion-header">
+        <a id="material" data-automation-id="accordion-a-material" href="#"><span>Material</span></a>
+        <button id="material-expander" data-automation-id="accordion-btn-material" class="btn">
+          <svg class="chevron icon">
+            <use href="#icon-caret-down"></use>
+          </svg>
+          <span class="audible">Expand</span>
+        </button>
+      </div>
+      <div class="accordion-pane">
+        <div class="accordion-content">
+          <p>
+            Revolutionize implement infrastructures social front-end, world-class bricks-and-clicks extensible
+            recontextualize? User-contributed e-business relationships widgets bleeding-edge transform, "viral
+            world-class, unleash sexy embrace cross-media best-of-breed wireless, functionalities." Markets, "transition
+            architectures, redefine infomediaries world-class back-end harness, mindshare blogospheres; schemas
+            disintermediate rich," benchmark integrated markets blogging synergies dynamic social back-end convergence.
+            Reinvent A-list A-list B2C rss-capable, mesh bandwidth mission-critical disintermediate strategize networks
+            distributed integrated bleeding-edge rss-capable partnerships incubate, web-enabled e-markets. A-list
+            channels enhance citizen-media, value solutions beta-test platforms enable interfaces, transition interfaces
+            one-to-one expedite scalable.
+          </p>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Modal]` Fixed a bug where fullsize responsive setting doesn't work on android phones in landscape mode. ([#4451](https://github.com/infor-design/enterprise/issues/4451))
 - `[Rating]` Fixed color of unclick rating star. ([#4853](https://github.com/infor-design/enterprise/issues/4853))
 - `[Tabs Module]` Fixed a bug where clear button was missing when clearable setting is activated in tabs module searchfield. ([#4898](https://github.com/infor-design/enterprise/issues/4898))
+- `[Textarea]` Fixed a bug where the textarea options like autogrow, autoGrowMaxHeight doesn't work after the initialization inside of the accordion. ([#4977](https://github.com/infor-design/enterprise/issues/4977))
 - `[Tooltip]` Fixed a bug in tooltip that prevented linking id-based tooltip content. ([#4827](https://github.com/infor-design/enterprise/issues/4827))
 
 ## v4.38.1

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -123,6 +123,13 @@ Accordion.prototype = {
       this.contentAreas = this.contentAreas.add(contentAreas);
     }
 
+    // Making the accordion pane to display
+    // so the scrollHeight in textarea will be calculated
+    const textAreaChild = $('.accordion-content').find('textarea');
+    if (textAreaChild) {
+      textAreaChild.parents('.accordion-pane').attr('style', 'display: block');
+    }
+
     let headersHaveIcons = false;
 
     // Accordion Headers that have an expandable pane need to have an


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes the textarea options being ignored after the page load inside of an accordion. Basically, the `scrollHeight` of the textarea was unable to find because of the accordion component. I found out that the accordion pane was hidden at first so technically, the textarea's `scrollHeight` wasn't there and will always be zero.

Fixed it via making the pane displayed so that the textarea gets its `scrollHeight` and gets calculated correctly.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/4977

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/accordion/test-textarea-inside-of-accordion.html
- Open/Click the `Auto Grow (Infinite)` header
- Notice that the textarea should behave as autogrow and infinite by adding more texts.
- Open/Click the `Auto Grow with Max Height`
- Textarea should be scrollable since it has a max height of 350.

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
