### PR TITLE
5099 - Change Reveal to use css instead of password

### DIFF
--- a/app/views/components/input/example-password.html
+++ b/app/views/components/input/example-password.html
@@ -1,20 +1,27 @@
 <div class="row">
   <div class="twelve columns">
+    <form autocomplete="off">
 
-    <div class="field">
-      <label for="password-no-reveal">Password (No Reveal)</label>
-      <input type="text" id="password-no-reveal" name="password-no-reveal" placeholder="Enter Password"/>
-    </div>
+      <div class="field">
+        <label for="password-no-reveal">Password (No Reveal)</label>
+        <input type="text" id="password-no-reveal" name="password-no-reveal" autocomplete="off" placeholder="Enter Password"/>
+      </div>
 
-    <div class="field">
-      <label for="password-reveal">Password (Reveal)</label>
-      <input type="password" data-init="false" id="password-reveal" name="password-reveal" placeholder="Enter Password" value="IHave2Kittens!"/>
-    </div>
+      <div class="field">
+        <label for="password-reveal">Password (Reveal)</label>
+        <input type="text" data-init="false" id="password-reveal" name="password-reveal" placeholder="Enter Password" autocomplete="off" value="IHave2Kittens!"/>
+      </div>
 
-    <div class="field">
-      <label for="password-reveal-init">Password (Reveal) - Auto Initialized</label>
-      <input type="password" id="password-reveal-init" name="password-reveal-init" class="input-password-reveal" placeholder="Enter Password" value="IHave3Birds!"/>
-    </div>
+      <div class="field">
+        <label for="password-reveal">Password (Reveal initialy shown)</label>
+        <input type="text" data-init="false" id="password-reveal2" name="password-reveal" placeholder="Enter Password" autocomplete="off" value="IHave8Geckos!"/>
+      </div>
+
+      <div class="field">
+        <label for="password-reveal-init">Password (Reveal) - Auto Initialized</label>
+        <input type="text" id="password-reveal-init" name="password-reveal-init" class="input-password-reveal" placeholder="Enter Password" autocomplete="off" value="IHave3Birds!"/>
+      </div>
+    </form>
 
   </div>
 </div>
@@ -22,5 +29,6 @@
 <script>
   $('body').on('initialized', function () {
     $('#password-reveal').revealText();
+    $('#password-reveal2').revealText({ initialState: 'show' });
   });
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[Datagrid]` Fixed an issue where stretching the last column of a table was not consistent when resizing the window. ([#5045](https://github.com/infor-design/enterprise/issues/5045))
 - `[Datagrid]` Fixed an issue where setting stretchColumn to 'last' did not stretch the last column in the table. ([#4913](https://github.com/infor-design/enterprise/issues/4913))
 - `[Datagrid]` Fixed an issue where the copy paste html to editable cell was cause to generate new cells. ([#4848](https://github.com/infor-design/enterprise/issues/4848))
+- `[Password]` Changed the password reveal feature to not use `text="password"` and use css instead. This makes it possible to hide autocomplete. ([#5098](https://github.com/infor-design/enterprise/issues/5098))
 - `[Locale]` Fixed an issue where the am/pm dot was causing issue to parseDate() method for greek language. ([#4793](https://github.com/infor-design/enterprise/issues/4793))
 - `[Toast]` Fixed a bug where toast message were unable to drag down to it's current position when `position` sets to 'bottom right'. ([#5015](https://github.com/infor-design/enterprise/issues/5015))
 - `[Tree]` Added api support for collapse/expand node methods. ([#4707](https://github.com/infor-design/enterprise/issues/4707))

--- a/src/components/form/_form-new.scss
+++ b/src/components/form/_form-new.scss
@@ -21,3 +21,7 @@
     margin-top: -29px !important;
   }
 }
+
+.input-hideshow-text {
+  transform: translate(calc(-100% + -8px), 8px);
+}

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -139,7 +139,7 @@
   cursor: pointer;
   position: absolute;
   text-transform: uppercase;
-  transform: translate(calc(-100% + -8px), 11px);
+  transform: translate(calc(-100% + -8px), 9px);
 }
 
 .input-hidepass {

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -142,11 +142,13 @@
   transform: translate(calc(-100% + -8px), 11px);
 }
 
-.input-hidepass {
+.input-hide-text {
   &::-ms-reveal,
   &::-ms-clear {
     display: none !important;
   }
+
+  -webkit-text-security: disc;
 }
 
 html[dir='rtl'] {

--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -139,7 +139,7 @@
   cursor: pointer;
   position: absolute;
   text-transform: uppercase;
-  transform: translate(calc(-100% + -8px), 9px);
+  transform: translate(calc(-100% + -8px), 11px);
 }
 
 .input-hidepass {

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -82,7 +82,6 @@ $.fn.revealText = function (settings) {
   const input = this;
   // Set the initial state
   input.addClass(settings?.initialState === 'show' ? 'input-show-text' : 'input-hide-text');
-  input.addClass('input-hidepass');
 
   // Add a text span and click events
   const textSpan = $(`<span class="input-hideshow-text">${Soho.Locale.translate(settings?.initialState === 'show' ? 'Hide' : 'Show')}</span>`); // eslint-disable-line
@@ -99,7 +98,7 @@ $.fn.revealText = function (settings) {
     }
 
     input.removeClass('input-show-text').addClass('input-hide-text');
-    input.attr('type', 'password');
+    input.attr('type', 'text');
     textSpan.text(Soho.Locale.translate('Show')); // eslint-disable-line
   };
 

--- a/test/components/input/input.e2e-spec.js
+++ b/test/components/input/input.e2e-spec.js
@@ -173,10 +173,10 @@ describe('Input Password Field tests', () => {
     await browser.driver
       .wait(protractor.ExpectedConditions.presenceOf(inputEl), config.waitsFor);
 
-    expect(await inputEl.getAttribute('type')).toEqual('password');
+    expect(await inputEl.getAttribute('class')).toEqual('input-hide-text');
 
     await element.all(by.css('.input-hideshow-text')).first().click();
 
-    expect(await inputEl.getAttribute('type')).toEqual('text');
+    expect(await inputEl.getAttribute('class')).toEqual('input-show-text');
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The password reveal feature is slightly off in uplift mode and a bigger problem because it used type="password" chrome would never let you ignore the autocomplete. To get around this i use the css way of setting the security feature on

**Related github/jira issue (required)**:
NA

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/input/example-password.html?theme=new
- and http://localhost:4000/components/input/example-password.html?theme=classic
- in both cases the hide/show password feature should be aligned
- to test the auto complete go to https://stackblitz.com/edit/ids-hidereveal-xvhqlq?file=index.html
- type in the field and hit enter
- type the same thing again.. it should not show password autocomplete

