### PR TITLE
4707 - Add api support for collapse/expand node with tree

### DIFF
--- a/app/views/components/tree/test-expand-collapse-node.html
+++ b/app/views/components/tree/test-expand-collapse-node.html
@@ -1,0 +1,133 @@
+<div class="row">
+  <div class="twelve columns">
+    <h2>Tree - expandNode() / collapseNode()</h2>
+    <br/><br/>
+    <button type="button" id="btn-toggle-node" class="btn-secondary"><span class="btn-text">Toggle Node</span></button>
+    <button type="button" id="btn-toggle-all" class="btn-secondary"><span class="btn-text">Toggle All</span></button>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+    <ul role="tree" aria-label="Asset Types" class="tree" data-init="false" id="json-tree">
+    </ul>
+  </div>
+</div>
+
+<script id="test-script">
+  var sampleData = [{
+    "id": "node1",
+    "text": "Node One",
+    "open": false,
+    "selected": false,
+    "href": '/somelink/'
+  }, {
+    "id": "node2",
+    "text": "Node Two",
+    "open": true,
+    "selected": false,
+    "children": [{
+        "id": "node3",
+        "text": "Node Three"
+      }, {
+        "id": "node4",
+        "text": "Node Four",
+        "children": [{
+          "id": "node5",
+          "text": "Node Five",
+          "children": [{
+            "id": "node6",
+            "text": "Node Six",
+            "icon": "icon-tree-chart",
+            "children": [{
+              "id": "node7",
+              "text": "Node Seven"
+            }, {
+              "id": "node8",
+              "text": "Node Eight"
+            }]
+          }]
+        }]
+      }]
+  }];
+
+  var treeElem = $('#json-tree');
+
+  // Initialize tree
+  treeElem
+    .tree({ dataset: sampleData })
+    .on('selected', function (e, args) {
+      console.log('selected:', args);
+    });
+
+  // Get tree Api
+  var treeApi = treeElem.data('tree');
+
+  var btnToggleNode = $('#btn-toggle-node');
+  var btnToggleAll = $('#btn-toggle-all');
+  var btnToggleNodeTextElem = btnToggleNode.find('.btn-text');
+  var btnToggleAllTextElem = btnToggleAll.find('.btn-text');
+
+  // Set target node
+  var node = $('#node5');
+
+  // Get target node text
+  var nodeText = node.find('.tree-text').text();
+
+  // Get node state collapsed/expanded
+  var isExpanded = {
+    node: function () { return node.attr('aria-expanded') === 'true'; },
+    all: function () {
+      var all = treeElem.find('ul.folder');
+      var open = treeElem.find('ul.folder.is-open');
+      return all.length === open.length;
+    }
+  };
+
+  // Set button text based on current state
+  var setButtonText = function () {
+    var toggleText = {
+      node: (isExpanded.node() ? 'Collapse' : 'Expand') + ' (' + nodeText + ')',
+      all: isExpanded.all() ? 'Collapse All' : 'Expand All'
+    };
+    btnToggleNodeTextElem.text(toggleText.node);
+    btnToggleAllTextElem.text(toggleText.all);
+  };
+
+  // Initialize tree the button text
+  setButtonText();
+
+  // Bind toggle button text on collapsed/expanded
+  treeElem.on('collapsed expanded', function () {
+    setTimeout(function() {
+      setButtonText();
+    }, 300); // wait for animation
+  });
+
+  // Bind toggle node button on click
+  btnToggleNode.on('click', function() {
+    if (treeApi) {
+      if (isExpanded.node()) {
+        treeApi.collapseNode(node); // Pass node as jQuery element
+        // treeApi.collapseNode('node5'); // Pass nodeID as string
+        // node.collapse(); // Run on node (jQuery element)
+      } else {
+        treeApi.expandNode(node); // Pass node as jQuery element
+        // treeApi.expandNode('node5'); // Pass nodeID as string
+        // node.expand(); // Run on node (jQuery element)
+      }
+    }
+  });
+
+  // Bind toggle all button on click
+  btnToggleAll.on('click', function() {
+    if (treeApi) {
+      if (isExpanded.all()) {
+        treeApi.collapseAll();
+      } else {
+        treeApi.expandAll();
+      }
+      setButtonText();
+    }
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Datagrid]` Fixed an issue where stretching the last column of a table was not consistent when resizing the window. ([#5045](https://github.com/infor-design/enterprise/issues/5045))
 - `[Datagrid]` Fixed an issue where setting stretchColumn to 'last' did not stretch the last column in the table. ([#4913](https://github.com/infor-design/enterprise/issues/4913))
+- `[Tree]` Added api support for collapse/expand node methods. ([#4707](https://github.com/infor-design/enterprise/issues/4707))
 
 ### v4.51.0 Issues
 

--- a/src/components/tree/tree.jquery.js
+++ b/src/components/tree/tree.jquery.js
@@ -15,3 +15,43 @@ $.fn.tree = function (settings) {
     }
   });
 };
+
+/**
+ * Expand or Collapse the given node.
+ * @param {HTMLElement} elem The element reference to a tree node.
+ * @param {string} method The name collapse or expand.
+ * @returns {void}
+ */
+function treeNodeExpandCollapse(elem, method) {
+  const node = $(elem);
+  const api = node.data(`${COMPONENT_NAME}Api`);
+  if (api) {
+    const methods = {
+      collapse: api.collapseNode,
+      expand: api.expandNode
+    };
+    if (typeof methods[method] === 'function') {
+      methods[method].apply(api, node);
+    }
+  }
+}
+
+/**
+ * Collapse jQuery method to run on a tree node.
+ * @returns {jQuery[]} jQuery self element to make chainable.
+ */
+$.fn.collapse = function () {
+  return this.each(function () {
+    treeNodeExpandCollapse(this, 'collapse');
+  });
+};
+
+/**
+ * Expand jQuery method to run on a tree node.
+ * @returns {jQuery[]} jQuery self element to make chainable.
+ */
+$.fn.expand = function () {
+  return this.each(function () {
+    treeNodeExpandCollapse(this, 'expand');
+  });
+};


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added api support for collapse/expand node methods with Tree. This feature can be achieve three ways.

**Related github/jira issue (required)**:
Closes #4707

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/tree/test-expand-collapse-node.html
- Open developer tools
- See `Node Five` is collapsed, under Node Four
- Click on button `Expand (Node Five)`, it will expand Node Five and Node Four (parent nodes should also be expanded)
- Now top button switch to `Collapse (Node Five)`
- Click on this button, it will collapse only `Node Five` and all its children nodes (parent nodes should NOT be collapse)

This example page set to use `tree.collapseNode(node);` and `tree.expandNode(node);`
Use console to test other way to do collapse/expand

```
var nodeID = 'node5';
var node = $('#' + nodeID);
var tree = $('#json-tree').data('tree');

// Three ways to collapse node
1) tree.collapseNode(node); // Pass node as jQuery or HTML element (example page set to use)
2) tree.collapseNode(nodeId); // Pass nodeID as string
3) node.collapse(); // Run on node (jQuery element)

// Three ways to expand node
1) tree.expandNode(node); // Pass node as jQuery or HTML element (example page set to use)
2) tree.expandNode(nodeId); // Pass nodeID as string
3) node.expand(); // Run on node (jQuery element)
```

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
