### PR TITLE
5157 - Add fix to hover states

### DIFF
--- a/app/views/components/datagrid/example-list-lookup.html
+++ b/app/views/components/datagrid/example-list-lookup.html
@@ -1,0 +1,73 @@
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+      //lookup data
+      var lookupOptions;
+      var lookupData = [];
+      var lookupColumns = [];
+
+      // Some Sample Data for Lookup
+      lookupData.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+      lookupData.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+      lookupData.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+      lookupData.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+      lookupData.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+      lookupData.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+      lookupData.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+      lookupData.push({ id: 7, productId: 11111111111, productName: 'Invalid Entry', activity:  'inspect and Repair', quantity: 42, price: 134.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+
+      // Define Columns for the Lookup Grid.
+      lookupColumns.push({ id: 'productId', name: 'Product Id', field: 'productId', width: 140});
+      lookupColumns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', width: 250, formatter: Formatters.Hyperlink});
+      lookupColumns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', width: 125});
+      lookupColumns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', width: 125});
+      lookupColumns.push({ id: 'price', name: 'Price', field: 'price', width: 125, formatter: Formatters.Decimal});
+      lookupColumns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+
+      lookupOptions = {
+        // field: 'productId',
+        field: function (row, field, grid) {
+          return row.productId;
+        },
+        match: function (value, row, field, grid) {
+          return (row.productId) === value;
+        },
+        options: {
+          columns: lookupColumns,
+          dataset: lookupData,
+          selectable: 'single', //multiselect or single
+          toolbar: {title: 'Find a Compressor', results: true, dateFilter: false ,keywordFilter: false, actions: true, views: true , rowHeight: true}
+        }
+      };
+
+      var grid,
+        columns = [];
+
+      // Define Columns for the Grid.
+      columns.push({ id: 'favorite', name: '', field: 'favorite', formatter: Formatters.Favorite});
+      columns.push({ id: 'companyName', name: 'Company Name', field: 'companyName', formatter: Formatters.Hyperlink});
+      columns.push({ id: 'phone', name: 'Phone', field: 'phone'});
+      columns.push({ id: 'location', name: 'Location', field: 'location'});
+      columns.push({ id: 'contact', name: 'Contact Name', field: 'contact'});
+      columns.push({ id: 'customerSince', name: 'Customer Since', field: 'customerSince', sortFunction: function (value) { return Locale.parseDate(value).getTime(); } });
+      columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Lookup, minWidth: 100, editor: Editors.Lookup, textOverflow: 'ellipsis', editorOptions: lookupOptions });
+
+      var url = '{{basepath}}api/companies';
+
+      $.getJSON(url, function(res) {
+        $('#datagrid').datagrid({
+          columns: columns,
+          editable: true,
+          isList: true,
+          dataset: res,
+          toolbar: {title: 'Results in Companies for "Gravel"', actions: true, rowHeight: true, personalize: true}
+        });
+      });
+    });
+</script>

