### PR TITLE
5441 - Follow up fix for timepicker and lookup

### DIFF
--- a/src/components/lookup/_lookup-new.scss
+++ b/src/components/lookup/_lookup-new.scss
@@ -49,6 +49,7 @@ html.is-firefox {
     .trigger {
       .icon {
         top: 0;
+        margin-top: -10px !important;
       }
     }
   }
@@ -61,7 +62,26 @@ html.is-firefox {
       }
     }
   }
-  
+
+}
+
+html.is-safari {
+  .field-short {
+    .lookup-wrapper {
+      .trigger {
+        top: 2px;
+      }
+    }
+  }
+
+  .form-layout-compact {
+    .lookup-wrapper {
+      .trigger,
+      .tooltip-description + .trigger {
+        top: 2px;
+      }
+    }
+  }
 }
 
 html[dir='rtl'] {

--- a/src/components/lookup/_lookup.scss
+++ b/src/components/lookup/_lookup.scss
@@ -315,11 +315,30 @@ html.is-safari {
   .field-short {
     .lookup-wrapper {
       .trigger {
-        top: 2px;
+        top: unset;
 
         .icon {
           margin-top: unset;
         }
+      }
+    }
+  }
+
+  .form-layout-compact {
+    .lookup-wrapper {
+      .trigger,
+      .tooltip-description + .trigger {
+        top: unset;
+      }
+    }
+  }
+}
+
+html.is-firefox {
+  .field-short {
+    .lookup-wrapper {
+      .trigger {
+        top: 1px;
       }
     }
   }

--- a/src/components/timepicker/_timepicker-new.scss
+++ b/src/components/timepicker/_timepicker-new.scss
@@ -47,6 +47,17 @@ html.is-firefox {
   }
 }
 
+html.is-safari {
+  .form-layout-compact {
+    .timepicker {
+      + .trigger,
+      + .tooltip-description + .trigger {
+        top: 2px;
+      }
+    }
+  }
+}
+
 html[dir='rtl'] {
   .timepicker {
     + .trigger,

--- a/src/components/timepicker/_timepicker.scss
+++ b/src/components/timepicker/_timepicker.scss
@@ -224,6 +224,15 @@ html.is-safari {
       }
     }
   }
+
+  .form-layout-compact {
+    .timepicker {
+      + .trigger,
+      + .tooltip-description + .trigger {
+        top: 1px;
+      }
+    }
+  }
 }
 
 // RTL Styles


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes a bug for both lookup and timepicker for short field and its icons not rendering properly.
It will also fix the box-shadow in spinbox-sm. (Follow up fix)

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5541
Closes https://github.com/infor-design/enterprise/issues/5558

**Steps necessary to review your pull request (required)**:
**1st Issue**
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/form/example-compact-mode.html using **Safari**
- Check on the timepicker and lookup buttons/icons

**2nd Issue**
- Go to http://localhost:4000/components/validation/example-short-fields.html using **Firefox**
- Check on the lookup buttons/icons

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

