### PR TITLE
NG#987 - Fix shared Popupmenu lifecycle

### DIFF
--- a/app/views/components/popupmenu/test-multiple.html
+++ b/app/views/components/popupmenu/test-multiple.html
@@ -1,9 +1,17 @@
 <div class="row">
   <div class="twelve columns">
+    <button id="popup-destroy-1" class="btn-secondary" type="button">
+      <span>Destroy 1st Field</span>
+    </button>
 
-      <button id="popdown-destroy" class="btn" type="button">
-        <span>Destroy</span>
-      </button>
+    <button id="popup-destroy-2" class="btn-secondary" type="button">
+      <span>Destroy 2nd Field</span>
+    </button>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
 
     <div class="field" id="field1">
       <label for="input-menu">Label</label>
@@ -59,22 +67,24 @@
 
   <script>
     // Like Angular
-    const contextMenu = $('#input-menu');
-    contextMenu.popupmenu({trigger:'rightClick', menu: "action-popupmenu" })
-    const contextMenuApi = contextMenu.data('popupmenu');
+    const input1 = $('#input-menu');
+    input1.popupmenu({trigger:'rightClick', menu: "action-popupmenu" })
+    const inputAPI1 = input1.data('popupmenu');
 
-    const contextMenu2 = $('#input-menu2')
-    contextMenu2.popupmenu({trigger:'rightClick', menu: "action-popupmenu" });
-    const contextMenuApi2 = contextMenu2.data('popupmenu');
+    const input2 = $('#input-menu2')
+    input2.popupmenu({trigger:'rightClick', menu: "action-popupmenu" });
+    const inputAPI2 = input2.data('popupmenu');
 
-    const popupMenu = $('#action-popupmenu');
-    popupMenu.popupmenu();
-    const popupMenuApi = popupMenu.data('popupmenu');
+    $('#popup-destroy-1').click(function() {
+      input1.off();
+      inputAPI1.destroy();
+      input1.parent().remove();
+    });
 
-    $('#popdown-destroy').click(function() {
-      contextMenu.off();
-      contextMenuApi.destroy();
-      contextMenu.parent().remove();
+    $('#popup-destroy-2').click(function () {
+      input2.off();
+      inputAPI2.destroy();
+      input2.parent().remove();
     });
   </script>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[Message]` Added automation id's to the message's modal main area dialog as well with `modal` prefix. ([#4871](https://github.com/infor-design/enterprise/issues/4871))
 - `[Modal]` Fixed a bug where fullsize responsive setting doesn't work on android phones in landscape mode. ([#4451](https://github.com/infor-design/enterprise/issues/4451))
 - `[Rating]` Fixed color of unclick rating star. ([#4853](https://github.com/infor-design/enterprise/issues/4853))
+- `[Popupmenu]` Fixed a lifecycle issue on menus that are shared between trigger elements, where these menus were incorrectly being torn down. ([NG#987](https://github.com/infor-design/enterprise-ng/issues/987))
 - `[Tabs Module]` Fixed a bug where clear button was missing when clearable setting is activated in tabs module searchfield. ([#4898](https://github.com/infor-design/enterprise/issues/4898))
 - `[Tooltip]` Fixed a bug in tooltip that prevented linking id-based tooltip content. ([#4827](https://github.com/infor-design/enterprise/issues/4827))
 

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -2482,7 +2482,7 @@ PopupMenu.prototype = {
    */
   teardown() {
     const self = this;
-    if (!this.menu || !this.menu.parent) {
+    if (!this.menu || !this.menu.length || !this.menu.parent()) {
       return this;
     }
     const wrapper = this.menu.parent('.popupmenu-wrapper');
@@ -2501,7 +2501,7 @@ PopupMenu.prototype = {
     this.predefinedItems = $();
 
     // Only unwrap/move this menu if there are no other menus attempting to control it (shared instance)
-    const menuId = this.menu[0].id;
+    const menuId = this.menu[0]?.id;
     const otherTriggers = $(`[aria-controls="${menuId}"]`).not(this.element);
     if (!otherTriggers.length) {
       const parentNode = this.menu.parent();

--- a/test/components/popupmenu/popupmenu.e2e-spec.js
+++ b/test/components/popupmenu/popupmenu.e2e-spec.js
@@ -1,3 +1,4 @@
+const { element, browser } = require('protractor');
 const popupmenuPageObject = require('./helpers/popupmenu-page-objects.js');
 
 const { browserStackErrorReporter } = requireHelper('browserstack-error-reporter');
@@ -253,6 +254,34 @@ describe('Popupmenu example-selectable-multiple tests', () => {
   }
 });
 
+fdescribe('Popupmenu shared instance tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/popupmenu/test-multiple?layout=nofrills');
+  });
+
+  it('does not unwrap and destroy Popupmenus if they are shared', async () => {
+    // Right click input 1 to open its Popupmenu
+    const input1 = await element(by.id('input-menu'));
+    await browser.actions().mouseMove(input1).perform();
+    await browser.actions().click(protractor.Button.RIGHT).perform();
+
+    // Right click input 2 to open its Popupmenu
+    const input2 = await element(by.id('input-menu2'));
+    await browser.actions().mouseMove(input2).perform();
+    await browser.actions().click(protractor.Button.RIGHT).perform();
+
+    // Click the button that destroys the 1st Popup Menu
+    await element(by.id('popup-destroy-1')).click();
+
+    // Right click input 2 to open its Popupmenu again
+    await browser.actions().mouseMove(input2).perform();
+    await browser.actions().click(protractor.Button.RIGHT).perform();
+
+    // The menu should be open and displayed with no issues
+    expect(await element(by.css('.popupmenu-wrapper')).isDisplayed()).toBeTruthy();
+  });
+});
+
 describe('Contextmenu created dynamically tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/datagrid/test-contextmenu-dynamic');
@@ -352,3 +381,4 @@ describe('Contextmenu Placement Tests', () => {
     });
   }
 });
+

--- a/test/components/popupmenu/popupmenu.e2e-spec.js
+++ b/test/components/popupmenu/popupmenu.e2e-spec.js
@@ -254,7 +254,7 @@ describe('Popupmenu example-selectable-multiple tests', () => {
   }
 });
 
-fdescribe('Popupmenu shared instance tests', () => {
+describe('Popupmenu shared instance tests', () => {
   beforeEach(async () => {
     await utils.setPage('/components/popupmenu/test-multiple?layout=nofrills');
   });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes an issue in Popupmenu instances that are shared between two or more trigger elements.  A regression recently occurred that caused Popupmenus to fully unwrap and revert their locations in the DOM, even while shared between different trigger elements.  This has been fixed.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#987
Related to infor-design/enterprise-ng#1012

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, run
- Open http://localhost:4000/components/popupmenu/test-multiple.html?layout=nofrills
- Right click each input field and open their menus at least once
- Click "Destroy 1st Field"
- Right click the remaining field and ensure the Popupmenu opens.
- Click "Destroy 2nd Field"
- Inspect the DOM and ensure there are no leftover `.popupmenu-wrapper` elements underneath the body tag.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

@volante007