### PR TITLE
NG#1101 - Add Buttonset API to Flex Toolbar `buttonset` areas and allow access from Contextual Action Panels

### DIFF
--- a/app/views/components/contextualactionpanel/test-complex-toolbar-flex.html
+++ b/app/views/components/contextualactionpanel/test-complex-toolbar-flex.html
@@ -1,0 +1,140 @@
+<div class="row top-padding">
+  <div class="six columns">
+    <h2>Toolbar Test: Complex Toolbar</h2>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+
+    <button id="my-cap" type="button" class="btn-secondary contextual-action-panel-trigger">
+      Contextual Action Panel
+    </button>
+    <div class="contextual-action-panel" style="display: none;">
+      <div id="cap-toolbar" class="flex-toolbar">
+        <div class="toolbar-section title">Company Information</div>
+        <div class="toolbar-section search">
+          <input class="searchfield" data-options='{"collapsible": mobile}'/>
+        </div>
+        <div class="toolbar-section buttonset">
+          <button class="btn-menu" type="button">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-sort-down"></use>
+            </svg>
+            <span>Filter</span>
+          </button>
+          <ul class="popupmenu top">
+            <li><a href="#">A</a></li>
+            <li><a href="#">B</a></li>
+            <li><a href="#">C</a></li>
+          </ul>
+
+          <div class="separator"></div>
+
+          <button name="close" class="btn" type="button">
+            <svg class="icon icon-close" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-close"></use>
+            </svg>
+            <span>Close</span>
+          </button>
+        </div>
+      </div>
+      <div class="row">
+        <div class="six columns">
+
+          <div class="field">
+            <label for="company-name">Company Name</label>
+            <select id="company-name" name="company-name" class="dropdown">
+              <option value=""></option>
+              <option value="jawbone" selected>Jawbone, Inc.</option>
+              <option value="infor">Infor</option>
+            </select>
+          </div>
+
+          <div class="field">
+            <label for="purchase-form">Purchase Form</label>
+            <select id="purchase-form" name="purchase-form" class="dropdown">
+              <option value=""></option>
+              <option value="3567" selected>3567</option>
+              <option value="3568">3568</option>
+              <option value="3569">3569</option>
+            </select>
+          </div>
+
+          <div class="field">
+            <label for="template">Template</label>
+            <select id="template" name="template" class="dropdown">
+              <option value="" selected>None</option>
+              <option value="1">Template #1</option>
+              <option value="2">Template #2</option>
+            </select>
+          </div>
+
+          <div class="field">
+            <label for="notes">Notes</label>
+            <textarea id="notes" name="notes"></textarea>
+          </div>
+
+        </div>
+        <div class="six columns">
+
+          <div class="field">
+            <label for="ship-terms">Ship Terms</label>
+            <select id="ship-terms" name="ship-terms" class="dropdown">
+              <option value=""></option>
+              <option value="default" selected>Default</option>
+              <option value="alternate">Alternate</option>
+            </select>
+          </div>
+
+          <div class="field">
+            <label for="ship-via">Ship Via</label>
+            <select id="ship-via" name="ship-via" class="dropdown">
+              <option value=""></option>
+              <option value="freight" selected>Freight</option>
+              <option value="air">USPS Air</option>
+            </select>
+          </div>
+
+          <div class="field">
+            <label for="issue-method">Issue Method</label>
+            <select id="issue-method" name="issue-method" class="dropdown">
+              <option value=""></option>
+              <option value="phone">Telephone</option>
+              <option value="email" selected>E-mail</option>
+              <option value="sms">SMS Message</option>
+            </select>
+          </div>
+
+          <div class="field">
+            <input type="checkbox" id="po-box" name="po-box" class="checkbox" checked />
+            <label for="po-box" class="checkbox-label">Freight</label>
+          </div>
+
+          <div class="field">
+            <input type="checkbox" id="filter-disable" name="filter-disable" class="checkbox" />
+            <label for="filter-disable" class="checkbox-label">Disable the "Filter" Button</label>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<script>
+  $('body').on('initialized', function() {
+    const capEl = document.querySelector('#my-cap');
+    const capAPI = $(capEl).data('contextualactionpanel');
+    const capButtonsetAPI = capAPI.buttonsetAPI;
+
+    function setDisabled(val) {
+      var filterBtn = capButtonsetAPI.buttons[0];
+      filterBtn.disabled = val;
+    }
+
+    $('#filter-disable').on('change.test', (e) => {
+      setDisabled(e.target.checked);
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `[Datagrid]` Adds the ability to update values of a specific column on Datagrid. ([#3491](https://github.com/infor-design/enterprise/issues/3491))
 - `[Icon]` Updated the launch icon to be less bulky. ([#5595](https://github.com/infor-design/enterprise/issues/5595))
 - `[Tabs]` Adds the ability to split the tabs. ([#4600](https://github.com/infor-design/enterprise/issues/4600))
+- `[Toolbar Flex]` Adds control of buttonset areas via the Buttonset API. ([NG#1101](https://github.com/infor-design/enterprise-ng/issues/1101))
 
 ## v4.56.0 Fixes
 

--- a/src/components/contextualactionpanel/contextualactionpanel.js
+++ b/src/components/contextualactionpanel/contextualactionpanel.js
@@ -124,6 +124,15 @@ ContextualActionPanel.prototype = {
   },
 
   /**
+   * @readonly
+   * @returns {Array<ButtonSet>} references to ButtonSet components inside CAP Toolbars, if available
+   */
+  get buttonsetAPI() {
+    const buttonsetEls = utils.getArrayFromList(this.panel[0].querySelectorAll('.buttonset'));
+    return $(buttonsetEls[0]).data('buttonset');
+  },
+
+  /**
   * Initialize the CAP.
   * @private
   */

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1046,7 +1046,7 @@ Modal.prototype = {
 
       // Making default focus when there's no default button set
       // for non contextual action panel.
-      if (!self.capAPI && self.buttonsetAPI) {
+      if (self.buttonsetAPI) {
         if (thisElem.buttonsetElem.find('.btn-modal-primary').length === 0) {
           const firstBtn = $('.modal-buttonset button')[0];
           focusElem = thisElem.buttonsetElem.find(firstBtn);

--- a/src/components/searchfield/searchfield.js
+++ b/src/components/searchfield/searchfield.js
@@ -474,7 +474,7 @@ SearchField.prototype = {
       self.calculateSearchfieldWidth();
     });
 
-    if (this.settings.collapsible === false || (this.settings.collapsible === 'mobile' && breakpoints.isAbove('phone-to-tablet'))) {
+    if (this.settings.collapsible === false) {
       this.expand(true);
     }
 
@@ -1726,7 +1726,7 @@ SearchField.prototype = {
         buttonset: buttonsetElemWidth
       };
 
-      if (!this.isContainedByFlexToolbar || breakpoints.isAbove('phone-to-tablet')) {
+      if (!this.isContainedByFlexToolbar && breakpoints.isAbove('phone-to-tablet')) {
         this.wrapper[0].classList.add('is-open');
       }
       this.calculateOpenWidth();

--- a/src/components/toolbar-flex/toolbar-flex.js
+++ b/src/components/toolbar-flex/toolbar-flex.js
@@ -5,6 +5,7 @@ import { Locale } from '../locale/locale';
 import { ToolbarFlexItem, TOOLBAR_ELEMENTS } from './toolbar-flex.item';
 
 // jQuery Components
+import '../button/button.set.jquery';
 import './toolbar-flex.item.jquery';
 
 // Component Name
@@ -53,7 +54,6 @@ ToolbarFlex.prototype = {
    */
   init() {
     this.uniqueId = utils.uniqueId(this.element);
-    this.sections = utils.getArrayFromList(this.element.querySelectorAll('.toolbar-section'));
     this.items = this.getElements().map((item) => {
       let itemComponentSettings = {};
       const isActionButton = $(item).hasClass('btn-actions');
@@ -75,10 +75,19 @@ ToolbarFlex.prototype = {
       });
       return $(item).data('toolbarflexitem');
     });
-
     if (!this.items) {
       return;
     }
+
+    // Connect Toolbar sections and apply `ButtonSet` component to any relevant sections
+    this.sections = utils.getArrayFromList(this.element.querySelectorAll('.toolbar-section'));
+    this.sections.forEach((section) => {
+      if (section.classList.contains('buttonset')) {
+        $(section).buttonset({
+          detectHTMLButtons: true
+        });
+      }
+    });
 
     // Check for a focused item
     if (!this.settings.allowTabs) {
@@ -330,6 +339,22 @@ ToolbarFlex.prototype = {
     }
 
     return item;
+  },
+
+  /**
+   * @readonly
+   * @returns {Array<HTMLElement>} references to all Toolbar sections labelled "buttonset"
+   */
+  get buttonsets() {
+    return this.sections.filter(el => el.classList.contains('buttonset'));
+  },
+
+  /**
+   * @readonly
+   * @returns {Array<ButtonSet>} references to all Toolbar Section buttonset APIs
+   */
+  get buttonsetAPIs() {
+    return this.buttonsets.map(e => $(e).data('buttonset'));
   },
 
   /**

--- a/test/components/contextualactionpanel/contextualactionpanel-as-settings.func-spec.js
+++ b/test/components/contextualactionpanel/contextualactionpanel-as-settings.func-spec.js
@@ -198,4 +198,14 @@ describe('Contextual Action Panel - Button API Access', () => {
 
     expect(toolbarEl.className.indexOf('is-disabled')).toEqual(-1);
   });
+
+  it('can control toolbar buttonsets and their buttons', () => {
+    capAPI = new ContextualActionPanel(document.body, simpleCAPSettings);
+    const capEl = document.querySelector('.contextual-action-panel');
+    const buttonsetAPI = capAPI.buttonsetAPI;
+    const settingsBtn = buttonsetAPI.buttons[0];
+    settingsBtn.disabled = true;
+
+    expect(capEl.querySelector('.btn').disabled).toBeTruthy();
+  });
 });

--- a/test/components/toolbar-flex/toolbar-flex-api.func-spec.js
+++ b/test/components/toolbar-flex/toolbar-flex-api.func-spec.js
@@ -301,6 +301,20 @@ describe('Flex Toolbar', () => { //eslint-disable-line
         done();
       }, 500);
     });
+
+    it('Can control buttons inside of buttonset sections', () => {
+      const buttonsetEl = toolbarAPI.buttonsets[0];
+      const buttonsetAPI = $(buttonsetEl).data('buttonset');
+
+      // Use ButtonSetAPI to switch disabled state
+      buttonsetAPI.buttons[1].disabled = true;
+
+      expect(toolbarAPI.items[1].disabled).toBeTruthy();
+
+      buttonsetAPI.buttons[1].disabled = false;
+
+      expect(toolbarAPI.items[1].disabled).toBeFalsy();
+    });
   });
 });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds a couple enhancements to some Enterprise components for finer-grain control of Toolbar buttons via the ButtonSet API:
- Flex Toolbars with `.toolbar-section.buttonset` elements now automatically invoke `ButtonSet` components on these sections.
- Flex Toolbars now provide access to the ButtonSet APIs on these sections via the `ButtonsetAPIs` property (returns an array since there can potentially be multiple ButtonSet components depending on the Toolbar)
- Contextual Action Panel components configured to use Flex Toolbars provide a reference to their Toolbar's first-found ButtonSet API using the `buttonsetAPI` property (mimicking how the Modal provides access).

**Related github/jira issue (required)**:
- Related to infor-design/enterprise-ng#1101
- Related to infor-design/enterprise-ng#1133

**Steps necessary to review your pull request (required)**:
- Pull, build, run!
- Open http://localhost:4000/components/contextualactionpanel/test-complex-toolbar-flex.html
- Click "Contextual Action Panel" button to open the panel
- Check/Uncheck the box that says "Disable the Filter Button".  The Filter button on the CAP's toolbar should disable/enable as expected.  This is using the CAP API's new reference to `buttonsetAPI` on the Flex Toolbar.
- New func tests for this feature should also be passing

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
