### PR TITLE
5105 - Enable tabs rename API to work with/without hash

### DIFF
--- a/app/views/components/tabs-module/test-lsf-addtabs-scenario-2.html
+++ b/app/views/components/tabs-module/test-lsf-addtabs-scenario-2.html
@@ -41,7 +41,7 @@
 
       control.addTabButton.on('click.tabs', () => {
         control.select('#new-tab-' + tabNum);
-        control.rename('#new-tab-' + tabNum, tabNum + " Tab");
+        control.rename('new-tab-' + tabNum, tabNum + " Tab");
         tabNum++;
       });
 

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -3061,6 +3061,7 @@ Tabs.prototype = {
     const tab = this.doGetTab(e, tabId);
     const hasCounts = this.settings.tabCounts;
     const hasTooltip = this.settings.moduleTabsTooltips || this.settings.multiTabsTooltips;
+    const hasDismissible = tab.hasClass('dismissible');
     const anchor = tab.children('a');
     let count;
 
@@ -3075,6 +3076,10 @@ Tabs.prototype = {
       const moreAnchorSelector = tabId.charAt(0) !== '#' ? `#${tabId}` : tabId;
       const moreAnchor = this.popupmenu.menu.find(`a[href="${moreAnchorSelector}"]`);
       moreAnchor.text(name);
+
+      if (hasDismissible) {
+        moreAnchor.append($.createIconElement({ icon: 'close', classes: 'icon close' }));
+      }
     }
 
     if (hasCounts) {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -3072,7 +3072,8 @@ Tabs.prototype = {
 
     // Rename the tab inside a currently-open "More Tabs" popupmenu, if applicable
     if (this.popupmenu) {
-      const moreAnchor = this.popupmenu.menu.find(`a[href="${tabId}"]`);
+      const moreAnchorSelector = tabId.charAt(0) !== '#' ? `#${tabId}` : tabId;
+      const moreAnchor = this.popupmenu.menu.find(`a[href="${moreAnchorSelector}"]`);
       moreAnchor.text(name);
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This is a followup fix for PR #5165 that addresses the following:
- lets the rename API fully work with/without a leading hash `#` symbol in the ID string.  The test page for the original issue has been modified to use the regular ID string without the hash.
- enables better detection of dismissible tabs when attempting to rename a tab in the "More" menu.  Previously the dismissible "X" button wasn't being passed to newly-renamed more menu items.

**Related github/jira issue (required)**:
Supersedes #5165
Closes #5105
 
**Steps necessary to review your pull request (required)**:
- Pull/Build/Run
- Open http://localhost:4000/components/tabs-module/test-lsf-addtabs-scenario-2
- Click the Add Tabs "+" button on the top-right of the viewport until the "More Tabs" menu appears, opens, and displays items. As you click the "+" button, the new line added should read something like "9 Tab", and not "New Tab 9".
- Hover the "renamed" overflowed tab (in this case "9 Tab") and ensure it has an "X" button, and that it is able to be dismissed

@s-werking 