### PR TITLE
4901 - Fix flickering of legend tag

### DIFF
--- a/app/views/components/radios/test-legend-tag-as-label.html
+++ b/app/views/components/radios/test-legend-tag-as-label.html
@@ -1,0 +1,30 @@
+<div class="row">
+  <div class="column one-half">
+    <fieldset class="radio-group">
+      <legend>legend1</legend>
+      <input type="radio" id="gregorianOption" class="radio" name="calendarGroup" value="GREGORIAN" />
+      <label for="gregorianOption" class="radio-label">label1</label>
+      <br>
+      <input type="radio" id="hijriOption" class="radio" name="calendarGroup" value="HIJRI" />
+      <label for="hijriOption" class="radio-label">label2</label>
+    </fieldset>
+    <br>
+    <fieldset class="radio-group">
+      <legend>legend2</legend>
+      <input type="radio" id="hr12Option" class="radio" name="timeFormatGroup" value="HR12" />
+      <label for="hr12Option" class="radio-label">label1</label>
+      <br>
+      <input type="radio" id="hr24Option" class="radio" name="timeFormatGroup" value="HR24" />
+      <label for="hr24Option" class="radio-label">label2</label>
+    </fieldset>
+    <br>
+    <fieldset class="radio-group">
+      <legend>legend3</legend>
+      <input type="radio" id="currencyPrefixOption" class="radio" name="currencySymbolPositionGroup" value="PREFIX" />
+      <label for="currencyPrefixOption" class="radio-label">label1</label>
+      <br>
+      <input type="radio" id="currencySuffixOption" class="radio" name="currencySymbolPositionGroup" value="SUFFIX" />
+      <label for="currencySuffixOption" class="radio-label">label2</label>
+    </fieldset>
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v4.52.0 Fixes
 
-- `[General]` Placeholder for new issues. ([#5027](https://github.com/infor-design/enterprise/issues/5027))
+- `[Radio]` Fixed a bug where legend tag blinks when clicking the radio buttons. ([#4901](https://github.com/infor-design/enterprise/issues/4901))
 
 ## v4.51.0
 

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -164,6 +164,7 @@
     color: $label-color;
     font-size: $input-size-regular-font-size;
     padding-bottom: 5px !important;
+    position: relative;
   }
 
   &.is-disabled,


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the flickering of legend tag as a label inside of the fieldset.

This issue only exists on Chrome. Found out that legend tag should be relative to the fieldset as it's parent. Adding `position: relative` will fix the issue.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/4901

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/radios/test-legend-tag-as-label.html
- Select a radio input that is not in the last fieldset.
- Click radio label1 and radio label2 several times to test
- Legend tag (as label) should not flicker

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
