### PR TITLE
986 - Fix to update selected rows with lookup

### DIFF
--- a/app/views/components/lookup/test-multiselect-description-only.html
+++ b/app/views/components/lookup/test-multiselect-description-only.html
@@ -2,6 +2,7 @@
   <div class="twelve columns">
     <div class="field">
       <button class="btn-secondary" type="button" id="btn-show-selected">Show Selected</button>
+      <button class="btn-secondary" type="button" id="btn-update-selected">Update Selected</button>
     </div>
   </div>
 </div>
@@ -1329,9 +1330,9 @@
           contextualToolbar: true
         },
         source: function (req, response) {
-          const startIndex = (req.activePage - 1) * req.pagesize;
-          const endIndex = req.activePage * req.pagesize;
-          const pageData = appInstanceData.slice(startIndex, endIndex);
+          var startIndex = (req.activePage - 1) * req.pagesize;
+          var endIndex = req.activePage * req.pagesize;
+          var pageData = appInstanceData.slice(startIndex, endIndex);
 
           req.total = appInstanceData.length;
           response(pageData, req);
@@ -1343,6 +1344,19 @@
   $('#btn-show-selected').on('click', function() {
     if (lookupApi) {
       console.log('Selected: ', lookupApi.selectedRows || []);
+    }
+  });
+
+  $('#btn-update-selected').on('click', function() {
+    if (lookupApi) {
+      var removeSelectedIdx = 0;
+      var updatedRows = lookupApi.selectedRows.slice();
+
+      if (updatedRows && updatedRows.length > 0) {
+        updatedRows.splice(removeSelectedIdx, 1);
+        // lookupApi.updateSelectedRows(); // clear selection
+        lookupApi.updateSelectedRows(updatedRows); // list of updated selected rows
+      }
     }
   });
 

--- a/app/views/components/lookup/test-multiselect-description-only.html
+++ b/app/views/components/lookup/test-multiselect-description-only.html
@@ -1352,7 +1352,7 @@
       var removeSelectedIdx = 0;
       var updatedRows = lookupApi.selectedRows.slice();
 
-      if (updatedRows && updatedRows.length > 0) {
+      if (updatedRows && updatedRows.length > removeSelectedIdx) {
         updatedRows.splice(removeSelectedIdx, 1);
         // lookupApi.updateSelectedRows(); // clear selection
         lookupApi.updateSelectedRows(updatedRows); // list of updated selected rows

--- a/src/components/lookup/lookup.js
+++ b/src/components/lookup/lookup.js
@@ -791,6 +791,31 @@ Lookup.prototype = {
   },
 
   /**
+   * Update currently selected rows
+   * @param {array} rows The list of updated selected rows
+   * @returns {void}
+   */
+  updateSelectedRows(rows) {
+    if (this.settings.options.source) {
+      rows = Array.isArray(rows) ? rows : [];
+      if (this.selectedRows.length !== rows.length) {
+        this.selectedRows = rows.slice();
+        const value = this.selectedRows
+          .map(r => (r.data ? r.data[this.settings.field] : ''))
+          .join(this.settings.delimiter);
+
+        if (this.grid) {
+          this.grid._selectedRows = this.selectedRows.slice();
+          this.grid.syncSelectedRows();
+          this.grid.syncSelectedUI();
+        }
+        this.element.val(value).trigger('change', [this.selectedRows]);
+        this.element.trigger('input', [this.selectedRows]);
+      }
+    }
+  },
+
+  /**
    * Given a field value, select the row
    * @param {object} val incoming value from the grid row
    * @returns {void}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed to update selection rows for server side and paging with Lookup.

**Related github/jira issue (required)**:
Fixes infor-design/enterprise-ng#986

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/lookup/test-multiselect-description-only.html
- Open lookup modal and select some rows
- Click `Apply` to close lookup modal
- Click `Show Selected` to see current selected rows in console
- Click `Update Selected` will remove first entry from `selectedRows`
- See in lookup input field and in console by `Show Selected` button



<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