--- a/app/views/components/mask/test-decimal.html
+++ b/app/views/components/mask/test-decimal.html
@@ -1,0 +1,19 @@
+<div class="row top-padding">
+  <div class="six columns">
+    <h2>Mask Test: Edit decimal value a second time ignoring decimal point</h2>
+    <p>1. Enter the value .8<br>
+       2. Blur out of the field, see that the value in it is 0.8<br>
+       3. Highlight the value and try and enter the value .7<br>
+       4. See that the . is ignored and that the value is 7 when it should be .7<br><br>
+    Note: using allow leading zeros allows you to enter 0.7 in step 3, which has the decimal point maintained</p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="one-half column">
+    <div class="field">
+      <label for="decimal-field">Currency Field</label>
+      <input id="decimal-field" name="decimal-field" type="text" inputmode="numeric" class="new-mask" data-options='{ "process": "number", "patternOptions": { "allowDecimal": true, "integerLimit": 20, "decimalLimit": 6, "allowLeadingZeros": true, "symbols": { "decimal": "." } } }' />
+    </div>
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@
 - `[Calendar]` Fixed a bug where calendar event is not rendered on WeekView if add event (modal) is used before add event (api). ([#5236](https://github.com/infor-design/enterprise/issues/5236))
 - `[Circle Pager]` Fixed size interactions and changes for mobile view port. ([#5251](https://github.com/infor-design/enterprise/issues/5251))
 - `[Datagrid]` Fixed a bug where animation blue circle is off-center. ([#5246](https://github.com/infor-design/enterprise/issues/5246))
-- `[Datagrid]` Fixed a bug where hovering lookup cells showed a grey background. ([# 5157](https://github.com/infor-design/enterprise/issues/ 5157))
+- `[Datagrid]` Fixed a bug where hovering lookup cells showed a grey background. ([#5157](https://github.com/infor-design/enterprise/issues/5157))
 - `[Datagrid]` Fixed an issue for xss where special characters was not sanitizing and make grid to not render. ([#975](https://github.com/infor-design/enterprise-ng/issues/975))
 - `[Datepicker]` Fixed a bug where the setting attributes were missing in datepicker input and datepicker trigger on NG wrapper. ([#1044](https://github.com/infor-design/enterprise-ng/issues/1044))
 - `[Datepicker]` Fixed a bug where the selection range was not being properly rendered in mobile. ([#5211](https://github.com/infor-design/enterprise/issues/5211))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Calendar]` Fixed a bug where calendar event is not rendered on WeekView if add event (modal) is used before add event (api). ([#5236](https://github.com/infor-design/enterprise/issues/5236))
 - `[Circle Pager]` Fixed size interactions and changes for mobile view port. ([#5251](https://github.com/infor-design/enterprise/issues/5251))
 - `[Datagrid]` Fixed a bug where animation blue circle is off-center. ([#5246](https://github.com/infor-design/enterprise/issues/5246))
+- `[Datagrid]` Fixed a bug where hovering lookup cells showed a grey background. ([# 5157](https://github.com/infor-design/enterprise/issues/ 5157))
 - `[Datepicker]` Fixed a bug where the setting attributes were missing in datepicker input and datepicker trigger on NG wrapper. ([#1044](https://github.com/infor-design/enterprise-ng/issues/1044))
 - `[Datepicker]` Fixed a bug where the selection range was not being properly rendered in mobile. ([#5211](https://github.com/infor-design/enterprise/issues/5211))
 - `[Datepicker]` Made the `autocomplete` attribute configurable by using the `autocompleteAttribute` setting. ([#5092](https://github.com/infor-design/enterprise/issues/5092))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -441,6 +441,11 @@ $datagrid-small-row-height: 25px;
       }
     }
 
+    .is-hover-row .datagrid-trigger-cell .icon {
+      background-color: transparent;
+      box-shadow: none;
+    }
+
     th {
       background-color: $datagrid-list-header-bg-color;
       border-left: 0 !important;
@@ -2379,7 +2384,6 @@ $datagrid-small-row-height: 25px;
         display: block;
         margin-bottom: 6px;
         margin-top: 5px;
-        vertical-align: middle;
       }
     }
 
@@ -3558,8 +3562,8 @@ $datagrid-small-row-height: 25px;
 
   .datagrid-expand-btn {
     left: -8px;
-    margin-top: 0;
     margin-right: 8px;
+    margin-top: 0;
     padding-left: 8.3px;
 
     .icon.plus-minus::before,


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adds a follow up fix to the hover state on is-list style datagrids. Also small cleanup in the css linting.
And an example for future testing.

**Related github/jira issue (required)**:
Fixes #5157 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-list-lookup
- hover the last column on the cell
- should show a lookup icon and not have a wierd grey background

**Included in this Pull Request**:
- [x] A note to the change log.
