### PR TITLE
5107 - Add aria-readonly to dropdown

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Datagrid]` Fixed an issue where setting stretchColumn to 'last' did not stretch the last column in the table. ([#4913](https://github.com/infor-design/enterprise/issues/4913))
 - `[Datagrid]` Fixed an issue where the copy paste html to editable cell was cause to generate new cells. ([#4848](https://github.com/infor-design/enterprise/issues/4848))
 - `[Datepicker]` Fixed an issue where time was changing, if selected time was before noon for Danish language locale da-DK. ([#4987](https://github.com/infor-design/enterprise/issues/4987))
+- `[Droopdown]` Improved accessibility on readonly dropdowns by adding the aria-readonly property. ([#5107](https://github.com/infor-design/enterprise/issues/5107))
 - `[General]` Fixed incorrect version that was showing up as `[Object]` in the about dialog and html. ([#5069](https://github.com/infor-design/enterprise/issues/5069))
 - `[Locale]` Fixed an issue where the date and available date validation was not working for Croatian locale hr-HR. ([#4964](https://github.com/infor-design/enterprise/issues/4964))
 - `[Locale]` Fixed an issue where the am/pm dot was causing issue to parseDate() method for greek language. ([#4793](https://github.com/infor-design/enterprise/issues/4793))

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -3533,6 +3533,7 @@ Dropdown.prototype = {
     this.pseudoElem
       .addClass('is-disabled')
       .removeClass('is-readonly')
+      .removeAttr('aria-readonly')
       .attr('tabindex', '-1')
       .prop('readonly', false)
       .prop('disabled', true);
@@ -3563,7 +3564,8 @@ Dropdown.prototype = {
       .prop('readonly', false)
       .attr('tabindex', '0')
       .removeClass('is-disabled')
-      .removeClass('is-readonly');
+      .removeClass('is-readonly')
+      .removeAttr('aria-readonly');
 
     if (this.settings.showTags) {
       this.pseudoElem.find('.tag').removeClass('is-disabled');
@@ -3580,6 +3582,7 @@ Dropdown.prototype = {
     this.pseudoElem
       .removeClass('is-disabled')
       .addClass('is-readonly')
+      .attr('aria-readonly', 'true')
       .attr('tabindex', this.element.attr('tabindex') || '0')
       .prop('disabled', false)
       .prop('readonly', true);
@@ -3616,6 +3619,7 @@ Dropdown.prototype = {
       this.readonly();
     } else {
       this.pseudoElem.removeClass('is-readonly');
+      this.pseudoElem.removeAttr('aria-readonly');
     }
 
     // update "disabled" prop

--- a/test/components/dropdown/dropdown-api.func-spec.js
+++ b/test/components/dropdown/dropdown-api.func-spec.js
@@ -66,6 +66,7 @@ describe('Dropdown API', () => {
     dropdownObj.readonly();
 
     expect(document.body.querySelector('.dropdown.is-readonly')).toBeTruthy();
+    expect(document.body.querySelector('.dropdown.is-readonly').getAttribute('aria-readonly')).toEqual('true');
     expect(dropdownObj.isDisabled()).toBeFalsy();
   });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Was pointed out by the TAAS team that the dropdown could use an aria-readonly attribute.

**Related github/jira issue (required)**:
Fixes #5107

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/dropdown/example-readonly.html
- inspect the main .dropdown div on one of the readonly examples
- should have aria-readonly: "true"

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
