### PR TITLE
5622 - Expand decimal support for format number

### DIFF
--- a/app/views/components/locale/test-format-number-15-decimal.html
+++ b/app/views/components/locale/test-format-number-15-decimal.html
@@ -1,0 +1,61 @@
+<div class="row">
+  <div class="six columns">
+    <p>When changing the contents of the first field below, the second field will display the output of the same number passed through `Soho.Locale.formatNumber()`.</p>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="six columns">
+    <div class="field">
+      <label for="number-field">Number Field</label>
+      <input id="number-field" />
+    </div>
+
+    <div class="field">
+      <label for="parsed-number-field">Formatted Number result</label>
+      <input id="parsed-number-field" readonly/>
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').on('initialized', function(locale, args) {
+    const numberInfo = Locale.currentLocale.data.numbers;
+
+    $('#number-field').mask({
+      process       : 'number',
+      patternOptions: {
+        allowDecimal           : true,
+        allowNegative          : false,
+        allowThousandsSeparator: true,
+        decimalLimit           : 2,
+        integerLimit           : 12,
+        symbols                : {
+          decimal  : numberInfo.decimal,
+          negative : numberInfo.minusSign,
+          thousands: numberInfo.group
+        }
+      }
+    })
+      .on('change', function() {
+        var value = $('#number-field').val();
+
+        // transform
+        var options = {
+          decimal: '.',
+          group: '',
+          maximumFractionDigits: 15,
+          minimumFractionDigits: 15,
+          round: true,
+          style: 'decimal'
+        }
+        var nbr = Soho.Locale.formatNumber(value, options);
+        $('#parsed-number-field').val(nbr);
+
+        $('body').toast({
+          title: 'Change Event Fired!',
+          message: 'Parsed Number: <b>'+ nbr +'</b>'
+        });
+      });
+  });
+</script>

--- a/app/views/components/locale/test-format-number-15-decimal.html
+++ b/app/views/components/locale/test-format-number-15-decimal.html
@@ -42,12 +42,9 @@
 
         // transform
         var options = {
-          decimal: '.',
-          group: '',
           maximumFractionDigits: 15,
           minimumFractionDigits: 15,
-          round: true,
-          style: 'decimal'
+          round: true
         }
         var nbr = Soho.Locale.formatNumber(value, options);
         $('#parsed-number-field').val(nbr);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Datagrid]` Add test page for `selectAllCurrentPage` with toolbar count. ([#4921](https://github.com/infor-design/enterprise/issues/4921))
 - `[Dropdown]` Fixed disabling of function keys F1 to F12. ([#4976](https://github.com/infor-design/enterprise/issues/4976))
 - `[Locale]` Fixed an additional case where large numbers cannot be formatted correctly. ([#5605](https://github.com/infor-design/enterprise/issues/5605))
+- `[Locale]` Expanded support from 10 to 20 decimal places. Max number is 21, 20 now. ([#5622](https://github.com/infor-design/enterprise/issues/5622))
 
 ## v4.55.1 Fixes
 

--- a/src/components/locale/readme.md
+++ b/src/components/locale/readme.md
@@ -124,6 +124,8 @@ Locale.convertNumberToEnglish('१२३४५६७८९०');         // Deva
 
 You can use the formatNumber to display a numeric type in a localized format. You can use parseNumber to convert that number back to the numeric type. Note that by default the formatNumber function uses truncation (.129 becomes .12). To use rounding add the `round: true` option.
 
+The maximum number that can be formatted is 21 significantDigits and 20 fractionDigits.
+
 ```javascript
 Soho.Locale.formatNumber(20.1, {style: 'decimal', round: true, minimumFractionDigits: 2}));
 // Returns 20.10

--- a/src/utils/number.js
+++ b/src/utils/number.js
@@ -33,6 +33,9 @@ numberUtils.round = function round(number, decimals = 2) {
  * @returns {string} The string formatted to the precision.
  */
 numberUtils.fixTo = function toFixed(number, decimals = 2) {
+  if (decimals > 10 && number.toString().indexOf('.') > -1) {
+    return number.toLocaleString('en-US', { useGrouping: false, minimumFractionDigits: decimals });
+  }
   return (+(Math.round(+(number + 'e' + decimals)) + 'e' + -decimals)).toFixed(decimals); //eslint-disable-line
 };
 
@@ -46,7 +49,7 @@ numberUtils.fixTo = function toFixed(number, decimals = 2) {
  * @returns {string} The string formatted to the precision.
  */
 numberUtils.toFixed = function toFixed(number, decimals = 2) {
-  // Parse the number into three parts. Max supported number is 18.6
+  // Parse the number into three parts. Max supported number is 18.15
   let numStr = number.toString();
   let hasMinus = false;
   if (numStr.substr(0, 1) === '-') {

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -705,6 +705,18 @@ describe('Locale API', () => {
     expect(Locale.parseNumber('-1,482,409,800.81')).toEqual(-1482409800.81);
   });
 
+  it('should format big decimal numbers', () => {
+    Locale.set('en-US');
+    expect(Locale.formatNumber(123.54, { maximumFractionDigits: 15, minimumFractionDigits: 15 })).toEqual('123.540000000000000');
+    expect(Locale.formatNumber(123.54, { maximumFractionDigits: 20, minimumFractionDigits: 20 })).toEqual('123.54000000000000000000');
+    expect(Locale.formatNumber(123, { maximumFractionDigits: 20, minimumFractionDigits: 20 })).toEqual('123.00000000000000000000');
+
+    Locale.set('de-DE');
+    expect(Locale.formatNumber(123.54, { maximumFractionDigits: 15, minimumFractionDigits: 15 })).toEqual('123,540000000000000');
+    expect(Locale.formatNumber(123.54, { maximumFractionDigits: 20, minimumFractionDigits: 20 })).toEqual('123,54000000000000000000');
+    expect(Locale.formatNumber(123, { maximumFractionDigits: 20, minimumFractionDigits: 20 })).toEqual('123,00000000000000000000');
+  });
+
   it('handle other big numbers', () => {
     expect(Locale.formatNumber('123456789012345671')).toEqual('123,456,789,012,345,671.00');
     expect(Locale.parseNumber('123456789012345671')).toEqual('123456789012345671');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Landmark uncovered using 15 decimal places rounded the number wrongly. Expand official support to 20 decimals as this is the max that can be done with toLocaleString

**Related github/jira issue (required)**:
Fixes #5622

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/locale/test-format-number-15-decimal.html
- type 1234.45 and tab and should get a total of 15 decimals
- try 123 and other numbers

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
