### PR TITLE
5138 - followup fix for UI issues with field options [4.52.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # What's New with Enterprise
 
+## v4.53.0 Fixes
+
+- `[Datepicker]` Fixed a bug where the setting attributes were missing in datepicker input and datepicker trigger on NG wrapper. ([#1044](https://github.com/infor-design/enterprise-ng/issues/1044))
+
 ## v4.52.0
 
 ### v4.52.0 Markup Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ids-enterprise",
   "slug": "ids-enterprise",
-  "version": "4.52.0-beta.0",
+  "version": "4.53.0-dev",
   "description": "Infor Design System (IDS) Enterprise Components for the web",
   "repository": {
     "type": "git",

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -194,6 +194,8 @@ DatePicker.prototype = {
 
     this.makeTabbable(this.settings.tabbable);
 
+    this.setExtraAttributes();
+
     // Enable classes and settings for week selection
     if (this.settings.range.selectWeek) {
       this.settings.selectForward = true;
@@ -562,6 +564,18 @@ DatePicker.prototype = {
       }
       this.element[0].setAttribute('placeholder', placeholder);
     }
+  },
+
+  /**
+   * Set extra attributes.
+   * @private
+   * @returns {void}
+   */
+  setExtraAttributes() {
+    if (!this.settings.attributes) return;
+
+    utils.addAttributes(this.element, this, this.settings.attributes);
+    utils.addAttributes(this.trigger, this, this.settings.attributes, 'trigger');
   },
 
   /**

--- a/src/components/field-options/_field-options-new.scss
+++ b/src/components/field-options/_field-options-new.scss
@@ -119,7 +119,7 @@
     }
 
     ~ .trigger-close.is-visible ~ .btn-actions {
-      left: 17px !important;
+      left: 16px !important;
     }
   }
 }
@@ -275,10 +275,6 @@
         top: 5px !important;
       }
 
-      .field-options.fileupload ~ .btn-actions {
-        left: -1px !important;
-      }
-
       .field-options.lookup ~ .btn-actions {
         left: -1px;
       }
@@ -326,7 +322,7 @@
     }
   }
 
-  input[type='text']:not(.spinbox):not(.searchfield) {
+  input[type='text']:not(.spinbox):not(.searchfield):not(.fileupload) {
     ~ .btn-actions {
       left: -1px !important;
       top: 1px;
@@ -397,7 +393,7 @@
     }
 
     ~ .trigger-close.is-visible ~ .btn-actions {
-      left: 25px !important;
+      left: 27px !important;
     }
   }
 }
@@ -518,6 +514,9 @@
     }
 
     .field-options.fileupload {
+      ~ .trigger-close.is-visible ~ .btn-actions {
+        left: 27px !important;
+      }
       ~ .btn-actions {
         left: -1px !important;
       }

--- a/src/components/field-options/_field-options.scss
+++ b/src/components/field-options/_field-options.scss
@@ -138,7 +138,7 @@
     }
 
     ~ .trigger-close.is-visible ~ .btn-actions {
-      left: 19px;
+      left: 18px;
     }
   }
 
@@ -348,7 +348,7 @@
     }
   }
 
-  input[type='text']:not(.spinbox):not(.searchfield) {
+  input[type='text']:not(.spinbox):not(.searchfield):not(.fileupload) {
     padding: 0 22px 0 5px;
 
     ~ .btn-actions {
@@ -390,7 +390,7 @@
     }
 
     ~ .trigger-close.is-visible ~ .btn-actions {
-      left: 26px !important;
+      left: 27px !important;
     }
   }
 
@@ -772,7 +772,7 @@
   .field-short.is-fieldoptions,
   .form-layout-compact .field.is-fieldoptions {
     .field-options ~ .btn-actions:not(.is-checkbox) {
-      top: 2px;
+      top: 1px;
     }
 
     button.btn-icon.close svg.close.icon {

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -101,6 +101,8 @@ describe('Datepicker example-index tests', () => {
     await element(by.css('#date-field-normal + .trigger')).click();
     await browser.driver.sleep(config.sleep);
 
+    expect(await element(by.id('date-field-normal')).getAttribute('data-automation-id')).toEqual('custom-automation-id');
+    expect(await element(by.id('custom-id')).getAttribute('data-automation-id')).toEqual('custom-automation-id');
     expect(await element(by.id('btn-monthyear-pane')).getAttribute('id')).toEqual('btn-monthyear-pane');
     expect(await element(by.id('custom-id-btn-cancel')).getAttribute('id')).toEqual('custom-id-btn-cancel');
     expect(await element(by.id('custom-id-btn-select')).getAttribute('id')).toEqual('custom-id-btn-select');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Follow up fix for close trigger in fileupload with field options.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5138

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/field-options/example-index
- go to fileupload section
- Open fileupload and select anything
- Click the fileupload to check the alignment with the field
- Close icon and field options should align correctly
- Test on Compact Mode

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
