### PR TITLE
4520 - Add sortable drag and drop to tabs

### DIFF
--- a/app/views/components/tabs-module/example-sortable.html
+++ b/app/views/components/tabs-module/example-sortable.html
@@ -1,0 +1,104 @@
+<body class="no-scroll">
+
+  <a href="#maincontent" class="skip-link" data-translate="text">SkipToMain</a>
+  {{> includes/svg-inline-refs}}
+  {{> includes/applicationmenu}}
+
+  <div class="page-container no-scroll">
+
+    <!-- Module Tabs -->
+    <section id="module-tabs-example" class="tab-container module-tabs is-personalizable" data-options="{ containerElement: '#module-tabs-container', 'appMenuTrigger': true, 'addTabButton': true, 'sortable': true }">
+      <div class="tab-list-container">
+        <ul class="tab-list">
+          <li class="tab is-selected"><a href="#first-tab">First Tab</a></li>
+          <li class="tab"><a href="#second-tab">Second Tab</a></li>
+          <li class="tab"><a href="#third-tab">Third Tab</a></li>
+          <li class="tab"><a href="#fourth-tab">Fourth Tab</a></li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- Page Container -->
+    <div id="module-tabs-container" class="page-container no-scroll">
+
+      <!-- Tab Panels -->
+      <div id="first-tab" class="tab-panel no-scroll">
+        <header class="header is-personalizable">
+          <div class="toolbar">
+            <div class="title">
+              <h1>Module Tabs Test: Sortable Tabs</h1>
+            </div>
+            <div class="buttonset"></div>
+            {{> includes/header-actionbutton}}
+          </div>
+        </header>
+        <div class="page-container scrollable">
+          <div class="row">
+            <div class="six columns">
+              <p>First Tab content</p>
+              <p>This tab is 1st tab, and will be resized by the Module Tabs algorithm.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div id="second-tab" class="tab-panel">
+        <header class="header is-personalizable">
+          <div class="toolbar">
+            <div class="title">
+              <h1>Second Tab</h1>
+            </div>
+            <div class="buttonset"></div>
+          </div>
+        </header>
+        <div class="page-container scrollable">
+          <div class="row">
+            <div class="six columns">
+              <p>Second Tab content</p>
+              <p>This tab is 2nd tab, and will be resized by the Module Tabs algorithm.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div id="third-tab" class="tab-panel">
+        <header class="header is-personalizable">
+          <div class="toolbar">
+            <div class="title">
+              <h1>Third Tab</h1>
+            </div>
+            <div class="buttonset"></div>
+          </div>
+        </header>
+        <div class="page-container scrollable">
+          <div class="row">
+            <div class="six columns">
+              <p>Third Tab content</p>
+              <p>This tab is 3rd tab, and will be resized by the Module Tabs algorithm.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div id="fourth-tab" class="tab-panel">
+        <header class="header is-personalizable">
+          <div class="toolbar">
+            <div class="title">
+              <h1>Fourth Tab</h1>
+            </div>
+            <div class="buttonset"></div>
+          </div>
+        </header>
+        <div class="page-container scrollable">
+          <div class="row">
+            <div class="six columns">
+              <p>Fourth Tab content</p>
+              <p>This tab is 4th tab, and will be resized by the Module Tabs algorithm.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+  </div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[Locale]` Fixed an issue where the am/pm dot was causing issue to parseDate() method for greek language. ([#4793](https://github.com/infor-design/enterprise/issues/4793))
 - `[Multiselect]` Fixed a bug where the position of dropdown list was not correct when selecting multiple items on mobile. ([#5021](https://github.com/infor-design/enterprise/issues/5021))
 - `[Password]` Changed the password reveal feature to not use `text="password"` and use css instead. This makes it possible to hide autocomplete. ([#5098](https://github.com/infor-design/enterprise/issues/5098))
+- `[Tabs]` Added support to sortable drag and drop tabs. Non touch devices it good with almost every type of tabs `Module`, `Vertical`, `Header`, `Scrollable` and `Regular`. For touch devices only support with `Module` and `Vertical` Tabs. ([#4520](https://github.com/infor-design/enterprise/issues/4520))
 - `[Toast]` Fixed a bug where toast message were unable to drag down to it's current position when `position` sets to 'bottom right'. ([#5015](https://github.com/infor-design/enterprise/issues/5015))
 - `[Toolbar]` Add fix for invisible inputs in the toolbar. ([#5122](https://github.com/infor-design/enterprise/issues/v))
 - `[Tree]` Added api support for collapse/expand node methods. ([#4707](https://github.com/infor-design/enterprise/issues/4707))

--- a/src/components/arrange/arrange.js
+++ b/src/components/arrange/arrange.js
@@ -18,6 +18,7 @@ const COMPONENT_NAME = 'arrange';
 * @param {boolean} [settings.isVisualItems] Use only index of visual items to trigger
 * @param {string} [settings.placeholder] The html for the element that appears while dragging
 * @param {string} [settings.placeholderCssClass='arrange-placeholder'] The class to add to the ghost element that is being dragged.
+* @param {boolean} [settings.useItemDimensions=false] If true, use item's dimensions to placeholder.
 */
 const ARRANGE_DEFAULTS = {
   handle: null, // The Class of the handle element
@@ -25,7 +26,8 @@ const ARRANGE_DEFAULTS = {
   connectWith: false,
   isVisualItems: false,
   placeholder: null,
-  placeholderCssClass: 'arrange-placeholder'
+  placeholderCssClass: 'arrange-placeholder',
+  useItemDimensions: false
 };
 
 function Arrange(element, settings) {
@@ -79,9 +81,11 @@ Arrange.prototype = {
    * @returns {void}
    */
   dragTouchElement(e, elm) {
-    const orig = e.originalEvent.changedTouches[0];
-    elm[0].style.top = `${(orig.pageY - this.offset.y)}px`;
-    elm[0].style.left = `${(orig.pageX - this.offset.x)}px`;
+    const orig = e.originalEvent.changedTouches;
+    if (elm && elm[0] && orig && orig[0] && this.offset) {
+      elm[0].style.top = `${(orig[0].pageY - this.offset.y)}px`;
+      elm[0].style.left = `${(orig[0].pageX - this.offset.x)}px`;
+    }
   },
 
   /**
@@ -246,24 +250,35 @@ Arrange.prototype = {
             return;
           }
 
+          // Get size of drag item and its position
+          const rect = self.dragging[0].getBoundingClientRect();
+
+          // Use item dimensions
+          if (s.useItemDimensions) {
+            placeholder[0].style.width = `${rect.width}px`;
+            placeholder[0].style.height = `${rect.height}px`;
+            placeholder[0].classList.add(...s.placeholderCssClass.split(' '));
+          }
+
           if (self.isTouch) {
-            const rect = self.dragging[0].getBoundingClientRect();
-            const touch = e.originalEvent.changedTouches[0];
+            const touch = e.originalEvent.changedTouches;
 
-            // Save offset
-            self.offset = {
-              x: touch.pageX - rect.left,
-              y: touch.pageY - rect.top
-            };
-            self.placeholderTouch = self.dragging
-              .clone().addClass('is-touch').attr('id', 'arrange-placeholder-touch')
-              .insertBefore(self.dragging);
-
-            self.dragTouchElement(e, self.placeholderTouch);
+            // Save the offset
+            if (touch && touch[0]) {
+              self.offset = {
+                x: touch[0].pageX - rect.left,
+                y: touch[0].pageY - rect.top
+              };
+            }
           } else {
             const dt = e.originalEvent.dataTransfer;
+            const offset = {
+              x: (e.originalEvent.clientX - rect.left),
+              y: (e.originalEvent.clientY - rect.top)
+            };
             dt.effectAllowed = 'move';
             dt.setData('Text', 'sample');
+            dt.setDragImage(self.dragging[0], offset.x, offset.y);
           }
         })
 
@@ -274,8 +289,12 @@ Arrange.prototype = {
           }
 
           if (self.isTouch) {
-            self.dragging.css('opacity', 1);
-            self.placeholderTouch.remove();
+            const rules = { opacity: 1 };
+            if (s.useItemDimensions) {
+              rules.position = '';
+            }
+            self.dragging.css(rules);
+            self.placeholderTouch?.remove();
           }
 
           self.placeholders.filter(':visible').after(self.dragging);
@@ -310,6 +329,14 @@ Arrange.prototype = {
           let overIndex;
           e.preventDefault();
 
+          if (self.isTouch && !self.placeholderTouch) {
+            self.placeholderTouch = self.dragging
+              .clone().addClass('is-touch').attr('id', 'arrange-placeholder-touch')
+              .insertBefore(self.dragging);
+
+            self.dragTouchElement(e, self.placeholderTouch);
+          }
+
           /**
           * Fires after finishing an arrange action.
           *
@@ -335,7 +362,11 @@ Arrange.prototype = {
 
           if (items.is(overItem) && placeholder.index() !== overItem.index()) {
             if (self.isTouch) {
-              self.dragging.css('opacity', 0);
+              const rules = { opacity: 0 };
+              if (s.useItemDimensions) {
+                rules.position = 'fixed';
+              }
+              self.dragging.css(rules);
             } else {
               self.dragging.hide();
             }

--- a/src/components/arrange/arrange.js
+++ b/src/components/arrange/arrange.js
@@ -297,6 +297,7 @@ Arrange.prototype = {
             self.placeholderTouch?.remove();
           }
 
+          self.element.removeClass('has-arrange-placeholder');
           self.placeholders.filter(':visible').after(self.dragging);
           self.dragging.removeClass('arrange-dragging').show();
           self.placeholders.detach();
@@ -383,6 +384,8 @@ Arrange.prototype = {
               idx = s.isVisualItems ?
                 self.getVisualIndex(placeholder) : overIndex;
             }
+
+            self.element.addClass('has-arrange-placeholder');
 
             $.extend(status, { over: overItem, overIndex: idx });
             self.element.triggerHandler('draggingarrange', status);

--- a/src/components/tabs-module/_tabs-module.scss
+++ b/src/components/tabs-module/_tabs-module.scss
@@ -71,6 +71,12 @@
     height: 34px;
     overflow: hidden;
     width: calc(100% - 1px); // 1px for the vertical centerer
+
+    &.has-arrange-placeholder {
+      .tab:hover {
+        background-color: $module-tabs-bg-color;
+      }
+    }
   }
 
   &.has-toolbar {

--- a/src/components/tabs-module/_tabs-module.scss
+++ b/src/components/tabs-module/_tabs-module.scss
@@ -146,14 +146,26 @@
       }
     }
 
-    &.is-selected {
-      background-color: $module-tabs-active-bg-color;
-      color: $module-tabs-active-text-color;
+    &.arrange-dragging.is-touch {
+      background-color: $module-tabs-bg-color;
     }
 
     &:hover {
       background-color: $module-tabs-hover-bg-color;
       color: $module-tabs-hover-text-color;
+
+      &.arrange-dragging.is-touch {
+        background-color: $module-tabs-hover-bg-color;
+      }
+    }
+
+    &.is-selected {
+      background-color: $module-tabs-active-bg-color;
+      color: $module-tabs-active-text-color;
+
+      &.arrange-dragging.is-touch {
+        background-color: $module-tabs-active-bg-color;
+      }
     }
 
     // Individual Tab Disable

--- a/src/components/tabs/_tabs-new.scss
+++ b/src/components/tabs/_tabs-new.scss
@@ -47,6 +47,13 @@
   }
 }
 
+.tab-container.has-placeholder {
+  .tab.draggable.arrange-placeholder {
+    height: 34px !important;
+    top: 0;
+  }
+}
+
 .popupmenu.tab-list-spillover,
 .popupmenu.dropdown-tab {
   .icon {

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -42,6 +42,17 @@
   font-size: 0;
   position: relative;
 
+  &.has-placeholder {
+    .tab.draggable {
+      top: -12px;
+
+      &.arrange-placeholder {
+        height: 32px !important;
+        top: 0;
+      }
+    }
+  }
+
   &.has-add-button {
     .add-tab-button {
       visibility: visible;

--- a/test/components/tabs/tabs-settings.func-spec.js
+++ b/test/components/tabs/tabs-settings.func-spec.js
@@ -40,7 +40,8 @@ describe('Tabs Settings', () => {
       sourceArguments: {},
       tabCounts: false,
       verticalResponsive: false,
-      attributes: null
+      attributes: null,
+      sortable: false
     };
     tabsObj.updated();
 
@@ -64,7 +65,8 @@ describe('Tabs Settings', () => {
       sourceArguments: {},
       tabCounts: false,
       verticalResponsive: false,
-      attributes: null
+      attributes: null,
+      sortable: false
     };
     tabsObj.updated(settings);
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added support to sortable drag and drop tabs. Non touch devices it's good with almost every type of tabs `Module`, `Vertical`, `Header`, `Scrollable` and `Regular`. For touch devices only support with `Module` and `Vertical` Tabs.

**Related github/jira issue (required)**:
Closes #4520

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/tabs-module/example-sortable.html
- Rearrange tabs use drag and drop
- It should work fine

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
