### PR TITLE
Changed the Safari disabled searchfield color

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Editor]`Adjusted the editor to not treat separators after headers as leading and removing them. ([#4751](https://github.com/infor-design/enterprise/issues/4751))
 - `[Environment]`Updated the regular expression search criteria from Edge to Edg to resolve the EDGE is not detected issue. ([#4603](https://github.com/infor-design/enterprise/issues/4603))
 - `[General]` We Updated jQuery to use 3.6.0. ([#1690](https://github.com/infor-design/enterprise/issues/1690))
+- `[Input]` Changed the disabled search field color for Safari to match that of other browsers. ([#4611](https://github.com/infor-design/enterprise/issues/4611))
 - `[Lookup]` Isolated the scss/css .close.icon class inside of .modal-content and removed any extra top property to fix the alignment issue.([#4933](https://github.com/infor-design/enterprise/issues/4933))
 - `[Line Chart]` Added support for double click to Area, Bubble, Line and Scatterplot. ([#3229](https://github.com/infor-design/enterprise/issues/3229))
 - `[Message]` Added automation id's to the message's modal main area dialog as well with `modal` prefix. ([#4871](https://github.com/infor-design/enterprise/issues/4871))

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -382,15 +382,10 @@ span.required::after {
 // don't want to use generally because it conflicts.
 .is-safari {
   input,
-  textarea {
-    &[disabled] {
-      -webkit-text-fill-color: $input-disabled-color;
-    }
-  }
-
+  textarea,
   .searchfield {
     &[disabled] {
-      -webkit-text-fill-color: $ids-color-palette-slate-70;
+      -webkit-text-fill-color: $input-disabled-color;
     }
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes an issue where the disabled search bar for inputs don't appear disabled in Safari

**Related github/jira issue (required)**:
#4611 

**Steps necessary to review your pull request (required)**:
1. Open Safari
2. Go to http://localhost:4000/components/form/example-disabled-field.html
3. Select "Click to Disable"
3. Observe the greyed out search bar in the bottom of the screen

![image](https://user-images.githubusercontent.com/72534276/112393643-ce2c5f00-8cd1-11eb-8022-b240d321aadc.png)

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
