### PR TITLE
5463 - Fix error when running custom builds containing Charts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v4.55.0 Features
 
 - `[ApplicationMenu]` Added the ability to resize the app menu. ([#5193](https://github.com/infor-design/enterprise/issues/5193))
+- `[Custom Builds]` Fixed a bug where importing the base Charts API directly would cause an error. ([#5463](https://github.com/infor-design/enterprise/issues/5463))
 - `[Datagrid]` Adds the ability to have a selection radio buttons on Datagrid. ([#5384](https://github.com/infor-design/enterprise/issues/5384))
 - `[Datagrid]` Added a `verticalScrollToEnd` property when you reached the end of the datagrid list. ([#5435](https://github.com/infor-design/enterprise/issues/5435))
 - `[Datagrid]` Added seperate mask options for filter row. ([#5519](https://github.com/infor-design/enterprise/issues/5519))

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -238,6 +238,7 @@ const changedExportNames = {
 };
 
 const lowercaseConstructorNames = {
+  charts: 'charts',
   masks: 'masks',
   longpress: 'longPress',
   renderloop: 'renderLoop'

--- a/src/components/charts/_charts-new.scss
+++ b/src/components/charts/_charts-new.scss
@@ -1,6 +1,9 @@
 // Uplift Chart - Svg and Css
 //================================================== //
 
+@import '../popupmenu/popupmenu-new';
+@import '../tooltip/tooltip-new';
+
 .chart-container {
   .chart-legend.is-bottom {
     padding-bottom: 0;

--- a/src/components/charts/_charts.scss
+++ b/src/components/charts/_charts.scss
@@ -1,6 +1,9 @@
 // Chart - Svg and Css
 //==================================================//
 
+@import '../popupmenu/popupmenu';
+@import '../tooltip/tooltip';
+
 // Alternate Text message
 .chart-message {
   background-color: $ids-color-palette-ruby-10;
@@ -300,7 +303,7 @@
 // Legend Popup Styling
 .chart-popup-menu {
   display: flex;
-  
+
   .chart-popup-menu-color {
     height: 15px;
     width: 15px;

--- a/src/components/charts/charts.js
+++ b/src/components/charts/charts.js
@@ -5,6 +5,7 @@ import { DOM } from '../../utils/dom';
 import { theme } from '../theme/theme';
 import { Locale } from '../locale/locale';
 
+import '../popover/popover.jquery';
 import '../popupmenu/popupmenu.jquery';
 
 const charts = {};


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR addresses a bug in the custom build system, where including the base charts API directly would throw a Node error due to an incorrectly-named import.  This issue has been fixed.

**Related github/jira issue (required)**:
Closes #5463 

**Steps necessary to review your pull request (required)**:
- Pull this branch
- Clean any previous builds: `npm run clean`
- Run a custom build with just charts:  `npm run build -- --components=charts`.  The build should complete without any errors
- Clean again: `npm run clean`
- Run a custom build that builds a pie chart:  `npm run build -- --components=charts,pie`
- Launch the demoapp: `npm run quickstart`
- Open http://localhost:4000/components/pie/example-donut?layout=nofrills.  Some elements on the page will not be fully loaded, but the core elements of the Pie chart (chart visual, legend, and tooltip) should all be present.

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
