### PR TITLE
Missing Event Highlight in Calendar Week View and Day View

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### v4.52.0 Fixes
 
 - `[About]` Fixed a bug where overflowing scrollbar in About Modal is shown on a smaller viewport. ([#5206](https://github.com/infor-design/enterprise/issues/5206))
+- `[Calendar]` Fixed a bug where if the calendar event is not set to whole day then the week view and day view will not properly render on UI. ([#5195](https://github.com/infor-design/enterprise/issues/5195))
 - `[Datagrid]` Fixed a bug where changing a selection mode between single and mixed on a datagrid with frozen columns were not properly rendered on UI. ([#5067](https://github.com/infor-design/enterprise/issues/5067))
 - `[Datagrid]` Fixed a bug where filter options were not opening anymore after doing sorting on server-side paging. ([#5073](https://github.com/infor-design/enterprise/issues/5073))
 - `[Lookup/Datagrid]` Fixed a bug where unselecting all items in an active page affects other selected items on other pages. ([#4503](https://github.com/infor-design/enterprise/issues/4503))

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -642,6 +642,7 @@ Calendar.prototype = {
     this.renderSelectedEventDetails();
     if (this.weekView) {
       this.weekView.settings.filteredTypes = filters;
+      this.weekView.settings.events = this.settings.events;
       this.weekView.renderAllEvents();
     }
     return this;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes a bug where if the calendar event is not set to whole day then the week view and day view will not properly render on UI.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5195

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/calendar/example-index.html
- Create an event `Add Event API`
- Click to Edit the newly created event
- Unchecked `All day` option to edit the time
- Change the time to 7am - 12pm
- Switch to WeekView or DayView
- Should be working by now and properly rendered

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

