### PR TITLE
5138 - Fix close icon position in searchfield with field options

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `[Dropdown]` Fixed a bug where automatic highlighting of a blank option after opening the list was not working ([#5095](https://github.com/infor-design/enterprise/issues/5095))
 - `[Dropdown/Multiselect]` Fixed a bug where the id attribute prefix were missing from the dropdown list when searching with typeahead settings. ([#5053](https://github.com/infor-design/enterprise/issues/5053))
 - `[Field Options]` Fixed misalignment of field options for the colorpicker, clearable input field, and clearable searchfield with its close icon. ([#5139](https://github.com/infor-design/enterprise/issues/5139))
+- `[Field Options]` Fixed misalignment of close button in searchfield with field options. ([#5138](https://github.com/infor-design/enterprise/issues/5138))
 - `[Homepage]` Fixed an issue where remove card event was not triggered on card/widget. ([#4798](https://github.com/infor-design/enterprise/issues/4798))
 - `[Locale]` Changed the start day of the week to monday as per translation team request. ([#5199](https://github.com/infor-design/enterprise/issues/5199))
 - `[Mask/Datagrid]` Fixed a bug in number masks where entering a decimal while the field's entire text content was selected could cause unexpected formatting. ([#4974](https://github.com/infor-design/enterprise/issues/4974))

--- a/src/components/field-options/_field-options-new.scss
+++ b/src/components/field-options/_field-options-new.scss
@@ -186,11 +186,18 @@
       }
     }
 
+    .searchfield-wrapper {
+      .field-options.searchfield ~ .btn-actions {
+        top: auto;
+      }
+    }
+
     .colorpicker-container ~ .btn-actions {
       left: -12px !important;
     }
   }
 
+  // Compact Mode for Firefox
   .field-short.is-fieldoptions,
   .form-layout-compact .field.is-fieldoptions {
     .btn-actions:not(.is-checkbox) {
@@ -199,6 +206,18 @@
 
       .icon {
         top: -5px;
+      }
+    }
+
+    input[type='text'].field-options[data-clearable='true'] {
+      ~ .btn-icon.close {
+        top: 4px;
+      }
+    }
+
+    .searchfield-wrapper .field-options.searchfield {
+      ~ .btn-icon.close ~ .btn-actions {
+        top: 2px !important;
       }
     }
 
@@ -239,19 +258,33 @@
     .field-short.is-fieldoptions,
     .form-layout-compact .field.is-fieldoptions {
       .btn-actions:not(.is-checkbox) {
-        top: 5px !important;
+        top: 2px !important;
       }
 
       .field-options.dropdown ~ .btn-actions,
       .field-options.multiselect ~ .btn-actions {
-        top: 3px !important;
+        top: 0 !important;
       }
 
       .field-options ~ .close ~ .icon ~ .btn-actions {
         top: 5px !important;
       }
 
+      .field-options.spinbox ~ .btn-actions {
+        left: -1px !important;
+        top: 5px !important;
+      }
+
+      .field-options.fileupload ~ .btn-actions {
+        left: -1px !important;
+      }
+
+      .field-options.lookup ~ .btn-actions {
+        left: -1px;
+      }
+
       .colorpicker-container ~ .btn-actions {
+        left: -1px !important;
         top: -4px !important;
       }
 
@@ -262,6 +295,13 @@
 
       .textarea ~ .btn-actions:not(.is-checkbox) {
         top: calc(50% - 0px) !important;
+      }
+    }
+
+    .field-short.is-fieldoptions,
+    .form-layout-compact {
+      .radio-group .field-options + .btn-actions {
+        left: -10px !important;
       }
     }
   }
@@ -286,14 +326,15 @@
     }
   }
 
-  input[type='text']:not(.spinbox) {
+  input[type='text']:not(.spinbox):not(.searchfield) {
     ~ .btn-actions {
-      left: -1px;
+      left: -1px !important;
+      top: 1px;
     }
 
     &[data-clearable='true'] ~ .btn-icon:not(.is-empty) {
       ~ .btn-actions {
-        left: -25px;
+        left: -25px !important;
       }
     }
   }
@@ -405,7 +446,8 @@
 .ie,
 .ie-edge,
 .ie-edge17 {
-  :not(.form-layout-compact) {
+  // Non Compact Mode
+  form:not(.form-layout-compact) {
     .field.is-fieldoptions {
       .dropdown-wrapper {
         ~ .btn-actions:not(.is-checkbox) {
@@ -448,16 +490,37 @@
     }
   }
 
+  // Compact Mode
   .form-layout-compact .field.is-fieldoptions {
-    .dropdown,
-    .multiselect {
-      .btn-actions:not(.is-checkbox) {
+    .btn-actions:not(.is-checkbox) {
+      left: -1px !important;
+    }
+
+    input[type='text'][data-clearable='true'] {
+      ~ button.close:not(.is-empty) {
+        ~ .btn-actions {
+          left: -25px !important;
+        }
+      }
+    }
+
+    .field-options.textarea {
+      ~ .btn-actions {
+        left: auto !important;
+      }
+    }
+
+    .field-options.dropdown,
+    .field-options.multiselect {
+      ~ .btn-actions:not(.is-checkbox) {
         top: 0;
       }
     }
 
-    .btn-actions:not(.is-checkbox) {
-      left: -1px !important;
+    .field-options.fileupload {
+      ~ .btn-actions {
+        left: -1px !important;
+      }
     }
   }
 

--- a/src/components/field-options/_field-options-new.scss
+++ b/src/components/field-options/_field-options-new.scss
@@ -271,13 +271,38 @@
 .field-short.is-fieldoptions,
 .form-layout-compact .field.is-fieldoptions {
   .btn-actions:not(.is-checkbox) {
-    left: -4px !important;
+    left: -1px;
     top: 1px;
   }
 
   .dropdown ~ .btn-actions,
   .multiselect ~ .btn-actions {
-    top: 3px;
+    top: 0;
+  }
+
+  .lookup-wrapper input[type='text'].lookup.field-options {
+    ~ .btn-actions {
+      top: 1px;
+    }
+  }
+
+  input[type='text']:not(.spinbox) {
+    ~ .btn-actions {
+      left: -1px;
+    }
+
+    &[data-clearable='true'] ~ .btn-icon:not(.is-empty) {
+      ~ .btn-actions {
+        left: -25px;
+      }
+    }
+  }
+
+  .searchfield-wrapper.has-close-icon-button {
+    .btn-icon.close:not(.is-empty) {
+      right: 41px;
+      top: 3px;
+    }
   }
 
   .spinbox-wrapper .btn-actions {
@@ -289,7 +314,7 @@
   }
 
   .colorpicker-container ~ .btn-actions {
-    top: -8px;
+    top: -5px;
   }
 
   .checkbox ~ .btn-actions {
@@ -308,7 +333,7 @@
 
   .searchfield-wrapper.has-focus:not(.toolbar-searchfield-wrapper) .btn-actions,
   .searchfield-wrapper .btn-actions {
-    left: -4px !important;
+    left: -1px !important;
   }
 
   .searchfield-wrapper.has-close-icon-button .searchfield {
@@ -321,13 +346,13 @@
   .textarea ~ .btn-actions,
   .textarea ~ .btn-actions {
     left: auto !important;
-    margin-left: -4px;
+    margin-left: -1px;
     top: calc(50% - 2px);
   }
 
   .fileupload {
     ~ .trigger-close:not(.is-visible) ~ .btn-actions {
-      left: -4px !important;
+      left: -1px;
     }
 
     ~ .trigger-close.is-visible ~ .btn-actions {
@@ -373,5 +398,70 @@
     .colorpicker-container ~ .btn-actions {
       top: 1px;
     }
+  }
+}
+
+// Edge
+.ie,
+.ie-edge,
+.ie-edge17 {
+  :not(.form-layout-compact) {
+    .field.is-fieldoptions {
+      .dropdown-wrapper {
+        ~ .btn-actions:not(.is-checkbox) {
+          top: 2px;
+        }
+      }
+  
+      .lookup-wrapper,
+      .spinbox-wrapper {
+        .btn-actions:not(.is-checkbox) {
+          left: -9px;
+        }
+      }
+
+      button.close:not(.is-empty) {
+        ~ .btn-actions:not(.is-checkbox) {
+          left: -36px;
+        }
+      }
+
+      textarea {
+        ~ .btn-actions:not(.is-checkbox) {
+          left: auto;
+        }
+      }
+  
+      .btn-actions:not(.is-checkbox) {
+        left: -12px;
+      }
+    }
+
+    .compound-field {
+      .field.is-fieldoptions {
+        input[type='text'] {
+          ~ .btn-actions:not(.is-checkbox) {
+            top: 0;
+          }
+        }
+      }
+    }
+  }
+
+  .form-layout-compact .field.is-fieldoptions {
+    .dropdown,
+    .multiselect {
+      .btn-actions:not(.is-checkbox) {
+        top: 0;
+      }
+    }
+
+    .btn-actions:not(.is-checkbox) {
+      left: -1px !important;
+    }
+  }
+
+  .dropdown-list.dropdown-short .trigger .icon {
+    left: -1px;
   }
 }

--- a/src/components/field-options/_field-options.scss
+++ b/src/components/field-options/_field-options.scss
@@ -43,6 +43,8 @@
 
 .field-options {
   max-width: ($field-md - 40px);
+  text-overflow: ellipsis;
+  white-space: nowrap;
   width: calc(100% - 40px);
 
   &.input-xs {
@@ -318,8 +320,8 @@
 .field-short.is-fieldoptions,
 .form-layout-compact .field.is-fieldoptions {
   .btn-actions:not(.is-checkbox) {
-    left: -3px;
-    top: 1px;
+    left: -2px;
+    top: 2px;
     width: $input-size-compact-height;
 
     .icon {
@@ -329,12 +331,37 @@
 
   .dropdown ~ .btn-actions,
   .multiselect ~ .btn-actions {
-    top: 2px;
+    top: 1px;
+  }
+
+  .lookup-wrapper {
+    input[type='text'].lookup.field-options {
+      ~ .btn-actions {
+        top: 2px;
+      }
+    }
+  }
+
+  input[type='text']:not(.spinbox):not(.searchfield) {
+    padding: 0 21px 0 5px;
+
+    ~ .btn-actions {
+      top: 1px;
+    }
+
+    &[data-clearable='true'] ~ .btn-icon:not(.is-empty) {
+      right: 25px;
+      top: 1px;
+
+      ~ .btn-actions {
+        left: -26px;
+      }
+    }
   }
 
   .colorpicker-container ~ .btn-actions {
-    left: -3px;
-    top: -8px;
+    left: -2px;
+    top: -5px;
     width: $input-size-compact-height;
   }
 
@@ -342,7 +369,7 @@
     box-shadow: none;
 
     .btn-actions {
-      top: 5px;
+      top: 6px;
     }
   }
 
@@ -353,7 +380,7 @@
 
   .fileupload {
     ~ .trigger-close:not(.is-visible) ~ .btn-actions {
-      left: -3px !important;
+      left: -2px !important;
     }
 
     ~ .trigger-close.is-visible ~ .btn-actions {
@@ -376,8 +403,13 @@
 
   .searchfield-wrapper.has-focus:not(.toolbar-searchfield-wrapper),
   .searchfield-wrapper {
+    .btn-icon.close {
+      right: 41px;
+      top: 13px;
+    }
+
     .btn-actions {
-      left: -3px;
+      left: -2px;
       top: 1px;
     }
 
@@ -398,8 +430,16 @@
 
   .textarea ~ .btn-actions {
     left: auto;
-    margin-left: -3px;
+    margin-left: -2px;
     top: calc(50% - 2px);
+  }
+}
+
+.form-layout-compact {
+  .radio-group {
+    .btn-actions {
+      left: -10px;
+    }
   }
 }
 
@@ -810,20 +850,6 @@
 // IE
 .ie {
   .field.is-fieldoptions {
-    .field-options {
-      ~ .btn-actions:not(.is-checkbox) {
-        top: auto;
-      }
-    }
-
-    .searchfield-wrapper {
-      input.field-options {
-        ~ .btn-actions.btn-menu {
-          top: 0;
-        }
-      }
-    }
-
     .dropdown,
     .multiselect {
       ~ .btn-actions:not(.is-checkbox) {
@@ -831,28 +857,9 @@
       }
     }
 
-    .datepicker,
-    .timepicker,
-    .lookup,
-    .field-options ~ .close {
-      ~ .btn-actions:not(.is-checkbox) {
-        top: -1px;
-      }
-    }
-
     .textarea {
       ~ .btn-actions:not(.is-checkbox) {
         top: calc(50% - 6px);
-      }
-    }
-  }
-
-  .compound-field {
-    .field.is-fieldoptions {
-      input[type='text'] {
-        ~ .btn-actions:not(.is-checkbox) {
-          top: -1px;
-        }
       }
     }
   }
@@ -867,7 +874,7 @@
 
   .radio-group {
     .btn-actions {
-      left: -9px;
+      left: -10px;
     }
   }
 

--- a/src/components/field-options/_field-options.scss
+++ b/src/components/field-options/_field-options.scss
@@ -823,6 +823,13 @@
         top: -1px;
       }
     }
+
+    .dropdown,
+    .multiselect {
+      ~ .btn-actions {
+        top: 0;
+      }
+    }
   }
 
   .radio-group {
@@ -841,10 +848,32 @@
 
   .form-layout-compact {
     .field.is-fieldoptions {
-      .colorpicker-container ~ .btn-actions,
+      .colorpicker-container ~ .btn-actions {
+        top: -5px;
+      }
+
       input[type='text'] ~ .btn-actions:not(.is-checkbox) {
         top: 1px;
       }
+
+      .lookup-wrapper input[type='text'].lookup.field-options {
+        ~ .btn-actions {
+          top: 1px !important;
+        }
+      }
+
+      .field-options.textarea {
+        ~ .btn-actions {
+          left: 260px;
+        }
+      }
+
+      .dropdown,
+      .multiselect {
+      ~ .btn-actions {
+        top: 1px;
+      }
+    }
 
       .spinbox-wrapper .btn-actions {
         top: 5px !important;

--- a/src/components/field-options/_field-options.scss
+++ b/src/components/field-options/_field-options.scss
@@ -342,11 +342,17 @@
     }
   }
 
-  input[type='text']:not(.spinbox):not(.searchfield) {
-    padding: 0 21px 0 5px;
-
+  input[type='text'][data-clearable='true'] ~ .btn-icon.close {
     ~ .btn-actions {
       top: 1px;
+    }
+  }
+
+  input[type='text']:not(.spinbox):not(.searchfield) {
+    padding: 0 22px 0 5px;
+
+    ~ .btn-actions {
+      top: 2px;
     }
 
     &[data-clearable='true'] ~ .btn-icon:not(.is-empty) {
@@ -430,7 +436,7 @@
 
   .textarea ~ .btn-actions {
     left: auto;
-    margin-left: -2px;
+    margin-left: -1px;
     top: calc(50% - 2px);
   }
 }
@@ -676,7 +682,7 @@
 
       &.dropdown ~ .btn-actions,
       &.multiselect ~ .btn-actions {
-        top: 2px;
+        top: 1px !important;
       }
 
       ~ .btn-actions:not(.is-checkbox) .icon {
@@ -691,6 +697,12 @@
 
     .colorpicker-container ~ .btn-actions {
       top: -8px;
+    }
+
+    .searchfield-wrapper .field-options.searchfield {
+      ~ .btn-icon.close ~ .btn-actions {
+        top: 0 !important;
+      }
     }
 
     .searchfield-wrapper .btn-actions,
@@ -763,6 +775,10 @@
       top: 2px;
     }
 
+    button.btn-icon.close svg.close.icon {
+      margin-top: 0;
+    }
+
     .field-options ~ .close,
     input[type='text'][readonly]:not(.fileupload) {
       ~ .btn-actions {
@@ -771,19 +787,19 @@
     }
 
     .lookup-wrapper .btn-actions {
-      left: -3px;
+      left: -2px;
     }
 
     .spinbox-wrapper .btn-actions {
-      left: -3px;
+      left: -1px;
       top: 5px !important;
       width: 25px;
     }
 
     .colorpicker-container {
       ~ .btn-actions {
-        left: -3px;
-        top: -7px;
+        left: -2px;
+        top: -5px;
       }
     }
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes (Compact and Non Compact Mode) on Edge
- Position of close icon in searchfield with field options
- Alignment of field options of all components in the test page

QA dm me about these issues.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5138
Related Issue https://github.com/infor-design/enterprise/issues/5139
Related PR https://github.com/infor-design/enterprise/pull/5230 https://github.com/infor-design/enterprise/pull/5216

**Steps necessary to review your pull request (required)**:
- Pull this branch build, and run the app

1.)
- Go to http://localhost:4000/components/field-options/example-index on it on Edge Browser
- Go to the clearable input and Clearable Searchfield section
- Click the field options, it should align with the input field (Test both)
- Search on it, clearable icon should align perfectly (Test both)
- Test this on Compact Mode, then follow above steps
- Additional: Test all the components to make sure field options are align correctly
- Test on Classic too

2.)
- Go to http://localhost:4000/components/field-options/example-no-init.html
- Go to the Colorpicker section
- Click the field option, it should perfectly align with the component
- Test on Classic

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
