### PR TITLE
5622 - More locale fixes

### DIFF
--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -1509,7 +1509,7 @@ const Locale = {  // eslint-disable-line
     }
 
     if (typeof number === 'string') {
-      number = Locale.parseNumber(number);
+      number = Locale.parseNumber(number, options);
     }
 
     if (number.toString().indexOf('e') > -1) {
@@ -1654,12 +1654,12 @@ const Locale = {  // eslint-disable-line
       numString = numString.toString();
     }
 
-    const group = options && options.group ? options.group : numSettings ? numSettings.group : ',';
+    const group = options && options.group !== undefined ? options.group : numSettings ? numSettings.group : ',';
     const decimal = options && options.decimal ? options.decimal : numSettings ? numSettings.decimal : '.';
     const percentSign = options && options.percentSign ? options.percentSign : numSettings ? numSettings.percentSign : '%';
     const currencySign = options && options.currencySign ? options.currencySign : localeData.currencySign || '$';
 
-    const exp = (group === ' ') ? new RegExp(/\s/g) : new RegExp(`\\${group}`, 'g');
+    const exp = (group === ' ' || group === '') ? new RegExp(/\s/g) : new RegExp(`\\${group}`, 'g');
     numString = numString.replace(exp, '');
     numString = numString.replace(decimal, '.');
     numString = numString.replace(percentSign, '');

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -717,6 +717,29 @@ describe('Locale API', () => {
     expect(Locale.formatNumber(123, { maximumFractionDigits: 20, minimumFractionDigits: 20 })).toEqual('123,00000000000000000000');
   });
 
+  it('should format big decimal numbers in different locales', () => {
+    Locale.set('el-GR');
+    expect(Locale.parseNumber('1234567890123456.77', { decimal: '.', group: '', round: false, style: 'decimal' })).toEqual('1234567890123456.77');
+    expect(Locale.formatNumber('1234567890123456.77', { decimal: '.', group: '', maximumFractionDigits: 15, minimumFractionDigits: 15, round: false, style: 'decimal' })).toEqual('1234567890123456.770000000000000');
+    expect(Locale.formatNumber('1234567890123456.77', { decimal: '.', group: '', maximumFractionDigits: 15, minimumFractionDigits: 15, round: false, style: 'decimal', locale: 'el-GR' })).toEqual('1234567890123456.770000000000000');
+    expect(Locale.formatNumber('1234567890123456.77', { style: 'decimal', round: true, minimumFractionDigits: 15, maximumFractionDigits: 15, locale: 'en-US', group: '' })).toEqual('1234567890123456.770000000000000');
+    expect(Locale.formatNumber('1234567890123456.77000000000000000', { style: 'decimal', round: true, minimumFractionDigits: 15, maximumFractionDigits: 15, locale: 'en-US', group: '' })).toEqual('1234567890123456.770000000000000');
+
+    Locale.set('es-ES');
+    expect(Locale.parseNumber('1234567890123456.77', { decimal: '.', group: '', round: false, style: 'decimal' })).toEqual('1234567890123456.77');
+    expect(Locale.formatNumber('1234567890123456.77', { decimal: '.', group: '', maximumFractionDigits: 15, minimumFractionDigits: 15, round: false, style: 'decimal' })).toEqual('1234567890123456.770000000000000');
+    expect(Locale.formatNumber('1234567890123456.77', { decimal: '.', group: '', maximumFractionDigits: 15, minimumFractionDigits: 15, round: false, style: 'decimal', locale: 'el-GR' })).toEqual('1234567890123456.770000000000000');
+    expect(Locale.formatNumber('1234567890123456.77', { style: 'decimal', round: true, minimumFractionDigits: 15, maximumFractionDigits: 15, locale: 'en-US', group: '' })).toEqual('1234567890123456.770000000000000');
+    expect(Locale.formatNumber('1234567890123456.77000000000000000', { style: 'decimal', round: true, minimumFractionDigits: 15, maximumFractionDigits: 15, locale: 'en-US', group: '' })).toEqual('1234567890123456.770000000000000');
+
+    Locale.set('en-US');
+    expect(Locale.parseNumber('1234567890123456.77', { decimal: '.', group: '', round: false, style: 'decimal' })).toEqual('1234567890123456.77');
+    expect(Locale.formatNumber('1234567890123456.77', { decimal: '.', group: '', maximumFractionDigits: 15, minimumFractionDigits: 15, round: false, style: 'decimal' })).toEqual('1234567890123456.770000000000000');
+    expect(Locale.formatNumber('1234567890123456.77', { decimal: '.', group: '', maximumFractionDigits: 15, minimumFractionDigits: 15, round: false, style: 'decimal', locale: 'el-GR' })).toEqual('1234567890123456.770000000000000');
+    expect(Locale.formatNumber('1234567890123456.77', { style: 'decimal', round: true, minimumFractionDigits: 15, maximumFractionDigits: 15, locale: 'en-US', group: '' })).toEqual('1234567890123456.770000000000000');
+    expect(Locale.formatNumber('1234567890123456.77000000000000000', { style: 'decimal', round: true, minimumFractionDigits: 15, maximumFractionDigits: 15, locale: 'en-US', group: '' })).toEqual('1234567890123456.770000000000000');
+  });
+
   it('handle other big numbers', () => {
     expect(Locale.formatNumber('123456789012345671')).toEqual('123,456,789,012,345,671.00');
     expect(Locale.parseNumber('123456789012345671')).toEqual('123456789012345671');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes parsing with no group. An addition to #5622. To be patched to 4.52, 4.54 and 4.55

**Related github/jira issue (required)**:
Fixes #5622

**Steps necessary to review your pull request (required)**:
- covered by tests but you can go to http://localhost:4000/components/locale/test-big-number.html
- and try these in the console
```
Locale.set('el-GR');
Locale.parseNumber('1234567890123456.77', { decimal: '.', group: '', round: false, style: 'decimal' });
Locale.formatNumber('1234567890123456.77', { decimal: '.', group: '', maximumFractionDigits: 15, minimumFractionDigits: 15, round: false, style: 'decimal' });
Locale.formatNumber('1234567890123456.77', { decimal: '.', group: '', maximumFractionDigits: 15, minimumFractionDigits: 15, round: false, style: 'decimal', locale: 'el-GR' });
Locale.formatNumber('1234567890123456.77', { style: 'decimal', round: true, minimumFractionDigits: 15, maximumFractionDigits: 15, locale: 'en-US', group: '' });
Locale.formatNumber('1234567890123456.77000000000000000', { style: 'decimal', round: true, minimumFractionDigits: 15, maximumFractionDigits: 15, locale: 'en-US', group: '' });
```

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
