### PR TITLE
5105 - Improve Tabs `rename()` API to also change the "More Tabs" menu items.

### DIFF
--- a/app/views/components/tabs-module/test-lsf-addtabs-scenario-2.html
+++ b/app/views/components/tabs-module/test-lsf-addtabs-scenario-2.html
@@ -1,0 +1,54 @@
+<body class="no-scroll">
+
+  <a href="#maincontent" class="skip-link" data-translate="text">SkipToMain</a>
+  {{> includes/svg-inline-refs}}
+  <!-- Masthead -->
+  {{> includes/masthead}}
+  {{> includes/applicationmenu}}
+
+  <div class="page-container no-scroll">
+    <!-- Module Tabs -->
+    <section id="module-tabs-example" class="tab-container module-tabs" data-options='{ "containerElement": "#module-tabs-container" }'>
+      <div class="tab-list-container">
+        <ul class="tab-list">
+        </ul>
+      </div>
+    </section>
+
+    <!-- Page Container -->
+    <div id="module-tabs-container" class="page-container no-scroll"></div>
+  </div>
+
+  <script>
+    let control;
+
+    $('body').on('initialized', function() {
+      let tabNum = 0;
+
+      const $tabs = $('#module-tabs-example').tabs({
+        containerElement: '#module-tabs-container',
+        addTabButton: true,
+        moduleTabsTooltips: true
+      });
+      control = $tabs.data('tabs');
+
+      control.add('tab1', {
+        name: 'This is a really really really really really really long title',
+        content: '<button id="rename-btn" class="btn-secondary" style="margin:2em;">Rename</button>'
+      });
+
+      control.select('tab1');
+
+      control.addTabButton.on('click.tabs', () => {
+        control.select('#new-tab-' + tabNum);
+        control.rename('#new-tab-' + tabNum, tabNum + " Tab");
+        tabNum++;
+      });
+
+      control.getPanel('tab1').find('#rename-btn').click(function() {
+        control.rename('tab1', 'Now this text is even longer longer longer longer longer longer longer longer longer longer longer');
+      });
+    });
+  </script>
+
+</body>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@
 - `[Password]` Changed the password reveal feature to not use `text="password"` and use css instead. This makes it possible to hide autocomplete. ([#5098](https://github.com/infor-design/enterprise/issues/5098))
 - `[Tabs]` Fixed a bug where where if urls contain a href with a forward slash (paths), then this would error. Note that in this situation you need to make sure the tab panel is linked without the hash. ([#5014](https://github.com/infor-design/enterprise/issues/5014))
 - `[Tabs]` Added support to sortable drag and drop tabs. Non touch devices it good with almost every type of tabs `Module`, `Vertical`, `Header`, `Scrollable` and `Regular`. For touch devices only support with `Module` and `Vertical` Tabs. ([#4520](https://github.com/infor-design/enterprise/issues/4520))
+- `[Tabs]` Changed the `rename()` method to also modify a tab's corresponding "More Tabs" menu item, if the menu is open. ([#5105](https://github.com/infor-design/enterprise/issues/5105))
 - `[Toast]` Fixed a bug where toast message were unable to drag down to it's current position when `position` sets to 'bottom right'. ([#5015](https://github.com/infor-design/enterprise/issues/5015))
 - `[Toolbar]` Add fix for invisible inputs in the toolbar. ([#5122](https://github.com/infor-design/enterprise/issues/v))
 - `[Tree]` Added api support for collapse/expand node methods. ([#4707](https://github.com/infor-design/enterprise/issues/4707))

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -3042,7 +3042,7 @@ Tabs.prototype = {
   /**
    * Renames a tab and resets the focusable bar/animation.
    * @param {jQuery.Event} e the jQuery Event
-   * @param {string} tabId a string representing the HTML `id` attribute of the new tab panel.
+   * @param {string} tabId a string representing the HTML `id` attribute of the tab panel.
    * @param {string} name the new tab name
    * @returns {void}
    */
@@ -3056,6 +3056,7 @@ Tabs.prototype = {
     if (!name) {
       return;
     }
+    name = name.toString();
 
     const tab = this.doGetTab(e, tabId);
     const hasCounts = this.settings.tabCounts;
@@ -3067,7 +3068,13 @@ Tabs.prototype = {
       count = anchor.find('.count').clone();
     }
 
-    anchor.text(name.toString());
+    anchor.text(name);
+
+    // Rename the tab inside a currently-open "More Tabs" popupmenu, if applicable
+    if (this.popupmenu) {
+      const moreAnchor = this.popupmenu.menu.find(`a[href="${tabId}"]`);
+      moreAnchor.text(name);
+    }
 
     if (hasCounts) {
       anchor.prepend(count);

--- a/test/components/tabs/tabs-module.e2e-spec.js
+++ b/test/components/tabs/tabs-module.e2e-spec.js
@@ -49,3 +49,25 @@ describe('Tabs Module Appmenu Tests', () => {
     });
   }
 });
+
+describe('Tabs Module (rename API)', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/tabs-module/test-lsf-addtabs-scenario-2');
+    const tabsEl = await element(by.id('module-tabs-example'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(tabsEl), config.waitsFor);
+  });
+
+  // Tests infor-design/enterprise#5105
+  it('should rename the "More Tabs" menu link corresponding to a renamed tab', async () => {
+    const buttonClicks = [];
+    for (let i = 0; i < 10; i++) {
+      buttonClicks.push(element(by.css('.add-tab-button')).click());
+    }
+
+    // eslint-disable-next-line
+    await Promise.all(buttonClicks).then(() => {
+      expect(element(by.css('[href="#new-tab-9"]')).getText()).toEqual('9 Tab');
+    });
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR makes a change to the `rename()` method on the Tabs API to also change the "More Tabs" menu items.  Previously, when updating a tab's name, the change would not immediately occur in the More Tabs menu if the menu was open.  This is no longer the case -- the menu item updates immediately.

**Related github/jira issue (required)**:
Closes #5105

**Steps necessary to review your pull request (required)**:
- Pull, run, build
- Open http://localhost:4000/components/tabs-module/test-lsf-addtabs-scenario-2
- Click the Add Tabs "+" button on the top-right of the viewport until the "More Tabs" menu appears, opens, and displays items.  As you click the "+" button, the new line added should read something like "9 Tab", and not "New Tab 9".

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

@s-werking @awbuboltz 