### PR TITLE
5144 - Fix hyperlinks for dark theme with personalization

### DIFF
--- a/app/views/components/personalize/example-classes.html
+++ b/app/views/components/personalize/example-classes.html
@@ -14,7 +14,7 @@
 
   <div id="maincontent" class="page-container scrollable is-personalizable" role="main">
     <div class="personalize-header personalize-horizontal-bottom-border">
-      <div class="row l-center">
+      <div class="row l-center  top-padding">
         <div class="one-fifth column one-half-mobile">
           <span class="object-count personalize-text">
             <span>Active <br/> Opportunities</span>
@@ -56,10 +56,10 @@
           &nbsp;
         </div>
         <div class="one column">
-          <a class="hyperlink personalize-actionable personalize-actionable-disabled" href="#">Incidents</a><br /><br />
+          <a class="hyperlink personalize-actionable personalize-actionable-disabled" href="#">Incidents</a>
         </div>
         <div class="one column">
-          <a class="hyperlink personalize-actionable" href="#">More Info</a><br /><br />
+          <a class="hyperlink personalize-actionable" href="#">More Info</a>
         </div>
       </div>
     </div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[Lookup]` Fixed a bug where lookup attributes are not added in the cancel and apply/save button. ([#5202](https://github.com/infor-design/enterprise/issues/5202))
 - `[Locale]` Fixed a bug where very large numbers would get a zero added. ([#5308](https://github.com/infor-design/enterprise/issues/5308))
 - `[Locale]` Fixed a bug where very large numbers with negative added an extra zero in formatNumber. ([#5318](https://github.com/infor-design/enterprise/issues/5318))
+- `[Personalization]` Fixed an issue where hyperlinks were not showing up for dark theme. ([#5144](https://github.com/infor-design/enterprise-ng/issues/5144))
 - `[Spinbox]` Fixed a bug where spinbox and its border is not properly rendered on responsive view. ([#5146](https://github.com/infor-design/enterprise/issues/5146))
 - `[Searchfield]` Fixed a bug where the close button is not rendered properly on mobile view. ([#5182](https://github.com/infor-design/enterprise/issues/5182))
 - `[Searchfield]` Fixed a bug where the search icon in search field is not aligned properly on firefox view. ([#5290](https://github.com/infor-design/enterprise/issues/5290))

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -635,24 +635,24 @@ html[class*="theme-new-"] .application-menu.is-personalizable .accordion.panel.i
 
 .is-personalizable .personalize-actionable,
 .is-personalizable .personalize-actionable svg {
-  color: ${colors.contrast};
+  color: ${colors.contrast} !important;
   opacity: .8;
 }
 
 .is-personalizable .personalize-actionable:hover:not([disabled]),
 .is-personalizable .personalize-actionable:hover:not([disabled]) svg {
-  color: ${colors.contrast};
+  color: ${colors.contrast} !important;
   opacity: 1;
 }
 
 .is-personalizable .personalize-actionable.is-focused:not(.hide-focus),
 .is-personalizable .personalize-actionable:focus:not(.hide-focus) {
-  border-color: ${colors.contrast};
+  border-color: ${colors.contrast} !important;
   box-shadow: 0 0 4px 3px rgba(0, 0, 0, 0.2);
 }
 
 .is-personalizable .personalize-actionable.hyperlink:focus:not(.hide-focus)::after {
-  border-color: ${colors.contrast};
+  border-color: ${colors.contrast} !important;
   opacity: 1;
   box-shadow: 0 0 4px 3px rgba(0, 0, 0, 0.2);
 }

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -648,13 +648,13 @@ html[class*="theme-new-"] .application-menu.is-personalizable .accordion.panel.i
 .is-personalizable .personalize-actionable.is-focused:not(.hide-focus),
 .is-personalizable .personalize-actionable:focus:not(.hide-focus) {
   border-color: ${colors.contrast} !important;
-  box-shadow: 0 0 4px 3px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 4px 3px rgba(255, 255, 255, 0.2);
 }
 
 .is-personalizable .personalize-actionable.hyperlink:focus:not(.hide-focus)::after {
   border-color: ${colors.contrast} !important;
   opacity: 1;
-  box-shadow: 0 0 4px 3px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 4px 3px rgba(255, 255, 255, 0.2);
 }
 
 .is-personalizable .personalize-vertical-border {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed hyperlinks were not showing up for dark theme with Personalization.

**Related github/jira issue (required)**:
Closes #5144

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/personalize/example-classes.html
- See the right side to hero section
- There are two hyperlinks `Incidents` and `More Info`
- Change theme the Mode to `Dark` and the Colors to `Amber`
- See those hyperlinks should show properly

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
