### PR TITLE
986 - Fix selection for server side and paging with lookup

### DIFF
--- a/app/views/components/lookup/test-multiselect-description-only.html
+++ b/app/views/components/lookup/test-multiselect-description-only.html
@@ -1342,7 +1342,7 @@
   var lookupApi = elem.data('lookup');
   $('#btn-show-selected').on('click', function() {
     if (lookupApi) {
-      console.log('Selected: ', lookupApi.getSelectedRows());
+      console.log('Selected: ', lookupApi.selectedRows || []);
     }
   });
 

--- a/app/views/components/lookup/test-multiselect-description-only.html
+++ b/app/views/components/lookup/test-multiselect-description-only.html
@@ -1,3 +1,11 @@
+<div class="row top-padding">
+  <div class="twelve columns">
+    <div class="field">
+      <button class="btn-secondary" type="button" id="btn-show-selected">Show Selected</button>
+    </div>
+  </div>
+</div>
+
 <div class="row">
   <div class="twelve columns">
     <div class="field">
@@ -1275,7 +1283,7 @@
       field: 'applicationInstanceGuid',
       hidden: true
     },
-    { id: 'pa.id', field: 'id', hidden: true },
+    { id: 'pa.id', field: 'id', hidden: false },
     {
       id: '222',
       name: 'Application Instance Name',
@@ -1296,11 +1304,10 @@
     }
   ];
 
-  let previouslySelectedRows = [];
-  let processing = false;
+  var elem = $('#product-lookup');
 
   // Initialize the Lookup
