### PR TITLE
Ng1075 - fix overlapping of checkbox with label when editorOptions.multiple is true

### DIFF
--- a/app/views/components/datagrid/test-multi-select-dropdown-selection.html
+++ b/app/views/components/datagrid/test-multi-select-dropdown-selection.html
@@ -1,0 +1,188 @@
+
+<div class="row">
+    <div class="twelve columns">
+      <div role="toolbar" class="toolbar">
+  
+        <div class="title">
+          Data Grid Header Title
+          <span class="datagrid-result-count">(N Results)</span>
+        </div>
+  
+        <div class="buttonset">
+            <button type="button" id="toggle-row-status" class="btn">
+              <span>Add Row Status</span>
+            </button>
+            <button type="button" id="validate" class="btn-menu">
+              <span>Validate</span>
+            </button>
+            <ul class="popupmenu">
+              <li><a href="#" data-action="specific-row-error">Specific Row Error</a></li>
+              <li><a href="#" data-action="all-cells-in-row">All Cells in Row</a></li>
+              <li><a href="#" data-action="all-rows-and-cells">All Rows and Cells</a></li>
+              <li class="separator"></li>
+              <li><a href="#" data-action="clear-specific-row-error">Clear Specific Row Error</a></li>
+              <!-- <li><a href="#" data-action="clear-all-cells-in-row">Clear All Cells in Row</a></li> -->
+              <li><a href="#" data-action="clear-all-rows-and-cells">Clear All Rows and Cells</a></li>
+            </ul>
+          <button class="btn-icon" type="button" id="add-btn">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-add"></use>
+            </svg>
+            <span class="audible">Add</span>
+          </button>
+        </div>
+  
+        <div class="more">
+          <button class="btn-actions" type="button">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-more"></use>
+            </svg>
+            <span class="audible">More Actions</span>
+          </button>
+          <ul class="popupmenu">
+            <li class="single-selectable-section"></li>
+            <li class="heading">Row Height</li>
+            <li class="is-selectable"><a data-option="row-extra-small" href="#" data-translate="text">ExtraSmall</a></li>
+            <li class="is-selectable"><a data-option="row-small" href="#" data-translate="text">Small</a></li>
+            <li class="is-selectable"><a data-option="row-medium" href="#" data-translate="text">Medium</a></li>
+            <li class="is-selectable is-checked"><a data-option="row-large" href="#" data-translate="text">Large</a></li>
+          </ul>
+  
+        </div>
+      </div>
+  
+      <div class="contextual-toolbar toolbar is-hidden">
+        <div class="title selection-count">1 Selected</div>
+        <div class="buttonset">
+          <button class="btn-icon" type="button" id="remove-btn">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-delete"></use>
+            </svg>
+            <span class="audible">Remove</span>
+          </button>
+        </div>
+      </div>
+  
+      <div id="datagrid"></div>
+    </div>
+  </div>
+  
+  <script>
+    var gridApi = null;
+  
+    $('body').one('initialized', function () {
+      var grid,
+        columns = [],
+        data = [];
+  
+      var isDisabled = function(row, cell, value, item) {
+        return (row % 2 === 0);
+      }
+  
+      // Some Sample Data
+      data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity: '<svg/onload=alert(1)>', quantity: 1, price: 210.99, status: 'OK', orderDate: '00000000', portable: false, action: 1, description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning'});
+      data.push({ id: 2, productId: 2241202, productName: 'console.log', activity: 'Inspect and Repair', quantity: 2, price: 210.991, status: '', orderDate: '', portable: false, action: 1, description: 'The kit has an air blow gun that can be used for cleaning'});
+      data.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity: '', portable: true, quantity: null, price: 120.992, status: null, orderDate: new Date(2014, 6, 3), action: 2});
+      data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity: 'Assemble Paint', portable: true, quantity: 3, price: null, status: 'OK', orderDate: new Date(2015, 3, 3), action: 3, description: 'Compressor comes with with air tool kit'});
+      data.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 1});
+      data.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity: 'Inspect and Repair', portable: false, quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 2});
+      data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity: 'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 2});
+  
+      //Define Columns for the Grid.
+      // columns.push({ id: 'rowStatus', sortable: false, resizable: false, formatter: Formatters.Status, align: 'center'});
+      columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
+      columns.push({ id: 'id', name: 'Row Id', field: 'id', formatter: Formatters.Readonly});
+      columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input});
+      columns.push({ id: 'activity', name: 'Activity', field: 'activity', required: true, editor: Editors.Input, validate: 'required'});  //maxLength: 2
+      columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', align: 'right', editor: Editors.Input, mask: '###', isEditable: isDisabled});
+      columns.push({ id: 'portable', name: 'Portable', field: 'portable', align: 'center', formatter: Formatters.Checkbox, editor: Editors.Checkbox});
+      columns.push({ id: 'price', name: 'Price', field: 'price', align: 'right', formatter: Formatters.Decimal, validate: 'required', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input});
+      columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date, editorOptions: {showLegend: true, legend: [{name: 'Weekend', color: '#579E95', dayOfWeek: [0,6]}], disable: { years: [], dates: [], minDate: '01-01-2015', maxDate: '01-01-2022', dayOfWeek: [], isEnable: false, restrictMonths: false }, showTime: false, showMonthYearPicker: true, placeholder: true}, validate: 'availableDate required date', width: 120});
+      columns.push({ id: "multiDropDown", name: "Multiple Selection", field: "multiDropDown", formatter: Soho.Formatters.Dropdown, editor: Editors.Dropdown, editorOptions: { multiple: true, closeOnSelect: false, }, options: [ { label: "Open", value: "op" }, { label: "On Hold", value: "oh" }, { label: "Shipped", value: "sh" }, { label: "Action", value: "ac" }, ]})
+  
+      //Init and get the api for the grid
+      grid = $('#datagrid').datagrid({
+        columns: columns,
+        dataset: data,
+        editable: true,
+        showNewRowIndicator: false,
+        clickToSelect: false,
+        selectable: 'multiple',
+        toolbar: {title: 'Data Grid Header Title', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: true,  collapsibleFilter: true},
+        paging: true,
+        pagesize: 5,
+        pagesizes: [2, 5, 6]
+      }).on('cellchange', function (e, args) {
+        console.log('cellchange', args);
+      }).on('rowadd', function (e, args) {
+        console.log(e, args);
+      }).on('rowremove', function (e, args) {
+        console.log(e, args);
+      }).on('dblclick', function (e, args) {
+        console.log('dblclick', args);
+      });
+  
+      gridApi = $('#datagrid').data('datagrid');
+  
+      //Example row status
+      $('#toggle-row-status').on('click', function () {
+        var btn = $(this).find('span');
+        var status = {
+          add: 'Add Row Status',
+          remove: 'Remove Row Status'
+        };
+        if (btn.text() === status.add) {
+          btn.text(status.remove);
+          gridApi.rowStatus(0, 'error', 'Error');
+          gridApi.rowStatus(0, 'error', 'Error 2');
+          gridApi.rowStatus(0, 'error', 'Error 3');
+          gridApi.rowStatus(1, 'alert', 'Alert');
+          gridApi.rowStatus(2, 'info', 'Info');
+          gridApi.rowStatus(3, 'in-progress', 'inProgress');
+          gridApi.rowStatus(4, 'success', 'Confirm');
+          gridApi.rowStatus(6, 'new', 'new');
+          gridApi.rowStatus(6, 'error', 'This row has errors');
+        } else {
+          btn.text(status.add);
+          gridApi.resetRowStatus();
+        }
+      });
+  
+      window.data = data;
+    });
+  
+    var newId = 8;
+    //Add Code for Add and icon-delete
+    $('#add-btn').on('click', function () {
+      gridApi.addRow({ id: newId++, productId: 2642206, productName: 'New Product'});
+      console.log(gridApi.settings.dataset[1]);
+    });
+  
+    //Add Code for Add and icon-delete
+    $('#remove-btn').on('click', function () {
+      gridApi.removeSelected();
+    });
+  
+    //A few other ways
+    $('#validate').on('selected', function (e, args) {
+      var action = args.attr('data-action');
+  
+      if (action === 'specific-row-error') {
+        gridApi.showRowError(2, 'This row has a custom error message.', 'error');
+      }
+      if (action === 'all-cells-in-row') {
+        gridApi.validateRow(2);
+      }
+      if (action === 'all-rows-and-cells') {
+        gridApi.validateAll();
+      }
+      if (action === 'clear-specific-row-error') {
+        gridApi.clearRowError(2);
+      }
+      if (action === 'clear-all-rows-and-cells') {
+        gridApi.clearAllErrors();
+      }
+    });
+  
+  </script>
+  

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## v4.55.0 Fixes
 
 - `[Charts]` Fixed a bug where automation ids is not properly rendered on legend, text and slices. ([#5441](https://github.com/infor-design/enterprise/issues/5441))
+- `[Datagrid]` Fixed a bug where the checkbox overlaps with the label when `editorOption` `multiple` is set to true. ([NG#1075](https://github.com/infor-design/enterprise-ng/issues/1075))
 - `[Message]` Added maxWidth setting to allow message to go full width when title is long. ([#5443](https://github.com/infor-design/enterprise/issues/5443))
 - `[Datagrid]` Fixed an issue where tree list indentation is not left aligned when row has no children and datagrid row height is extra small or small. ([#5487](https://github.com/infor-design/enterprise/issues/5487))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,9 +8,9 @@
 ## v4.55.0 Fixes
 
 - `[Charts]` Fixed a bug where automation ids is not properly rendered on legend, text and slices. ([#5441](https://github.com/infor-design/enterprise/issues/5441))
-- `[Datagrid]` Fixed a bug where the checkbox overlaps with the label when `editorOption` `multiple` is set to true. ([NG#1075](https://github.com/infor-design/enterprise-ng/issues/1075))
-- `[Message]` Added maxWidth setting to allow message to go full width when title is long. ([#5443](https://github.com/infor-design/enterprise/issues/5443))
+- `[Datagrid]` Fixed a bug where the checkbox overlaps with the label when `editorOptions.multiple` is set to true. ([NG#1075](https://github.com/infor-design/enterprise-ng/issues/1075))
 - `[Datagrid]` Fixed an issue where tree list indentation is not left aligned when row has no children and datagrid row height is extra small or small. ([#5487](https://github.com/infor-design/enterprise/issues/5487))
+- `[Message]` Added maxWidth setting to allow message to go full width when title is long. ([#5443](https://github.com/infor-design/enterprise/issues/5443))
 
 ## v4.54.0 Features
 

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -4198,6 +4198,15 @@ td .btn-actions {
   border-radius: 0 0 3px 3px;
   margin-top: -1px;
 
+  &.multiple {
+    ul[role='listbox'] .dropdown-option {
+      a {
+        left: 10px;
+        position: relative;
+      }
+    }
+  }
+
   &.is-editing {
     margin-top: -2.5px;
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the overlapping of the checkbox with the label when `editorOptions.multiple` is set to true.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise-ng/issues/1075

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-multi-select-dropdown-selection.html
- Go to `multiple selection` column
- Open the dropdown list
- Checkboxes and labels should not be overlapping each other

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
