### PR TITLE
4751 - Fix Editor separator

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Datagrid]` Fixed a bug where filter dropdown menus did not close when focusing a filter input. ([#4766](https://github.com/infor-design/enterprise/issues/4766))
 - `[Datagrid]` Fixed an error seen clicking items if using a flex toolbar for the datagrid toolbar. ([#4941](https://github.com/infor-design/enterprise/issues/4941))
 - `[Datepicker]` Updated validation.js to check if date picker contains a time value ([#4888](https://github.com/infor-design/enterprise/issues/4888))
+- `[Editor]`Adjusted the editor to not treat separators after headers as leading and removing them. ([#4751](https://github.com/infor-design/enterprise/issues/4751))
 - `[Environment]`Updated the regular expression search criteria from Edge to Edg to resolve the EDGE is not detected issue. ([#4603](https://github.com/infor-design/enterprise/issues/4603))
 - `[General]` We Updated jQuery to use 3.6.0. ([#1690](https://github.com/infor-design/enterprise/issues/1690))
 - `[Message]` Added automation id's to the message's modal main area dialog as well with `modal` prefix. ([#4871](https://github.com/infor-design/enterprise/issues/4871))

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -69,7 +69,7 @@
 
       &.is-disabled {
         span {
-          opacity: 0.5;
+          color: $breadcrumb-disabled-color;
         }
 
         .hyperlink {
@@ -89,7 +89,7 @@
 
         &.is-disabled {
           span {
-            opacity: 0.5;
+            color: $breadcrumb-disabled-color;
           }
         }
 

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -214,12 +214,12 @@ Editor.prototype = {
         foundOldSettings = true;
         styles.push(new FontPickerStyle(`header${hLevel}`, `Header ${hLevel}`, `h${hLevel}`));
       }
+      if (s.buttons.editor[0] === 'separator') {
+        s.buttons.editor.splice(0, 1);
+      }
       if (foundOldSettings) {
         s.buttons.editor = s.buttons.editor.filter(el => el.substr(0, 6) !== 'header');
         s.fontpickerSettings = { styles };
-      }
-      if (s.buttons.editor[0] === 'separator') {
-        s.buttons.editor.splice(0, 1);
       }
       if (foundOldSettings) {
         s.buttons.editor = ['fontPicker'].concat(s.buttons.editor);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed an issue where separators that appear immediately after the header drop-downs don't appear.

**Related github/jira issue (required)**:
#4751 

**Steps necessary to review your pull request (required)**:
Go to http://localhost:4000/components/editor/example-customize-buttons.html and see that there is now a separator after the initial header dropdown.

Before:
![image](https://user-images.githubusercontent.com/72534276/112197705-bde98680-8be2-11eb-99a1-027cd20c3607.png)

After:
![image](https://user-images.githubusercontent.com/72534276/112201726-ec696080-8be6-11eb-8c53-6d3df2c828be.png)


**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
