### PR TITLE
5308 - Add a fix for big negative numbers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[Datepicker]` Fixed a bug where the selection range was not being properly rendered in mobile. ([#5211](https://github.com/infor-design/enterprise/issues/5211))
 - `[Editor]` Fixed a bug where automation id attributes are not properly rendered on editor elements. ([#5082](https://github.com/infor-design/enterprise/issues/5082))
 - `[Lookup]` Fixed a bug where lookup attributes are not added in the cancel and apply/save button. ([#5202](https://github.com/infor-design/enterprise/issues/5202))
+- `[Locale]` Fixed a bug where very large numbers with negative added an extra zero in formatNumber. ([#5308](https://github.com/infor-design/enterprise/issues/5308))
 - `[Spinbox]` Fixed a bug where spinbox and its border is not properly rendered on responsive view. ([#5146](https://github.com/infor-design/enterprise/issues/5146))
 - `[Searchfield]` Fixed a bug where the close button is not rendered properly on mobile view. ([#5182](https://github.com/infor-design/enterprise/issues/5182))
 - `[Searchfield]` Fixed a bug where the search icon in search field is not aligned properly on firefox view. ([#5290](https://github.com/infor-design/enterprise/issues/5290))

--- a/src/utils/number.js
+++ b/src/utils/number.js
@@ -47,7 +47,12 @@ numberUtils.fixTo = function toFixed(number, decimals = 2) {
  */
 numberUtils.toFixed = function toFixed(number, decimals = 2) {
   // Parse the number into three parts. Max supported number is 18.6
-  const numStr = number.toString();
+  let numStr = number.toString();
+  let hasMinus = false;
+  if (numStr.substr(0, 1) === '-') {
+    hasMinus = true;
+    numStr = numStr.replace('-', '');
+  }
   let parsedNum = '';
   const noDecimals = numStr.split('.');
   const parts = [noDecimals[0].substr(0, 10), noDecimals[0].substr(10), noDecimals[1]];
@@ -66,6 +71,9 @@ numberUtils.toFixed = function toFixed(number, decimals = 2) {
   }
   if (lastPart && lastPart.substr(0, 1) === '0') {
     parsedNum = `${firstPart}0${parsedNum}`;
+  }
+  if (hasMinus) {
+    return `-${parsedNum}`;
   }
   return parsedNum;
 };


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Due to a bug in the toFixed function, super larger negative numbers got an extra zero added when calling formatNumber. This issue fixes that.

**Related github/jira issue (required)**:
Fixes #5308 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/locale/test-format-big-negative.html
- paste in -1482409800.81
- click format
- check that the number is exact
- try more numbers as you want
- tests for this pass

**Included in this Pull Request**:
- [ x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
