### PR TITLE
5095 - Enable highlighting of blank dropdown options

### DIFF
--- a/app/views/components/dropdown/test-virtual-scroll-blank-option.html
+++ b/app/views/components/dropdown/test-virtual-scroll-blank-option.html
@@ -1,0 +1,34 @@
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="field">
+      <label for="big-dropdown">Test Dropdown with tooltips and 12000 items</label>
+      <select id="big-dropdown" name="big-dropdown" class="dropdown">
+      </select>
+    </div>
+
+  </div>
+</div>
+
+<script>
+  var ele = $('#big-dropdown');
+  var markup = '';
+  for (var i = 0; i < 12000; i++) {
+    if (i === 0) {
+      markup += `<option value="blank"></option>`;
+    } else {
+      var date = new Date();
+      date.setDate(date.getDate() + i);
+      markup += `<option value="option${i}" title="${date}">${date}</option>`;
+    }
+  }
+
+  ele.append(markup).dropdown({ width: 420, virtualScroll: true }).on('change', function (e, args) {
+    $('body').toast({
+      'title': 'Change Event Fired',
+      'message': 'Value changed to <span class="text-strong">' + $(this)[0].selectedOptions[0].innerText + '</span> '
+    });
+  });
+
+  $('body').initialize();
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[Datagrid]` When fixing bugs in datagrid hover states we removed the use of `is-focused` on table `td` elements. ([#5091](https://github.com/infor-design/enterprise/issues/5091))
 - `[Datagrid/Lookup]` Fixed a bug where the plus minus icon animation was cut off. ([#4962](https://github.com/infor-design/enterprise/issues/4962))
 - `[Datagrid]` Fixed a bug where unselecting all items in an active page affects other selected items on other pages. ([#4503](https://github.com/infor-design/enterprise/issues/4503))
+- `[Dropdown]` Fixed a bug where automatic highlighting of a blank option after opening the list was not working ([#5095](https://github.com/infor-design/enterprise/issues/5095))
 - `[Homepage]` Fixed an issue where remove card event was not triggered on card/widget. ([#4798](https://github.com/infor-design/enterprise/issues/4798))
 - `[Locale]` Changed the start day of the week to monday as per translation team request. ([#5199](https://github.com/infor-design/enterprise/issues/5199))
 - `[Mask/Datagrid]` Fixed a bug in number masks where entering a decimal while the field's entire text content was selected could cause unexpected formatting. ([#4974](https://github.com/infor-design/enterprise/issues/4974))

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -2765,15 +2765,12 @@ Dropdown.prototype = {
     // Set activedescendent for new option
     this.searchInput.attr('aria-activedescendant', listOption.children('a').attr('id'));
 
-    const isEmpty = (option.val() === '' || listOption.attr('data-val') === '' || option.hasClass('clear'));
-    if (!isEmpty) {
-      this.setItemIconOverColor(listOption);
-      listOption.addClass('is-focused')
-        .children('a').attr({ tabindex: '0' });
+    this.setItemIconOverColor(listOption);
+    listOption.addClass('is-focused')
+      .children('a').attr({ tabindex: '0' });
 
-      if (!noScroll || noScroll === false || noScroll === undefined) {
-        this.scrollToOption(listOption);
-      }
+    if (!noScroll || noScroll === false || noScroll === undefined) {
+      this.scrollToOption(listOption);
     }
   },
 

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -762,12 +762,12 @@ describe('Dropdown "No Search" stay-open behavior', () => {
 
     expect(await element(by.className('is-focused')).getText()).toEqual('93');
 
-    // Try to find one that doesn't exist.  All items will become unhighlighted.
+    // Try to find one that doesn't exist. The blank item will become highlighted.
     await searchInput.click();
     await searchInput.clear().sendKeys('104');
     await browser.driver.sleep(config.sleep);
 
-    expect(await element(by.className('is-focused')).isPresent()).toBeFalsy();
+    expect(await element(by.className('is-focused')).getText()).toEqual(' ');
   });
 
   it('can select keyed values with ENTER', async () => {

--- a/test/components/dropdown/dropdown.e2e-spec.js
+++ b/test/components/dropdown/dropdown.e2e-spec.js
@@ -808,3 +808,29 @@ describe('Dropdown "No Search" stay-open behavior', () => {
     expect(await element.all(by.css('div.dropdown span')).first().getText()).toBe('');
   });
 });
+
+describe('Dropdown blank option tests', () => {
+  it('Highlights the blank option when the list is opened', async () => {
+    await utils.setPage('/components/dropdown/test-blank-initially.html?layout=nofrills');
+    await utils.checkForErrors();
+
+    const dropdownEl = await element(by.css('div.dropdown'));
+    await dropdownEl.click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.id('dropdown-list'))), config.waitsFor);
+
+    expect(await element(by.css('.dropdown-option.is-selected')).getAttribute('data-val')).toBe('blank');
+  });
+
+  it('Highlights the blank option when the list is opened and virtual scrolling is enabled', async () => {
+    await utils.setPage('/components/dropdown/test-virtual-scroll-blank-option.html?layout=nofrills');
+    await utils.checkForErrors();
+
+    const dropdownEl = await element(by.css('div.dropdown'));
+    await dropdownEl.click();
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(element(by.id('dropdown-list'))), config.waitsFor);
+
+    expect(await element(by.css('.dropdown-option.is-selected')).getAttribute('data-val')).toBe('blank');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a bug in Dropdown where it wasn't possible for the dropdown to highlight blank options in the list when the list opened. This is now possible.

**Related github/jira issue (required)**:
Closes #5095

**Steps necessary to review your pull request (required)**:
- Pull, build, run!
- Open http://localhost:4000/components/dropdown/test-blank-option.html
- Open the dropdown list.  The second option "Alabama" should be highlighted in blue.
- Press the up arrow key once to highlight the blank option.
- Press "Enter" on the keyboard.  The blank option should become selected and the list should close.
- Re-open the menu. The blank option should remain highlighted in blue.
- Test this on Virtual Scrolling as well: http://localhost:4000/components/dropdown/test-virtual-scroll-blank-option.html

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
