### PR TITLE
5211 - Fixed Bug Issue in Mobile Selection Range Rendering

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### v4.52.0 Markup Changes
 
 - `[Datagrid]` When fixing bugs in datagrid hover states we removed the use of `is-focused` on table `td` elements. ([#5091](https://github.com/infor-design/enterprise/issues/5091))
+- `[Datepicker]` Fixed a bug where the selection range was not being properly rendered in mobile. ([#5211](https://github.com/infor-design/enterprise/issues/5211))
 
 ### v4.52.0 Fixes
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,6 @@
 ### v4.52.0 Markup Changes
 
 - `[Datagrid]` When fixing bugs in datagrid hover states we removed the use of `is-focused` on table `td` elements. ([#5091](https://github.com/infor-design/enterprise/issues/5091))
-- `[Datepicker]` Fixed a bug where the selection range was not being properly rendered in mobile. ([#5211](https://github.com/infor-design/enterprise/issues/5211))
 
 ### v4.52.0 Fixes
 
@@ -25,6 +24,7 @@
 - `[Datagrid]` Fixed a bug where unselecting all items in an active page affects other selected items on other pages. ([#4503](https://github.com/infor-design/enterprise/issues/4503))
 - `[Datagrid]` Fixed a bug where the tag text in the column is not shown properly when hovering it on Alternate Row Shading. ([#5210](https://github.com/infor-design/enterprise/issues/5210))
 - `[Datagrid]` Fixed a bug where the clear filter icons position were not properly aligned with the lookup. ([#5239](https://github.com/infor-design/enterprise/issues/5239))
+- `[Datepicker]` Fixed a bug where the selection range was not being properly rendered in mobile. ([#5211](https://github.com/infor-design/enterprise/issues/5211))
 - `[Dropdown]` Fixed a bug where automatic highlighting of a blank option after opening the list was not working ([#5095](https://github.com/infor-design/enterprise/issues/5095))
 - `[Dropdown/Multiselect]` Fixed a bug where the id attribute prefix were missing from the dropdown list when searching with typeahead settings. ([#5053](https://github.com/infor-design/enterprise/issues/5053))
 - `[Field Options]` Fixed misalignment of field options for the colorpicker, clearable input field, and clearable searchfield with its close icon. ([#5139](https://github.com/infor-design/enterprise/issues/5139))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v4.53.0 Fixes
 
 - `[Datepicker]` Fixed a bug where the setting attributes were missing in datepicker input and datepicker trigger on NG wrapper. ([#1044](https://github.com/infor-design/enterprise-ng/issues/1044))
+- `[Datepicker]` Fixed a bug where the selection range was not being properly rendered in mobile. ([#5211](https://github.com/infor-design/enterprise/issues/5211))
 
 ## v4.52.0
 
@@ -24,7 +25,6 @@
 - `[Datagrid]` Fixed a bug where unselecting all items in an active page affects other selected items on other pages. ([#4503](https://github.com/infor-design/enterprise/issues/4503))
 - `[Datagrid]` Fixed a bug where the tag text in the column is not shown properly when hovering it on Alternate Row Shading. ([#5210](https://github.com/infor-design/enterprise/issues/5210))
 - `[Datagrid]` Fixed a bug where the clear filter icons position were not properly aligned with the lookup. ([#5239](https://github.com/infor-design/enterprise/issues/5239))
-- `[Datepicker]` Fixed a bug where the selection range was not being properly rendered in mobile. ([#5211](https://github.com/infor-design/enterprise/issues/5211))
 - `[Dropdown]` Fixed a bug where automatic highlighting of a blank option after opening the list was not working ([#5095](https://github.com/infor-design/enterprise/issues/5095))
 - `[Dropdown/Multiselect]` Fixed a bug where the id attribute prefix were missing from the dropdown list when searching with typeahead settings. ([#5053](https://github.com/infor-design/enterprise/issues/5053))
 - `[Field Options]` Fixed misalignment of field options for the colorpicker, clearable input field, and clearable searchfield with its close icon. ([#5139](https://github.com/infor-design/enterprise/issues/5139))

--- a/src/components/monthview/_monthview.scss
+++ b/src/components/monthview/_monthview.scss
@@ -265,9 +265,9 @@
         and (max-device-width: $breakpoint-big-phone + 88)
         and (-webkit-min-device-pixel-ratio: 2)
         and (orientation: portrait) {
-        height: 32px;
-        line-height: 32px;
-        width: 32px;
+        height: 36px;
+        line-height: 36px;
+        width: 36px;
       }
     }
 

--- a/src/components/monthview/_monthview.scss
+++ b/src/components/monthview/_monthview.scss
@@ -399,6 +399,7 @@
           position: absolute;
           width: 43px;
           z-index: -1;
+          margin-left: -1px;
         }
       }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the selection range rendering in the mobile view.

**Related github/jira issue (required)**:
Closes #5211 

**Steps necessary to review your pull request (required)**:

- Pull this branch down, then build and run the app
- Go to http://localhost:4000/components/datepicker/example-range.html
- Open up mobile view
- Check if selection range rendering looks like the following: 
<img width="359" alt="Screen Shot 2021-06-03 at 10 19 50 AM" src="https://user-images.githubusercontent.com/52171753/120660440-560eb200-c455-11eb-92a6-522cf566300a.png">

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
