### PR TITLE
5199 - Change thai start day to monday

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,8 +9,9 @@
 ### v4.52.0 Fixes
 
 - `[Datagrid]` When fixing bugs in datagrid hover states we removed the use of `is-focused` on table `td` elements. ([#5091](https://github.com/infor-design/enterprise/issues/5091))
-- `[Lookup/Datagrid]` Fixed a bug where the plus minus icon animation was cut off. ([#4962](https://github.com/infor-design/enterprise/issues/4962))
+- `[Datagrid/Lookup]` Fixed a bug where the plus minus icon animation was cut off. ([#4962](https://github.com/infor-design/enterprise/issues/4962))
 - `[Datagrid]` Fixed a bug where unselecting all items in an active page affects other selected items on other pages. ([#4503](https://github.com/infor-design/enterprise/issues/4503))
+- `[Locale]` Changed the start day of the week to monday as per translation team request. ([#5199](https://github.com/infor-design/enterprise/issues/5199))
 
 ## v4.51.1
 

--- a/src/components/locale/cultures/th-TH.js
+++ b/src/components/locale/cultures/th-TH.js
@@ -43,7 +43,7 @@ Soho.Locale.addCulture('th-TH', {
     timeFormat: 'HH:mm',
     // ca-gregorian/main/dates/calendars/gregorian/dayPeriods/wide
     dayPeriods: ['ก่อนเที่ยง', 'หลังเที่ยง'],
-    firstDayofWeek: 0 // Starts on Sun
+    firstDayofWeek: 1 // Starts on Mon
   }],
   // numbers/currencyFormats-numberSystem-latn/standard
   currencySign: 'kr',


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The first day in the thai calendar should be monday according to the translation team so updated it. Monday === จ

**Related github/jira issue (required)**:
Fixes #5199

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datepicker/example-index.html?locale=th-TH
- open calendar
- first day of the week should be `จ`

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
