### PR TITLE
5053 - Fix missing prefix id attribute when searching with typeahead settings

### DIFF
--- a/app/views/components/dropdown/test-typeahead-automation-id.html
+++ b/app/views/components/dropdown/test-typeahead-automation-id.html
@@ -1,0 +1,43 @@
+<div class="row">
+  <div class="six columns">
+
+    <h2>Dropdown Test: Typeahead Automation ID</h2>
+
+    <p>The dropdown control on this page has its options created by loading from an external source with an AJAX request.
+    </p>
+
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="field">
+      <label for="ajax-test">Ajax with Typeahead</label>
+      <select id="ajax-test" name="ajax-test" class="dropdown" data-init="false"></select>
+    </div>
+
+  </div>
+</div>
+
+<script>
+  $('body').on('initialized', function() {
+
+    $('#ajax-test').dropdown({
+      source: function (response, term) {
+        var apiRoute = '{{basepath}}api/states';
+        if (term && typeof term === 'string' && term.length) {
+          apiRoute += '?term=' + term;
+        }
+
+        $.getJSON(apiRoute, function(data) {
+          response(data);
+        });
+      },
+      attributes: [{'name': 'id', 'value': 'SomeIdPrefix'}],
+      showSearchUnderSelected: true,
+      reload: 'typeahead'
+    });
+
+  });
+</script>

--- a/app/views/components/multiselect/test-typeahead-automation-id.html
+++ b/app/views/components/multiselect/test-typeahead-automation-id.html
@@ -1,0 +1,68 @@
+<div class="row">
+  <div class="six columns">
+
+    <h2>Multiselect Test: Typeahead Automation ID</h2>
+    <br/>
+  </div>
+</div>
+
+<div class="row">
+  <div class="six columns">
+
+    <div class="field">
+      <label for="ajax-test">Search Typeahead</label>
+      <select id="ajax-test" name="ajax-test" class="multiselect" data-init="false" multiple>
+        <option selected value="FL">Florida</option>
+      </select>
+    </div>
+
+  </div>
+</div>
+
+<script>
+  var cachedTerm,
+    cachedData,
+    cachingEnabled = true;
+
+  function getCacheSetting() {
+    return $('#caching-on').prop('checked');
+  }
+
+  function resetCache() {
+    cachedTerm = undefined;
+    cachedData = undefined;
+    console.log('Multiselect search term/data cache has been cleared');
+  }
+
+  // Source method implementation that contains support for caching search terms/retreived data.
+  function callExternalSource(response, term) {
+    if (cachingEnabled && cachedData && cachedTerm === term) {
+      console.log('Using cached data for search term "' + term + '" instead of performing a new search...');
+      response(cachedData);
+      return;
+    }
+
+    cachedTerm = term;
+
+    var apiRoute = '{{basepath}}api/states-multiselect';
+    if (term && typeof term === 'string' && term.length) {
+      apiRoute += '?term=' + term;
+    }
+
+    console.log('Searching for term: "' + term + '".');
+    $.getJSON(apiRoute, function(data) {
+      cachedData = data;
+      response(data);
+    });
+  }
+
+  $('body').on('initialized', function() {
+    // Tie the external source method to the multiselect
+    $('#ajax-test').multiselect({
+      source: callExternalSource,
+      attributes: [{'name': 'id', 'value': 'SomeIdPrefix'}],
+      showSearchUnderSelected: true,
+      reload: 'typeahead'
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[Datagrid]` When fixing bugs in datagrid hover states we removed the use of `is-focused` on table `td` elements. ([#5091](https://github.com/infor-design/enterprise/issues/5091))
 - `[Datagrid/Lookup]` Fixed a bug where the plus minus icon animation was cut off. ([#4962](https://github.com/infor-design/enterprise/issues/4962))
 - `[Datagrid]` Fixed a bug where unselecting all items in an active page affects other selected items on other pages. ([#4503](https://github.com/infor-design/enterprise/issues/4503))
+- `[Dropdown/Multiselect]` Fixed a bug where the id attribute prefix were missing from the dropdown list when searching with typeahead settings. ([#5053](https://github.com/infor-design/enterprise/issues/5053))
 - `[Homepage]` Fixed an issue where remove card event was not triggered on card/widget. ([#4798](https://github.com/infor-design/enterprise/issues/4798))
 - `[Locale]` Changed the start day of the week to monday as per translation team request. ([#5199](https://github.com/infor-design/enterprise/issues/5199))
 - `[Mask/Datagrid]` Fixed a bug in number masks where entering a decimal while the field's entire text content was selected could cause unexpected formatting. ([#4974](https://github.com/infor-design/enterprise/issues/4974))

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -970,6 +970,15 @@ Dropdown.prototype = {
       this.searchInput = this.list.find('#dropdown-search');
     } else {
       this.listUl.html(ulContents);
+
+      if (self.settings.attributes) {
+        const options = this.listUl.find('.dropdown-option a');
+
+        options.each(function (i) {
+          const opt = $(this);
+          utils.addAttributes(opt, self, self.settings.attributes, `option-${i}`, true);
+        });
+      }
     }
 
     if (env.os.name === 'ios' || env.os.name === 'android') {

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -808,3 +808,32 @@ describe('Dropdown "No Search" stay-open behavior', () => {
     expect(await element.all(by.css('div.dropdown span')).first().getText()).toBe('');
   });
 });
+
+describe('Dropdown typeahead tests with automation id', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/dropdown/test-typeahead-automation-id');
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  if (!utils.isSafari()) {
+    it('Should be able to set the prefix id with typeahead settings', async () => {
+      const dropdownEl = await element(by.css('div.dropdown'));
+      await browser.driver
+        .wait(protractor.ExpectedConditions.presenceOf(dropdownEl), config.waitsFor);
+      await browser.driver.sleep(config.sleep);
+      await dropdownEl.click();
+      await browser.driver.sleep(config.sleep);
+
+      const dropdownListSearchEl = await element(by.css('.dropdown-search'));
+      await dropdownListSearchEl.sendKeys('a');
+      await browser.driver.sleep(config.sleep);
+
+      expect(await element(by.id('SomeIdPrefix-option-0')).getAttribute('id')).toEqual('SomeIdPrefix-option-0');
+      expect(await element(by.id('SomeIdPrefix-option-1')).getAttribute('id')).toEqual('SomeIdPrefix-option-1');
+      expect(await element(by.id('SomeIdPrefix-option-2')).getAttribute('id')).toEqual('SomeIdPrefix-option-2');
+    });
+  }
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR Fixes a bug where the prefix id were missing in dropdown list when searching with typeahead settings. This fixes both dropdown and multiselect.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5053

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app

1.) Test in Dropdown component
- Go to http://localhost:4000/components/dropdown/test-typeahead-automation-id
- Open dropdown and search
- Then check the elements, it should have the prefix id for all the list items

2.) Test in Multiselect component
- Go to http://localhost:4000/components/multiselect/test-typeahead-automation-id
- Open the multiselect and search
- Check the elements, it should have the prefix id for all the list items

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
