### PR TITLE
4933 button single select

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Datepicker]` Updated validation.js to check if date picker contains a time value ([#4888](https://github.com/infor-design/enterprise/issues/4888))
 - `[Environment]`Updated the regular expression search criteria from Edge to Edg to resolve the EDGE is not detected issue. ([#4603](https://github.com/infor-design/enterprise/issues/4603))
 - `[General]` We Updated jQuery to use 3.6.0. ([#1690](https://github.com/infor-design/enterprise/issues/1690))
+- `[Lookup]` Isolated the scss/css .close.icon class inside of .modal-content and removed any extra top property to fix the alignment issue.([#4933](https://github.com/infor-design/enterprise/issues/4933))
 - `[Message]` Added automation id's to the message's modal main area dialog as well with `modal` prefix. ([#4871](https://github.com/infor-design/enterprise/issues/4871))
 - `[Modal]` Fixed a bug where fullsize responsive setting doesn't work on android phones in landscape mode. ([#4451](https://github.com/infor-design/enterprise/issues/4451))
 - `[Rating]` Fixed color of unclick rating star. ([#4853](https://github.com/infor-design/enterprise/issues/4853))

--- a/src/components/lookup/_lookup-new.scss
+++ b/src/components/lookup/_lookup-new.scss
@@ -70,7 +70,7 @@ html[dir='rtl'] {
             .close.icon {
               display: block;
               left: 4px;
-              top: 0.5px;
+              top: -1px;
             }
           }
         }

--- a/src/components/lookup/_lookup-new.scss
+++ b/src/components/lookup/_lookup-new.scss
@@ -62,15 +62,18 @@ html[dir='rtl'] {
     .buttonset {
       .searchfield-wrapper {
         .btn-icon {
+          top: 4px;
+          
           .close.icon {
-            top: -3px;
+            border: 1px solid transparent;
+            top: -1px;
           }
 
           &:focus {
             .close.icon {
               display: block;
               left: 4px;
-              top: -1px;
+              top: 0.5px;
             }
           }
         }

--- a/src/components/lookup/_lookup-new.scss
+++ b/src/components/lookup/_lookup-new.scss
@@ -63,7 +63,7 @@ html[dir='rtl'] {
       .searchfield-wrapper {
         .btn-icon {
           top: 4px;
-          
+
           .close.icon {
             border: 1px solid transparent;
             top: -1px;

--- a/src/components/lookup/_lookup-new.scss
+++ b/src/components/lookup/_lookup-new.scss
@@ -62,15 +62,16 @@ html[dir='rtl'] {
     .buttonset {
       .searchfield-wrapper {
         .btn-icon {
+          .close.icon {
+            top: -3px;
+          }
+
           &:focus {
             .close.icon {
               display: block;
               left: 4px;
               top: 0.5px;
             }
-          }
-          .close.icon {
-            top: -3px;
           }
         }
       }

--- a/src/components/lookup/_lookup-new.scss
+++ b/src/components/lookup/_lookup-new.scss
@@ -56,3 +56,24 @@ html[dir='rtl'] {
     }
   }
 }
+
+.modal-content {
+  .toolbar {
+    .buttonset {
+      .searchfield-wrapper {
+        .btn-icon {
+          &:focus {
+            .close.icon {
+              display: block;
+              left: 4px;
+              top: 0.5px;
+            }
+          }
+          .close.icon {
+            top: -3px;
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added a scss/css statement to encapsulate the .the close.icon selectors to remove any extra top property to fix the alignment issue in the lookup component 

**Related github/jira issue (required)**:
Fixed https://github.com/infor-design/enterprise/issues/4933

**Steps necessary to review your pull request (required)**:
Include:
- Navigate to the lookup component page 
http://localhost:4000/components/lookup/example-index.html
- Click on the magnifying glass inside of in the input to open the modal
- Inside of the input type a search were keyword is described.
- After typing the search the X will appear on the right side of the input.  
- Click the tab key to change the focus to the button the X should still appear. 
<img width="1217" alt="os_version=10 browser=Firefox browser_version=86" src="https://user-images.githubusercontent.com/5215954/112159005-14dd6480-8bbf-11eb-8d88-4a4834960fbf.png">
<img width="1194" alt="os=android os_version=11" src="https://user-images.githubusercontent.com/5215954/112159008-14dd6480-8bbf-11eb-9c53-a85ae7ec369a.png">
<img width="1200" alt="os=iOS os_version=14 0 device_browser=safari" src="https://user-images.githubusercontent.com/5215954/112159009-1575fb00-8bbf-11eb-802d-a137886647d5.png">
<img width="1161" alt="os=OS+X os_version=Big+Sur browser" src="https://user-images.githubusercontent.com/5215954/112159011-1575fb00-8bbf-11eb-8b86-b32388565d91.png">
<img width="1195" alt="os=OS+X os_version=Big+Sur browser=Chrome browser_version=89" src="https://user-images.githubusercontent.com/5215954/112159012-1575fb00-8bbf-11eb-84b5-990b97cb2ace.png">
<img width="1190" alt="os=OS+X os_version=Big+Sur browser=Edge browser_version=89" src="https://user-images.githubusercontent.com/5215954/112159015-160e9180-8bbf-11eb-8c16-18ca0bd7d57a.png">
<img width="1201" alt="os=OS+X os_version=Big+Sur browser=Firefox browser_version=86" src="https://user-images.githubusercontent.com/5215954/112159017-160e9180-8bbf-11eb-86d1-04a70b7d2814.png">
<img width="1217" alt="os=Windows os_version=10 browser=Chrome browser_version=89" src="https://user-images.githubusercontent.com/5215954/112159019-16a72800-8bbf-11eb-8eb5-8923dbf011ec.png">
<img width="1222" alt="os=Windows os_version=10 browser=Edge browser_version=89 0 device_browser" src="https://user-images.githubusercontent.com/5215954/112159020-16a72800-8bbf-11eb-9f8a-0f231906792c.png">

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
