### PR TITLE
5533 - Fix the selection color on clickable tags

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `[ContextualActionPanel]` Added `title` prop in CAP to control the title via `modaSettings`, and added missing `beforeclose` event. ([NG#1048](https://github.com/infor-design/enterprise-ng/issues/1048))
 - `[ContextMenu]` Fixed a bug where field option is not rendered properly on mobile ([#5335](https://github.com/infor-design/enterprise/issues/5335))
 - `[Datagrid]` - Fixed a bug where the row height cut off the focus ring on the Action Item buttons for Classic/New mode and XS, S, M settings ([#5394](https://github.com/infor-design/enterprise/issues/5394))
+- `[Datagrid]` - Fixed a bug where the selection color would bleed through clickable tags. ([#5533](https://github.com/infor-design/enterprise/issues/5533))
 - `[Datagrid]` Fixed an issue where toggling the selectable setting did not correctly enable the checkbox. ([#5482](https://github.com/infor-design/enterprise/issues/5482))
 - `[Datagrid]` Fixed an issue where row reorder handle align was not right for extra small and small height. ([#5233](https://github.com/infor-design/enterprise/issues/5233))
 - `[Datagrid]` - Fixed a bug where the first two columns row heights did not match the others for the Medium setting ([#5366](https://github.com/infor-design/enterprise/issues/5366))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -2055,7 +2055,7 @@ $datagrid-small-row-height: 25px;
     &.is-selected:not(.hide-selected-color) td:not(.is-editing) .datagrid-cell-wrapper {
       background-color: $datagrid-row-selected-color;
 
-      .icon:not(.icon-rowstatus):not(.plus-minus) {
+      .icon:not(.icon-rowstatus):not(.plus-minus):not(.caret-right) {
         @include trigger-icon-background($datagrid-row-selected-color);
       }
     }

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -558,7 +558,7 @@ const formatters = {
     const ranges = formatters.ClassRange(row, cell, value, col);
     if (col?.editorOptions?.clickable) {
       return `<span class="tag is-linkable hide-focus ${ranges.classes}"><a class="tag-content" href="#">#${value}</a><button class="btn-linkable" focusable="false" tabindex="-1">
-        <svg class="icon" focusable="false" aria-hidden="true" role="presentation"><use href="#icon-caret-right"></use></svg>
+        <svg class="icon caret-right" focusable="false" aria-hidden="true" role="presentation"><use href="#icon-caret-right"></use></svg>
       </button></span>`;
     }
     return `<span class="tag ${ranges.classes} hide-focus"><span class="tag-content">${value}</span></span>`;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes a bug where the selection color would bleed through the clickable tags (easy one found in triage).

**Related github/jira issue (required)**:
Fixes #5533

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-alerts.html
- select a row
- look at the tags and make sure the selection color isnt bleeding through the icon


**Included in this Pull Request**:
- [x] A note to the change log.
