### PR TITLE
Fix hide focus for custom icons with tree

### DIFF
--- a/src/components/tree/tree.js
+++ b/src/components/tree/tree.js
@@ -1948,7 +1948,7 @@ Tree.prototype = {
       // Icon
       const classAttribute = node.getAttribute('class');
       if (classAttribute && classAttribute.indexOf('icon') > -1) {
-        entry.icon = classAttribute;
+        entry.icon = classAttribute.replace(/\s?hide-focus\s?/g, '');
       }
 
       // Children


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed hide-focus was added to custom icons with Tree

**Related github/jira issue (required)**:
N/A

**Steps necessary to review your pull request (required)**:
Tests should pass

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
