### PR TITLE
5139 - Fix misalignment of (colorpicker, clearable input, clearable searchfield) on field options

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Datagrid/Lookup]` Fixed a bug where the plus minus icon animation was cut off. ([#4962](https://github.com/infor-design/enterprise/issues/4962))
 - `[Datagrid]` Fixed a bug where unselecting all items in an active page affects other selected items on other pages. ([#4503](https://github.com/infor-design/enterprise/issues/4503))
 - `[Dropdown/Multiselect]` Fixed a bug where the id attribute prefix were missing from the dropdown list when searching with typeahead settings. ([#5053](https://github.com/infor-design/enterprise/issues/5053))
+- `[Field Options]` Fixed misalignment of field options of the colorpicker, clearable input field, and clearable searchfield with its close icon. ([#5139](https://github.com/infor-design/enterprise/issues/5139))
 - `[Homepage]` Fixed an issue where remove card event was not triggered on card/widget. ([#4798](https://github.com/infor-design/enterprise/issues/4798))
 - `[Locale]` Changed the start day of the week to monday as per translation team request. ([#5199](https://github.com/infor-design/enterprise/issues/5199))
 - `[Mask/Datagrid]` Fixed a bug in number masks where entering a decimal while the field's entire text content was selected could cause unexpected formatting. ([#4974](https://github.com/infor-design/enterprise/issues/4974))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@
 - `[Datagrid/Lookup]` Fixed a bug where the plus minus icon animation was cut off. ([#4962](https://github.com/infor-design/enterprise/issues/4962))
 - `[Datagrid]` Fixed a bug where unselecting all items in an active page affects other selected items on other pages. ([#4503](https://github.com/infor-design/enterprise/issues/4503))
 - `[Dropdown/Multiselect]` Fixed a bug where the id attribute prefix were missing from the dropdown list when searching with typeahead settings. ([#5053](https://github.com/infor-design/enterprise/issues/5053))
-- `[Field Options]` Fixed misalignment of field options of the colorpicker, clearable input field, and clearable searchfield with its close icon. ([#5139](https://github.com/infor-design/enterprise/issues/5139))
+- `[Field Options]` Fixed misalignment of field options for the colorpicker, clearable input field, and clearable searchfield with its close icon. ([#5139](https://github.com/infor-design/enterprise/issues/5139))
 - `[Homepage]` Fixed an issue where remove card event was not triggered on card/widget. ([#4798](https://github.com/infor-design/enterprise/issues/4798))
 - `[Locale]` Changed the start day of the week to monday as per translation team request. ([#5199](https://github.com/infor-design/enterprise/issues/5199))
 - `[Mask/Datagrid]` Fixed a bug in number masks where entering a decimal while the field's entire text content was selected could cause unexpected formatting. ([#4974](https://github.com/infor-design/enterprise/issues/4974))

--- a/src/components/field-options/_field-options-new.scss
+++ b/src/components/field-options/_field-options-new.scss
@@ -35,7 +35,7 @@
   .colorpicker-container {
     + .btn-actions {
       left: -12px;
-      top: -13px;
+      top: -10px;
       width: $input-size-regular-height;
     }
   }
@@ -53,9 +53,22 @@
     top: 0;
   }
 
-  .field-options ~ .close ~ .btn-actions {
-    left: -12px;
-    top: 0;
+  .field-options {
+    ~ .close {
+      &:not(.is-empty) {
+        top: 0;
+
+        ~ .btn-actions {
+          left: -36px;
+          top: 0;
+        }
+      }
+      &.is-empty {
+        ~ .btn-actions {
+          left: -12px;
+        }
+      }
+    }
   }
 
   [data-clearable='true'] + .icon.close {
@@ -69,6 +82,13 @@
     .btn-actions {
       left: -7px;
       width: $input-size-regular-height;
+    }
+
+    .btn-icon {
+      &.close:not(.is-empty) {
+        right: 45px;
+        top: 7px;
+      }
     }
   }
 

--- a/src/components/field-options/_field-options.scss
+++ b/src/components/field-options/_field-options.scss
@@ -208,7 +208,7 @@
   .colorpicker-container {
     ~ .btn-actions {
       left: -10px;
-      top: -13px;
+      top: -10px;
       width: $input-size-regular-height;
     }
   }
@@ -249,6 +249,12 @@
       left: -7px;
       top: -1px;
     }
+
+    .btn-icon {
+      &.close:not(.is-empty) {
+        right: 45px;
+      }
+    }
   }
 
   .spinbox-wrapper {
@@ -282,8 +288,18 @@
 
   // Clearable Inputs that are not Searchfields
   [data-clearable='true'] {
+    ~ .btn-icon {
+      top: 0;
+      transform: none;
+
+      &:not(.is-empty) {
+        ~ .btn-actions {
+          left: -34px;
+        }
+      }
+    }
     ~ .btn-actions {
-      left: -5px;
+      left: -10px;
     }
 
     ~ .icon.close.is-empty ~ .btn-actions {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes multiple UI misalignments
- Colorpicker field options
- Clearable input field options once close button is visible
- Clearable searchfield close button

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5139

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/field-options/example-no-init.html
- Find the `Color Picker`, then hover on it to show the field options button, then click to trigger
- Field options should align with colorpicker input
- Find `Clearable Input`, then do a search
- Field options should align with clearable input
- Find `Clearable Searchfield`, then do a search
- Close button should align inside of the input

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
