### PR TITLE
5139 - Additional fix for field options on Safari, Firefox, and Edge

### DIFF
--- a/src/components/field-options/_field-options-new.scss
+++ b/src/components/field-options/_field-options-new.scss
@@ -367,21 +367,6 @@
     }
   }
 
-  .field.is-fieldoptions {
-    .colorpicker-container {
-      ~ .btn-actions {
-        top: 1px;
-      }
-    }
-
-    .field-options ~ .close,
-    input[type='text'][readonly]:not(.fileupload) {
-      ~ .btn-actions {
-        top: 0;
-      }
-    }
-  }
-
   .field-short.is-fieldoptions,
   .form-layout-compact .field.is-fieldoptions {
     .field-options ~ .close ~ .btn-actions,

--- a/src/components/field-options/_field-options-new.scss
+++ b/src/components/field-options/_field-options-new.scss
@@ -188,7 +188,6 @@
 
     .colorpicker-container ~ .btn-actions {
       left: -12px !important;
-      top: -13px !important;
     }
   }
 

--- a/src/components/field-options/_field-options.scss
+++ b/src/components/field-options/_field-options.scss
@@ -761,12 +761,6 @@
   }
 
   .field.is-fieldoptions {
-    .colorpicker-container {
-      ~ .btn-actions {
-        top: 0;
-      }
-    }
-
     .field-options ~ .close,
     input[type='text'][readonly]:not(.fileupload) {
       ~ .btn-actions {

--- a/src/components/field-options/_field-options.scss
+++ b/src/components/field-options/_field-options.scss
@@ -699,7 +699,7 @@
     .colorpicker-container {
       ~ .btn-actions {
         left: -11px;
-        top: -14px;
+        top: -10px;
       }
     }
 
@@ -813,6 +813,14 @@
     .field-options {
       ~ .btn-actions:not(.is-checkbox) {
         top: auto;
+      }
+    }
+
+    .searchfield-wrapper {
+      input.field-options {
+        ~ .btn-actions.btn-menu {
+          top: 0;
+        }
       }
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR is a follow up fix on Safari, Firefox, and Edge issue in Field Options Colorpicker and clearable input.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5139, https://github.com/infor-design/enterprise/issues/5138
Related PR https://github.com/infor-design/enterprise/pull/5216

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Open on Safari, Firefox and Edge
- Go to http://localhost:4000/components/field-options/example-no-init.html
- Find the `Color Picker`, then hover on it to show the field options button, then click to trigger
- Field options should align with colorpicker input
- Find `Clearable Input`, then do a search
- Field options should align with clearable input
- Find `Clearable Searchfield`, then do a search
- Close button should align inside of the input

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
