### PR TITLE
4798 - Fix trigger event for remove card with homepage

### DIFF
--- a/app/views/components/homepage/example-editable.html
+++ b/app/views/components/homepage/example-editable.html
@@ -64,5 +64,6 @@
     .on('removecard', function(event, card, data){ console.log("Homepage: removecard event: ", [card, data])});
   $('.widget')
     .on('resizecard', function(event, card, data){ console.log("Widget: resizecard event: ", [card, data])})
-    .on('reordercard', function(event, card, data){ console.log("Widget: reordercard event: ", [card, data])});
+    .on('reordercard', function(event, card, data){ console.log("Widget: reordercard event: ", [card, data])})
+    .on('removecard', function (event, card, data) { console.log("Widget: removecard event: ", [card, data]) });
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[Datagrid]` When fixing bugs in datagrid hover states we removed the use of `is-focused` on table `td` elements. ([#5091](https://github.com/infor-design/enterprise/issues/5091))
 - `[Lookup/Datagrid]` Fixed a bug where the plus minus icon animation was cut off. ([#4962](https://github.com/infor-design/enterprise/issues/4962))
 - `[Datagrid]` Fixed a bug where unselecting all items in an active page affects other selected items on other pages. ([#4503](https://github.com/infor-design/enterprise/issues/4503))
+- `[Homepage]` Fixed an issue where remove card event was not trigged on card/widget. ([#4798](https://github.com/infor-design/enterprise/issues/4798))
 
 ## v4.51.1
 

--- a/src/components/homepage/homepage.js
+++ b/src/components/homepage/homepage.js
@@ -214,10 +214,13 @@ Homepage.prototype = {
           removeButton.insertBefore(header)
             .on('click.card-remove', () => {
               const removeCard = () => {
+                const cloned = card.clone(true);
                 card.remove();
                 homepage.refresh(false);
                 setTimeout(() => {
                   homepage.element.triggerHandler('removecard', [card, homepage.state]);
+                  cloned.triggerHandler('removecard', [card, homepage.state]);
+                  cloned.remove();
                 }, 0);
               };
               if (this.settings && typeof this.settings.onBeforeRemoveCard === 'function') {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed remove card event was not trigger on card/widget with homepage.

**Related github/jira issue (required)**:
Closes #4798

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/homepage/example-editable.html
- Open developer tools
- Click on (x) button to remove the card
- See in console should fire two event both `removecard` one on `Homepage` and another on `Widget`


**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
