### PR TITLE
1030 - Fix execute script with bar chart

### DIFF
--- a/app/views/components/bar-grouped/test-execute-script.html
+++ b/app/views/components/bar-grouped/test-execute-script.html
@@ -1,0 +1,71 @@
+
+<div class="row">
+  <div class="two-thirds column">
+      <div class="widget">
+        <div class="widget-header">
+          <h2 class="widget-title">Grouped Bar Chart - Image tag</h2>
+        </div>
+        <div class="widget-content">
+          <div id="bar-grouped-example" class="chart-container">
+          </div>
+        </div>
+      </div>
+  </div>
+</div>
+
+<script>
+$('body').on('initialized', function () {
+
+  var dataset = [{
+        data: [{
+            name: 'Jan',
+            value: 12,
+        }, {
+            name: 'Feb',
+            value: 11
+        }, {
+            name: 'Mar',
+            value: 14
+        }, {
+            name: 'Apr',
+            value: 10
+        }],
+        name: '<img src=x onerror=prompt(1)>'
+      }, {
+        data: [{
+            name: 'Jan',
+            value: 22,
+        }, {
+            name: 'Feb',
+            value: 21
+        }, {
+            name: 'Mar',
+            value: 24
+        }, {
+            name: 'Apr',
+            value: 20
+        }],
+        name: 'Component B'
+      }, {
+        data: [{
+            name: 'Jan',
+            value: 32
+        }, {
+            name: 'Feb',
+            value: 31
+        }, {
+            name: 'Mar',
+            value: 34
+        }, {
+            name: 'Apr',
+            value: 30
+        }],
+        name: 'Component C'
+      }];
+
+  $('#bar-grouped-example').chart({
+    type: 'bar-grouped', dataset: dataset
+  });
+
+});
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### v4.52.0 Fixes
 
 - `[About]` Fixed a bug where overflowing scrollbar in About Modal is shown on a smaller viewport. ([#5206](https://github.com/infor-design/enterprise/issues/5206))
+- `[Bar Chart]` Fixed an issue where onerror script was able to execute. ([#1030](https://github.com/infor-design/enterprise-ng/issues/1030))
 - `[Calendar]` Fixed a bug where if the calendar event is not set to whole day then the week view and day view will not properly render on UI. ([#5195](https://github.com/infor-design/enterprise/issues/5195))
 - `[Datagrid]` Fixed a bug where changing a selection mode between single and mixed on a datagrid with frozen columns were not properly rendered on UI. ([#5067](https://github.com/infor-design/enterprise/issues/5067))
 - `[Datagrid]` Fixed a bug where filter options were not opening anymore after doing sorting on server-side paging. ([#5073](https://github.com/infor-design/enterprise/issues/5073))

--- a/src/components/bar/bar.js
+++ b/src/components/bar/bar.js
@@ -819,7 +819,12 @@ Bar.prototype = {
               .attr('x', `-${brief.transX}`)
               .attr('y', '-1em')
               .attr('requiredFeatures', 'http://www.w3.org/TR/SVG11/feature#Extensibility')
-              .html(`<div class="text ellipsis" resizeable="false" xmlns="http://www.w3.org/1999/xhtml">${d.name}</div>`);
+              .html('<div class="text ellipsis" resizeable="false" xmlns="http://www.w3.org/1999/xhtml"></div>');
+            const ellipsisEl = parentNode.querySelector('.text.ellipsis');
+            if (ellipsisEl) {
+              const textContent = document.createTextNode(d.name);
+              ellipsisEl.appendChild(textContent);
+            }
           }
 
           d3.select(parentNode)

--- a/src/components/line/line.js
+++ b/src/components/line/line.js
@@ -931,7 +931,12 @@ Line.prototype = {
             .attr('x', `-${(brief.boxWidth + (this.isRTL ? 12 : 16))}`)
             .attr('y', '-1em')
             .attr('requiredFeatures', 'http://www.w3.org/TR/SVG11/feature#Extensibility')
-            .html(`<div class="text ellipsis" resizeable="false" xmlns="http://www.w3.org/1999/xhtml">${text}</div>`);
+            .html('<div class="text ellipsis" resizeable="false" xmlns="http://www.w3.org/1999/xhtml"></div>');
+          const ellipsisEl = parentNode.querySelector('.text.ellipsis');
+          if (ellipsisEl) {
+            const textContent = document.createTextNode(text);
+            ellipsisEl.appendChild(textContent);
+          }
           brief.elem = parentNode.querySelector('.text');
         } else {
           tick.textContent = charts.trimText(text, 5);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed onerror script was able to execute with bar chart.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#1030

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/bar-grouped/test-execute-script.html
- Open developer tools
- See the yAxis first entry should be `<img src=x onerror=prompt(1)>`
- In dev tools change view to `Responsive` mode (around width: 445)
- See the yAxis first entry should updated to `<img src=x one...`
- It should not execute the `prompt(1)` script


Test NG
- Pull and build NG branch ([main](https://github.com/infor-design/enterprise-ng.git))
- Copy and replace "dist" folder from `enterprise` to `⁨enterprise-ng⁩/node_modules⁩/ids-enterprise`
- Edit `enterprise-ng/src/app/chart/chart-demo.service.ts`
    - Line17 change `name: 'Schedule Adherence By Quantity',` to `name: '<img src=x onerror=prompt(1)>',`
- Compile and navigate to http://localhost:4200/ids-enterprise-ng-demo/chart
- Minimize the viewport to enable ellipsis `...` on yAxis
- See the yAxis first entry should updated to have ellipsis `...`
- It should not execute the `prompt(1)` script

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
