### PR TITLE
5090/5158 - X Button Issues and Predictable Safari Behavior

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -100,7 +100,7 @@
 - `[Radar Chart]` Added support for double click. ([#3229](https://github.com/infor-design/enterprise/issues/3229))
 - `[Rating]` Fixed color of the un-checked rating star. ([#4853](https://github.com/infor-design/enterprise/issues/4853))
 - `[Popupmenu]` Fixed a lifecycle issue on menus that are shared between trigger elements, where these menus were incorrectly being torn down. ([NG#987](https://github.com/infor-design/enterprise-ng/issues/987))
-- `[Searchfield]` Fixed an issue where certain variants/scenarios had the clear button vertically below center ([#4989](https://github.com/infor-design/enterprise/issues/4989), [#5096](https://github.com/infor-design/enterprise/issues/5096))
+- `[Searchfield]` Fixed alignment issues with the close button in various scenarios ([#4989](https://github.com/infor-design/enterprise/issues/4989), [#5096](https://github.com/infor-design/enterprise/issues/5096), [#5158](https://github.com/infor-design/enterprise/issues/4989), [#5090](https://github.com/infor-design/enterprise/issues/4989))
 - `[Switch]` Adjust styles to be more discernable between checked and checked+disabled ([#4341](https://github.com/infor-design/enterprise/issues/4341))
 - `[Tabs (Horizontal/Header)]` Fixed bug with the placement of the focus state in RTL mode, and other minor visual improvements. ([#4877](https://github.com/infor-design/enterprise/issues/4877))
 - `[Tabs Module]` Fixed a bug where clear button was missing when clearable setting is activated in tabs module searchfield. ([#4898](https://github.com/infor-design/enterprise/issues/4898))

--- a/src/components/lookup/_lookup-new.scss
+++ b/src/components/lookup/_lookup-new.scss
@@ -86,20 +86,20 @@ html[dir='rtl'] {
   .toolbar {
     .buttonset {
       .searchfield-wrapper {
-        .btn-icon {
-          top: 4px;
+        &:not(.has-text) {
+          button.close {
+            display: none;
+          }
+        }
 
+        .btn-icon {
           svg.close.icon {
             border: 1px solid transparent;
-            left: 4px;
-            top: 7px;
           }
 
           &:focus {
             .close.icon {
               display: block;
-              left: 4px;
-              top: 7px;
             }
           }
         }

--- a/src/components/searchfield/_searchfield-new.scss
+++ b/src/components/searchfield/_searchfield-new.scss
@@ -172,12 +172,3 @@ html[dir='rtl'] {
   }
 }
 
-/**
- * targets toolbar searchfield close button inside of
- * a tab container, with variant wrapped in button
- */
-.tab-container > .toolbar > .buttonset {
-  > .searchfield-wrapper.toolbar-searchfield-wrapper > .btn-icon.close {
-    top: -2px;
-  }
-}

--- a/src/components/searchfield/_searchfield-new.scss
+++ b/src/components/searchfield/_searchfield-new.scss
@@ -58,22 +58,23 @@
     }
   }
 
-  &:not(.is-open) {
+  &:not(.is-Ropen) {
     .icon:not(.close) {
       top: 8px;
     }
   }
 
   .btn-icon.close {
+    align-items: center;
+    display: flex;
+    justify-content: center;
     overflow: visible;
-
-    &:not(.is-empty) {
-      top: 6px;
-    }
+    top: 50%;
+    transform: translateY(-50%);
 
     & > svg.close.icon {
-      top: calc(50% - 6px);
-      transform: translateY(-50%);
+      position: relative;
+      top: 1px;
     }
   }
 }

--- a/src/components/searchfield/_searchfield-new.scss
+++ b/src/components/searchfield/_searchfield-new.scss
@@ -58,7 +58,7 @@
     }
   }
 
-  &:not(.is-Ropen) {
+  &:not(.is-open) {
     .icon:not(.close) {
       top: 8px;
     }

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -995,10 +995,21 @@ html[dir='rtl'] {
 .header > .toolbar > .buttonset > .toolbar-searchfield-wrapper.non-collapsible.has-go-button.has-categories {
   button.close:not(.is-empty) {
     height: auto;
-    top: 5px;
+    top: 50%;
+    transform: translateY(-50%);
 
     svg.close {
       display: block;
+      top: 0px !important;
     }
+  }
+}
+
+/**
+ * there is no "new" theme file for toolbar, so placing hotfix here
+ */
+html[class*='theme-new-'] .header > .toolbar > .buttonset > .toolbar-searchfield-wrapper.non-collapsible.has-go-button.has-categories {
+  button.close:not(.is-empty) svg.close {
+    top: 1px !important;
   }
 }

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -1000,8 +1000,12 @@ html[dir='rtl'] {
 
     svg.close {
       display: block;
-      top: 0px !important;
+      top: 0 !important;
     }
+  }
+
+  @media (max-width: $breakpoint-phone-to-tablet) {
+    right: 29px;
   }
 }
 

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -995,7 +995,7 @@ html[dir='rtl'] {
 .header > .toolbar > .buttonset > .toolbar-searchfield-wrapper.non-collapsible.has-go-button.has-categories {
   button.close:not(.is-empty) {
     height: auto;
-    top: 4px;
+    top: 5px;
 
     svg.close {
       display: block;

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -984,3 +984,21 @@ html[dir='rtl'] {
     }
   }
 }
+
+/**
+ * dirty fix; fixes a quirk where on JS side sometimes there is no ".active" on
+ * searchfield-wrapper
+ * due to text field losing scope of some sort when triggering
+ * X focus; can test case this at
+ * /tabs-module/example-category-searchfield-go-button-home.html#maincontent
+ */
+.header > .toolbar > .buttonset > .toolbar-searchfield-wrapper.non-collapsible.has-go-button.has-categories {
+  button.close:not(.is-empty) {
+    height: auto;
+    top: 4px;
+
+    svg.close {
+      display: block;
+    }
+  }
+}

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -574,3 +574,14 @@ html[dir='rtl'] {
     top: 0;
   }
 }
+
+/**
+ * align large searchfield search icon
+ */
+.header > .full-searchfield-container .searchfield-wrapper {
+  & > svg.icon:nth-child(1) {
+    height: 100%;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+}

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -602,4 +602,10 @@ html[class*='theme-classic-'] {
       top: -1px;
     }
   }
+
+  .application-menu.has-searchfield {
+    .searchfield-wrapper.has-close-icon-button > .btn-icon.close > svg.close.icon {
+      top: 0;
+    }
+  }
 }

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -585,3 +585,21 @@ html[dir='rtl'] {
     transform: translateY(-50%);
   }
 }
+
+/**
+ * need explicit theme-classic on these base
+ * close button rules just because it's a bit hairy
+ * at this point to un-target other rules
+ */
+html[class*='theme-classic-'] {
+  .btn-icon.close {
+    top: 50%;
+    transform: translateY(-50%);
+
+    & > svg.close.icon {
+      position: relative;
+      right: unset;
+      top: -1px;
+    }
+  }
+}

--- a/src/components/searchfield/searchfield.js
+++ b/src/components/searchfield/searchfield.js
@@ -936,7 +936,7 @@ SearchField.prototype = {
     const wrapperElem = this.wrapper[0];
 
     if (this.settings.tabbable && wrapperElem.contains(active) && $(active).is('button.close')) {
-      return false;
+      return true;
     }
 
     // If another element inside the Searchfield Wrapper is focused, the entire component

--- a/src/components/tabs-module/_tabs-module.scss
+++ b/src/components/tabs-module/_tabs-module.scss
@@ -827,3 +827,21 @@ html[dir='rtl'] {
     }
   }
 }
+
+/**
+ * targets toolbar searchfield close button inside of
+ * a tab container, with variant wrapped in button
+ */
+.tab-container > .toolbar > .buttonset {
+  > .searchfield-wrapper.toolbar-searchfield-wrapper > .btn-icon.close {
+    height: auto;
+    margin-top: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 24px;
+
+    svg.icon.close {
+      top: 0;
+    }
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
There were cases of several alignment search issues, and we had not covered all permutations in Safari.
Particularly we are focused on addressing alignment on 5090 and 5158 in this branch, but there were a few other fixes in regards to this as well and in general Safari should be more similar to Chrome.

Note: this is not for off-by-one issues in specific theme/browser, as those can be very particular/nuanced to isolate. There may be other functional pre-existing issues in these icons but the main goal was to make sure the disappearing X and any pronounced/super easily distinguishable alignment issues as those can be particular obvious for end users.

To be able to keep the scope of this contained for the sprint to not flow over into other priorities, please open a new issue if not related to 5090/5158 (realize this may be tedious but it is much appreciated).

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #5090
Closes #5158

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

#5090

Go to http://localhost:4000/components/tabs-module/example-category-searchfield-go-button-home.html
Begin typing in the searchfield
Tab to access the close button
Close Button should not have the following issue
![image](https://user-images.githubusercontent.com/1799905/116765747-c8bee480-a9f4-11eb-8c48-79afad175012.png)

#5158 

Go to http://localhost:4000/components/header/example-non-collapsible-searchfield.html
Enter text in searchfield
X icon should be aligned
Go to http://localhost:4000//components/header/example-searchfield-expanded.html
Enter text in searchfield
X Button should be aligned

![image](https://user-images.githubusercontent.com/1799905/116765759-e4c28600-a9f4-11eb-94ca-c1ca9d222d81.png)

Misc: besides close button: vertical centering on large search icon 
visit http://localhost:4000/components/header/example-searchfield-large
The search icon should be vertically aligned

Regression Testing
========================
Below is a list of places to make sure just that the general alignment is not completely off for close buttons (note: if there is an off-by-one in one instance vs major alignment issue, please open a new ticket as the scope is already very large in changes and becomes harder to not mix up issues/review targeted issues on).

These should be run with both minimum Chrome and Safari.

http://localhost:4000/components/datagrid/example-keyword-search.html?theme=classic&mode=light
http://localhost:4000/components/tabs-module/example-category-searchfield-go-button.html
http://localhost:4000/components/tabs-module/example-category-searchfield-go-button.html?theme=classic
http://localhost:4000/components/tabs-module/example-category-searchfield.html
http://localhost:4000/components/tabs-module/example-toolbar-with-spillover.html
http://localhost:4000/components/header/example-tabs-alternate.html
http://localhost:4000/components/header/example-tabs-alternate.html?theme=classic
http://localhost:4000/components/header/example-searchfield-large
http://localhost:4000/components/header/example-searchfield-large?theme=classic
http://localhost:4000/components/listview/example-search.html?theme=classic
http://localhost:4000/components/listview/example-search.html
http://localhost:4000/components/toolbar-flex/example-index.html?theme=new
http://localhost:4000/components/toolbar-flex/example-index.html?theme=classic
http://localhost:4000/components/toolbar-flex/example-searchfield-collapsible.html?theme=classic&mode=light
http://localhost:4000/components/toolbar-flex/example-searchfield-collapsible.html?theme=new&mode=light
http://localhost:4000/components/toolbarsearchfield/example-alternate-style-with-categories.html (Chrome only)
http://localhost:4000/components/toolbarsearchfield/example-alternate-style-with-categories.html?theme=classic (Chrome only)

http://localhost:4000/components/toolbarsearchfield/example-alternate-style.html (Chrome Only)
http://localhost:4000/components/toolbarsearchfield/example-alternate-style.html?theme=classic (Chrome Only)

http://localhost:4000/components/lookup/example-clearable.html (+Click lookup and test modal)
http://localhost:4000/components/lookup/example-clearable.html?theme=classic (+Click lookup and test modal)

http://localhost:4000/components/applicationmenu/example-filterable?theme=classic (Enter Menu on Top-left)
http://localhost:4000/components/applicationmenu/example-filterable (Enter Menu on Top-left)

Known issue in lookup/example-clearable: clearing text does not clear search close state; this is unrelated to ticket scope/functional in nature.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [X] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
