### PR TITLE
5285 - Add Required Asterisk to Fileupload Label

### DIFF
--- a/app/views/components/fileupload/test-required.html
+++ b/app/views/components/fileupload/test-required.html
@@ -4,12 +4,12 @@
 
     <div class="field">
       <label for="test-required">Upload a File</label>
-      <input type="file" class="fileupload" id="test-required" name="test-required" data-validate="required">
+      <input type="file" class="fileupload required" id="test-required" name="test-required" data-validate="required">
     </div>
 
     <div class="field">
       <label class="required" for="fileupload">Upload a File</label>
-      <input type="file" class="fileupload" id="fileupload" aria-required="true" name="fileupload" data-validate="required">
+      <input type="file" class="fileupload required" id="fileupload" aria-required="true" name="fileupload" data-validate="required">
     </div>
 
     <div class="field">

--- a/app/views/components/fileupload/test-required.html
+++ b/app/views/components/fileupload/test-required.html
@@ -3,7 +3,7 @@
   <div class="twelve columns">
 
     <div class="field">
-      <label class="required" for="test-required">Upload a File</label>
+      <label for="test-required">Upload a File</label>
       <input type="file" class="fileupload" id="test-required" name="test-required" data-validate="required">
     </div>
 

--- a/app/views/components/fileupload/test-required.html
+++ b/app/views/components/fileupload/test-required.html
@@ -3,13 +3,13 @@
   <div class="twelve columns">
 
     <div class="field">
-      <label for="test-required">Upload a File</label>
-      <input type="file" class="fileupload required" id="test-required" name="test-required" data-validate="required">
+      <label class="required" for="test-required">Upload a File</label>
+      <input type="file" class="fileupload" id="test-required" name="test-required" data-validate="required">
     </div>
 
     <div class="field">
       <label class="required" for="fileupload">Upload a File</label>
-      <input type="file" class="fileupload required" id="fileupload" aria-required="true" name="fileupload" data-validate="required">
+      <input type="file" class="fileupload" id="fileupload" aria-required="true" name="fileupload" data-validate="required">
     </div>
 
     <div class="field">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,7 +21,7 @@
 -`[Datagrid]` Fixed issues with NaN displaying on Decimal and Dropdown inputs when blank options are selected. ([#5395](https://github.com/infor-design/enterprise/issues/5395))
 - `[Donut]` Changed legend design when item exceeds maximum width of chart. ([#5292](https://github.com/infor-design/enterprise/issues/5292))
 - `[Dropdown]` Fixed a bug where backspace in Dropdown is not working when pressed. ([#5113](https://github.com/infor-design/enterprise/issues/5113))
-- `[Fileupload]` Fixed a bug where the required asterisk does not appear on the labels associated with required fields. ([#5385](https://github.com/infor-design/enterprise/issues/5385))
+- `[Fileupload]` Fixed a bug where the required asterisk does not appear on the labels associated with required fields. ([#5285](https://github.com/infor-design/enterprise/issues/5285))
 - `[Icon]` Changed button icon colors to slate6 ([#5307](https://github.com/infor-design/enterprise/issues/5307))
 - `[Input]` Fixed a bug where clear icon were not properly aligned with the input field in classic mode. ([#5324](https://github.com/infor-design/enterprise/issues/5324))
 - `[Lookup]` Fixed an issue where selection for server side and paging was not working. ([#986](https://github.com/infor-design/enterprise-ng/issues/986))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 -`[Datagrid]` Fixed issues with NaN displaying on Decimal and Dropdown inputs when blank options are selected. ([#5395](https://github.com/infor-design/enterprise/issues/5395))
 - `[Donut]` Changed legend design when item exceeds maximum width of chart. ([#5292](https://github.com/infor-design/enterprise/issues/5292))
 - `[Dropdown]` Fixed a bug where backspace in Dropdown is not working when pressed. ([#5113](https://github.com/infor-design/enterprise/issues/5113))
+- `[Fileupload]` Fixed a bug where the required asterisk does not appear on the labels associated with required fields. ([#5385](https://github.com/infor-design/enterprise/issues/5385))
 - `[Icon]` Changed button icon colors to slate6 ([#5307](https://github.com/infor-design/enterprise/issues/5307))
 - `[Input]` Fixed a bug where clear icon were not properly aligned with the input field in classic mode. ([#5324](https://github.com/infor-design/enterprise/issues/5324))
 - `[Lookup]` Fixed an issue where selection for server side and paging was not working. ([#986](https://github.com/infor-design/enterprise-ng/issues/986))
@@ -33,7 +34,7 @@
 
 ### v4.54.0 Markup Changes
 
-- `[TrackDirty]` Removed Track Dirty from the main components list and integrated the underlying examples into their corresponding individual components.
+- `[TrackDirty]` Removed Track Dirty from the main components list and integrated the underlying examples into their corresponding individual components.([#5319](https://github.com/infor-design/enterprise/issues/5319))
 
 ## v4.53.3 Fixes
 

--- a/src/components/fileupload/fileupload.js
+++ b/src/components/fileupload/fileupload.js
@@ -66,6 +66,10 @@ FileUpload.prototype = {
         orgLabel = elem.parent().prev('label');
       }
 
+      if (orgLabel.hasClass('required')) {
+        this.shadowLabel.addClass('required');
+      }
+
       this.shadowLabel.html(`${orgLabel.text()} <span class="audible">${instructions}</span>`);
       orgLabel.addClass('audible').add(this.fileInput).attr('tabindex', '-1').attr('aria-hidden', 'true');
     }

--- a/src/components/fileupload/fileupload.js
+++ b/src/components/fileupload/fileupload.js
@@ -135,6 +135,7 @@ FileUpload.prototype = {
     if (this.fileInput.attr('data-validate')) {
       this.textInput.attr('data-validate', this.fileInput.attr('data-validate'));
       this.textInput.validate();
+      this.shadowLabel.addClass(this.fileInput.attr('data-validate'));
     }
 
     if (this.fileInput.attr('readonly')) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
This PR adds the "required" asterisk to fileupload labels at page `components/fileupload/test-required`.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #5285 .

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull branch, run app
- Visit http://localhost:4000/components/fileupload/test-required.html
- Ensure the required asterisk appears on required fields.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
