### PR TITLE
5256 - Action Sheet design Q/A changes

### DIFF
--- a/app/views/components/actionsheet/example-breakpoints.html
+++ b/app/views/components/actionsheet/example-breakpoints.html
@@ -87,10 +87,9 @@
   }
 
   function onCancel() {
-    $('body').toast({
-      title: 'Cancelled',
-      message: 'The Action Sheet was cancelled'
-    });
+    if (console) {
+      console.info('`onCancel` was triggered');
+    }
   }
 
   actionSheetTriggerBtn.actionsheet({

--- a/app/views/components/actionsheet/example-breakpoints.html
+++ b/app/views/components/actionsheet/example-breakpoints.html
@@ -7,7 +7,7 @@
 <div class="row top-padding">
   <div class="twelve columns">
     <div class="field">
-      <button id="action-sheet-trigger" class="btn-icon" data-init="false">
+      <button id="action-sheet-trigger" class="btn-actions vertical" data-init="false">
         <span class="audible">Trigger Action Sheet</span>
         <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
           <use href="#icon-more"></use>

--- a/app/views/components/actionsheet/example-callbacks.html
+++ b/app/views/components/actionsheet/example-callbacks.html
@@ -8,7 +8,7 @@
 <div class="row top-padding">
   <div class="twelve columns">
     <div class="field">
-      <button id="action-sheet-trigger" class="btn-icon" data-init="false">
+      <button id="action-sheet-trigger" class="btn-actions vertical" data-init="false">
         <span class="audible">Trigger Action Sheet</span>
         <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
           <use href="#icon-more"></use>

--- a/app/views/components/actionsheet/example-callbacks.html
+++ b/app/views/components/actionsheet/example-callbacks.html
@@ -27,10 +27,9 @@
   }
 
   function onCancel() {
-    $('body').toast({
-      title: 'Cancelled',
-      message: 'The Action Sheet was cancelled'
-    });
+    if (console) {
+      console.info('`onCancel` was triggered');
+    }
   }
 
   $('#action-sheet-trigger').actionsheet({

--- a/app/views/components/actionsheet/example-index.html
+++ b/app/views/components/actionsheet/example-index.html
@@ -28,10 +28,9 @@
   }
 
   function onCancel() {
-    $('body').toast({
-      title: 'Cancelled',
-      message: 'The Action Sheet was cancelled'
-    });
+    if (console) {
+      console.info('`onCancel` was triggered');
+    }
   }
 
   $('#action-sheet-trigger').actionsheet({

--- a/app/views/components/actionsheet/example-index.html
+++ b/app/views/components/actionsheet/example-index.html
@@ -9,7 +9,7 @@
 <div class="row top-padding">
   <div class="twelve columns">
     <div class="field">
-      <button id="action-sheet-trigger" class="btn-icon" data-init="false">
+      <button id="action-sheet-trigger" class="btn-actions vertical" data-init="false">
         <span class="audible">Trigger Action Sheet</span>
         <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
           <use href="#icon-more"></use>

--- a/app/views/components/actionsheet/example-no-icons.html
+++ b/app/views/components/actionsheet/example-no-icons.html
@@ -8,7 +8,7 @@
 <div class="row top-padding">
   <div class="twelve columns">
     <div class="field">
-      <button id="action-sheet-trigger" class="btn-icon" data-init="false">
+      <button id="action-sheet-trigger" class="btn-actions vertical" data-init="false">
         <span class="audible">Trigger Action Sheet</span>
         <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
           <use href="#icon-more"></use>

--- a/app/views/components/actionsheet/example-no-icons.html
+++ b/app/views/components/actionsheet/example-no-icons.html
@@ -27,10 +27,9 @@
   }
 
   function onCancel() {
-    $('body').toast({
-      title: 'Cancelled',
-      message: 'The Action Sheet was cancelled'
-    });
+    if (console) {
+      console.info('`onCancel` was triggered');
+    }
   }
 
   $('#action-sheet-trigger').actionsheet({

--- a/app/views/components/actionsheet/test-many-actions.html
+++ b/app/views/components/actionsheet/test-many-actions.html
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="twelve columns">
     <div class="field">
-      <button id="action-sheet-trigger" class="btn-icon" data-init="false">
+      <button id="action-sheet-trigger" class="btn-actions vertical" data-init="false">
         <span class="audible">Trigger Action Sheet</span>
         <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
           <use href="#icon-more"></use>

--- a/app/views/components/actionsheet/test-many-actions.html
+++ b/app/views/components/actionsheet/test-many-actions.html
@@ -20,10 +20,9 @@
   }
 
   function onCancel() {
-    $('body').toast({
-      title: 'Cancelled',
-      message: 'The Action Sheet was cancelled'
-    });
+    if (console) {
+      console.info('`onCancel` was triggered');
+    }
   }
 
   $('#action-sheet-trigger').actionsheet({

--- a/app/views/components/actionsheet/test-no-cancel.html
+++ b/app/views/components/actionsheet/test-no-cancel.html
@@ -8,7 +8,7 @@
 <div class="row top-padding">
   <div class="twelve columns">
     <div class="field">
-      <button id="action-sheet-trigger" class="btn-icon" data-init="false">
+      <button id="action-sheet-trigger" class="btn-actions vertical" data-init="false">
         <span class="audible">Trigger Action Sheet</span>
         <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
           <use href="#icon-more"></use>

--- a/app/views/components/actionsheet/test-no-cancel.html
+++ b/app/views/components/actionsheet/test-no-cancel.html
@@ -27,10 +27,9 @@
   }
 
   function onCancel() {
-    $('body').toast({
-      title: 'Cancelled',
-      message: 'The Action Sheet was cancelled'
-    });
+    if (console) {
+      console.info('`onCancel` was triggered');
+    }
   }
 
   $('#action-sheet-trigger').actionsheet({

--- a/src/components/actionsheet/_actionsheet.scss
+++ b/src/components/actionsheet/_actionsheet.scss
@@ -22,19 +22,6 @@
   right: 0;
   -webkit-touch-callout: none;
   z-index: 4000;
-
-  // Alignment of the items is different when icons are present
-  // ==============================
-  &.has-icons {
-    [class^='btn'] {
-      text-align: left;
-    }
-
-    .btn-primary,
-    .btn-secondary {
-      padding: 0 36px;
-    }
-  }
 }
 
 .ids-actionsheet-container {

--- a/src/components/actionsheet/actionsheet.js
+++ b/src/components/actionsheet/actionsheet.js
@@ -219,6 +219,7 @@ ActionSheet.prototype = {
       autoFocus: this.settings.autoFocus,
       attributes: this.settings.attributes,
       menu: $menuEl,
+      offset: { y: 10 },
       trigger: 'immediate',
       removeOnDestroy: true
     });

--- a/src/components/actionsheet/actionsheet.js
+++ b/src/components/actionsheet/actionsheet.js
@@ -3,6 +3,7 @@ import { breakpoints } from '../../utils/breakpoints';
 
 // jQuery Components
 import '../../utils/behaviors';
+import '../button/button.jquery';
 import '../icons/icons.jquery';
 import '../popupmenu/popupmenu.jquery';
 
@@ -50,8 +51,14 @@ ActionSheet.prototype = {
     }
 
     // Decorate trigger element
-    this.element[0].classList.add('ids-actionsheet-trigger');
+    const el = this.element[0];
+    el.classList.add('ids-actionsheet-trigger');
     utils.addAttributes(this.element, this, this.settings.attributes, 'trigger');
+
+    // Invoke an IDS Button component, if applicable
+    if (el.tagName === 'BUTTON' || el.className.includes('btn')) {
+      this.element.button();
+    }
 
     // Render this action sheet
     if (!this.actionSheetElem) {
@@ -95,6 +102,9 @@ ActionSheet.prototype = {
       // Attach to the root elem
       this.actionSheetElem.insertAdjacentHTML('afterbegin', actionSheetHTML);
       this.rootElem.append(this.actionSheetElem);
+
+      // Invoke an IDS Button component on each action, if applicable
+      $(this.actionSheetElem).find('button').button();
     }
   },
 
@@ -140,6 +150,9 @@ ActionSheet.prototype = {
    * @returns {boolean} true if the Action Sheet is currently visible
    */
   get visible() {
+    if (this.popupmenuAPI) {
+      return this.hasOpenPopupMenu;
+    }
     return this.rootElem.classList.contains('engaged');
   },
 
@@ -155,13 +168,13 @@ ActionSheet.prototype = {
    * @returns {void}
    */
   open() {
-    if (!this.currentlyNeedsActionSheet) {
-      this.openPopupMenu();
+    // Don't try to open if the Action Sheet is currently open
+    if (this.visible) {
       return;
     }
 
-    // Don't try to open if the Action Sheet is currently open
-    if (this.visible) {
+    if (!this.currentlyNeedsActionSheet) {
+      this.openPopupMenu();
       return;
     }
 
@@ -522,6 +535,12 @@ ActionSheet.prototype = {
       this.close();
     }
     this.element.off('click.trigger');
+
+    // Remove the Action Sheet Element
+    if (this.actionSheetElem) {
+      $(this.actionSheetElem).find('button').destroy();
+      this.actionSheetElem.remove();
+    }
 
     // Undecorate
     this.element[0].classList.remove('ids-actionsheet-trigger');

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -509,6 +509,16 @@ a.btn-close {
   }
 }
 
+// Some Actions Buttons can be vertical
+.btn-icon,
+.btn-actions {
+  &.vertical {
+    svg {
+      transform: rotate(90deg);
+    }
+  }
+}
+
 // Set the size of the "X"
 .btn-close {
   > .icon {

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -166,7 +166,7 @@ Button.prototype = {
 
     // Derive X/Y coordinates from input events
     if (e) {
-      if (!env.features.touch) {
+      if (e.originalEvent instanceof MouseEvent) {
         // Standard Mouse Click
         xPos = e.pageX - btnOffset.left;
         yPos = e.pageY - btnOffset.top;
@@ -182,8 +182,8 @@ Button.prototype = {
     }
 
     // If values have not been defined, simply set them to the center of the element.
-    xPos = (xPos < 0) ? this.element.outerWidth() / 2 : xPos;
-    yPos = (yPos < 0) ? this.element.outerHeight() / 2 : yPos;
+    if (!xPos) { xPos = this.element.outerWidth() / 2; }
+    if (!yPos) { yPos = this.element.outerHeight() / 2; }
 
     // Create/place the ripple effect
     const ripple = $(`<svg class="ripple-effect" focusable="false" aria-hidden="true" role="presentation">

--- a/src/components/cards/_cards.scss
+++ b/src/components/cards/_cards.scss
@@ -131,7 +131,7 @@
 
           &:hover {
             color: $card-content-button-color;
-        
+
             .icon {
               color: $card-content-button-color;
             }
@@ -168,12 +168,6 @@
     .widget-content {
       height: auto;
       min-height: 0;
-    }
-  }
-
-  .btn-actions.vertical {
-    svg {
-      transform: rotate(90deg);
     }
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR addresses items brought to us during design Q/A (@kevinwhitedesign).  Also included in this PR:
- Fixed a minor lifecycle bug I discovered while testing that would accidentally render the menu markup multiple times if the trigger button was clicked multiple times.
- Moved some code around from the recent work on the new card design from #5295 to enable use of the "vertical" actions button everywhere. (@ericangeles) 

**Related github/jira issue (required)**:
Closes #5256
Related to #5305 

**Steps necessary to review your pull request (required)**:
- Pull, Run, Build!
- Open http://localhost:4000/components/actionsheet/example-index.
- Make sure the trigger button's icon is vertically-aligned (per Figma designs)
- Click on the trigger button.  It should produce the ripple effect (called "pulse" in the Figma designs)
- If the action sheet isn't open, close the popupmenu, shrink the page down very small, and click the trigger button again. 
- Ensure the Actions inside the Action Sheet are center-aligned
- Either click the cancel button, or click inside the dark overlay area.  When the action sheet is cancelled, no toast should display.
- Check all examples in http://localhost:4000/components/actionsheet and make sure vertical actions button is being used.

_To test lifecycle bug:_
- Open http://localhost:4000/components/actionsheet/example-index
- Make sure the page is large enough to open the Popupmenu and click the trigger button
- Click the trigger button again.  No stray HTML markup should be generated and placed in the page.

_To test moved Cards code:_
- Open http://localhost:4000/components/cards/example-expandable-cards.html
- Make sure the icon looks correct
