### PR TITLE
5435 vertical scroll to end

### DIFF
--- a/app/views/components/datagrid/example-vertical-scroll-to-end-event.html
+++ b/app/views/components/datagrid/example-vertical-scroll-to-end-event.html
@@ -1,0 +1,39 @@
+<div class="row top-padding">
+  <div class="twelve columns">
+
+    <div id="datagrid" style="height: 300px;">
+    </div>
+
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+
+      var grid,
+        columns = [];
+
+      //Define Columns for the Grid.
+      columns.push({ id: 'productId', name: 'Product Id', field: 'productId', width: 140, formatter: Formatters.Readonly});
+      columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', width: 150, formatter: Formatters.Hyperlink});
+      columns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', width: 125});
+      columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity'});
+      columns.push({ id: 'price', name: 'Price', field: 'price', formatter: Formatters.Decimal});
+      columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+
+      var url = '{{basepath}}api/compressors?pageNum=1&pageSize=75';
+
+      $.getJSON(url, function(res) {
+
+        //Show the grid
+        $('#datagrid').datagrid({
+          columns: columns,
+          dataset: res.data,
+          columnReorder: true,
+          rowHeight: 'small',
+          toolbar: {title: 'Data Grid Header Title', results: true, dateFilter: false ,keywordFilter: false, advancedFilter: false, actions: true, views: true, rowHeight: true}
+        });
+
+      });
+  });
+</script>

--- a/app/views/components/datagrid/example-vertical-scroll-to-end-event.html
+++ b/app/views/components/datagrid/example-vertical-scroll-to-end-event.html
@@ -34,6 +34,15 @@
           toolbar: {title: 'Data Grid Header Title', results: true, dateFilter: false ,keywordFilter: false, advancedFilter: false, actions: true, views: true, rowHeight: true}
         });
 
+        $('.datagrid-wrapper.center').on('scroll', function() {
+          if ($('#datagrid').data('datagrid').isVerticalScrollToEnd) {
+            $('body').toast({
+              title: 'Vertical Scroll to End',
+              message: 'Hooray! You reached the bottom of the list.',
+            });
+          }
+        });
+
       });
   });
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[ApplicationMenu]` Added the ability to resize the app menu. ([#5193](https://github.com/infor-design/enterprise/issues/5193))
 - `[Datagrid]` Adds the ability to have a selection radio buttons on Datagrid. ([#5384](https://github.com/infor-design/enterprise/issues/5384))
+- `[Datagrid]` Added a `verticalScrollToEnd` property when you reached the end of the datagrid list. ([#5435](https://github.com/infor-design/enterprise/issues/5435))
 - `[Message]` Add an optional close button setting to dismiss the message. ([#5464](https://github.com/infor-design/enterprise/issues/5464))
 - `[Modal]` Added the ability to have a custom tooltip on modal close button. ([#5391](https://github.com/infor-design/enterprise/issues/5391))
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -491,13 +491,14 @@ Datagrid.prototype = {
   /**
    * Checks if the datagrid body has vertical scrollbar.
    * @private
+   * @returns {boolean}
    */
   hasScrollbarY() {
     const self = this;
     const height = parseInt(self.bodyWrapperCenter[0].offsetHeight, 10);
     const hasVerticalScrollbar = parseInt(self.bodyWrapperCenter[0].scrollHeight, 10) > height + 2;
 
-    self.hasVerticalScrollbar = hasVerticalScrollbar ? true : false;
+    self.hasVerticalScrollbar = hasVerticalScrollbar !== false;
   },
 
   /**
@@ -6410,6 +6411,20 @@ Datagrid.prototype = {
   },
 
   /**
+   * Adds support when the datagrid container scrolls to the end of the list.
+   * @private
+   * @param {jQuery} e The event object.
+   * @returns {boolean}
+   */
+  verticalScrollToEnd(e) {
+    const el = e.currentTarget;
+    const isAtTheBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 1;
+
+    // Has the control to do some logic when it's at the bottom of the list
+    this.isVerticalScrollToEnd = isAtTheBottom !== false;
+  },
+
+  /**
    * Sync the containers when scrolling on the y axis.
    * @private
    * @param  {jQuery} e The event object
@@ -6516,6 +6531,7 @@ Datagrid.prototype = {
       self.element.find('.datagrid-wrapper')
         .on('scroll.table', (e) => {
           self.handleScrollY(e);
+          self.verticalScrollToEnd(e);
         });
 
       self.element.find('.datagrid-wrapper')
@@ -6524,6 +6540,7 @@ Datagrid.prototype = {
             e.currentTarget.scrollTop += (e.originalEvent.deltaY);
             e.preventDefault();
             self.handleScrollY(e);
+            self.verticalScrollToEnd(e);
           }
         });
     }

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -313,6 +313,7 @@ Datagrid.prototype = {
     this.setRowGrouping();
     this.setTreeRootNodes();
     this.firstRender();
+    this.hasScrollbarY();
     this.handleEvents();
     this.handleKeys();
 
@@ -485,6 +486,18 @@ Datagrid.prototype = {
 
     this.handlePaging();
     this.triggerSource('initial');
+  },
+
+  /**
+   * Checks if the datagrid body has vertical scrollbar.
+   * @private
+   */
+  hasScrollbarY() {
+    const self = this;
+    const height = parseInt(self.bodyWrapperCenter[0].offsetHeight, 10);
+    const hasVerticalScrollbar = parseInt(self.bodyWrapperCenter[0].scrollHeight, 10) > height + 2;
+
+    self.hasVerticalScrollbar = hasVerticalScrollbar ? true : false;
   },
 
   /**
@@ -6499,7 +6512,7 @@ Datagrid.prototype = {
     }
 
     // Sync Header and Body During scrolling
-    if (this.hasLeftPane || this.hasRightPane) {
+    if (this.hasLeftPane || this.hasRightPane || this.hasVerticalScrollbar) {
       self.element.find('.datagrid-wrapper')
         .on('scroll.table', (e) => {
           self.handleScrollY(e);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR adds `verticalScrollToEnd` property when you reach the end of the Datagrid list. This will only work on the list that has a vertical scrollbar.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/5435

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/example-vertical-scroll-to-end-event.html
- Scroll until you hit the bottom of the list
- A toast message will appear `Hooray! You reached the bottom of the list.`
- Play around with the list, scrolling up and down to test the functionality

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
