### PR TITLE
5387 fix for tabbing issue toolbarflex

### DIFF
--- a/app/views/components/toolbar-flex/example-allowed-tabs-test.html
+++ b/app/views/components/toolbar-flex/example-allowed-tabs-test.html
@@ -1,0 +1,17 @@
+<div class="flex-toolbar" data-options="{ 'attributes': [ { 'name': 'data-automation-id', 'value': 'my-toolbar'} ] }" role="toolbar" data-automation-id="my-toolbar">
+  <div class="toolbar-section buttonset">
+    <button class="btn" tabindex="0" data-automation-id="my-toolbar-button-0">
+      <span>Text Button</span>
+    </button>
+    <button class="btn" tabindex="0" data-automation-id="my-toolbar-button-0">
+      <span>Text Button 2</span>
+    </button>
+  </div>
+
+  <div class="more toolbar-section"><button class="btn-actions" aria-haspopup="true"><svg class="icon "><use xlink:href="#icon-more"></use></svg></button><div class="popupmenu-wrapper bottom"><div class="arrow"></div></div></div>
+</div>
+
+<script>
+  let toolbarShowing = false;
+  const toolbarElem = $(".flex-toolbar").toolbarflex({ allowTabs: true });
+</script>

--- a/src/components/toolbar-flex/toolbar-flex.js
+++ b/src/components/toolbar-flex/toolbar-flex.js
@@ -372,7 +372,11 @@ ToolbarFlex.prototype = {
     }
 
     for (let i = 0; i < this.items.length; i++) {
-      this.items[i].focused = false;
+      if (this.items[i].settings.allowTabs) {
+        this.items[i].focused = true;
+      } else {
+        this.items[i].focused = false;
+      }
     }
     item.focused = true;
     this.trueFocusedItem = item;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

added logic that sets tab-index to zero when allowTabs is set to true for a toolbar-flex item. this should allow the user to tab through toolbar options and prevent the situation where the user can neither tab or use arrow key navigation to reach valid options

**Related github/jira issue (required)**:

([Closes #5387](https://github.com/infor-design/enterprise/issues/5387))

**Steps necessary to review your pull request (required)**:

-build and run the application
-navigate to the following example http://localhost:4000/components/toolbar-flex/example-allowed-tabs-test.html
-using tab navigation you should be able to reach every button on the page.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.