-  $('#product-lookup').lookup({
+  elem.lookup({
      field: 'applicationInstanceName',
      allowDuplicates: true,
      options: {
@@ -1311,6 +1318,7 @@
         pagesizes: [5, 10, 25],
         selectable: 'multiple',
         allowSelectAcrossPages: true,
+        columnIds: ['applicationInstanceName', 'applicationInstanceGuid'], // Required, in order to work server-side selection
         toolbar: {
           results: true,
           keywordFilter: false,
@@ -1329,26 +1337,13 @@
           response(pageData, req);
         }
      }
-  })
-  .on('selected', function(e, selectedRows, op, rowData) {
-    if (processing) {
-      return;
-    }
-    previouslySelectedRows = selectedRows.slice();
-    console.log('selected', previouslySelectedRows);
-  }).on('afterpaging', function(e, pagingInfo, lookup) {
-    processing = true;
-    lookup.grid.unSelectAllRows(true);
-    for (let i = 0; i < previouslySelectedRows.length; i++) {
-      lookup.selectRowByValue('id', previouslySelectedRows[i].data.id);
-    }
-
-    // If using the contextual toolbar
-    if (lookup.grid.contextualToolbar) {
-      lookup.grid.syncSelectedUI();
-      lookup.grid.contextualToolbar.find('.selection-count').text(`${previouslySelectedRows.length} ${Locale.translate('Selected')}`);
-    }
-    lookup.isChanged = false;
-    processing = false;
   });
+
+  var lookupApi = elem.data('lookup');
+  $('#btn-show-selected').on('click', function() {
+    if (lookupApi) {
+      console.log('Selected: ', lookupApi.getSelectedRows());
+    }
+  });
+
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[Dropdown]` Fixed a bug where backspace in Dropdown is not working when pressed. ([#5113](https://github.com/infor-design/enterprise/issues/5113))
 - `[Icon]` Changed button icon colors to slate6 ([#5307](https://github.com/infor-design/enterprise/issues/5307))
 - `[Input]` Fixed a bug where clear icon were not properly aligned with the input field in classic mode. ([#5324](https://github.com/infor-design/enterprise/issues/5324))
+- `[Lookup]` Fixed an issue where selection for server side and paging was not working. ([#986](https://github.com/infor-design/enterprise-ng/issues/986))
 - `[Lookup]` Added api setting to allow duplicate selected value to input element. ([#986](https://github.com/infor-design/enterprise-ng/issues/986))
 - `[Modal]` Enter key will trigger primary button when in an input field. ([#5198](https://github.com/infor-design/enterprise/issues/5198))
 - `[Monthview]` Fixed a bug where a vertical scroll is showing when it is unnecessary. ([#5350](https://github.com/infor-design/enterprise/issues/5350))

--- a/src/components/lookup/lookup.js
+++ b/src/components/lookup/lookup.js
@@ -698,13 +698,17 @@ Lookup.prototype = {
     // Restore selected rows when pages change
     if (this.settings.options.source) {
       lookupGrid.off('afterpaging.lookup').on('afterpaging.lookup', (e, pagingInfo) => {
+        if (!(self.settings.options.source && self.settings.options.selectable === 'multiple')) {
+          const fieldVal = self.element.val();
+          this.selectGridRows(fieldVal);
+        }
         this.element.trigger('afterpaging', [pagingInfo, this]);
       });
     }
 
     if (this.settings.options) {
       lookupGrid.on('selected.lookup', (e, selectedRows, op, rowData) => {
-        if (self.settings.options.source) {
+        if (self.settings.options.source && self.settings.options.selectable === 'multiple') {
           self.element.trigger('selected', [selectedRows, op, rowData, self]);
           return;
         }

--- a/src/components/lookup/lookup.js
+++ b/src/components/lookup/lookup.js
@@ -705,7 +705,7 @@ Lookup.prototype = {
     if (this.settings.options) {
       lookupGrid.on('selected.lookup', (e, selectedRows, op, rowData) => {
         if (self.settings.options.source) {
-          self.element.trigger('selected', [selectedRows, op, rowData]);
+          self.element.trigger('selected', [selectedRows, op, rowData, self]);
           return;
         }
 
@@ -720,7 +720,7 @@ Lookup.prototype = {
         // Only proceed if a row is selected
         if (!selectedRows || selectedRows.length === 0) {
           if (op === 'deselect') {
-            self.element.trigger('selected', [selectedRows, op, rowData]);
+            self.element.trigger('selected', [selectedRows, op, rowData, self]);
           }
           return;
         }
@@ -733,7 +733,7 @@ Lookup.prototype = {
           self.modal.close();
           self.insertRows();
         }
-        self.element.trigger('selected', [selectedRows, op, rowData]);
+        self.element.trigger('selected', [selectedRows, op, rowData, self]);
       });
     }
 
@@ -1024,14 +1024,6 @@ Lookup.prototype = {
     this.element.trigger('input', [this.selectedRows]);
     this.applyAutoWidth();
     this.element.focus();
-  },
-
-  /**
-   * Get currently selected rows.
-   * @returns {array} Selected rows
-   */
-  getSelectedRows() {
-    return this.selectedRows || [];
   },
 
   /**

--- a/src/components/lookup/lookup.js
+++ b/src/components/lookup/lookup.js
@@ -698,14 +698,17 @@ Lookup.prototype = {
     // Restore selected rows when pages change
     if (this.settings.options.source) {
       lookupGrid.off('afterpaging.lookup').on('afterpaging.lookup', (e, pagingInfo) => {
-        const fieldVal = self.element.val();
-        this.selectGridRows(fieldVal);
         this.element.trigger('afterpaging', [pagingInfo, this]);
       });
     }
 
     if (this.settings.options) {
       lookupGrid.on('selected.lookup', (e, selectedRows, op, rowData) => {
+        if (self.settings.options.source) {
+          self.element.trigger('selected', [selectedRows, op, rowData]);
+          return;
+        }
+
         this.isChanged = true;
         if (op === 'deselect') {
           if (!self.grid.recentlyRemoved) {
@@ -716,6 +719,9 @@ Lookup.prototype = {
 
         // Only proceed if a row is selected
         if (!selectedRows || selectedRows.length === 0) {
+          if (op === 'deselect') {
+            self.element.trigger('selected', [selectedRows, op, rowData]);
+          }
           return;
         }
 
@@ -734,19 +740,42 @@ Lookup.prototype = {
     // Set init values after render the grid
     if (this.settings.options.source) {
       this.grid.element.one('afterrender.lookup', () => {
-        if (!this.initValues || (this.initValues && !this.initValues.length)) {
+        const hasServersideSelection = this.settings.options.source && this.selectedRows?.length;
+        if (!this.initValues || (this.initValues && !this.initValues.length) || hasServersideSelection) {
           this.initValues = [];
-          const isMatch = (node, v) => ((node[this.settings.field] || '').toString() === v.toString());
-          const fieldVal = this.element.val();
-          if (fieldVal) {
-            const fieldValues = (fieldVal.indexOf(this.settings.delimiter) > 1) ?
-              fieldVal.split(this.settings.delimiter) : [fieldVal];
-            fieldValues.forEach((v) => {
-              this.initValues.push({
-                value: v,
-                visited: !!(this.grid.settings.dataset.filter(node => isMatch(node, v)).length) // eslint-disable-line
+          if (hasServersideSelection) {
+            setTimeout(() => {
+              const pagingInfo = this.grid?.pagerAPI?.state;
+              if (pagingInfo) {
+                const records = {
+                  min: ((pagingInfo.activePage * pagingInfo.pagesize) - pagingInfo.pagesize),
+                  max: ((pagingInfo.activePage * pagingInfo.pagesize) - 1)
+                };
+                const inRange = x => x.pagingIdx >= records.min && x.pagingIdx <= records.max;
+                this.selectedRows.forEach((row) => {
+                  this.initValues.push({
+                    value: row.data[this.settings.field],
+                    visited: inRange(row)
+                  });
+                });
+                this.grid._selectedRows = this.selectedRows.slice();
+                this.grid.syncSelectedRows();
+                this.grid.syncSelectedUI();
+              }
+            }, 310);
+          } else {
+            const isMatch = (node, v) => ((node[this.settings.field] || '').toString() === v.toString());
+            const fieldVal = this.element.val();
+            if (fieldVal) {
+              const fieldValues = (fieldVal.indexOf(this.settings.delimiter) > 1) ?
+                fieldVal.split(this.settings.delimiter) : [fieldVal];
+              fieldValues.forEach((v) => {
+                this.initValues.push({
+                  value: v,
+                  visited: !!(this.grid.settings.dataset.filter(node => isMatch(node, v)).length) // eslint-disable-line
+                });
               });
-            });
+            }
           }
         }
       });
@@ -952,12 +981,12 @@ Lookup.prototype = {
    * @returns {void}
    */
   insertRows() {
-    if (!this.isChanged) {
+    if (!this.isChanged && !this.settings.options.source) {
       return;
     }
     let value = [];
 
-    this.selectedRows = this.grid.selectedRows();
+    this.selectedRows = this.grid.selectedRows().slice();
 
     for (let i = 0; i < this.selectedRows.length; i++) {
       let currValue = '';
@@ -995,6 +1024,14 @@ Lookup.prototype = {
     this.element.trigger('input', [this.selectedRows]);
     this.applyAutoWidth();
     this.element.focus();
+  },
+
+  /**
+   * Get currently selected rows.
+   * @returns {array} Selected rows
+   */
+  getSelectedRows() {
+    return this.selectedRows || [];
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed selection for server side and paging was not working with Lookup.

**Related github/jira issue (required)**:
Fixes infor-design/enterprise-ng#986

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app
Navigate to: http://localhost:4000/components/lookup/test-multiselect-description-only.html

scenario 1
- Refresh the page
- Open lookup modal and select anything
- Click on `Show Selected` and see log in console should show results

scenario 2
- Refresh the page
- Open lookup modal and select single record on any page
- After modal close, click on `Show Selected` should show one record in array
- Open again modal and unselect the same record
- After modal close, click on `Show Selected` should show empty array

scenario 3
- Refresh the page
- Open lookup modal and select first record of the first page
- Go to 2nd page and select first records and click on `Apply`
- Now again open modal and uncheck the first page record and click `Apply`
- Click on `Show Selected` and see log in console should show results

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
