### PR TITLE
5443: Message max-width is hardcoded in modal

### DIFF
--- a/app/views/components/message/example-index.html
+++ b/app/views/components/message/example-index.html
@@ -9,7 +9,6 @@
     <button class="btn-secondary" type="button" id="allow-tags">Allow Tags</button><br/><br/>
     <button class="btn-secondary" type="button" id="disallow-tags">Disallow Tags</button><br/><br/>
     <button class="btn-secondary" type="button" id="huge-message">Huge Message</button><br/><br/>
-    <button class="btn-secondary" type="button" id="huge-title">Huge Title</button><br/><br/>
   </div>
 </div>
 
@@ -171,29 +170,6 @@
       $('body').message({
         title: 'Message with a lot of text',
         message: 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?',
-        returnFocus: $(this),
-        buttons: [{
-          text: 'Ok',
-          click: function(e, modal) {
-            console.log('Ok');
-            modal.close();
-          },
-          isDefault: true
-        }, {
-          text: 'Dismiss',
-          click: function(e, modal) {
-            console.log('Dismiss');
-            modal.close();
-          }
-        }]
-      });
-    });
-
-    $('#huge-title').on('click', function() {
-      $('body').message({
-        title: 'Title with a whole lot of text that will wrap to a second line if message width settings are chosen as smaller than the auto title width.',
-        message: 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.',
-        width: 1000,
         returnFocus: $(this),
         buttons: [{
           text: 'Ok',

--- a/app/views/components/message/test-long-title.html
+++ b/app/views/components/message/test-long-title.html
@@ -1,0 +1,33 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <button class="btn-secondary" type="button" id="huge-title">Long Title</button><br/><br/>
+  </div>
+</div>
+
+<script>
+  $('body').on('initialized', function() {
+    $('#huge-title').on('click', function() {
+      $('body').message({
+        title: 'Title with a whole lot of text that will wrap to a second line if message width settings are chosen as smaller than the auto title width.',
+        message: 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.',
+        maxWidth: 'initial',
+        returnFocus: $(this),
+        buttons: [{
+          text: 'Ok',
+          click: function(e, modal) {
+            console.log('Ok');
+            modal.close();
+          },
+          isDefault: true
+        }, {
+          text: 'Dismiss',
+          click: function(e, modal) {
+            console.log('Dismiss');
+            modal.close();
+          }
+        }]
+      });
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## v4.55.0 Fixes
 
 - `[Charts]` Fixed a bug where automation ids is not properly rendered on legend, text and slices. ([#5441](https://github.com/infor-design/enterprise/issues/5441))
-- `[Message]` Removed max width on message when width is set in settings as not auto. ([#5443](https://github.com/infor-design/enterprise/issues/5443))
+- `[Message]` Added maxWidth setting to allow message to go full width when title is long. ([#5443](https://github.com/infor-design/enterprise/issues/5443))
 
 ## v4.54.0 Features
 

--- a/src/components/message/message.js
+++ b/src/components/message/message.js
@@ -98,12 +98,10 @@ Message.prototype = {
     if (this.settings.width !== 'auto') {
       this.content.closest('.modal')[0].style.maxWidth = 'none';
       this.content.closest('.modal')[0].style.width = this.settings.width + (/(px|%)/i.test(`${this.settings.width}`) ? '' : 'px');
-      this.content.find('#message-text')[0].style.maxWidth = 'none';
     }
 
     // Adjust Max Width if Set as a Setting
     if (this.settings.maxWidth) {
-      console.log(this.settings.maxWidth);
       this.content.find('.message')[0].style.maxWidth = this.settings.maxWidth;
     }
 

--- a/src/components/message/message.js
+++ b/src/components/message/message.js
@@ -32,6 +32,7 @@ const MESSAGE_DEFAULTS = {
   status: '',
   message: 'Message Summary',
   width: 'auto',
+  maxWidth: null,
   buttons: null,
   cssClass: null,
   returnFocus: null,
@@ -97,6 +98,12 @@ Message.prototype = {
     if (this.settings.width !== 'auto') {
       this.content.closest('.modal')[0].style.maxWidth = 'none';
       this.content.closest('.modal')[0].style.width = this.settings.width + (/(px|%)/i.test(`${this.settings.width}`) ? '' : 'px');
+    }
+
+    // Adjust Max Width if Set as a Setting
+    if (this.settings.maxWidth) {
+      console.log(this.settings.maxWidth);
+      this.content.find('.message')[0].style.maxWidth = this.settings.maxWidth;
     }
 
     if (this.settings.cssClass) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Message max-width is hard-coded in modal so when title size is long the message width does not increase to the size of it's container.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Fixes #5443 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull branch, run app, visit http://localhost:4000/components/message/test-long-title.html
- Click the  button
- Notice the message text extends to the full width of it's container.
- Also notice that the modal now resizes toward it's max-width if the message text is long (this may be an undesired side-effect of simply removing the max-width from the message and perhaps we should consider placing a max-width setting option on modal and determine a default there)

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
