### PR TITLE
1047 - Fix tooltip for 2nd page with standalone pager

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Editor]` Fixed a bug where automation id attributes are not properly rendered on editor elements. ([#5082](https://github.com/infor-design/enterprise/issues/5082))
 - `[Lookup]` Fixed a bug where lookup attributes are not added in the cancel and apply/save button. ([#5202](https://github.com/infor-design/enterprise/issues/5202))
 - `[Locale]` Fixed a bug where very large numbers with negative added an extra zero in formatNumber. ([#5308](https://github.com/infor-design/enterprise/issues/5308))
+- `[Pager]` Fixed an issue where tooltip was not working after switch to 2nd page for disable/enable buttons with standalone Pager. ([#1047](https://github.com/infor-design/enterprise-ng/issues/1047))
 - `[Spinbox]` Fixed a bug where spinbox and its border is not properly rendered on responsive view. ([#5146](https://github.com/infor-design/enterprise/issues/5146))
 - `[Searchfield]` Fixed a bug where the close button is not rendered properly on mobile view. ([#5182](https://github.com/infor-design/enterprise/issues/5182))
 - `[Searchfield]` Fixed a bug where the search icon in search field is not aligned properly on firefox view. ([#5290](https://github.com/infor-design/enterprise/issues/5290))

--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -631,15 +631,29 @@ Pager.prototype = {
       return;
     }
 
+    const btnJQ = $(btn);
+    const tooltipContent = this.settings[`${type}PageTooltip`];
+
     // Change the DOM
     if (toggleOption) {
       btn.disabled = false;
       btn.parentNode.classList.remove('is-disabled');
-      $(btn).removeAttr('disabled');
+      btnJQ.removeAttr('disabled aria-disabled');
+      const tooltipApi = btnJQ.data('tooltip');
+      if (tooltipApi && !tooltipApi.content) {
+        tooltipApi.content = tooltipContent;
+      }
     } else {
       btn.disabled = true;
       btn.parentNode.classList.add('is-disabled');
-      $(btn).attr('disabled', 'disabled');
+      btnJQ.attr({ disabled: 'disabled', 'aria-disabled': 'true' });
+      const tooltipEl = btnJQ.find('.disabled-tooltip');
+      if (!tooltipEl.length) {
+        const tooltipApi = btnJQ.data('tooltip');
+        tooltipApi.destroy();
+        btnJQ.append(`<div class="disabled-tooltip" title="${tooltipContent}"></div>`);
+        btnJQ.find('.disabled-tooltip').tooltip();
+      }
     }
   },
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed tooltip was not working after switch to 2nd page for disable/enable buttons with standalone Pager.

**Related github/jira issue (required)**:
Closes infor-design/enterprise-ng#1047

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app (This issue was only reproduce with NG)
- Pull and build NG branch ([main](https://github.com/infor-design/enterprise-ng.git))
- Copy and replace "dist" folder from `enterprise` to `⁨enterprise-ng⁩/node_modules⁩/ids-enterprise`
- Navigate to http://localhost:4200/ids-enterprise-ng-demo/datagrid-standalone-pager
- After clicking next in pager button, the first and previous buttons are gets enable, and see the tooltip should show up.

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
