### PR TITLE
5631 - Fix the selection idx for tree with Datagrid

### DIFF
--- a/app/views/components/datagrid/test-tree-selected-rows-idx.html
+++ b/app/views/components/datagrid/test-tree-selected-rows-idx.html
@@ -1,0 +1,131 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <div class="toolbar" role="toolbar">
+      <div class="title">
+        Tree Selected Row Example
+      </div>
+      <div class="buttonset">
+        <button type="button" class="btn" id="selectedRows">
+          <span>Selected Rows Idx</span>
+        </button>
+      </div>
+    </div>
+
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script id="test-script">
+  $('body').one('initialized', function () {
+
+    var columns = [];
+    var initData = [
+    {
+      id: 1,
+      demoDataId: 0,
+      depth: 1,
+      expanded: false,
+      name: 'A',
+      children: []
+    },
+    {
+      id: 8,
+      depth: 1,
+      expanded: false,
+      name: 'Z'
+    }];
+
+    var mockChildDataSets = {
+      0: [
+        {
+          id: 2,
+          demoDataId: 1,
+          depth: 2,
+          expanded: false,
+          name: 'AA',
+          children: []
+        },
+        {
+          id: 3,
+          demoDataId: 2,
+          depth: 2,
+          expanded: false,
+          name: 'BB',
+          children: []
+        }
+      ],
+      1: [
+        {
+          id: 4,
+          depth: 3,
+          expanded: false,
+          name: 'AAA'
+        },
+        {
+          id: 5,
+          depth: 3,
+          expanded: false,
+          name: 'BBB'
+        }
+      ],
+      2: [
+        {
+          id: 6,
+          depth: 3,
+          expanded: false,
+          name: 'AAA'
+        },
+        {
+          id: 7,
+          depth: 3,
+          expanded: false,
+          name: 'BBB'
+        }
+      ]
+    }
+
+    // Define Columns for the Grid.
+    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, width: 50, formatter: Formatters.SelectionCheckbox, align: 'center'});
+    columns.push({ id: 'name', name: 'Name', field: 'name', formatter: Formatters.Tree });
+    columns.push({ id: 'id', name: 'Id', field: 'id' });
+
+    // Initialize the Grid
+    $('#datagrid').datagrid({
+      columns: columns,
+      dataset: initData,
+      selectable: 'mixed',
+      treeGrid: true,
+      toolbar: {title: 'Test Updating Data using updateDataSet()', results: true, personalize: true}
+    })
+    // Bind on Expand Row
+    .on('expandrow', function (e, args) {
+      initData.map(function callback(v) {
+        if (v.children && v.children.length > 0) {
+          v.children.map(callback);
+        }
+
+        if (v.id === args.rowData.id) {
+          v.children = mockChildDataSets[args.rowData.demoDataId];
+        }
+      });
+      // Mock ajax call
+      setTimeout(function() {
+        var grid = $('#datagrid').data('datagrid');
+        grid.updateDataset(initData)
+      });
+    });
+
+    $('#selectedRows').click(function() {
+      var selectedRows = $('#datagrid').data('datagrid').selectedRows();
+      var rows = selectedRows.map(selectedRows => selectedRows.idx);
+      var selectedIndexes = '';
+      rows.forEach(function (row) {
+        selectedIndexes += row + ' ';
+      })
+      alert('Selected Rows Index' + (rows.length > 1 ? 'es' : '') + ' = ' + selectedIndexes);
+    });
+
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - `[Datagrid]` Date format should reflect in date filter when range option is selected. ([#4864](https://github.com/infor-design/enterprise/issues/4864))
 - `[Datagrid]` Add test page for `selectAllCurrentPage` with toolbar count. ([#4921](https://github.com/infor-design/enterprise/issues/4921))
+- `[Datagrid]` Fixed an issue where the selection idx was not updating after append/update data to child nodes for tree. ([#5631](https://github.com/infor-design/enterprise/issues/5631))
 - `[Dropdown]` Fixed disabling of function keys F1 to F12. ([#4976](https://github.com/infor-design/enterprise/issues/4976))
 - `[Dropdown]` Fixed an accessibility issue where the error message was unannounced using a screen reader. ([#5130](https://github.com/infor-design/enterprise/issues/5130))
 - `[Icons]` Fix sizes on some of the icons in classic mode. ([#5626](https://github.com/infor-design/enterprise/issues/5626))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -742,6 +742,7 @@ Datagrid.prototype = {
     }
 
     this.loadData(dataset, pagerInfo);
+    this.syncSelectedRowsIdx();
   },
 
   /**
@@ -8289,18 +8290,18 @@ Datagrid.prototype = {
    * @returns {void}
    */
   syncSelectedRowsIdx() {
-    const dataset = this.settings.groupable && this.originalDataset ?
-      this.originalDataset : this.settings.dataset;
+    const dataset = this.getActiveDataset();
     if (this._selectedRows.length === 0 || dataset.length === 0) {
       return;
     }
     this._selectedRows = [];
 
     for (let i = 0; i < dataset.length; i++) {
-      if (dataset[i]._selected) {
+      const node = this.settings.treeGrid ? dataset[i].node : dataset[i];
+      if (node._selected) {
         const selectedRow = {
           idx: i,
-          data: dataset[i],
+          data: node,
           elem: this.dataRowNode(i),
           pagingIdx: i,
           pagesize: this.settings.pagesize


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed the selection idx was not updating after append/update data to child nodes for tree with Datagrid.

**Related github/jira issue (required)**:
Closes #5631

**Steps necessary to review your pull request (required)**:
- Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/datagrid/test-tree-selected-rows-idx.html
- Click on checkbox in 2nd row to select `z`
- Click on top button `Selected Row Idx`
- Alert should display `Selected Rows Index = 1`
- Click ok to close alert
- Click on `+` plus sign in 1st row
- It should insert child nodes to 1st row
- Now click again on top button `Selected Row Idx`
- This time alert should display `Selected Rows Index = 3`

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
