### PR TITLE
5067 - Fix rendering of UI on different row height (Changing selectable mode from single to mixed, vice versa)

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5546,9 +5546,16 @@ Datagrid.prototype = {
     this.tableBody.find(`> tr > td:nth-child(${idx - frozenLeft + 1})`).removeClass('is-hidden');
     this.bodyColGroup.find('col').eq(idx - frozenLeft).removeClass('is-hidden');
 
-    if (frozenLeft) this.tableBodyLeft.find(`> tr > td:nth-child(${idx + 1})`).removeClass('is-hidden');
-    if (this.headerNodeCheckbox) this.headerRowLeft?.find('> tr').prepend(this.headerNodeCheckbox);
-    if (this.bodyNodeCheckboxes) this.tableBodyLeft?.find('> tr').prepend(this.bodyNodeCheckboxes[idx]);
+    if (frozenLeft) {
+      this.tableBodyLeft.find(`> tr > td:nth-child(${idx + 1})`).removeClass('is-hidden');
+
+      if (this.headerNodeCheckbox && !this.headerRowLeft.find(`> tr th:nth-child(${idx + 1}) .datagrid-checkbox-wrapper`).length) {
+        this.headerRowLeft?.find('> tr').prepend(this.headerNodeCheckbox);
+      }
+      if (this.bodyNodeCheckboxes && !this.tableBodyLeft.find(`> tr td:nth-child(${idx + 1}) .datagrid-checkbox-wrapper`).length) {
+        this.tableBodyLeft?.find('> tr').prepend(this.bodyNodeCheckboxes[idx]);
+      }
+    }
 
     // Shrink or add colgroups
     this.updateColumnGroup(idx, true);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This is a follow up fix for https://github.com/infor-design/enterprise/issues/5067 PR (https://github.com/infor-design/enterprise/pull/5203)

QA saw that the checkbox was being added to the next column when changing the row height.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5067
Related PR https://github.com/infor-design/enterprise/pull/5203

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-change-selectable-with-frozen-columns.html
- Toggle the `Switch Select Mode` to activate the `mixed`
- Then toggle again it to activate `single`
- Change the row height to `Extra Small`
- Click again the `Switch Select Mode`
- It should render the UI correctly
- Play around the row height to make sure it will render correctly

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
