### PR TITLE
4848 - Fixed copy paste html to editable cell with datagrid

### DIFF
--- a/app/views/components/datagrid/test-copy-paste-from-excel.html
+++ b/app/views/components/datagrid/test-copy-paste-from-excel.html
@@ -48,6 +48,7 @@
           columns: columns,
           dataset: data,
           editable: true,
+          allowPasteFromExcel: true,
           clickToSelect: false,
           selectable: 'multiple',
           toolbar: {title: 'Data Grid Header Title', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: true,  collapsibleFilter: true},

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Datagrid]` Fixed an issue where stretching the last column of a table was not consistent when resizing the window. ([#5045](https://github.com/infor-design/enterprise/issues/5045))
 - `[Datagrid]` Fixed an issue where setting stretchColumn to 'last' did not stretch the last column in the table. ([#4913](https://github.com/infor-design/enterprise/issues/4913))
+- `[Datagrid]` Fixed an issue where the copy paste html to editable cell was cause to generate new cells. ([#4848](https://github.com/infor-design/enterprise/issues/4848))
 - `[Tree]` Added api support for collapse/expand node methods. ([#4707](https://github.com/infor-design/enterprise/issues/4707))
 
 ### v4.51.0 Issues

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -147,6 +147,7 @@ const COMPONENT_NAME = 'datagrid';
  * and do not add any children nodes
  * or if one or more child node got match then add parent node and only matching children nodes
  * @param {string} [settings.attributes] Add extra attributes like id's to the toast element. For example `attributes: { name: 'id', value: 'my-unique-id' }`
+ * @param {boolean} [settings.allowPasteFromExcel=false] If true will allow data copy/paste from excel
 */
 const DATAGRID_DEFAULTS = {
   // F2 - toggles actionableMode "true" and "false"
@@ -239,7 +240,8 @@ const DATAGRID_DEFAULTS = {
   searchExpandableRow: true,
   allowChildExpandOnMatchOnly: false,
   allowChildExpandOnMatch: false,
-  attributes: null
+  attributes: null,
+  allowPasteFromExcel: false,
 };
 
 function Datagrid(element, settings) {
@@ -6286,7 +6288,7 @@ Datagrid.prototype = {
       });
 
     // Add a paste event for handling pasting from excel
-    if (self.settings.editable) {
+    if (self.settings.allowPasteFromExcel && self.settings.editable) {
       this.element.off('paste.datagrid').on('paste.datagrid', (e) => {
         let pastedData;
         if (e.originalEvent.clipboardData && e.originalEvent.clipboardData.getData) {

--- a/test/components/datagrid/datagrid-settings.func-spec.js
+++ b/test/components/datagrid/datagrid-settings.func-spec.js
@@ -124,7 +124,8 @@ describe('Datagrid Settings', () => { //eslint-disable-line
       emptyMessage: { title: (Locale ? Locale.translate('NoData') : 'No Data Available'), info: '', icon: 'icon-empty-no-data', height: null },
       searchExpandableRow: true,
       allowChildExpandOnMatchOnly: false,
-      allowChildExpandOnMatch: false
+      allowChildExpandOnMatch: false,
+      allowPasteFromExcel: false
     };
     datagridObj = new Datagrid(datagridEl, { dataset: data, columns });
   });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed copy paste html to editable cell was cause to generate new cells with Datagrid.

**Related github/jira issue (required)**:
Closes #4848

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/example-editable.html
- Copy below html
```
<!DOCTYPE html>
<html>
<body>
<p>Click the button to alert the hostname of the current URL.</p>

<button onclick="myFunction()">Try it</button>

<script>
function myFunction() {
  alert(location.hostname);
}
</script>

</body>
</html>
```
- Click on any cell in column `Activity*`
- This cell should be in edit mode now
- Paste here the copied html
- See it should not create any new row/cell after paste

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
