### PR TITLE
4921 - Add test page for selectAllCurrentPage with toolbar count

### DIFF
--- a/app/views/components/datagrid/test-count-in-select-all-current-page-setting.html
+++ b/app/views/components/datagrid/test-count-in-select-all-current-page-setting.html
@@ -1,0 +1,43 @@
+<div class="row">
+  <div class="twelve columns">
+      <div class="contextual-toolbar toolbar is-hidden">
+          <div class="title selection-count">1 Selected</div>
+          <div class="buttonset">
+          </div>
+        </div>
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script id="test-script">
+  $('body').one('initialized', function () {
+    var data = [];
+    var columns = [];
+
+    // Define Columns for the Grid.
+    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
+    columns.push({ id: 'id', name: 'Row Id', field: 'id', formatter: Formatters.Readonly });
+    columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink });
+    columns.push({ id: 'activity', name: 'Activity', field: 'activity' });
+
+    var url = '{{basepath}}api/compressors?pageNum=1&pageSize=100';
+
+    $.getJSON(url, function(res) {
+      // Init
+      $('#datagrid').datagrid({
+        dataset: res.data,
+        columns: columns,
+        selectable: 'multiple',
+        selectAllCurrentPage: true,
+        toolbar: {title: 'Data Grid Header Title', results: true, selectCount: true},
+        paging: true,
+        pagesize: 10,
+        pagesizes: [5, 10, 25, 50]
+      }).on('selected', function (e, args) {
+        console.log(args);
+      });
+    });
+
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # What's New with Enterprise
 
+## v4.56.0 Fixes
+
+- `[Datagrid]` Add test page for `selectAllCurrentPage` with toolbar count. ([#4921](https://github.com/infor-design/enterprise/issues/4921))
+
 ## v4.55.0 Features
 
 - `[ApplicationMenu]` Added the ability to resize the app menu. ([#5193](https://github.com/infor-design/enterprise/issues/5193))


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR adds a test page for the `selectAllCurrentPage` setting with toolbar count to verify and test further. It has been an issue from `4.38.x` to `4.52.x` that the count doesn't update correctly/immediately when selecting/removing rows in the other pages.

Resolved in `4.53.x` EP.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/4921

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-count-in-select-all-current-page-setting
- Select all items
- Count should be 10
- Move to page 2
- Count should still be 10
- Select 2 items
- Count update to 12
- Go back to page 1
- Deselect all
- Count should update immediately to 2
- Then select all again
- Count should change immediately and should be corrected
- Test other variations and scenarios

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
