### PR TITLE
986 - Add api setting to allow duplicates with lookup

### DIFF
--- a/app/views/components/lookup/test-multiselect-description-only.html
+++ b/app/views/components/lookup/test-multiselect-description-only.html
@@ -1302,6 +1302,7 @@
   // Initialize the Lookup
   $('#product-lookup').lookup({
      field: 'applicationInstanceName',
+     allowDuplicates: true,
      options: {
         columns: columns,
         dataset: [],

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `[Donut]` Changed legend design when item exceeds maximum width of chart. ([#5292](https://github.com/infor-design/enterprise/issues/5292))
 - `[Dropdown]` Fixed a bug where backspace in Dropdown is not working when pressed. ([#5113](https://github.com/infor-design/enterprise/issues/5113))
 - `[Input]` Fixed a bug where clear icon were not properly aligned with the input field in classic mode. ([#5324](https://github.com/infor-design/enterprise/issues/5324))
+- `[Lookup]` Added api setting to allow duplicate selected value to input element. ([#986](https://github.com/infor-design/enterprise-ng/issues/986))
 - `[Monthview]` Fixed a bug where a vertical scroll is showing when it is unnecessary. ([#5350](https://github.com/infor-design/enterprise/issues/5350))
 - `[Multiselect]` Fixed a regression bug where clear icon were not properly aligned on compact mode. ([#5396](https://github.com/infor-design/enterprise/issues/5396))
 - `[Popdown]` Remove deprecation console warning. We still consider this component deprecated but will not remove until 5.0 version. The warning was only removed for now. ([#1070](https://github.com/infor-design/enterprise-ng/issues/1070))

--- a/src/components/lookup/lookup.js
+++ b/src/components/lookup/lookup.js
@@ -74,6 +74,7 @@ function addSuffixToAttributes(parentAttrs = [], childAttrs = [], suffix) {
  * @param {int} [settings.minWidth=400] Applys a minimum width to the lookup
  * @param {boolean} [settings.clearable=false] Add an ability to clear the lookup field. If "true", it will affix an "x" button to the right section of the field.
  * @param {boolean} [settings.tabbable=true] If true, causes the Lookup's trigger icon to be focusable with the keyboard.
+ * @param {boolean} [settings.allowDuplicates=false] If true, will show all duplicate selected values in input element.
  */
 const LOOKUP_DEFAULTS = {
   click: null,
@@ -94,6 +95,7 @@ const LOOKUP_DEFAULTS = {
   clearable: false,
   attributes: null,
   tabbable: true,
+  allowDuplicates: false,
 };
 
 function Lookup(element, settings) {
@@ -977,7 +979,9 @@ Lookup.prototype = {
     }
 
     // Eliminate duplicate values.
-    value = value.filter((a, b) => value.indexOf(a) === b);
+    if (!this.settings.allowDuplicates) {
+      value = value.filter((a, b) => value.indexOf(a) === b);
+    }
 
     /**
       * Fires on input value change.


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added api setting to allow duplicate selected value to input element with Lookup.

**Related github/jira issue (required)**:
Fixes infor-design/enterprise-ng#986

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/lookup/test-multiselect-description-only.html
- Open lookup modal, on 1st page, select three rows value with `Soxtest` from 1st column and press `Apply`
- See lookup input value should be `Soxtest,Soxtest,Soxtest`

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
