### PR TITLE
5332 - Fixed Additional Bug Preventing Order Date Column From Being Exported

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,7 +24,7 @@
 - `[Datagrid]` Fixed a bug where the font color on tags was black when a row was hovered over in dark mode. Font color now white. ([#5289](https://github.com/infor-design/enterprise/issues/5289))
 - `[Datagrid]` Fixed issues with NaN displaying on Decimal and Dropdown inputs when blank options are selected. ([#5395](https://github.com/infor-design/enterprise/issues/5395))
 - `[Datepicker]` Fixed a bug where the -/+ keys were not detected in datepicker. ([#5353](https://github.com/infor-design/enterprise/issues/5353))
-- `[Datagrid]` Fixed a bug that prevented the headers of the right frozen columns from being exported properly. ([#5332](https://github.com/infor-design/enterprise/issues/5332))
+- `[Datagrid]` Fixed a bug that prevented the headers of the right frozen columns as well as the order date column from being exported properly. ([#5332](https://github.com/infor-design/enterprise/issues/5332))
 - `[Datagrid]` Fixed a bug where the font color on tags was black when a row was hovered over in dark mode. Font color now white. ([#5289](https://github.com/infor-design/enterprise/issues/5289))
 - `[Datagrid]` Fixed issues with NaN displaying on Decimal and Dropdown inputs when blank options are selected. ([#5395](https://github.com/infor-design/enterprise/issues/5395))
 - `[Donut]` Changed legend design when item exceeds maximum width of chart. ([#5292](https://github.com/infor-design/enterprise/issues/5292))

--- a/src/utils/excel.js
+++ b/src/utils/excel.js
@@ -38,7 +38,10 @@ excel.cleanExtra = function (customDs, self) {
         // THEAD
         const attrExportable = el.getAttribute('data-exportable');
         if (attrExportable && attrExportable === 'no') {
-          const index = parseInt(el.id.slice(-1), 10);
+          let index = el.id.match(/-header-\d+/g);
+          index = index ? index[0].match(/\d+/g) : null;
+          index = index ? index[0] : el.id.slice(-1);
+          index = parseInt(index, 10);
           nonExportables.push(index + 1);
           removeNode(el);
           return;
@@ -80,7 +83,7 @@ excel.cleanExtra = function (customDs, self) {
     const clonedTable = self.table.clone(true);
 
     if (self.settings.frozenColumns.left.length || self.settings.frozenColumns.right.length) {
-      clonedTable.find('.datagrid-header tr:first()').html(self.headerNodes().clone(true)); 
+      clonedTable.find('.datagrid-header tr:first()').html(self.headerNodes().clone(true));
     }
 
     table = excel.appendRows(dataset, clonedTable[0], self);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixed bug that prevented the order date column (not including the header) from being exported.

**Related github/jira issue (required)**:

Closes #5332 

**Steps necessary to review your pull request (required)**:

- Pull this branch down, then build and run the app
- Go to http://localhost:4000/components/datagrid/example-frozen-columns.html
- Click on the more button and then select Export to Excel
- Open the excel document and see if all column headers (specifically Order Date) match the following data below it 
   <img width="1440" alt="Screen Shot 2021-07-30 at 12 19 03 PM" src="https://user-images.githubusercontent.com/52171753/127682640-b05b0210-2db6-434c-9a26-e683737fa345.png">

**Included in this Pull Request**:

- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
