### PR TITLE
Add custom mask example

### DIFF
--- a/app/views/components/mask/example-custom-function.html
+++ b/app/views/components/mask/example-custom-function.html
@@ -1,0 +1,30 @@
+<div class="row">
+  <div class="twelve columns">
+    <h2>Custom Mask Function</h2>
+    <p>This input field will only accept commas and digits
+    </p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+    <div class="field">
+      <label for="test-input">Numbers and Commas</label>
+      <input id="test-input" name="test-input" value="100,101,102" />
+    </div>
+  </div>
+</div>
+
+<script id="test-script">
+  $('#test-input').mask({
+    patternOptions: {
+      onlyUseNumbersAndCommas: true
+    },
+    pattern: function customMask(rawValue, options) {
+      // Returns an array matching the length of the rawValue
+      // that will be used to match only commas and digits.
+      const match = /[,\d]/;
+      return rawValue.split('').map(() => match);
+    }
+  });
+</script>


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds an example of defining a custom Mask function that will throw away input against a dynamically-sized mask.  We  previously didn't have any examples of a user-defined mask function in 4.x, but this functionality is used in Date/Time/Number/Range masks already.

**Related github/jira issue (required)**:
N/A

**Steps necessary to review your pull request (required)**:
- Pull/Build/Run
- Open http://localhost:4000/components/mask/example-custom-function.html
- Try typing anything in the input besides numbers and commas.  The input shouldn't be accepted.
- Try adding an indeterminate amount of numbers and/or commas.  It should be allowed.

**Additional Context**:
Addresses a question on [MS Teams](https://teams.microsoft.com/l/message/19:2b0c9ce520b0481a9ce115f0ca4a326f@thread.skype/1629379993540?tenantId=457d5685-0467-4d05-b23b-8f817adda47c&groupId=4f50ef7d-e88d-4ccb-98ca-65f26e57fe35&parentMessageId=1629379993540&teamName=IDS%20Enterprise%20Development&channelName=General&createdTime=1629379993540) from @Sovia 