### PR TITLE
5395 nan appears in datagrid fields for undefined selections

### DIFF
--- a/app/views/components/datagrid/example-placeholder.html
+++ b/app/views/components/datagrid/example-placeholder.html
@@ -76,7 +76,7 @@
         columns.push({ id: 'price', name: 'Price', field: 'price', align: 'right', formatter: Formatters.Decimal, placeholder: 'Default Price', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input});
         columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date , validate: 'required date'});
         columns.push({ id: 'action', name: 'Action', field: 'action', formatter: Formatters.Dropdown, editor: Editors.Dropdown, placeholder: 'Default Action',
-        options: [{id: '', label: '', value: -1}, {id: 'oh1', label: 'On Hold', value: 'oh'}, {id: 'sh1', label: 'Shipped', value: 'sh'} , {id: 'ac1', label: 'Action', value: 'ac'}]
+        options: [{id: '', label: '', value: ''}, {id: 'oh1', label: 'On Hold', value: 'oh'}, {id: 'sh1', label: 'Shipped', value: 'sh'} , {id: 'ac1', label: 'Action', value: 'ac'}]
         });
 
         //Init and get the api for the grid

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[Multiselect]` Fixed a regression bug where clear icon were not properly aligned on compact mode. ([#5396](https://github.com/infor-design/enterprise/issues/5396))
 - `[Popdown]` Remove deprecation console warning. We still consider this component deprecated but will not remove until 5.0 version. The warning was only removed for now. ([#1070](https://github.com/infor-design/enterprise-ng/issues/1070))
 -`[Datagrid]` Fixed a bug where the font color on tags was black when a row was hovered over in dark mode. Font color now white. ([#5289](https://github.com/infor-design/enterprise/issues/5289))
+-`[Datagrid]` Fixed issues with NaN displaying on Decimal and Dropdown inputs when blank options are selected. ([#5395] (https://github.com/infor-design/enterprise/issues/5395))
 
 ### v4.54.0 Markup Changes
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,7 +22,7 @@
 - `[Multiselect]` Fixed a regression bug where clear icon were not properly aligned on compact mode. ([#5396](https://github.com/infor-design/enterprise/issues/5396))
 - `[Popdown]` Remove deprecation console warning. We still consider this component deprecated but will not remove until 5.0 version. The warning was only removed for now. ([#1070](https://github.com/infor-design/enterprise-ng/issues/1070))
 -`[Datagrid]` Fixed a bug where the font color on tags was black when a row was hovered over in dark mode. Font color now white. ([#5289](https://github.com/infor-design/enterprise/issues/5289))
--`[Datagrid]` Fixed issues with NaN displaying on Decimal and Dropdown inputs when blank options are selected. ([#5395] (https://github.com/infor-design/enterprise/issues/5395))
+-`[Datagrid]` Fixed issues with NaN displaying on Decimal and Dropdown inputs when blank options are selected. ([#5395](https://github.com/infor-design/enterprise/issues/5395))
 
 ### v4.54.0 Markup Changes
 

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -226,13 +226,15 @@ const formatters = {
 
   Decimal(row, cell, value, col, item) {
     let formatted = value;
+    // eslint-disable-next-line no-useless-escape
+    const checkIfNaN = /[\s]*($)?[#,0-9\s\.]+%?[\s]*/;
 
     if (typeof Locale !== 'undefined' &&
-        formatted !== null && formatted !== undefined && formatted !== '' && !isNaN(formatted)) {
+        formatted !== null && formatted !== undefined && formatted !== '' && checkIfNaN.test(formatted)) {
       formatted = Locale.formatNumber(value, col.numberFormat);
     }
 
-    formatted = (formatted === null || formatted === undefined || isNaN(formatted)) ? '' : formatted;
+    formatted = (formatted === null || formatted === undefined || formatted === 'NaN' || !checkIfNaN.test(formatted)) ? '' : formatted;
 
     const placeholder = calculatePlaceholder(formatted, row, cell, value, col, item);
     if (placeholder !== '') {

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -228,11 +228,11 @@ const formatters = {
     let formatted = value;
 
     if (typeof Locale !== 'undefined' &&
-        formatted !== null && formatted !== undefined && formatted !== '') {
+        formatted !== null && formatted !== undefined && formatted !== '' && !isNaN(formatted)) {
       formatted = Locale.formatNumber(value, col.numberFormat);
     }
 
-    formatted = (formatted === null || formatted === undefined || formatted === 'NaN') ? '' : formatted;
+    formatted = (formatted === null || formatted === undefined || isNaN(formatted)) ? '' : formatted;
 
     const placeholder = calculatePlaceholder(formatted, row, cell, value, col, item);
     if (placeholder !== '') {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10352,6 +10352,7 @@ Datagrid.prototype = {
    */
   coerceValue(value, oldVal, col, row, cell) {
     let newVal;
+    let nonNumberCharacters = /[A-Za-z!@#$%^&*()_+\-=\[\]{};':"\\|<>\/?]/
 
     if (col.serialize) {
       const s = this.settings;
@@ -10368,7 +10369,7 @@ Datagrid.prototype = {
       } else {
         newVal = Locale.formatDate(value, { pattern: col.sourceFormat });
       }
-    } else if (typeof oldVal === 'number' && value) {
+    } else if (typeof oldVal === 'number' && value && !nonNumberCharacters.test(value)) {
       newVal = Locale.parseNumber(value); // remove thousands sep , keep a number a number
     }
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10352,7 +10352,7 @@ Datagrid.prototype = {
    */
   coerceValue(value, oldVal, col, row, cell) {
     let newVal;
-    let nonNumberCharacters = /[A-Za-z!@#$%^&*()_+\-=\[\]{};':"\\|<>\/?]/
+    const nonNumberCharacters = /[A-Za-z!@#$%^&*()_+\-=\[\]{};':"\\|<>\/?]/
 
     if (col.serialize) {
       const s = this.settings;

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10352,7 +10352,7 @@ Datagrid.prototype = {
    */
   coerceValue(value, oldVal, col, row, cell) {
     let newVal;
-    const nonNumberCharacters = /[A-Za-z!@#$%^&*()_+\-=\[\]{};':"\\|<>\/?]/
+    const nonNumberCharacters = /[A-Za-z!@#$%^&*()_+\-=\[\]{};':"\\|<>\/?]/;
 
     if (col.serialize) {
       const s = this.settings;

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10352,7 +10352,8 @@ Datagrid.prototype = {
    */
   coerceValue(value, oldVal, col, row, cell) {
     let newVal;
-    const nonNumberCharacters = /[A-Za-z!@#$%^&*()_+\-=\[\]{};':"\\|<>\/?]/;
+    // eslint-disable-next-line no-useless-escape
+    const nonNumberCharacters = /[A-Za-z!@#$%^&*()_+\-=\[\]{};':"\\|<>/?]/;
 
     if (col.serialize) {
       const s = this.settings;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Updated the Decimal formatter to prevent NaN from being displayed when the user doesn't enter a value and updated the placeholder example page dropdown so that the blank value was not a number which caused other options to display NaN when selected. Additionally added more type safety to coercion to prevent edge cases like the drop down from causing future issues

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes ([#5395](https://github.com/infor-design/enterprise/issues/5395))

**Steps necessary to review your pull request (required)**:

-Build and Run the application
- navigate to the datagrid placeholder example http://localhost:4000/components/datagrid/example-placeholder.html

To test the price issue
- click into the price column of row one
- click outside the cell
- no NaN should appear in the field

To test the date issue
-select the Action dropdown in row one
-select the blank option
-select the Action dropdown again
-select On Hold
-the field should display On Hold instead of NaN

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
