### PR TITLE
5074 - Toolbar Resize Menu Stagger & Close Button fix

### DIFF
--- a/src/components/searchfield/_searchfield-new.scss
+++ b/src/components/searchfield/_searchfield-new.scss
@@ -66,12 +66,13 @@
 
   .btn-icon.close {
     overflow: visible;
+
     &:not(.is-empty) {
       top: 6px;
     }
 
     & > svg.close.icon {
-      top: calc( 50% - 6px );
+      top: calc(50% - 6px);
       transform: translateY(-50%);
     }
   }

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -542,6 +542,15 @@ html[dir='rtl'] {
   }
 }
 
-.buttonset > .toolbar-searchfield-wrapper:nth-last-child(2) > .icon.close {
-  transform: translateY(0%);
+/*
+  target phone-size case when the menu first hides on resize
+  when resizing (must have dev tools off to trigger this for
+  some reason)
+*/
+.buttonset {
+  > .searchfield-wrapper.toolbar-searchfield-wrapper:not(.is-open):nth-last-child(2):first-child {
+    > .icon.close {
+      transform: translateY(0%);
+    }
+  }
 }

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -541,3 +541,7 @@ html[dir='rtl'] {
     }
   }
 }
+
+.buttonset > .toolbar-searchfield-wrapper:nth-last-child(2) > .icon.close {
+  transform: translateY(0%);
+}

--- a/src/components/searchfield/searchfield.js
+++ b/src/components/searchfield/searchfield.js
@@ -2061,7 +2061,7 @@ SearchField.prototype = {
 
     // Used to determine if the "Tab" key was involved in switching focus to the searchfield.
     this.removeDocumentDeactivationEvents();
-    $('body').off(`breakpoint-change`);
+    $('body').off('breakpoint-change');
 
     if (this.autocomplete) {
       this.autocomplete.destroy();

--- a/src/components/searchfield/searchfield.js
+++ b/src/components/searchfield/searchfield.js
@@ -778,12 +778,12 @@ SearchField.prototype = {
         self.collapse();
       });
 
-      $('body').on(`resize.${this.id}`, () => {
+      $('body').on('breakpoint-change', () => {
         self.adjustOnBreakpoint();
       });
       self.adjustOnBreakpoint();
     } else {
-      $('body').on(`resize.${this.id}`, () => {
+      $('body').on('breakpoint-change', () => {
         self.simpleAdjustOnBreakpoint();
       });
       self.simpleAdjustOnBreakpoint();
@@ -2061,7 +2061,7 @@ SearchField.prototype = {
 
     // Used to determine if the "Tab" key was involved in switching focus to the searchfield.
     this.removeDocumentDeactivationEvents();
-    $('body').off(`resize.${this.id}`);
+    $('body').off(`breakpoint-change`);
 
     if (this.autocomplete) {
       this.autocomplete.destroy();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Searchfield in certain cases was staggering when you resize the window. In addition, the X button was briefly hovering slightly higher when this event was triggered.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->

Closes #5076 
(the functionality fix does not have specific issue -- was just related)

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- pull  `5074-toolbar-resize-menu-stagger-and-close-button-fix`  locally
- visit http://localhost:4000/components/toolbar/example-no-action-button.html

(1) trigger staggering issue
- make sure dev tools are closed
- resize window to width slightly above the minimum breakpoint in Chrome
- type any text into search field
- drag browser edge to resize the window horizontally. This can be repeated.
- You should *not* see this staggering happening on each resize in phone size.
![searchfield_issue](https://user-images.githubusercontent.com/1799905/115057648-4ee61180-9eb2-11eb-959a-5a874942c931.gif)

(2) since the resize stagger was fixed, the second issue of seeing the searchfield X off is harder to spot but can be simulated to check the X is not moving:
- type any text into search field
- open dev tools and go into selection mode
![image](https://user-images.githubusercontent.com/1799905/115058127-e186b080-9eb2-11eb-96e8-2f80b64734b9.png)
- click on the searchfield in the main area where text is, then go to "Elements" on right and remove `is-open` by doubleclicking in the `span` that has `searchfield-wrapper` class.
![image](https://user-images.githubusercontent.com/1799905/115058523-5c4fcb80-9eb3-11eb-9a82-d1c8bd1dd846.png)
The close button "X" shouldn't move upwards or downwards now.
![image](https://user-images.githubusercontent.com/1799905/115058817-a20c9400-9eb3-11eb-8d92-121e602dbd62.png)


**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

Note: there are not changes in the change-log since there's several searchfield issues that to the end user seem the same. This one had a functional scope as well and could also be isolated really specifically for the style, but doesn't capture all the cases yet.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
