### PR TITLE
5222 - Fixed Bug Issue Updating Dropwndown Value When the "More Actions" Button Was Selected

### DIFF
--- a/app/views/components/dropdown/example-setvalue.html
+++ b/app/views/components/dropdown/example-setvalue.html
@@ -15,7 +15,7 @@
 
 <script>
     // Set the value to three every time using the API function
-    $('button').on('click', function () {
+    $('#update-btn').on('click', function () {
 	    var api = $('#updatable').data('dropdown');
 			api.selectValue("3");
     });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Datagrid]` Fixed a bug where animation blue circle is off-center. ([#5246](https://github.com/infor-design/enterprise/issues/5246))
 - `[Datepicker]` Fixed a bug where the setting attributes were missing in datepicker input and datepicker trigger on NG wrapper. ([#1044](https://github.com/infor-design/enterprise-ng/issues/1044))
 - `[Datepicker]` Fixed a bug where the selection range was not being properly rendered in mobile. ([#5211](https://github.com/infor-design/enterprise/issues/5211))
+- `[Dropdown]` Fixed a bug that resulted in the updatable dropdown value being changed when selecting the more actions button. ([#5222](https://github.com/infor-design/enterprise/issues/5222))
 - `[Editor]` Fixed a bug where automation id attributes are not properly rendered on editor elements. ([#5082](https://github.com/infor-design/enterprise/issues/5082))
 - `[Lookup]` Fixed a bug where lookup attributes are not added in the cancel and apply/save button. ([#5202](https://github.com/infor-design/enterprise/issues/5202))
 - `[Locale]` Fixed a bug where very large numbers with negative added an extra zero in formatNumber. ([#5308](https://github.com/infor-design/enterprise/issues/5308))


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the dropdown value from updating whenever the "more actions" button is selected

**Related github/jira issue (required)**:

Closes #5222 

**Steps necessary to review your pull request (required)**:

- Pull this branch down, then build and run the app.
- Go to http://localhost:4000/components/dropdown/example-setvalue.html
- Click on the "more actions" button
- Check if the dropdown value is still Option One
<img width="1440" alt="Screen Shot 2021-06-17 at 9 51 44 AM" src="https://user-images.githubusercontent.com/52171753/122410198-b28fc800-cf51-11eb-8f45-ae00d6272c7e.png">

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
