### PR TITLE
5069 - Fix bad version display

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[Datagrid]` Fixed an issue where stretching the last column of a table was not consistent when resizing the window. ([#5045](https://github.com/infor-design/enterprise/issues/5045))
 - `[Datagrid]` Fixed an issue where setting stretchColumn to 'last' did not stretch the last column in the table. ([#4913](https://github.com/infor-design/enterprise/issues/4913))
 - `[Datagrid]` Fixed an issue where the copy paste html to editable cell was cause to generate new cells. ([#4848](https://github.com/infor-design/enterprise/issues/4848))
+- `[General]` Fixed incorrect version that was showing up as `[Object]` in the about dialog and html. ([#5069](https://github.com/infor-design/enterprise/issues/5069))
 - `[Locale]` Fixed an issue where the am/pm dot was causing issue to parseDate() method for greek language. ([#4793](https://github.com/infor-design/enterprise/issues/4793))
 - `[Toast]` Fixed a bug where toast message were unable to drag down to it's current position when `position` sets to 'bottom right'. ([#5015](https://github.com/infor-design/enterprise/issues/5015))
 - `[Tree]` Added api support for collapse/expand node methods. ([#4707](https://github.com/infor-design/enterprise/issues/4707))

--- a/src/utils/environment.js
+++ b/src/utils/environment.js
@@ -1,4 +1,4 @@
-import version from '../../package.json';
+import packageJson from '../../package.json';
 import { breakpoints } from './breakpoints';
 
 // jQuery Components
@@ -34,7 +34,7 @@ const Environment = {
    * Builds run-time environment settings
    */
   set() {
-    $('html').attr('data-sohoxi-version', version);
+    $('html').attr('data-sohoxi-version', packageJson.version);
 
     // Set the viewport meta tag to limit scaling
     this.viewport = document.querySelector('meta[name=viewport]');

--- a/test/components/about/about.e2e-spec.js
+++ b/test/components/about/about.e2e-spec.js
@@ -19,6 +19,21 @@ describe('About index tests', () => {
     expect(await element(by.id('about-modal')).isDisplayed()).toBeTruthy();
   });
 
+  it('Should display the version', async () => {
+    const buttonEl = await element(by.id('about-trigger'));
+    await buttonEl.click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.visibilityOf(await element(by.id('about-modal'))), config.waitsFor);
+
+    expect(await element(by.css('.modal-body')).getText()).toContain('IDS Version : 4.');
+  });
+
+  it('Should show the version in the html', async () => {
+    const html = await element(by.css('html'));
+
+    expect(await html.getAttribute('data-sohoxi-version')).toContain('.');
+  });
+
   it('Should not have errors', async () => {
     await utils.checkForErrors();
   });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The version was displaying as [Object][Object]. This is the fix

**Related github/jira issue (required)**:
Fixes #5069

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/about/example-index.html
- open the about and scroll to the bottom
- The IDS Version should display as a number (fx 4.51.0-dev)
- Inspect the dom and look at the html element at the top. The data-sohoxi-version should also display as a number (fx 4.51.0-dev) 

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
