### PR TITLE
4566 - Fix inconsistency in tabs event

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - `[General]` We bumped the version from 4.39 (four - thirty nine) to 4.50 (four - fifty) to correspond with the general release of Soho (IDS) Design system 4.5 so the versions sync up better. We could not use 4.5 since it was already in use previously. ([#5012](https://github.com/infor-design/enterprise/issues/5012))
 - `[General]` We Updated development dependencies. Most important things to note are: we now support node 14 for development and this is recommended. ([#4998](https://github.com/infor-design/enterprise/issues/4998))
+- `[Tabs]` Changed the target element from 'li' to 'a' to be consistent. ([#4566](https://github.com/infor-design/enterprise/issues/4566))
 
 ### v4.50.0 Fixes
 

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -2614,7 +2614,7 @@ Tabs.prototype = {
     let prevLi = targetLi.prev();
 
     if (!disableBeforeClose) {
-      const canClose = this.element.triggerHandler('beforeclose', [targetLi]);
+      const canClose = this.element.triggerHandler('beforeclose', [targetAnchor]);
       if (canClose === false) {
         return false;
       }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the inconsistency of element in tabs event. Changing from `li` to `a` element for consistency. It was reported in NG but the fix is in enterprise. 

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/4566

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app.
- Link the enterprise dist to the NG project
- Go to http://localhost:4200/ids-enterprise-ng-demo/tabs-dismissible (in NG)
- console.log the `tab` param in demo ts file `(tabs-dismissible.demo.ts)`
- Dismiss a tab
- The `a` element should be the target and not the `li`

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
