### PR TITLE
5462 - Add better fix for orderlist tag formatting

### DIFF
--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -705,15 +705,19 @@ Editor.prototype = {
     switch (orderedListTag.attr('type')) {
       case types.loweralpha:
         editor.addClass('type-l-alpha');
+        editor.removeClass('type-u-alpha');
         break;
       case types.upperalpha:
         editor.addClass('type-u-alpha');
+        editor.removeClass('type-l-alpha');
         break;
       case types.lowerroman:
         editor.addClass('type-l-roman');
+        editor.removeClass('type-u-roman');
         break;
       case types.upperroman:
         editor.addClass('type-u-roman');
+        editor.removeClass('type-l-roman');
         break;
       default:
         break;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the identifier of order list tag formatting (uppercase and lowercase) for both alphabetical and roman numbers.

**Related github/jira issue (required)**:

Closes #5462

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/editor/example-index.html
- Select all the text in editor
- Click the Number List button
- Toggle the `HTML` button
- Add `type="a"` in `<ol>` tag e.g. `<ol type="a">`
- Click the`Visual` button
- Format should be alphabetical lowercase
- Then back to the source
- Change  the type to `"A"`
- Back to visual
- Format should be alphabetical uppercase
- Then back again to the source and change to `"a"`
- It should go back to lowercase when in visual
- Do the same steps for roman format by using `type="i"` for lowercase and `type="I"` for uppercase

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
