### PR TITLE
5149 - Add fix for non-editable lookup

### DIFF
--- a/app/views/components/lookup/test-states.html
+++ b/app/views/components/lookup/test-states.html
@@ -14,6 +14,11 @@
     </div>
 
     <div class="field">
+      <label for="non-editable" class="label">Not Editable</label>
+      <input id="non-editable" class="lookup" data-options="{editable: false}" name="readonly" type="text">
+    </div>
+
+    <div class="field">
       <label for="disabled" class="label">Disabled</label>
       <input id="disabled" class="lookup" name="disabled" disabled type="text">
     </div>
@@ -40,7 +45,7 @@
     var lookup;
 
     //In this Test we have an Ajax call that returns the columns and lookup data
-    lookup = $('#normal, #dirty').lookup({
+    lookup = $('#normal, #dirty, #non-editable').lookup({
         field: 'productId',
         beforeShow: function (api, response) {
           var url = '{{basepath}}api/lookupInfo';

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[General]` Fixed incorrect version that was showing up as `[Object]` in the about dialog and html. ([#5069](https://github.com/infor-design/enterprise/issues/5069))
 - `[Locale]` Fixed an issue where the date and available date validation was not working for Croatian locale hr-HR. ([#4964](https://github.com/infor-design/enterprise/issues/4964))
 - `[Locale]` Fixed an issue where the am/pm dot was causing issue to parseDate() method for greek language. ([#4793](https://github.com/infor-design/enterprise/issues/4793))
+- `[Lookup]` Fixed an issue where readonly lookups showed up as enabled. ([#5149](https://github.com/infor-design/enterprise/issues/5149))
 - `[Multiselect]` Fixed a bug where the position of dropdown list was not correct when selecting multiple items on mobile. ([#5021](https://github.com/infor-design/enterprise/issues/5021))
 - `[Password]` Changed the password reveal feature to not use `text="password"` and use css instead. This makes it possible to hide autocomplete. ([#5098](https://github.com/infor-design/enterprise/issues/5098))
 - `[Toast]` Fixed a bug where toast message were unable to drag down to it's current position when `position` sets to 'bottom right'. ([#5015](https://github.com/infor-design/enterprise/issues/5015))

--- a/src/components/lookup/lookup.js
+++ b/src/components/lookup/lookup.js
@@ -221,8 +221,8 @@ Lookup.prototype = {
       this.disable();
     }
 
-    if (!this.settings.editable || this.element.is('[readonly]')) {
-      this.readonly();
+    if (!this.settings.editable) {
+      this.element.attr('readonly', 'true').addClass('is-not-editable');
     }
 
     this.makeTabbable(this.settings.tabbable);
@@ -1007,7 +1007,7 @@ Lookup.prototype = {
    * @returns {void}
    */
   readonly() {
-    this.element.prop('readonly', true).addClass('is-not-editable');
+    this.element.prop('readonly', true);
     this.icon.prop('disabled', false);
   },
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Reverted some changes in https://github.com/infor-design/enterprise/commit/b90bb8e8406baac8c842932af039991cfcbb8339#diff-3f1934dc1d84a5236f9e5386034c6900619e2e2b910caef8c0d8153dc8c8ec26 as it caused readonly lookups to appear not readonly. It was perhaps not noticed that there is a non-editable lookup and a readonly lookup

**Related github/jira issue (required)**:
Fixes #5149

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/lookup/test-states.html
- notice there is a readonly field with right styling again
- and now a non editable lookup example (you cant type)
- recheck http://localhost:4000/components/form/example-readonly-inputs.html -> should also be readonly state again

**Included in this Pull Request**:
- [x] A note to the change log.
