### PR TITLE
5290 - Fix Searchfield Icon is not properly aligned in Firefox

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[Datepicker]` Fixed a bug where the setting attributes were missing in datepicker input and datepicker trigger on NG wrapper. ([#1044](https://github.com/infor-design/enterprise-ng/issues/1044))
 - `[Datepicker]` Fixed a bug where the selection range was not being properly rendered in mobile. ([#5211](https://github.com/infor-design/enterprise/issues/5211))
 - `[Searchfield]` Fixed a bug where the close button is not rendered properly on mobile view. ([#5182](https://github.com/infor-design/enterprise/issues/5182))
+- `[Searchfield]` Fixed a bug where the search icon in search field is not aligned properly on firefox view. ([#5290](https://github.com/infor-design/enterprise/issues/5290))
 - `[Searchbar]` Fixed a bug where searchbar overlapped the "Websites" header when browser is minimized or viewed in mobile. ([#5248](https://github.com/infor-design/enterprise/issues/5248))
 
 ## v4.52.0

--- a/src/components/searchfield/_searchfield-new.scss
+++ b/src/components/searchfield/_searchfield-new.scss
@@ -131,8 +131,20 @@ html.is-firefox {
       }
     }
 
+    .collapse-button {
+      height: 35px !important;
+    }
+
     > .icon {
       top: 10px;
+
+      &.close {
+        top: 18px;
+
+        @media only screen and (max-width: $breakpoint-phone-to-tablet) {
+          margin-right: 5px;
+        }  
+      }
     }
 
     &.is-open,

--- a/src/components/searchfield/_searchfield-new.scss
+++ b/src/components/searchfield/_searchfield-new.scss
@@ -123,7 +123,7 @@ html.is-firefox {
       }
 
       .icon:not(.close) {
-        top: 12px;
+        top: 8px;
       }
 
       .icon.close {
@@ -132,7 +132,7 @@ html.is-firefox {
     }
 
     > .icon {
-      top: 12px;
+      top: 10px;
     }
 
     &.is-open,


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the searchfield icon that is not properly aligned in firefox view.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5290

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/toolbar-flex/example-searchfield-collapsible.html
- Click on the searchfield button

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

