### PR TITLE
4793 - Fixed am/pm dot issue for greek language with locale

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Datagrid]` Fixed an issue where stretching the last column of a table was not consistent when resizing the window. ([#5045](https://github.com/infor-design/enterprise/issues/5045))
 - `[Datagrid]` Fixed an issue where setting stretchColumn to 'last' did not stretch the last column in the table. ([#4913](https://github.com/infor-design/enterprise/issues/4913))
+- `[Locale]` Fixed an issue where the am/pm dot was causing issue to parseDate() method for greek language. ([#4793](https://github.com/infor-design/enterprise/issues/4793))
 - `[Tree]` Added api support for collapse/expand node methods. ([#4707](https://github.com/infor-design/enterprise/issues/4707))
 
 ### v4.51.0 Issues

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -981,6 +981,11 @@ const Locale = {  // eslint-disable-line
     const isUTC = (dateString.toLowerCase().indexOf('z') > -1);
     let i;
     let l;
+    const ampmHasDot = !!thisLocaleCalendar.dayPeriods.filter(x => x.indexOf('.') > -1).length &&
+      // dateFormat.indexOf('.') > -1 &&
+      dateFormat.indexOf('a') > -1 &&
+      dateFormat.indexOf('ah') < 0 &&
+      dateFormat.indexOf('H') < 0;
     const hasDot = (dateFormat.match(/M/g) || []).length === 3 && thisLocaleCalendar &&
       thisLocaleCalendar.months && thisLocaleCalendar.months.abbreviated &&
         thisLocaleCalendar.months.abbreviated.filter(v => /\./.test(v)).length;
@@ -996,7 +1001,8 @@ const Locale = {  // eslint-disable-line
       // Replace [space & colon & dot] with "/"
       const regex = hasDot ? /[T\s:-]/g : /[T\s:.-]/g;
       dateFormat = dateFormat.replace(regex, '/').replace(/z/i, '');
-      dateString = dateString.replace(regex, '/').replace(/z/i, '');
+      dateFormat = ampmHasDot ? dateFormat.replace('//', '/') : dateFormat;
+      dateString = dateString.replace(ampmHasDot ? /[T\s:-]/g : regex, '/').replace(/z/i, '');
     }
 
     // Remove spanish de
@@ -1104,8 +1110,13 @@ const Locale = {  // eslint-disable-line
     const year = this.getDatePart(formatParts, dateStringParts, 'yy', 'yyyy');
     let hasDays = false;
     let hasAmFirst = false;
-    const amSetting = thisLocaleCalendar.dayPeriods[0].replace(/\./g, '');
-    const pmSetting = thisLocaleCalendar.dayPeriods[1].replace(/\./g, '');
+    let amSetting = thisLocaleCalendar.dayPeriods[0];
+    let pmSetting = thisLocaleCalendar.dayPeriods[1];
+
+    if (!ampmHasDot) {
+      amSetting = amSetting.replace(/\./g, '');
+      pmSetting = pmSetting.replace(/\./g, '');
+    }
 
     for (i = 0, l = dateStringParts.length; i < l; i++) {
       const pattern = `${formatParts[i]}`;

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -982,7 +982,6 @@ const Locale = {  // eslint-disable-line
     let i;
     let l;
     const ampmHasDot = !!thisLocaleCalendar.dayPeriods.filter(x => x.indexOf('.') > -1).length &&
-      // dateFormat.indexOf('.') > -1 &&
       dateFormat.indexOf('a') > -1 &&
       dateFormat.indexOf('ah') < 0 &&
       dateFormat.indexOf('H') < 0;

--- a/src/components/timepicker/timepicker.js
+++ b/src/components/timepicker/timepicker.js
@@ -779,8 +779,14 @@ TimePicker.prototype = {
     let parts;
     let endParts;
     const timeparts = {};
+    const timeFormat = this.settings.timeFormat;
+    const ampmHasDot = !!this.dayPeriods.filter(x => x.indexOf('.') > -1).length &&
+      val.indexOf('.') > -1 &&
+      timeFormat.indexOf('a') > -1 &&
+      timeFormat.indexOf('ah') < 0 &&
+      !this.is24HourFormat();
 
-    val = val.replace(/[T\s:.-]/g, sep).replace(/z/i, '');
+    val = val.replace((ampmHasDot ? /[T\s:-]/g : /[T\s:.-]/g), sep).replace(/z/i, '');
     val = val.replace('午', `午${sep}`);
     parts = val.split(sep);
 
@@ -956,7 +962,7 @@ TimePicker.prototype = {
     const hours = this.hourSelect ? this.hourSelect[0]?.value : '';
     const minutes = this.minuteSelect ? this.minuteSelect[0]?.value : '';
     const seconds = this.secondSelect ? this.secondSelect[0]?.value : '';
-    let period = (this.periodSelect ? this.periodSelect[0]?.value : '').toUpperCase();
+    let period = (this.periodSelect ? this.periodSelect[0]?.value : '');
     const sep = this.getTimeSeparator();
     let timeString = `${hours}${sep}${minutes}${this.hasSeconds() ? sep + seconds : ''}`;
 

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -677,6 +677,17 @@ describe('Locale API', () => {
     expect(Locale.parseDate('18.10.2019', Locale.calendar().dateFormat.short, true).getTime()).toEqual(new Date(2019, 9, 18, 0, 0, 0).getTime());
   });
 
+  it('Should parseDate in el-GR', () => {
+    Locale.set('el-GR');
+
+    expect(Locale.parseDate('18/10/2019 7:15 π.μ.', Locale.calendar().dateFormat.datetime).getTime()).toEqual(new Date(2019, 9, 18, 7, 15, 0).getTime());
+    expect(Locale.parseDate('18/10/2019 7:15 μ.μ.', Locale.calendar().dateFormat.datetime).getTime()).toEqual(new Date(2019, 9, 18, 19, 15, 0).getTime());
+    expect(Locale.parseDate('18/10/2019 12:00 π.μ.', Locale.calendar().dateFormat.datetime).getTime()).toEqual(new Date(2019, 9, 18, 0, 0, 0).getTime());
+    expect(Locale.parseDate('18/10/2019 12:00 μ.μ.', Locale.calendar().dateFormat.datetime).getTime()).toEqual(new Date(2019, 9, 18, 12, 0, 0).getTime());
+    expect(Locale.parseDate('18/10/2019 11:59 π.μ.', Locale.calendar().dateFormat.datetime).getTime()).toEqual(new Date(2019, 9, 18, 11, 59, 0).getTime());
+    expect(Locale.parseDate('18/10/2019 11:59 μ.μ.', Locale.calendar().dateFormat.datetime).getTime()).toEqual(new Date(2019, 9, 18, 23, 59, 0).getTime());
+  });
+
   it('Should parseDate with single digit formats', () => {
     expect(Locale.parseDate('18.10.2019 7.15', 'd.M.yyyy H.mm').getTime()).toEqual(new Date(2019, 9, 18, 7, 15, 0).getTime());
     expect(Locale.parseDate('18.10.2019 7.15', 'd.M.yyyy H.mm', true).getTime()).toEqual(new Date(2019, 9, 18, 7, 15, 0).getTime());


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed am/pm dot was causing issue to parseDate() method for greek language with Locale.

**Related github/jira issue (required)**:
Closes #4793

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to:
- http://localhost:4000/components/timepicker/example-index.html?locale=el-GR
- http://localhost:4000/components/datepicker/example-timeformat.html?locale=el-GR
- Open picker
- Change around dropdown and pick that changed time
- After close the picker see, it should have the value you selected
- Open picker again, see now it should set to the value was picked
- Check for both `π.μ.` and `μ.μ.`
- Open developer tools and run
```
Soho.Locale.parseDate("25/2/2021 7:59 π.μ.","d/M/yyyy h.mm. a");
// It should return: Thu Feb 25 2021 7:59:00 GMT-0500 (Eastern Standard Time)

Soho.Locale.parseDate("25/2/2021 7:59 μ.μ.","d/M/yyyy h.mm. a");
// It should return: Thu Feb 25 2021 19:59:00 GMT-0500 (Eastern Standard Time)
```

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
