### PR TITLE
4974 - Allow decimal input on replacement of number masked field value

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Datagrid]` When fixing bugs in datagrid hover states we removed the use of `is-focused` on table `td` elements. ([#5091](https://github.com/infor-design/enterprise/issues/5091))
 - `[Lookup/Datagrid]` Fixed a bug where the plus minus icon animation was cut off. ([#4962](https://github.com/infor-design/enterprise/issues/4962))
 - `[Datagrid]` Fixed a bug where unselecting all items in an active page affects other selected items on other pages. ([#4503](https://github.com/infor-design/enterprise/issues/4503))
+- `[Mask/Datagrid]` Fixed a bug in number masks where entering a decimal while the field's entire text content was selected could cause unexpected formatting. ([#4974](https://github.com/infor-design/enterprise/issues/4974))
 
 ## v4.51.1
 

--- a/src/components/mask/mask-api.js
+++ b/src/components/mask/mask-api.js
@@ -430,6 +430,10 @@ MaskAPI.prototype = {
         // We substring from the beginning until the position after the last filled
         // placeholder char.
         resultStr = resultStr.substr(0, indexOfLastFilledPlaceholderChar + 1);
+      } else if (rawValue !== '' && resultStr.indexOf(rawValue) > -1) {
+        // The raw value provided exists within the character literals left by processing, so
+        // we simply do nothing to the results string in this case.
+        caretPos += rawValue.length;
       } else {
         // If we couldn't find `indexOfLastFilledPlaceholderChar` that means the user deleted
         // the first character in the mask. So we return an empty string.

--- a/src/components/mask/masks.js
+++ b/src/components/mask/masks.js
@@ -197,13 +197,16 @@ masks.numberMask = function sohoNumberMask(rawValue, options) {
       thisRawValue === masks.EMPTY_STRING ||
       (thisRawValue[0] === PREFIX[0] && rawValueLength === 1)
     ) {
-      return PREFIX.split(masks.EMPTY_STRING).concat([masks.DIGITS_REGEX])
+      return PREFIX.split(masks.EMPTY_STRING)
+        .concat([masks.DIGITS_REGEX])
         .concat(SUFFIX.split(masks.EMPTY_STRING));
     }
+
     if (
       thisRawValue === DECIMAL && options.allowDecimal
     ) {
-      return PREFIX.split(masks.EMPTY_STRING).concat(['0', DECIMAL, masks.DIGITS_REGEX])
+      return PREFIX.split(masks.EMPTY_STRING)
+        .concat(['0', masks.CARET_TRAP, DECIMAL, masks.CARET_TRAP, masks.DIGITS_REGEX])
         .concat(SUFFIX.split(masks.EMPTY_STRING));
     }
 

--- a/test/components/mask/mask.e2e-spec.js
+++ b/test/components/mask/mask.e2e-spec.js
@@ -99,6 +99,26 @@ describe('Number Masks', () => {
 
     await (utils.checkForErrors());
   });
+
+  it('Correctly handles only formatting the decimal', async () => {
+    await utils.setPage('/components/mask/test-number-leading-zeroes.html');
+    const thisInputId = 'test1';
+    const inputEl = await element(by.id(thisInputId));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(inputEl), config.waitsFor);
+
+    await inputEl.clear();
+    await inputEl.sendKeys('123.123');
+
+    expect(await inputEl.getAttribute('value')).toEqual('123.123');
+
+    // Select the entire input field, then input a decimal
+    await browser.executeScript(`document.querySelector('#${thisInputId}').select();`);
+    await browser.driver.sleep(config.sleepShort);
+    await inputEl.sendKeys('.25');
+
+    expect(await inputEl.getAttribute('value')).toEqual('0.25');
+  });
 });
 
 describe('Date Masks (custom formats)', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a bug in number masks where trying to replace the value of a number-masked input field with a valid decimal input would incorrectly cause the value to disappear.  The expected behavior, which is pre-filling a zero and accepting the decimal input, is now correctly implemented instead.

**Related github/jira issue (required)**:
Closes #4974

**Steps necessary to review your pull request (required)**:
- Pull/Build/Run
- Open https://main-enterprise.demo.design.infor.com/components/mask/test-number-leading-zeroes.html
- In the first input field, type "123.123"
- Select all the text in the field (CMD/CTRL + A)
- Type the decimal point ".".  The formatted value should read "0.", and the text caret should be placed at the end of the field.
- Also try typing "0.25", or any combination of integers with ".25".  All should be valid.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.