### PR TITLE
NG1075 - Add fix for other row heights

### DIFF
--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -4205,6 +4205,24 @@ td .btn-actions {
         position: relative;
       }
     }
+
+    &.medium-rowheight {
+      ul[role='listbox'] .dropdown-option a {
+        left: 15px;
+      }
+    }
+
+    &.small-rowheight {
+      ul[role='listbox'] .dropdown-option a {
+        left: 20px;
+      }
+    }
+
+    &.extra-small-rowheight {
+      ul[role='listbox'] .dropdown-option a {
+        left: 20px;
+      }
+    }
   }
 
   &.is-editing {

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -4201,26 +4201,27 @@ td .btn-actions {
   &.multiple {
     ul[role='listbox'] .dropdown-option {
       a {
-        left: 10px;
+        bottom: 1px;
+        left: 12px;
         position: relative;
       }
     }
 
     &.medium-rowheight {
       ul[role='listbox'] .dropdown-option a {
-        left: 15px;
+        left: 17px;
       }
     }
 
     &.small-rowheight {
       ul[role='listbox'] .dropdown-option a {
-        left: 20px;
+        left: 22px;
       }
     }
 
     &.extra-small-rowheight {
       ul[role='listbox'] .dropdown-option a {
-        left: 20px;
+        left: 22px;
       }
     }
   }

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -640,7 +640,6 @@ const formatters = {
         // Converting the array of values to it's label to display the correct information.
         if ((typeof compareValue === 'object' || Array.isArray(compareValue)) && col.editorOptions.multiple) {
           for (let j = 0; j < compareValue.length; j++) {
-            console.log(compareValue[j]);
             if (col.options[i].value === compareValue[j]) {
               formattedValue += `${option.label}, `;
             }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the alignment of multiple checkboxes and text on `medium`, `small`, and `extra-small` row heights.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise-ng/issues/1075

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-multi-select-dropdown-selection.html?theme=new&mode=light&colors=2578a9
- Open the multiselect dropdown
- Checkboxes and text should not overlapping each other
- Test on different row heights

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
