### PR TITLE
4851 - Fix dropdown focus and arrow keys with datagrid

### DIFF
--- a/app/views/components/datagrid/test-editable-dropdown-width.html
+++ b/app/views/components/datagrid/test-editable-dropdown-width.html
@@ -80,10 +80,11 @@
         data.push({ action: 'val1' });
         data.push({ action: 'val5' });
 
-        //Define Columns for the Grid.
+        // Define Columns for the Grid.
+        columns.push({ id: 'c0', name: 'Action 0', field: 'action', formatter: Formatters.Dropdown, editor: Editors.Dropdown, validate: 'required', options: dropdowndOptions, editorOptions: { noSearch: true }, width: 170 });
         columns.push({ id: 'c1', name: 'Action 1', field: 'action', formatter: Formatters.Dropdown, editor: Editors.Dropdown, validate: 'required', options: dropdowndOptions, width: 170 });
-        columns.push({ id: 'c2', name: 'Action 1', field: 'action', formatter: Formatters.Dropdown, editor: Editors.Dropdown, validate: 'required', options: dropdowndOptions });
-        columns.push({ id: 'c3', name: 'Action 1', field: 'action', formatter: Formatters.Dropdown, editor: Editors.Dropdown, validate: 'required', options: dropdowndOptions });
+        columns.push({ id: 'c2', name: 'Action 2', field: 'action', formatter: Formatters.Dropdown, editor: Editors.Dropdown, validate: 'required', options: dropdowndOptions });
+        columns.push({ id: 'c3', name: 'Action 3', field: 'action', formatter: Formatters.Dropdown, editor: Editors.Dropdown, validate: 'required', options: dropdowndOptions });
 
         $('#datagrid').datagrid({
           columns: columns,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Datagrid]` Fixed an issue where stretching the last column of a table was not consistent when resizing the window. ([#5045](https://github.com/infor-design/enterprise/issues/5045))
 - `[Datagrid]` Fixed an issue where time format HHmm was not working for time picker editor. ([#4926](https://github.com/infor-design/enterprise/issues/4926))
 - `[Datagrid]` Fixed an issue where setting stretchColumn to 'last' did not stretch the last column in the table. ([#4913](https://github.com/infor-design/enterprise/issues/4913))
+- `[Datagrid]` Fixed an issue where dropdown focus and arrow key was moving across the grid columns, which let open multiple dropdowns. ([#4851](https://github.com/infor-design/enterprise/issues/4851))
 - `[Datagrid]` Fixed an issue where the copy paste html to editable cell was cause to generate new cells. ([#4848](https://github.com/infor-design/enterprise/issues/4848))
 - `[Datepicker]` Fixed an issue where time was changing, if selected time was before noon for Danish language locale da-DK. ([#4987](https://github.com/infor-design/enterprise/issues/4987))
 - `[Datepicker]` Removed deprecation warning for close method. ([#5120](https://github.com/infor-design/enterprise/issues/5120))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@
 - `[Datagrid]` Fixed an issue where stretching the last column of a table was not consistent when resizing the window. ([#5045](https://github.com/infor-design/enterprise/issues/5045))
 - `[Datagrid]` Fixed an issue where time format HHmm was not working for time picker editor. ([#4926](https://github.com/infor-design/enterprise/issues/4926))
 - `[Datagrid]` Fixed an issue where setting stretchColumn to 'last' did not stretch the last column in the table. ([#4913](https://github.com/infor-design/enterprise/issues/4913))
-- `[Datagrid]` Fixed an issue where dropdown focus and arrow key was moving across the grid columns, which let open multiple dropdowns. ([#4851](https://github.com/infor-design/enterprise/issues/4851))
+- `[Datagrid]` Fixed an issue where when focusing dropdowns and then using arrow key, it would move across the grid columns leaving multiple open dropdowns. ([#4851](https://github.com/infor-design/enterprise/issues/4851))
 - `[Datagrid]` Fixed an issue where the copy paste html to editable cell was cause to generate new cells. ([#4848](https://github.com/infor-design/enterprise/issues/4848))
 - `[Datepicker]` Fixed an issue where time was changing, if selected time was before noon for Danish language locale da-DK. ([#4987](https://github.com/infor-design/enterprise/issues/4987))
 - `[Datepicker]` Removed deprecation warning for close method. ([#5120](https://github.com/infor-design/enterprise/issues/5120))

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1817,7 +1817,7 @@ Dropdown.prototype = {
     selectText();
 
     // Set focus back to the element
-    if (input) {
+    if (input && document.activeElement.tagName !== 'INPUT') {
       input[0].focus();
     }
   },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed dropdown focus and arrow key was moving across the grid cells, which let open multiple dropdowns with Datagrid.

**Related github/jira issue (required)**:
Closes #4851

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/test-editable-dropdown-width.html
- Click on any cell in 1st column `Action 0` (the dropdown will open)
- Press enter to close the dropdown, then press enter twice to open it up again
- Press right arrow key
- Focus should not move to next column, it should stay in opened dropdown input

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
