### PR TITLE
5253 - Fix template rendering in angular interpolation

### DIFF
--- a/src/components/cards/cards.js
+++ b/src/components/cards/cards.js
@@ -85,6 +85,7 @@ Cards.prototype = {
     const expanded = this.element.hasClass('is-expanded');
     const selectText = (Locale ? Locale.translate('Select') : 'Select');
     const isSingle = this.settings.selectable === 'single';
+
     this.renderTemplate();
 
     // This is basically the build for the selection state cards (single and multiple)
@@ -232,13 +233,13 @@ Cards.prototype = {
    * Render the template using mustache
    */
   renderTemplate() {
-    if (this.settings.selectable === false) {
+    if (!this.settings.template) {
       return;
     }
 
     const s = this.settings;
 
-    if (typeof Tmpl === 'object' && this.settings.template) {
+    if (typeof Tmpl === 'object' && s.dataset && this.settings.template) {
       if (this.settings.template instanceof $) {
         this.settings.template = `${this.settings.template.html()}`;
       } else if (typeof this.settings.template === 'string') {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes issues when using angular's interpolation. Getting an error when you don't have anything set in template setting. This is a blocker in angular.

**Related github/jira issue (required)**:

Closes #5253 

**Steps necessary to review your pull request (required)**:

- To make sure it works, you just need to remove the template setting in either `example-single-select` or `example-multi-select` test page in Cards component.

- You should not get any error in the console regarding template utils.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
