### PR TITLE
5541/5558 - Fix for Lookup/Timepicker icon not rendering properly in Safari. Fix for Spinbox box shadow not rendering properly

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## v4.56.0 Fixes
 
-- `[Lookup/Validation]` Fixed a bug for short field and its icons not rendering properly. ([#5541](https://github.com/infor-design/enterprise/issues/5541))
+- `[Lookup]` Fixed a bug for short field and its icons not rendering properly. ([#5541](https://github.com/infor-design/enterprise/issues/5541))
+- `[Timepicker]` Fixed a bug timepicker icon not rendering properly. ([#5558](https://github.com/infor-design/enterprise/issues/5558))
 
 ## v4.55.0 Features
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # What's New with Enterprise
 
+## v4.56.0 Fixes
+
+- `[Lookup/Validation]` Fixed a bug for short field and its icons not rendering properly. ([#5541](https://github.com/infor-design/enterprise/issues/5541))
+
 ## v4.55.0 Features
 
 - `[ApplicationMenu]` Added the ability to resize the app menu. ([#5193](https://github.com/infor-design/enterprise/issues/5193))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,10 +1,5 @@
 # What's New with Enterprise
 
-## v4.56.0 Fixes
-
-- `[Lookup]` Fixed a bug for short field and its icons not rendering properly. ([#5541](https://github.com/infor-design/enterprise/issues/5541))
-- `[Timepicker]` Fixed a bug for timepicker icon not rendering properly. ([#5558](https://github.com/infor-design/enterprise/issues/5558))
-
 ## v4.55.0 Features
 
 - `[ApplicationMenu]` Added the ability to resize the app menu. ([#5193](https://github.com/infor-design/enterprise/issues/5193))
@@ -12,11 +7,13 @@
 - `[Datagrid]` Added a `verticalScrollToEnd` property when you reached the end of the datagrid list. ([#5435](https://github.com/infor-design/enterprise/issues/5435))
 - `[Datagrid]` Added seperate mask options for filter row. ([#5519](https://github.com/infor-design/enterprise/issues/5519))
 - `[Editor]` Added support for `ol` type attribute to be able to use the other list styles (`alphabetically ordered (lowercase and uppercase)`, and `roman numbers (lowercase and uppercase)`) of `ol` tag. ([#5462](https://github.com/infor-design/enterprise/issues/5462))
+- `[Lookup]` Fixed a bug for short field and its icons not rendering properly. ([#5541](https://github.com/infor-design/enterprise/issues/5541))
 - `[Message]` Add info status handling to message.([#5459](https://github.com/infor-design/enterprise/issues/5459))
 - `[Message]` Add an optional close button setting to dismiss the message. ([#5464](https://github.com/infor-design/enterprise/issues/5464))
 - `[Modal]` Added the ability to have a custom tooltip on modal close button. ([#5391](https://github.com/infor-design/enterprise/issues/5391))
 - `[Swaplist]` Added option to copy items from lists instead of moving them. ([#5513](https://github.com/infor-design/enterprise/issues/5513))
 - `[Popdown]` Added a click outside event in popdown. ([#3618](https://github.com/infor-design/enterprise/issues/3618))
+- `[Timepicker]` Fixed a bug for timepicker icon not rendering properly. ([#5558](https://github.com/infor-design/enterprise/issues/5558))
 - `[Typography]` New typography paragraph text style. ([#5325](https://github.com/infor-design/enterprise/issues/5325))
 
 ## v4.55.0 Fixes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v4.56.0 Fixes
 
 - `[Lookup]` Fixed a bug for short field and its icons not rendering properly. ([#5541](https://github.com/infor-design/enterprise/issues/5541))
-- `[Timepicker]` Fixed a bug timepicker icon not rendering properly. ([#5558](https://github.com/infor-design/enterprise/issues/5558))
+- `[Timepicker]` Fixed a bug for timepicker icon not rendering properly. ([#5558](https://github.com/infor-design/enterprise/issues/5558))
 
 ## v4.55.0 Features
 

--- a/src/components/datepicker/_datepicker-new.scss
+++ b/src/components/datepicker/_datepicker-new.scss
@@ -42,7 +42,7 @@
     .datepicker {
       + .trigger,
       + .tooltip-description + .trigger {
-        margin-top: 8px;
+        margin-top: 4px;
       }
     }
   }

--- a/src/components/lookup/_lookup-new.scss
+++ b/src/components/lookup/_lookup-new.scss
@@ -52,6 +52,16 @@ html.is-firefox {
       }
     }
   }
+
+  .field-short,
+  .form-layout-compact .field {
+    .lookup-wrapper {
+      .trigger {
+        margin-top: 2px;
+      }
+    }
+  }
+  
 }
 
 html[dir='rtl'] {

--- a/src/components/lookup/_lookup.scss
+++ b/src/components/lookup/_lookup.scss
@@ -305,6 +305,22 @@
   }
 }
 
+html.is-safari {
+  .lookup-wrapper {
+    .trigger {
+      position: relative;
+    }
+  }
+
+  .field-short {
+    .lookup-wrapper {
+      .trigger {
+        top: 3px;
+      }
+    }
+  }
+}
+
 // RTL Styles
 html[dir='rtl'] {
   .lookup-wrapper .trigger {

--- a/src/components/lookup/_lookup.scss
+++ b/src/components/lookup/_lookup.scss
@@ -315,7 +315,11 @@ html.is-safari {
   .field-short {
     .lookup-wrapper {
       .trigger {
-        top: 3px;
+        top: 2px;
+
+        .icon {
+          margin-top: unset;
+        }
       }
     }
   }

--- a/src/components/spinbox/_spinbox.scss
+++ b/src/components/spinbox/_spinbox.scss
@@ -177,7 +177,7 @@ input::-webkit-inner-spin-button {
 .spinbox-md,
 .spinbox-lg {
   input {
-    width: calc(100% - 66px) !important;
+    width: calc(100% - 50px) !important;
   }
 }
 
@@ -196,19 +196,19 @@ input::-webkit-inner-spin-button {
 }
 
 .spinbox-sm {
-  width: 150px;
+  width: 130px;
 }
 
 .spinbox-mm {
-  width: 226px;
+  width: 206px;
 }
 
 .spinbox-md {
-  width: 300px;
+  width: 280px;
 }
 
 .spinbox-lg {
-  width: 400px;
+  width: 380px;
 }
 
 // When on smaller form factors make 400px fields go down to medium size.

--- a/src/components/timepicker/_timepicker.scss
+++ b/src/components/timepicker/_timepicker.scss
@@ -216,7 +216,11 @@ html.is-safari {
   .field-short {
     .timepicker {
       + .trigger {
-        top: 3px;
+        top: 2px;
+
+        .icon {
+          margin-top: unset;
+        }
       }
     }
   }

--- a/src/components/timepicker/_timepicker.scss
+++ b/src/components/timepicker/_timepicker.scss
@@ -206,6 +206,22 @@
   }
 }
 
+html.is-safari {
+  .timepicker {
+    + .trigger {
+      position: relative;
+    }
+  }
+
+  .field-short {
+    .timepicker {
+      + .trigger {
+        top: 3px;
+      }
+    }
+  }
+}
+
 // RTL Styles
 html[dir='rtl'] {
   .timepicker {

--- a/src/components/validation/validator.js
+++ b/src/components/validation/validator.js
@@ -670,9 +670,7 @@ Validator.prototype = {
       Validation.ValidationTypes.error;
 
     if (!isHelpMessage) {
-      setTimeout(() => {
-        loc.addClass(rule.type === 'icon' ? 'custom-icon' : rule.type);
-      }, 100);
+      loc.addClass(rule.type === 'icon' ? 'custom-icon' : rule.type);
     }
 
     // Inline messages are now an array
@@ -947,9 +945,7 @@ Validator.prototype = {
     }
 
     if (!isHelpMessage) {
-      setTimeout(() => {
-        loc.addClass(rule.type === 'icon' ? 'custom-icon' : rule.type); 
-      }, 100);
+      loc.addClass(rule.type === 'icon' ? 'custom-icon' : rule.type);
     }
 
     if (field.is('.spinbox')) {

--- a/src/components/validation/validator.js
+++ b/src/components/validation/validator.js
@@ -670,7 +670,9 @@ Validator.prototype = {
       Validation.ValidationTypes.error;
 
     if (!isHelpMessage) {
-      loc.addClass(rule.type === 'icon' ? 'custom-icon' : rule.type);
+      setTimeout(() => {
+        loc.addClass(rule.type === 'icon' ? 'custom-icon' : rule.type);
+      }, 100);
     }
 
     // Inline messages are now an array
@@ -936,16 +938,18 @@ Validator.prototype = {
         </div>`;
     }
 
-    if (!isHelpMessage) {
-      loc.addClass(rule.type === 'icon' ? 'custom-icon' : rule.type);
-    }
-
     if (field.is(':radio')) {
       this.toggleRadioMessage(field, rule.message, validationType.type, markup, true);
     } else { // All other components
       loc.closest('.field, .field-short').find('.formatter-toolbar').addClass(validationType.type === 'icon' ? 'custom-icon' : validationType.type);
       loc.closest('.field, .field-short').append(markup);
       loc.closest('.field, .field-short').find('.colorpicker-container').addClass(validationType.type === 'icon' ? 'custom-icon' : validationType.type);
+    }
+
+    if (!isHelpMessage) {
+      setTimeout(() => {
+        loc.addClass(rule.type === 'icon' ? 'custom-icon' : rule.type); 
+      }, 100);
     }
 
     if (field.is('.spinbox')) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes a bug for both lookup and timepicker for short field and its icons not rendering properly.
It will also fix the box-shadow in spinbox-sm.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5541
Closes https://github.com/infor-design/enterprise/issues/5558

**Steps necessary to review your pull request (required)**:
**#5541**
**1st Issue**
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/validation/example-short-fields.html using all your browsers
- Click on spinbox-sm

**2nd Issue**
- Go to http://localhost:4000/components/validation/example-short-fields.html & http://localhost:4000/components/validation/example-multiple-errors.html using Safari
- Click on lookup icon on example multiple errors & lookup and timepicker icons on example short fields

**3rd Issue**
- Go to http://localhost:4000/components/validation/example-short-fields.html using Firefox
- Click on Lookup & Datepicker button

**#5558**
- Go to http://localhost:4000/components/timepicker/example-index.html?locale=zh-Hans (CN/Hant/TW) using Safari
- Click on Timepicker icon

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

