### PR TITLE
5115 - Fixed datagrid resize when zoomed

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v4.52.0 Fixes
 
-- `[General]` Placeholder for new issues. ([#5027](https://github.com/infor-design/enterprise/issues/5027))
+- `[Datagrid]` Fixed an issue where the datagrid resize did not work when zoomed, this was only occuring in some situations like frozen columns and colspans. ([#5115](https://github.com/infor-design/enterprise/issues/5115))
 
 ## v4.51.0
 

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -393,7 +393,6 @@ $datagrid-small-row-height: 25px;
   }
 
   .resize-handle {
-    border: 0;
     cursor: col-resize;
     height: $datagrid-header-height;
     left: -999px;
@@ -2378,7 +2377,6 @@ $datagrid-small-row-height: 25px;
         display: block;
         margin-bottom: 6px;
         margin-top: 5px;
-        vertical-align: middle;
       }
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Slightly tricky issue. Found that when resizing the frozen columns while zoomed it behaved quite odd.
To fix recalculated some widths against the device pixel ration.

**Related github/jira issue (required)**:
Fixes #5115 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-frozen-columns-resizable-with-colspan.html
- try and resize the second to third column (and try other columns too)
- use the browser and zoom in one level
- try and resize the second to third column (and try other columns too)
- use the browser and zoom out one level

**Included in this Pull Request**:
- [x] A note to the change log.
