### PR TITLE
4503 - Fix unselected items on active page and display counts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v4.52.0 Fixes
 
-- `[General]` Placeholder for new issues. ([#5027](https://github.com/infor-design/enterprise/issues/5027))
+- `[Lookup/Datagrid]` Fixed a bug where unselecting all items in an active page affects other selected items on other pages. ([#4503](https://github.com/infor-design/enterprise/issues/4503))
 
 ## v4.51.0
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7374,6 +7374,10 @@ Datagrid.prototype = {
     // Sync the Ui and call the events
     this.dontSyncUi = false;
 
+    // It should not clear the selectedRows in lookup
+    const isLookup = $('.lookup-modal.is-visible');
+    this._selectedRows = !isLookup.length ? [] : this._selectedRows;
+
     // Update the display counts when unselecting all rows
     this.displayCounts();
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7374,10 +7374,6 @@ Datagrid.prototype = {
     // Sync the Ui and call the events
     this.dontSyncUi = false;
 
-    // It should not clear the selectedRows in lookup
-    const isLookup = $('.lookup');
-    this._selectedRows = !isLookup.length ? [] : this._selectedRows;
-
     // Update the display counts when unselecting all rows
     this.displayCounts();
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7373,7 +7373,9 @@ Datagrid.prototype = {
     this.settings.dataset.map((row) => { delete row._selected; }); //eslint-disable-line
     // Sync the Ui and call the events
     this.dontSyncUi = false;
-    this._selectedRows = [];
+
+    // Update the display counts when unselecting all rows
+    this.displayCounts();
 
     if (!nosync) {
       this.syncSelectedUI();

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7374,6 +7374,10 @@ Datagrid.prototype = {
     // Sync the Ui and call the events
     this.dontSyncUi = false;
 
+    // It should not clear the selectedRows in lookup
+    const isLookup = $('.lookup');
+    this._selectedRows = !isLookup.length ? [] : this._selectedRows;
+
     // Update the display counts when unselecting all rows
     this.displayCounts();
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7375,8 +7375,8 @@ Datagrid.prototype = {
     this.dontSyncUi = false;
 
     // It should not clear the selectedRows in lookup
-    const isLookup = $('.lookup-modal.is-visible');
-    this._selectedRows = !isLookup.length ? [] : this._selectedRows;
+    const isLookup = this.element.closest('.lookup-modal');
+    this._selectedRows = isLookup.length === 1 ? this._selectedRows : [];
 
     // Update the display counts when unselecting all rows
     this.displayCounts();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
 
This PR fixes a bug where unselecting all items in an active page affects other selected items on other pages as well.

There's a line of code that resets the `this._selectedRows` after mapping it.

I also noticed that the selected counts don't reflect immediately. Fixed it too.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/4503

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/lookup/example-multiselect-paging-serverside
- Click the lookup button
- Tick top checkbox to Select all on first page
- Move to Page 2
- Tick top checkbox to Select all on second page
- Tick top checkbox to Unselect all on second page
- It should back to `5 Selected` and not remove the toolbar
- Go Back to page 1
- It should not reset or unselect all the items on Page 1

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
