### PR TITLE
4857 - Prevent single buttons from remaining in Toolbar overflow

### DIFF
--- a/app/views/components/tabs-module/example-category-searchfield-go-button-home.html
+++ b/app/views/components/tabs-module/example-category-searchfield-go-button-home.html
@@ -71,8 +71,7 @@
       'goButtonAction': goButtonAction,
       'showGoButton': true,
       'categories': [ 'Books', 'Movies', 'Music', 'Video Games' ],
-      'showCategoryText': true,
+      'showCategoryText': false,
       'clearable': true
     });
-
   </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,7 +28,8 @@
 - `[Tabs]` Fixed a bug where where if urls contain a href with a forward slash (paths), then this would error. Note that in this situation you need to make sure the tab panel is linked without the hash. ([#5014](https://github.com/infor-design/enterprise/issues/5014))
 - `[Tabs]` Added support to sortable drag and drop tabs. Non touch devices it good with almost every type of tabs `Module`, `Vertical`, `Header`, `Scrollable` and `Regular`. For touch devices only support with `Module` and `Vertical` Tabs. ([#4520](https://github.com/infor-design/enterprise/issues/4520))
 - `[Toast]` Fixed a bug where toast message were unable to drag down to it's current position when `position` sets to 'bottom right'. ([#5015](https://github.com/infor-design/enterprise/issues/5015))
-- `[Toolbar]` Add fix for invisible inputs in the toolbar. ([#5122](https://github.com/infor-design/enterprise/issues/v))
+- `[Toolbar]` Add fix for invisible inputs in the toolbar. ([#5122](https://github.com/infor-design/enterprise/issues/5122))
+- `[Toolbar]` Prevent individual buttons from getting stuck inside the Toolbar's overflow menu ([#4857](https://github.com/infor-design/enterprise/issues/4857))
 - `[Tree]` Added api support for collapse/expand node methods. ([#4707](https://github.com/infor-design/enterprise/issues/4707))
 
 ### v4.51.0 Issues

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -860,16 +860,16 @@ Toolbar.prototype = {
    * @returns {void}
    */
   handleResize(containerDims) {
+    const buttons = this.getButtonsetButtons();
+    for (let i = 0; i < buttons.length; i++) {
+      buttons[i].removeClass('is-overflowed');
+    }
+
     if (this.settings.resizeContainers) {
       const title = containerDims ? containerDims.title : undefined;
       const buttonset = containerDims ? containerDims.buttonset : undefined;
 
       this.sizeContainers(title, buttonset);
-    }
-
-    const buttons = this.getButtonsetButtons();
-    for (let i = 0; i < buttons.length; i++) {
-      buttons[i].removeClass('is-overflowed');
     }
 
     if (this.element.is(':not(:hidden)')) {

--- a/test/components/toolbar/toolbar.e2e-spec.js
+++ b/test/components/toolbar/toolbar.e2e-spec.js
@@ -1,0 +1,35 @@
+const { browserStackErrorReporter } = requireHelper('browserstack-error-reporter');
+const config = requireHelper('e2e-config');
+const utils = requireHelper('e2e-utils');
+requireHelper('rejection');
+
+jasmine.getEnv().addReporter(browserStackErrorReporter);
+
+describe('Toolbar (overflow)', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/tabs-module/example-category-searchfield-go-button-home.html');
+    await browser.driver
+      .wait(protractor.ExpectedConditions
+        .presenceOf(element(by.id('module-tab-panel-container'))), config.waitsFor);
+  });
+
+  it('should not have any errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('will not force buttons to remain in overflow', async () => {
+    // Store the original window size
+    const windowSize = await browser.driver.manage().window().getSize();
+
+    // Shrink the window to be absurdly small, and allow time for the calculation to occur
+    await browser.driver.manage().window().setSize(320, 480);
+    await browser.driver.sleep(config.sleepLonger);
+
+    // Put the window size back, allowing time for recalculation
+    await browser.driver.manage().window().setSize(windowSize.width, windowSize.height);
+    await browser.driver.sleep(config.sleepLonger);
+
+    // Check the Home button, and make sure it's not overflowed
+    expect(await element(by.id('home-button')).getAttribute('class')).not.toContain('is-overflowed');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a bug in the original Toolbar code (when coupled with Searchfields) that in some cases would force a single toolbar button to sit inside of the "More Actions" menu, when the button could instead just stand by itself.  The order of the overflow calculation has been adjusted to prevent this issue.

**Related github/jira issue (required)**:
Closes #4857 

**Steps necessary to review your pull request (required)**:
- Pull/build/run
- Open http://localhost:4000/components/tabs-module/example-category-searchfield-go-button-home.html?layout=nofrills
- Open developer tools and toggle the device toolbar.  Set the mode to "responsive"
- Shrink the size of the window to be incredibly small, width-wise.
- Resize the width back to a "normal" size.
- See that the icon in the top-right section of the Toolbar should now be a "home" button instead of a "More Actions" button containing the Home button.

![Screen Shot 2021-05-03 at 12 14 18 PM](https://user-images.githubusercontent.com/3249601/116902422-190e9000-ac09-11eb-891c-4361b2b5b6d8.png)

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
