### PR TITLE
5527 - Fix empty message chart with an auto height widget/card

### DIFF
--- a/app/views/components/emptymessage/example-chart-with-auto-height.html
+++ b/app/views/components/emptymessage/example-chart-with-auto-height.html
@@ -1,0 +1,24 @@
+<div class="row">
+    <div class="two-thirds column">
+        <div class="widget auto-height">
+          <div class="widget-header">
+            <h2 class="widget-title">Empty Bar Chart </h2>
+          </div>
+          <div class="widget-content">
+            <div id="bar-example" class="chart-container">
+            </div>
+          </div>
+        </div>
+    </div>
+  </div>
+  
+  <script>
+  $('body').on('initialized', function () {
+    $('#bar-example').chart({
+      type: 'bar',
+      dataset: [],
+      emptyMessage: {title: 'Nothing To See', color: 'azure'
+    }});
+  });
+  </script>
+  

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # What's New with Enterprise
 
+## v4.56.0 Fixes
+
+- `[EmptyMessage]` Fixed a bug where the empty message chart were not properly rendered when using auto height widget/card. ([#5527](https://github.com/infor-design/enterprise/issues/5527))
+
 ## v4.55.0 Features
 
 - `[ApplicationMenu]` Added the ability to resize the app menu. ([#5193](https://github.com/infor-design/enterprise/issues/5193))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,9 +1,5 @@
 # What's New with Enterprise
 
-## v4.56.0 Fixes
-
-- `[EmptyMessage]` Fixed a bug where the empty message chart were not properly rendered when using auto height widget/card. ([#5527](https://github.com/infor-design/enterprise/issues/5527))
-
 ## v4.55.0 Features
 
 - `[ApplicationMenu]` Added the ability to resize the app menu. ([#5193](https://github.com/infor-design/enterprise/issues/5193))
@@ -31,6 +27,7 @@
 - `[Datagrid]` Fix an XSS vulnerability in the name property of the columns objects array. ([#5428](https://github.com/infor-design/enterprise/issues/5428))
 - `[Datagrid]` Fixed an issue where the excel export did not download in MS Edge. ([#5507](https://github.com/infor-design/enterprise/issues/5507))
 - `[Editor]` Fixed an issue where font color was not working and extra spaces were get removed. ([#5137](https://github.com/infor-design/enterprise/issues/5137))
+- `[EmptyMessage]` Fixed a bug where the empty message chart were not properly rendered when using auto height widget/card. ([#5527](https://github.com/infor-design/enterprise/issues/5527))
 - `[Message]` Added maxWidth setting to allow message to go full width when title is long. ([#5443](https://github.com/infor-design/enterprise/issues/5443))
 - `[Modal]` Fixed a bug where events are not properly called when calling stacked dialogs. ([#5471](https://github.com/infor-design/enterprise/issues/5471))
 - `[Timepicker]` Fixed a bug where the chinese time format doesn't render correctly after selecting time and periods (AM/PM). ([#5420](https://github.com/infor-design/enterprise/issues/5420))

--- a/src/components/homepage/_homepage.scss
+++ b/src/components/homepage/_homepage.scss
@@ -168,7 +168,9 @@
   @include auto-height;
 
   .chart-container {
+    margin-top: 0;
     padding-bottom: 20px;
+    transform: translateY(0);
   }
 }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the position of the empty message of the chart when using the auto height widget/card.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/5527

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/emptymessage/example-chart-with-auto-height.html
- Empty message should be visible and it should be inside of the card/widget container
- Test on classic mode too

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
