### PR TITLE
5441 - Fix automation ids not showing on legends, text and slices

### DIFF
--- a/app/views/components/donut/example-index.html
+++ b/app/views/components/donut/example-index.html
@@ -30,7 +30,7 @@ $('body').on('initialized', function () {
         value: 12,
         attributes: [
           { name: 'id', value: 'comp-b' },
-          { name: 'data-automation-id', value: 'comp-ba-automation-id' }
+          { name: 'data-automation-id', value: 'comp-b-automation-id' }
         ]
     }, {
         name: 'Component C',

--- a/app/views/components/donut/test-automation-attributes.html
+++ b/app/views/components/donut/test-automation-attributes.html
@@ -1,0 +1,49 @@
+
+<div class="row">
+    <div class="two-thirds column">
+        <div class="widget">
+          <div class="widget-header">
+            <h2 class="widget-title">Pie Chart Center Tooltip</h2>
+          </div>
+          <div class="widget-content">
+            <div id="pie-chart-example" class="chart-container">
+            </div>
+          </div>
+        </div>
+    </div>
+  </div>
+  
+  <script>
+  $('body').on('initialized', function () {
+  
+    var pieData = [{
+      data: [{
+          name: 'Resources',
+          shortName: 'Resources',
+          value: 16000,
+          color: 'good'
+        }, {
+          name: 'Expenses',
+          shortName: 'Expenses',
+          value: 5500,
+          color: 'error'
+        }],
+        centerLabel: '<tspan  x="0" dy="-0.4em">Total Value</tspan> <tspan x="0" dy="1.4em">$16,000</tspan>'
+      }];
+  
+    $('#pie-chart-example').chart({
+      type: 'donut',
+      dataset: pieData,
+      labels: {
+        contentsTop: 'value',
+        formatterTop: '$,.2f',// f or .2f for decimals
+      },
+      attributes: [
+        { name: 'data-automation-id', value: 'chart-donut-automation' }
+      ],
+      showTooltips: true
+    });
+  
+  });
+  </script>
+  

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # What's New with Enterprise
 
-## v4.54.0 Fixes
+## v4.55.0 Fixes
 
 - `[Charts]` Fixed a bug where automation ids is not properly rendered on legend, text and slices. ([#5441](https://github.com/infor-design/enterprise/issues/5441))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # What's New with Enterprise
 
+## v4.54.0 Fixes
+
+- `[Charts]` Fixed a bug where automation ids is not properly rendered on legend, text and slices. ([#5441](https://github.com/infor-design/enterprise/issues/5441))
+
 ## v4.54.0 Features
 
 - `[Cards]` Added the ability of single and multi selection of cards. ([#5253](https://github.com/infor-design/enterprise/issues/5253))

--- a/src/components/charts/charts.js
+++ b/src/components/charts/charts.js
@@ -422,7 +422,13 @@ charts.addLegend = function (series, chartType, settings, container) {
     }
     seriesLine = $(seriesLine);
     seriesLine.append(color, `<span class="audible">${Locale.translate('Highlight')}</span>`, textBlock);
-    utils.addAttributes(seriesLine, series[i], series[i]?.data?.attributes, 'legend');
+    
+    const suffix = `legend-${i}`;
+    if (settings.attributes) {
+      utils.addAttributes(seriesLine, series[i], settings.attributes, suffix, true);
+    } else {
+      utils.addAttributes(seriesLine, series[i], series[i]?.data?.attributes, suffix, true);
+    }
 
     if ((chartType === 'pie' || chartType === 'donut') && settings.showMobile) {
       legend.find('.container').append(seriesLine);

--- a/src/components/pie/pie.js
+++ b/src/components/pie/pie.js
@@ -454,6 +454,12 @@ Pie.prototype = {
 
       if (self.settings.attributes) {
         utils.addAttributes($('.chart-donut-text'), self, self.settings.attributes, 'text', true);
+        utils.addAttributes(self.element.find('.slices'), self, self.settings.attributes, 'slices', true);
+        utils.addAttributes(self.element.find('.labels'), self, self.settings.attributes, 'labels', true);
+        utils.addAttributes(self.element.find('.labels').children(), self, self.settings.attributes, 'label', true);
+        utils.addAttributes(self.element.find('.lines'), self, self.settings.attributes, 'lines', true);
+        utils.addAttributes(self.element.find('.lines').children('polyline'), self, self.settings.attributes, 'polyline', true);
+        utils.addAttributes(self.element.find('.lines').children('.circles'), self, self.settings.attributes, 'circle', true);
       }
     }, 100);
 

--- a/src/components/pie/pie.js
+++ b/src/components/pie/pie.js
@@ -428,8 +428,8 @@ Pie.prototype = {
     let timer = 0;
     // Make sure the default to get prevent not bubble up.
 
-    if (self.settings?.showCenterTooltip) {
-      setTimeout(() => {
+    setTimeout(() => {
+      if (self.settings?.showCenterTooltip) {
         $('.chart-donut-text')
           .off('mouseenter.text')
           .on('mouseenter.text', function () {
@@ -450,8 +450,12 @@ Pie.prototype = {
             charts.hideTooltip();
             $('.is-pie').removeClass('is-center');
           });
-      }, 100);
-    }
+      }
+
+      if (self.settings.attributes) {
+        utils.addAttributes($('.chart-donut-text'), self, self.settings.attributes, 'text', true);
+      }
+    }, 100);
 
     self.element
       .off(`dblclick.${self.namespace}`)
@@ -466,9 +470,14 @@ Pie.prototype = {
       .attr('class', 'slice')
       .call((d) => {
         d._groups.forEach((slices) => {
-          slices.forEach((pieSlice) => {
+          slices.forEach((pieSlice, index) => {
             const dat = pieSlice.__data__;
-            utils.addAttributes($(pieSlice), dat, dat.data.attributes);
+            const suffix = `slice-${index}`;
+            if (self.settings.attributes) {
+              utils.addAttributes($(pieSlice), dat, self.settings.attributes, suffix, true);
+            } else {
+              utils.addAttributes($(pieSlice), dat, dat.data.attributes, suffix, true);
+            }
           });
         });
       })

--- a/test/components/area/area.e2e-spec.js
+++ b/test/components/area/area.e2e-spec.js
@@ -63,12 +63,12 @@ describe('Area Chart tests', () => {
     expect(await element(by.id('area-comp-c-line')).getAttribute('id')).toEqual('area-comp-c-line');
     expect(await element(by.id('area-comp-c-line')).getAttribute('data-automation-id')).toEqual('automation-id-area-comp-c-line');
 
-    expect(await element(by.id('area-comp-a-legend')).getAttribute('id')).toEqual('area-comp-a-legend');
-    expect(await element(by.id('area-comp-a-legend')).getAttribute('data-automation-id')).toEqual('automation-id-area-comp-a-legend');
-    expect(await element(by.id('area-comp-b-legend')).getAttribute('id')).toEqual('area-comp-b-legend');
-    expect(await element(by.id('area-comp-b-legend')).getAttribute('data-automation-id')).toEqual('automation-id-area-comp-b-legend');
-    expect(await element(by.id('area-comp-c-legend')).getAttribute('id')).toEqual('area-comp-c-legend');
-    expect(await element(by.id('area-comp-c-legend')).getAttribute('data-automation-id')).toEqual('automation-id-area-comp-c-legend');
+    expect(await element(by.id('area-comp-a-legend-0')).getAttribute('id')).toEqual('area-comp-a-legend-0');
+    expect(await element(by.id('area-comp-a-legend-0')).getAttribute('data-automation-id')).toEqual('automation-id-area-comp-a-legend-0');
+    expect(await element(by.id('area-comp-b-legend-1')).getAttribute('id')).toEqual('area-comp-b-legend-1');
+    expect(await element(by.id('area-comp-b-legend-1')).getAttribute('data-automation-id')).toEqual('automation-id-area-comp-b-legend-1');
+    expect(await element(by.id('area-comp-c-legend-2')).getAttribute('id')).toEqual('area-comp-c-legend-2');
+    expect(await element(by.id('area-comp-c-legend-2')).getAttribute('data-automation-id')).toEqual('automation-id-area-comp-c-legend-2');
   });
 });
 

--- a/test/components/bar/bar-grouped.e2e-spec.js
+++ b/test/components/bar/bar-grouped.e2e-spec.js
@@ -65,10 +65,10 @@ describe('Grouped Bar Chart example-index tests', () => {
     expect(await element(by.id('bargroup-c-apr-bar')).getAttribute('id')).toEqual('bargroup-c-apr-bar');
     expect(await element(by.id('bargroup-c-apr-bar')).getAttribute('data-automation-id')).toEqual('automation-id-bargroup-c-apr-bar');
 
-    expect(await element(by.id('bargroup-a-jan-legend')).getAttribute('data-automation-id')).toEqual('automation-id-bargroup-a-jan-legend');
-    expect(await element(by.id('bargroup-a-feb-legend')).getAttribute('data-automation-id')).toEqual('automation-id-bargroup-a-feb-legend');
-    expect(await element(by.id('bargroup-a-mar-legend')).getAttribute('data-automation-id')).toEqual('automation-id-bargroup-a-mar-legend');
-    expect(await element(by.id('bargroup-a-apr-legend')).getAttribute('data-automation-id')).toEqual('automation-id-bargroup-a-apr-legend');
+    expect(await element(by.id('bargroup-a-jan-legend-0')).getAttribute('data-automation-id')).toEqual('automation-id-bargroup-a-jan-legend-0');
+    expect(await element(by.id('bargroup-a-feb-legend-1')).getAttribute('data-automation-id')).toEqual('automation-id-bargroup-a-feb-legend-1');
+    expect(await element(by.id('bargroup-a-mar-legend-2')).getAttribute('data-automation-id')).toEqual('automation-id-bargroup-a-mar-legend-2');
+    expect(await element(by.id('bargroup-a-apr-legend-3')).getAttribute('data-automation-id')).toEqual('automation-id-bargroup-a-apr-legend-3');
   });
 
   if (utils.isChrome() && utils.isCI()) {

--- a/test/components/bar/bar-stacked.e2e-spec.js
+++ b/test/components/bar/bar-stacked.e2e-spec.js
@@ -58,8 +58,8 @@ describe('Bar (Stacked) Chart example-index tests', () => {
     expect(await element(by.id('barstacked-s2-2010-bar')).getAttribute('id')).toEqual('barstacked-s2-2010-bar');
     expect(await element(by.id('barstacked-s2-2010-bar')).getAttribute('data-automation-id')).toEqual('automation-id-barstacked-s2-2010-bar');
 
-    expect(await element(by.id('barstacked-series1-legend')).getAttribute('data-automation-id')).toEqual('automation-id-barstacked-series1-legend');
-    expect(await element(by.id('barstacked-series2-legend')).getAttribute('data-automation-id')).toEqual('automation-id-barstacked-series2-legend');
+    expect(await element(by.id('barstacked-series1-legend')).getAttribute('data-automation-id')).toEqual('automation-id-barstacked-series1-legend-0');
+    expect(await element(by.id('barstacked-series2-legend')).getAttribute('data-automation-id')).toEqual('automation-id-barstacked-series2-legend-1');
   });
 
   if (utils.isChrome() && utils.isCI()) {
@@ -120,8 +120,8 @@ describe('Bar (Stacked) Chart 100% tests', () => {
     expect(await element(by.id('barstacked-c2-2015-bar')).getAttribute('id')).toEqual('barstacked-c2-2015-bar');
     expect(await element(by.id('barstacked-c2-2015-bar')).getAttribute('data-automation-id')).toEqual('automation-id-barstacked-c2-2015-bar');
 
-    expect(await element(by.id('barstacked-comp1-legend')).getAttribute('data-automation-id')).toEqual('automation-id-barstacked-comp1-legend');
-    expect(await element(by.id('barstacked-comp2-legend')).getAttribute('data-automation-id')).toEqual('automation-id-barstacked-comp2-legend');
+    expect(await element(by.id('barstacked-comp1-legend-0')).getAttribute('data-automation-id')).toEqual('automation-id-barstacked-comp1-legend-0');
+    expect(await element(by.id('barstacked-comp2-legend-1')).getAttribute('data-automation-id')).toEqual('automation-id-barstacked-comp2-legend-1');
   });
 
   if (utils.isChrome() && utils.isCI()) {

--- a/test/components/bar/bar-stacked.e2e-spec.js
+++ b/test/components/bar/bar-stacked.e2e-spec.js
@@ -58,8 +58,8 @@ describe('Bar (Stacked) Chart example-index tests', () => {
     expect(await element(by.id('barstacked-s2-2010-bar')).getAttribute('id')).toEqual('barstacked-s2-2010-bar');
     expect(await element(by.id('barstacked-s2-2010-bar')).getAttribute('data-automation-id')).toEqual('automation-id-barstacked-s2-2010-bar');
 
-    expect(await element(by.id('barstacked-series1-legend')).getAttribute('data-automation-id')).toEqual('automation-id-barstacked-series1-legend-0');
-    expect(await element(by.id('barstacked-series2-legend')).getAttribute('data-automation-id')).toEqual('automation-id-barstacked-series2-legend-1');
+    expect(await element(by.id('barstacked-series1-legend-0')).getAttribute('data-automation-id')).toEqual('automation-id-barstacked-series1-legend-0');
+    expect(await element(by.id('barstacked-series2-legend-1')).getAttribute('data-automation-id')).toEqual('automation-id-barstacked-series2-legend-1');
   });
 
   if (utils.isChrome() && utils.isCI()) {

--- a/test/components/bubble/bubble.e2e-spec.js
+++ b/test/components/bubble/bubble.e2e-spec.js
@@ -83,9 +83,9 @@ describe('Bubble example-index tests', () => {
     expect(await element(by.id('bubble-series2-line')).getAttribute('id')).toEqual('bubble-series2-line');
     expect(await element(by.id('bubble-series2-line')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-series2-line');
 
-    expect(await element(by.id('bubble-series1-legend')).getAttribute('id')).toEqual('bubble-series1-legend');
-    expect(await element(by.id('bubble-series1-legend')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-series1-legend');
-    expect(await element(by.id('bubble-series2-legend')).getAttribute('id')).toEqual('bubble-series2-legend');
-    expect(await element(by.id('bubble-series2-legend')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-series2-legend');
+    expect(await element(by.id('bubble-series1-legend-0')).getAttribute('id')).toEqual('bubble-series1-legend-0');
+    expect(await element(by.id('bubble-series1-legend-0')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-series1-legend-0');
+    expect(await element(by.id('bubble-series2-legend-1')).getAttribute('id')).toEqual('bubble-series2-legend-1');
+    expect(await element(by.id('bubble-series2-legend-1')).getAttribute('data-automation-id')).toEqual('automation-id-bubble-series2-legend-1');
   });
 });

--- a/test/components/column/column-grouped.e2e-spec.js
+++ b/test/components/column/column-grouped.e2e-spec.js
@@ -58,22 +58,22 @@ describe('Column Grouped Chart example-index tests', () => {
     expect(await element(by.id('columngrouped-c3-jun-bar')).getAttribute('id')).toEqual('columngrouped-c3-jun-bar');
     expect(await element(by.id('columngrouped-c3-jun-bar')).getAttribute('data-automation-id')).toEqual('automation-id-columngrouped-c3-jun-bar');
 
-    expect(await element(by.id('columngrouped-c1-jan-legend')).getAttribute('id')).toEqual('columngrouped-c1-jan-legend');
-    expect(await element(by.id('columngrouped-c1-jan-legend')).getAttribute('data-automation-id')).toEqual('automation-id-columngrouped-c1-jan-legend');
+    expect(await element(by.id('columngrouped-c1-jan-legend-0')).getAttribute('id')).toEqual('columngrouped-c1-jan-legend-0');
+    expect(await element(by.id('columngrouped-c1-jan-legend-0')).getAttribute('data-automation-id')).toEqual('automation-id-columngrouped-c1-jan-legend-0');
 
-    expect(await element(by.id('columngrouped-c1-feb-legend')).getAttribute('id')).toEqual('columngrouped-c1-feb-legend');
-    expect(await element(by.id('columngrouped-c1-feb-legend')).getAttribute('data-automation-id')).toEqual('automation-id-columngrouped-c1-feb-legend');
+    expect(await element(by.id('columngrouped-c1-feb-legend-1')).getAttribute('id')).toEqual('columngrouped-c1-feb-legend-1');
+    expect(await element(by.id('columngrouped-c1-feb-legend-1')).getAttribute('data-automation-id')).toEqual('automation-id-columngrouped-c1-feb-legend-1');
 
-    expect(await element(by.id('columngrouped-c1-mar-legend')).getAttribute('id')).toEqual('columngrouped-c1-mar-legend');
-    expect(await element(by.id('columngrouped-c1-mar-legend')).getAttribute('data-automation-id')).toEqual('automation-id-columngrouped-c1-mar-legend');
+    expect(await element(by.id('columngrouped-c1-mar-legend-2')).getAttribute('id')).toEqual('columngrouped-c1-mar-legend-2');
+    expect(await element(by.id('columngrouped-c1-mar-legend-2')).getAttribute('data-automation-id')).toEqual('automation-id-columngrouped-c1-mar-legend-2');
 
-    expect(await element(by.id('columngrouped-c1-apr-legend')).getAttribute('id')).toEqual('columngrouped-c1-apr-legend');
-    expect(await element(by.id('columngrouped-c1-apr-legend')).getAttribute('data-automation-id')).toEqual('automation-id-columngrouped-c1-apr-legend');
+    expect(await element(by.id('columngrouped-c1-apr-legend-3')).getAttribute('id')).toEqual('columngrouped-c1-apr-legend-3');
+    expect(await element(by.id('columngrouped-c1-apr-legend-3')).getAttribute('data-automation-id')).toEqual('automation-id-columngrouped-c1-apr-legend-3');
 
-    expect(await element(by.id('columngrouped-c1-may-legend')).getAttribute('id')).toEqual('columngrouped-c1-may-legend');
-    expect(await element(by.id('columngrouped-c1-may-legend')).getAttribute('data-automation-id')).toEqual('automation-id-columngrouped-c1-may-legend');
+    expect(await element(by.id('columngrouped-c1-may-legend-4')).getAttribute('id')).toEqual('columngrouped-c1-may-legend-4');
+    expect(await element(by.id('columngrouped-c1-may-legend-4')).getAttribute('data-automation-id')).toEqual('automation-id-columngrouped-c1-may-legend-4');
 
-    expect(await element(by.id('columngrouped-c1-jun-legend')).getAttribute('id')).toEqual('columngrouped-c1-jun-legend');
-    expect(await element(by.id('columngrouped-c1-jun-legend')).getAttribute('data-automation-id')).toEqual('automation-id-columngrouped-c1-jun-legend');
+    expect(await element(by.id('columngrouped-c1-jun-legend-5')).getAttribute('id')).toEqual('columngrouped-c1-jun-legend-5');
+    expect(await element(by.id('columngrouped-c1-jun-legend-5')).getAttribute('data-automation-id')).toEqual('automation-id-columngrouped-c1-jun-legend-5');
   });
 });

--- a/test/components/column/column-stacked.e2e-spec.js
+++ b/test/components/column/column-stacked.e2e-spec.js
@@ -95,13 +95,13 @@ describe('Column Stacked Chart tests', () => {
     expect(await element(by.id('columnstacked-2016-dec-bar')).getAttribute('id')).toEqual('columnstacked-2016-dec-bar');
     expect(await element(by.id('columnstacked-2016-dec-bar')).getAttribute('data-automation-id')).toEqual('automation-id-columnstacked-2016-dec-bar');
 
-    expect(await element(by.id('columnstacked-2018-legend')).getAttribute('id')).toEqual('columnstacked-2018-legend');
-    expect(await element(by.id('columnstacked-2018-legend')).getAttribute('data-automation-id')).toEqual('automation-id-columnstacked-2018-legend');
+    expect(await element(by.id('columnstacked-2018-legend-0')).getAttribute('id')).toEqual('columnstacked-2018-legend-0');
+    expect(await element(by.id('columnstacked-2018-legend-0')).getAttribute('data-automation-id')).toEqual('automation-id-columnstacked-2018-legend-0');
 
-    expect(await element(by.id('columnstacked-2017-legend')).getAttribute('id')).toEqual('columnstacked-2017-legend');
-    expect(await element(by.id('columnstacked-2017-legend')).getAttribute('data-automation-id')).toEqual('automation-id-columnstacked-2017-legend');
+    expect(await element(by.id('columnstacked-2017-legend-1')).getAttribute('id')).toEqual('columnstacked-2017-legend-1');
+    expect(await element(by.id('columnstacked-2017-legend-1')).getAttribute('data-automation-id')).toEqual('automation-id-columnstacked-2017-legend-1');
 
-    expect(await element(by.id('columnstacked-2016-legend')).getAttribute('id')).toEqual('columnstacked-2016-legend');
-    expect(await element(by.id('columnstacked-2016-legend')).getAttribute('data-automation-id')).toEqual('automation-id-columnstacked-2016-legend');
+    expect(await element(by.id('columnstacked-2016-legend-2')).getAttribute('id')).toEqual('columnstacked-2016-legend-2');
+    expect(await element(by.id('columnstacked-2016-legend-2')).getAttribute('data-automation-id')).toEqual('automation-id-columnstacked-2016-legend-2');
   });
 });

--- a/test/components/dount/donut.e2e-spec.js
+++ b/test/components/dount/donut.e2e-spec.js
@@ -15,10 +15,10 @@ describe('Donut Chart tests', () => {
   });
 
   it('Should be able to set id/automation id', async () => {
-    expect(await element(by.id('comp-a')).getAttribute('id')).toEqual('comp-a');
-    expect(await element(by.id('comp-a')).getAttribute('data-automation-id')).toEqual('comp-a-automation-id');
-    expect(await element(by.id('comp-a-legend')).getAttribute('id')).toEqual('comp-a-legend');
-    expect(await element(by.id('comp-a-legend')).getAttribute('data-automation-id')).toEqual('comp-a-automation-id-legend');
+    expect(await element(by.id('comp-a-slice-0')).getAttribute('id')).toEqual('comp-a-slice-0');
+    expect(await element(by.id('comp-a-slice-0')).getAttribute('data-automation-id')).toEqual('comp-a-automation-id-slice-0');
+    expect(await element(by.id('comp-a-legend-0')).getAttribute('id')).toEqual('comp-a-legend-0');
+    expect(await element(by.id('comp-a-legend-0')).getAttribute('data-automation-id')).toEqual('comp-a-automation-id-legend-0');
   });
 
   if (utils.isChrome() && utils.isCI()) {

--- a/test/components/line/line.e2e-spec.js
+++ b/test/components/line/line.e2e-spec.js
@@ -76,12 +76,12 @@ describe('Line Chart tests', () => {
     expect(await element(by.id('line-comp-c-line')).getAttribute('id')).toEqual('line-comp-c-line');
     expect(await element(by.id('line-comp-c-line')).getAttribute('data-automation-id')).toEqual('automation-id-line-comp-c-line');
 
-    expect(await element(by.id('line-comp-a-legend')).getAttribute('id')).toEqual('line-comp-a-legend');
-    expect(await element(by.id('line-comp-a-legend')).getAttribute('data-automation-id')).toEqual('automation-id-line-comp-a-legend');
-    expect(await element(by.id('line-comp-b-legend')).getAttribute('id')).toEqual('line-comp-b-legend');
-    expect(await element(by.id('line-comp-b-legend')).getAttribute('data-automation-id')).toEqual('automation-id-line-comp-b-legend');
-    expect(await element(by.id('line-comp-c-legend')).getAttribute('id')).toEqual('line-comp-c-legend');
-    expect(await element(by.id('line-comp-c-legend')).getAttribute('data-automation-id')).toEqual('automation-id-line-comp-c-legend');
+    expect(await element(by.id('line-comp-a-legend-0')).getAttribute('id')).toEqual('line-comp-a-legend-0');
+    expect(await element(by.id('line-comp-a-legend-0')).getAttribute('data-automation-id')).toEqual('automation-id-line-comp-a-legend-0');
+    expect(await element(by.id('line-comp-b-legend-1')).getAttribute('id')).toEqual('line-comp-b-legend-1');
+    expect(await element(by.id('line-comp-b-legend-1')).getAttribute('data-automation-id')).toEqual('automation-id-line-comp-b-legend-1');
+    expect(await element(by.id('line-comp-c-legend-2')).getAttribute('id')).toEqual('line-comp-c-legend-2');
+    expect(await element(by.id('line-comp-c-legend-2')).getAttribute('data-automation-id')).toEqual('automation-id-line-comp-c-legend-2');
   });
 });
 

--- a/test/components/pie/pie.e2e-spec.js
+++ b/test/components/pie/pie.e2e-spec.js
@@ -15,10 +15,10 @@ describe('Pie Chart tests', () => {
   });
 
   it('Should be able to set id/automation id', async () => {
-    expect(await element(by.id('item-a')).getAttribute('id')).toEqual('item-a');
-    expect(await element(by.id('item-a')).getAttribute('data-automation-id')).toEqual('item-a-automation-id');
-    expect(await element(by.id('item-a-legend')).getAttribute('id')).toEqual('item-a-legend');
-    expect(await element(by.id('item-a-legend')).getAttribute('data-automation-id')).toEqual('item-a-automation-id-legend');
+    expect(await element(by.id('item-a-slice-0')).getAttribute('id')).toEqual('item-a-slice-0');
+    expect(await element(by.id('item-a-slice-0')).getAttribute('data-automation-id')).toEqual('item-a-automation-id-slice-0');
+    expect(await element(by.id('item-a-legend-0')).getAttribute('id')).toEqual('item-a-legend-0');
+    expect(await element(by.id('item-a-legend-0')).getAttribute('data-automation-id')).toEqual('item-a-automation-id-legend-0');
   });
 
   if (utils.isChrome() && utils.isCI()) {

--- a/test/components/positive-negative/positive-negative.e2e-spec.js
+++ b/test/components/positive-negative/positive-negative.e2e-spec.js
@@ -67,14 +67,14 @@ describe('Positive Negative Chart tests', () => {
     expect(await element(by.id('positive-negative-dec-bar')).getAttribute('id')).toEqual('positive-negative-dec-bar');
     expect(await element(by.id('positive-negative-dec-bar')).getAttribute('data-automation-id')).toEqual('automation-id-positive-negative-dec-bar');
 
-    expect(await element(by.id('positive-negative-revenue-legend')).getAttribute('id')).toEqual('positive-negative-revenue-legend');
-    expect(await element(by.id('positive-negative-revenue-legend')).getAttribute('data-automation-id')).toEqual('automation-id-positive-negative-revenue-legend');
+    expect(await element(by.id('positive-negative-revenue-legend-0')).getAttribute('id')).toEqual('positive-negative-revenue-legend-0');
+    expect(await element(by.id('positive-negative-revenue-legend-0')).getAttribute('data-automation-id')).toEqual('automation-id-positive-negative-revenue-legend-0');
 
-    expect(await element(by.id('positive-negative-profit-legend')).getAttribute('id')).toEqual('positive-negative-profit-legend');
-    expect(await element(by.id('positive-negative-profit-legend')).getAttribute('data-automation-id')).toEqual('automation-id-positive-negative-profit-legend');
+    expect(await element(by.id('positive-negative-profit-legend-1')).getAttribute('id')).toEqual('positive-negative-profit-legend-1');
+    expect(await element(by.id('positive-negative-profit-legend-1')).getAttribute('data-automation-id')).toEqual('automation-id-positive-negative-profit-legend-1');
 
-    expect(await element(by.id('positive-negative-loss-legend')).getAttribute('id')).toEqual('positive-negative-loss-legend');
-    expect(await element(by.id('positive-negative-loss-legend')).getAttribute('data-automation-id')).toEqual('automation-id-positive-negative-loss-legend');
+    expect(await element(by.id('positive-negative-loss-legend-2')).getAttribute('id')).toEqual('positive-negative-loss-legend-2');
+    expect(await element(by.id('positive-negative-loss-legend-2')).getAttribute('data-automation-id')).toEqual('automation-id-positive-negative-loss-legend-2');
   });
 
   if (utils.isChrome() && utils.isCI()) {

--- a/test/components/radar/radar.e2e-spec.js
+++ b/test/components/radar/radar.e2e-spec.js
@@ -76,12 +76,12 @@ describe('Radar example-index tests', () => {
     expect(await element(by.id('radar-nokia-stroke')).getAttribute('id')).toEqual('radar-nokia-stroke');
     expect(await element(by.id('radar-nokia-stroke')).getAttribute('data-automation-id')).toEqual('automation-id-radar-nokia-stroke');
 
-    expect(await element(by.id('radar-iphone-legend')).getAttribute('id')).toEqual('radar-iphone-legend');
-    expect(await element(by.id('radar-iphone-legend')).getAttribute('data-automation-id')).toEqual('automation-id-radar-iphone-legend');
-    expect(await element(by.id('radar-samsung-legend')).getAttribute('id')).toEqual('radar-samsung-legend');
-    expect(await element(by.id('radar-samsung-legend')).getAttribute('data-automation-id')).toEqual('automation-id-radar-samsung-legend');
-    expect(await element(by.id('radar-nokia-legend')).getAttribute('id')).toEqual('radar-nokia-legend');
-    expect(await element(by.id('radar-nokia-legend')).getAttribute('data-automation-id')).toEqual('automation-id-radar-nokia-legend');
+    expect(await element(by.id('radar-iphone-legend-0')).getAttribute('id')).toEqual('radar-iphone-legend-0');
+    expect(await element(by.id('radar-iphone-legend-0')).getAttribute('data-automation-id')).toEqual('automation-id-radar-iphone-legend-0');
+    expect(await element(by.id('radar-samsung-legend-1')).getAttribute('id')).toEqual('radar-samsung-legend-1');
+    expect(await element(by.id('radar-samsung-legend-1')).getAttribute('data-automation-id')).toEqual('automation-id-radar-samsung-legend-1');
+    expect(await element(by.id('radar-nokia-legend-2')).getAttribute('id')).toEqual('radar-nokia-legend-2');
+    expect(await element(by.id('radar-nokia-legend-2')).getAttribute('data-automation-id')).toEqual('automation-id-radar-nokia-legend-2');
   });
 
   if (utils.isChrome() && utils.isCI()) {

--- a/test/components/scatterplot/scatterplot.e2e-spec.js
+++ b/test/components/scatterplot/scatterplot.e2e-spec.js
@@ -72,9 +72,9 @@ describe('Scatterplot Chart tests', () => {
     expect(await element(by.id('scatterplot-series2-line')).getAttribute('id')).toEqual('scatterplot-series2-line');
     expect(await element(by.id('scatterplot-series2-line')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-series2-line');
 
-    expect(await element(by.id('scatterplot-series1-legend')).getAttribute('id')).toEqual('scatterplot-series1-legend');
-    expect(await element(by.id('scatterplot-series1-legend')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-series1-legend');
-    expect(await element(by.id('scatterplot-series2-legend')).getAttribute('id')).toEqual('scatterplot-series2-legend');
-    expect(await element(by.id('scatterplot-series2-legend')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-series2-legend');
+    expect(await element(by.id('scatterplot-series1-legend-0')).getAttribute('id')).toEqual('scatterplot-series1-legend-0');
+    expect(await element(by.id('scatterplot-series1-legend-0')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-series1-legend-0');
+    expect(await element(by.id('scatterplot-series2-legend-1')).getAttribute('id')).toEqual('scatterplot-series2-legend-1');
+    expect(await element(by.id('scatterplot-series2-legend-1')).getAttribute('data-automation-id')).toEqual('automation-id-scatterplot-series2-legend-1');
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes a bug where automation ids is not properly rendered on legend, text and slices in charts.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5441

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/donut/test-automation-attributes.html
- Open Inspect, check the legends, slices and text for automation ids.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

