### PR TITLE
NG#1046 - Fix unwanted navigation link on Angular

### DIFF
--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -1282,10 +1282,12 @@ PopupMenu.prototype = {
         return undefined;
       });
 
-      $(document).off(`click.btn-menu.${this.id}`).on(`click.btn-menu.${this.id}`, (e) => {
-        e.preventDefault();
-        return false;
-      });
+      if (!self.element.hasClass('ids-actionsheet-trigger')) {
+        $(document).off(`click.btn-menu.${this.id}`).on(`click.btn-menu.${this.id}`, (e) => {
+          e.preventDefault();
+          return false;
+        });
+      }
     }, 1);
   },
 

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -1023,10 +1023,6 @@ PopupMenu.prototype = {
       self.handleItemClick(e, a);
     });
 
-    this.menu.on(`click.btn-menu.${this.id}`, function (e) {
-      e.preventDefault();
-    });
-
     const excludes = 'li:not(.separator):not(.hidden):not(.heading):not(.group):not(.is-disabled):not(.is-placeholder)';
 
     // Select on Focus
@@ -1284,6 +1280,11 @@ PopupMenu.prototype = {
           self.element[0].value = val;
         }
         return undefined;
+      });
+
+      $(document).off(`click.btn.${this.id}`).on(`click.btn-menu.${this.id}`, (e) => {
+        e.preventDefault();
+        return false;
       });
     }, 1);
   },
@@ -2333,12 +2334,6 @@ PopupMenu.prototype = {
     if (this.menu && this.menu.length) {
       this.menu.off('click.popupmenu touchend.popupmenu touchcancel.popupmenu dragstart.popupmenu');
     }
-
-    setTimeout(() => {
-      if (this.menu && this.menu.length) {
-        this.menu.off(`click.btn-menu.${this.id}`);
-      }
-    }, 1);
 
     $('iframe').each(function () {
       const frame = $(this);

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -1282,7 +1282,7 @@ PopupMenu.prototype = {
         return undefined;
       });
 
-      $(document).off(`click.btn.${this.id}`).on(`click.btn-menu.${this.id}`, (e) => {
+      $(document).off(`click.btn-menu.${this.id}`).on(`click.btn-menu.${this.id}`, (e) => {
         e.preventDefault();
         return false;
       });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the unwanted navigation link `#` that occurs on the URL on NG wrapper. My guess is that when using the `ngIf` directive, before the e.preventDefault() being called, it does remove the element in the DOM. It doesn't recognize the `this.menu` element since it was being removed already. Changing it to `$(document)` instead.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/pull/5356
Dependency PR https://github.com/infor-design/enterprise-ng/pull/1128

**Steps necessary to review your pull request (required)**:
- Pull this branch, and build
- The build here is the dependency (basically the fix on angular) but you can test it also here in EP
- Go to http://localhost:4000/components/popupmenu/test-unwanted-navigation-when-menu-destroyed.html
- Click the `Normal Menu`
- Select the first item `Menu Option #1`
- It should destroy the popupmenu and it should not append hash on the URL

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
