### PR TITLE
5233 - Fix row reorder handle align for xs and sm height with datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## v4.54.0 Fixes
 
 - `[Datagrid]` - Fixed a bug where the row height cut off the focus ring on the Action Item buttons for Classic/New mode and XS, S, M settings ([#5394](https://github.com/infor-design/enterprise/issues/5394))
+- `[Datagrid]` Fixed an issue where row reorder handle align was not right for extra small and small height. ([#5233](https://github.com/infor-design/enterprise/issues/5233))
 - `[Blockgrid]` Added additional design with no image ([#5379](https://github.com/infor-design/enterprise/issues/5379))
 - `[Charts]` Fixed a bug where the vertical grid line strokes were invisible when in High Contrast and Colors was non-Default ([#5301](https://github.com/infor-design/enterprise/issues/5301))
 - `[CirclePager]` Fixed a bug where the slides were not properly showing for RTL languages ([#2885](https://github.com/infor-design/enterprise/issues/2885))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1791,6 +1791,10 @@ $datagrid-small-row-height: 25px;
           }
         }
       }
+
+      &.reorder-group-child-col .datagrid-reorder-icon {
+        padding-left: 39px;
+      }
     }
   }
 
@@ -1833,6 +1837,10 @@ $datagrid-small-row-height: 25px;
           height: $datagrid-extra-small-row-height - 53;
           line-height: $datagrid-extra-small-row-height - 5;
         }
+      }
+
+      &.reorder-group-child-col .datagrid-reorder-icon {
+        padding-left: 42px;
       }
 
       .hyperlink {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3079,6 +3079,12 @@ Datagrid.prototype = {
       return null;
     };
 
+    // Detect left mouse button
+    const isLeftButton = (e) => {
+      const btn = e.buttons || e.which || e.button;
+      return !(e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) ? btn === 1 : false;
+    };
+
     this.tableBody.find(rowSelector)
       .find('.datagrid-reorder-icon').each(function () {
         let clone = null;
@@ -3089,6 +3095,10 @@ Datagrid.prototype = {
         const handle = $(this);
         handle.off('mousedown.datagrid').on('mousedown.datagrid', (e) => {
           e.preventDefault();
+          // Only use left mouse button
+          if (!isLeftButton(e)) {
+            return;
+          }
 
           handle.closest('tr').drag({
             axis: 'y',


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed row reorder handle align was not right for extra small and small height with Datagrid.

**Related github/jira issue (required)**:
Fixes #5233

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/example-grouping-row-reorder.html
- Try small and extra small datagrid height
- See reorder handle should not misalign

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
