### PR TITLE
5015 - Fix draggable toast message at bottom right position

### DIFF
--- a/app/views/components/toast/test-bottom-right-draggable-position.html
+++ b/app/views/components/toast/test-bottom-right-draggable-position.html
@@ -9,6 +9,7 @@
     $('body').toast({
       title: 'Application Offline',
       message: msg,
+      savePosition: true,
       draggable: true,
       position: 'bottom right',
       uniqueid: uniqueid,

--- a/app/views/components/toast/test-bottom-right-draggable-position.html
+++ b/app/views/components/toast/test-bottom-right-draggable-position.html
@@ -1,0 +1,21 @@
+<div class="row">
+  <div class="twelve columns">
+    <button class="btn-secondary" type="button" id="show-toast-message1">Show Toast Message</button>
+  </div>
+</div>
+
+<script>
+  function showToastMsg(uniqueid, msg) {
+    $('body').toast({
+      title: 'Application Offline',
+      message: msg,
+      draggable: true,
+      position: 'bottom right',
+      uniqueid: uniqueid,
+      timeout: 9000
+    });
+  }
+  $('#show-toast-message1').on('click', function() {
+    showToastMsg('some-uniqueid', 'This is a Toast message.(1)');
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[Datagrid]` Fixed an issue where stretching the last column of a table was not consistent when resizing the window. ([#5045](https://github.com/infor-design/enterprise/issues/5045))
 - `[Datagrid]` Fixed an issue where setting stretchColumn to 'last' did not stretch the last column in the table. ([#4913](https://github.com/infor-design/enterprise/issues/4913))
 - `[Locale]` Fixed an issue where the am/pm dot was causing issue to parseDate() method for greek language. ([#4793](https://github.com/infor-design/enterprise/issues/4793))
+- `[Toast]` Fixed a bug where toast message were unable to drag down to it's current position when `position` sets to 'bottom right'. ([#5015](https://github.com/infor-design/enterprise/issues/5015))
 - `[Tree]` Added api support for collapse/expand node methods. ([#4707](https://github.com/infor-design/enterprise/issues/4707))
 
 ### v4.51.0 Issues

--- a/src/components/toast/_toast.scss
+++ b/src/components/toast/_toast.scss
@@ -9,6 +9,10 @@
   &.toast-bottom-right {
     bottom: 10px;
     right: 10px;
+
+    &.is-dragging {
+      bottom: auto;
+    }
   }
 
   &.toast-bottom-left {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the issue of  where it's unable to drag down the toast message to its current position if the `position` setting is set to `bottom right`.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5015

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/toast/test-bottom-right-draggable-position.html
- Click the button to trigger the toast message
- Drag toast message up then let go
- Grab again and try to drag down
- It should be able to move/drag it down

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
