### PR TITLE
4918 - datagrid rowstatus and dirty indicator overlapping

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@
 - `[Column Chart]` Added support for double click to Column, Column Grouped, Column Stacked, Column Stacked-singular and Column Positive Negative. ([#3229](https://github.com/infor-design/enterprise/issues/3229))
 - `[Datagrid]` Fixed a bug where filter dropdown menus did not close when focusing a filter input. ([#4766](https://github.com/infor-design/enterprise/issues/4766))
 - `[Datagrid]` Fixed an error seen clicking items if using a flex toolbar for the datagrid toolbar. ([#4941](https://github.com/infor-design/enterprise/issues/4941))
+- `[Datagrid]` Only show row status when dirty indicator and row status both exist to address conflicting visual issue. ([#4918](https://github.com/infor-design/enterprise/issues/4918))
+- `[Datagrid]` Fix issue where selecting a row added background to row-status. ([#4918](https://github.com/infor-design/enterprise/issues/4918))
 - `[Datepicker]` Updated validation.js to check if date picker contains a time value ([#4888](https://github.com/infor-design/enterprise/issues/4888))
 - `[Editor]`Adjusted the editor to not treat separators after headers as leading and removing them. ([#4751](https://github.com/infor-design/enterprise/issues/4751))
 - `[Environment]`Updated the regular expression search criteria from Edge to Edg to resolve the EDGE is not detected issue. ([#4603](https://github.com/infor-design/enterprise/issues/4603))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1892,7 +1892,7 @@ $datagrid-small-row-height: 25px;
         box-shadow: none;
       }
 
-      .icon {
+      .icon:not(.icon-rowstatus) {
         @include trigger-icon-background($datagrid-row-hover-color);
       }
     }
@@ -1901,7 +1901,7 @@ $datagrid-small-row-height: 25px;
     &.is-selected:not(.hide-selected-color) td:not(.is-editing) .datagrid-cell-wrapper {
       background-color: $datagrid-row-selected-color;
 
-      .icon {
+      .icon:not(.icon-rowstatus) {
         @include trigger-icon-background($datagrid-row-selected-color);
       }
     }

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1601,11 +1601,6 @@ $datagrid-small-row-height: 25px;
             top: -15px;
           }
 
-          &.is-dirty-cell::before {
-            border-width: 0;
-            margin: 0;
-          }
-
           .icon-rowstatus {
             left: -1px;
             top: 0;
@@ -2813,7 +2808,7 @@ $datagrid-small-row-height: 25px;
       }
     }
 
-    &.is-dirty-cell {
+    &.is-dirty-cell:not(.rowstatus-cell) {
       position: relative;
 
       &::before {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Data grid row indicators and row statuses overlap.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #4918 
**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

1. Visit http://localhost:4000/components/datagrid/test-dirty-indication.html
2. Open console and type:
```
const grid = $('#datagrid').data('datagrid');
grid.rowStatus(0, "error", "some test status");
grid.setDirtyIndicator(0, 0, true);
```
-> See that there is no dirty indicator, but row status exists
![image](https://user-images.githubusercontent.com/1799905/112506674-5fe4ac80-8d64-11eb-9f35-82679a7094c7.png)

3. Select first row
-> See that there is no visual background artifacts on status cell.
![image](https://user-images.githubusercontent.com/1799905/112506833-81459880-8d64-11eb-98a9-5594503fad3e.png)

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [X] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
