### PR TITLE
5420 - Fix dropdown alignment on chinese locale

### DIFF
--- a/src/components/timepicker/_timepicker-new.scss
+++ b/src/components/timepicker/_timepicker-new.scss
@@ -86,3 +86,16 @@ html:not([lang='en-US']) {
     width: 75px;
   }
 }
+
+// For Chinese Locale fix only
+html[lang='zh-CN'] {
+  #timepicker-popup {
+    .dropdown {
+      padding: 6px 30px 8px 10px;
+
+      + .icon {
+        top: 4px;
+      }
+    }
+  }
+}

--- a/src/components/timepicker/_timepicker.scss
+++ b/src/components/timepicker/_timepicker.scss
@@ -254,3 +254,14 @@ html[dir='rtl'] {
     }
   }
 }
+
+// Fix for Chinese locale only
+html[lang='zh-CN'] {
+  #timepicker-popup {
+    select.period + .dropdown-wrapper {
+      .dropdown {
+        padding-top: 6px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This is a follow-up fix for https://github.com/infor-design/enterprise/issues/5420.

Fixes the current dropdown value alignment when you open up the dropdown list for the Chinese locale only.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/5420

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/timepicker/example-index.html?locale=zh-CN
- Open the list of `hours`, `minutes`, and `period`
- Do it repeatedly to test
- The value  and the dropdown icon should not move
- Test for both `New` and `Classic` theme

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
