### PR TITLE
5139 - Fix field options of clearable input and colorpicker

### DIFF
--- a/src/components/field-options/_field-options-new.scss
+++ b/src/components/field-options/_field-options-new.scss
@@ -172,6 +172,10 @@
       width: 38px;
     }
 
+    .field-options[data-clearable='true'] ~ .btn-actions:not(.is-checkbox) {
+      top: 0;
+    }
+
     .dropdown,
     .multiselect {
       ~ .btn-actions:not(.is-checkbox) {
@@ -194,6 +198,7 @@
 
     .colorpicker-container ~ .btn-actions {
       left: -12px !important;
+      top: -10px;
     }
   }
 

--- a/src/components/field-options/_field-options.scss
+++ b/src/components/field-options/_field-options.scss
@@ -648,7 +648,7 @@
 
     .colorpicker-container {
       ~ .btn-actions {
-        top: -12px;
+        top: -9px;
       }
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This is a follow up fix for field options issues on clearable input and colorpicker in Windows Firefox

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/5139

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Use a windows machine or a BrowserStack
- Go to https://github.com/infor-design/enterprise/issues/5139
- Go to colorpicker section, and click the field options
- Should align with the colorpicker field
- Go to Clearable Input section, click the field options
- Should align with the Clearable Input
- Test on both themes

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
