### PR TITLE
5073 - Fix reopening of filter options after doing sorting on server-side paging

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### v4.52.0 Fixes
 
+- `[Datagrid]` Fixed a bug where filter options were not opening anymore after doing sorting on server-side paging. ([#5073](https://github.com/infor-design/enterprise/issues/5073))
 - `[Lookup/Datagrid]` Fixed a bug where unselecting all items in an active page affects other selected items on other pages. ([#4503](https://github.com/infor-design/enterprise/issues/4503))
 
 ## v4.51.1

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1608,24 +1608,13 @@ Datagrid.prototype = {
     let activeMenu = null;
 
     // Attach Keyboard support
-    this.element.off('click.datagrid-filter').on('click.datagrid-filter', '.btn-filter', function (event) {
+    this.element.off('click.datagrid-filter').on('click.datagrid-filter', '.btn-filter', function () {
       const filterBtn = $(this);
       const popupOpts = { trigger: 'immediate', offset: { y: 15 }, placementOpts: { strategies: ['flip', 'nudge'] } };
       const popupmenu = filterBtn.data('popupmenu');
-      const parentElem = $(event.target).parent();
-      const popupmenuElem = parentElem.find('.popupmenu');
 
       if (popupmenu) {
         popupmenu.close(true, true);
-
-        // If the menu is missing in the Datagrid filter wrapper,
-        // it will re-attach to the parent in the correct position.
-        if (!popupmenuElem.length) {
-          if (popupmenu.wrapperPlace) {
-            popupmenu.wrapper.off().remove();
-          }
-          popupmenu.menu.insertAfter(filterBtn);
-        }
       } else {
         filterBtn.off('beforeopen.datagrid-filter').on('beforeopen.datagrid-filter', (e, menu, api) => {
           self.hideTooltip();
@@ -1684,6 +1673,15 @@ Datagrid.prototype = {
 
     this.element.off('focus.datagrid-filter-focus')
       .on('focus.datagrid-filter-focus', '.datagrid-filter-wrapper input', () => {
+        activeMenu?.close();
+        const dropdownId = $('#dropdown-list').attr('data-element-id');
+        const dropdown = $(`#${dropdownId}`).data('dropdown');
+        if (dropdown && dropdown.isOpen()) {
+          dropdown.closeList('click');
+        }
+      });
+    this.element.off('click.datagrid-filter-click')
+      .on('click.datagrid-filter-click', 'th', () => {
         activeMenu?.close();
         const dropdownId = $('#dropdown-list').attr('data-element-id');
         const dropdown = $(`#${dropdownId}`).data('dropdown');
@@ -4827,7 +4825,8 @@ Datagrid.prototype = {
         if (diff < colWidth) {
           this.stretchColumnWidth = colWidth;
         } else {
-          this.stretchColumnDiff = colWidth = diff;
+          this.stretchColumnDiff = colWidth;
+          this.stretchColumnDiff = diff;
         }
       }
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1608,13 +1608,24 @@ Datagrid.prototype = {
     let activeMenu = null;
 
     // Attach Keyboard support
-    this.element.off('click.datagrid-filter').on('click.datagrid-filter', '.btn-filter', function () {
+    this.element.off('click.datagrid-filter').on('click.datagrid-filter', '.btn-filter', function (event) {
       const filterBtn = $(this);
       const popupOpts = { trigger: 'immediate', offset: { y: 15 }, placementOpts: { strategies: ['flip', 'nudge'] } };
       const popupmenu = filterBtn.data('popupmenu');
+      const parentElem = $(event.target).parent();
+      const popupmenuElem = parentElem.find('.popupmenu');
 
       if (popupmenu) {
         popupmenu.close(true, true);
+
+        // If the menu is missing in the Datagrid filter wrapper,
+        // it will re-attach to the parent in the correct position.
+        if (!popupmenuElem.length) {
+          if (popupmenu.wrapperPlace) {
+            popupmenu.wrapper.off().remove();
+          }
+          popupmenu.menu.insertAfter(filterBtn);
+        }
       } else {
         filterBtn.off('beforeopen.datagrid-filter').on('beforeopen.datagrid-filter', (e, menu, api) => {
           self.hideTooltip();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

After the new implementation of shared popupmenu lifecycle, for some reason, the server-side paging in Datagrid does not work properly or it appears to affect the behavior of the Popupmenu instance.

This PR fixes reopening of filter options after doing sorting on server-side paging.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/5073

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-filter-paging-server-side.html
- Click on any filter options dropdown (keep it open)
- Do a sort (on any of the columns)
- Close the filter options dropdown
- Reopen the filter options dropdown
- It should open the filter options dropdown

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
