### PR TITLE
5649/5648 - Revert fix for popupmenu that handled clicks different

### DIFF
--- a/app/views/components/splitter/example-searchfield.html
+++ b/app/views/components/splitter/example-searchfield.html
@@ -1,0 +1,25 @@
+<div class="page-container two-column fixed splitter-container">
+  <section class="main">
+    <div class="content scrollable">
+      <div class="row full-width">
+        <div class="field">
+          <label for="searchfield">Search</label>
+          <input id="searchfield" name="searchfield" class="searchfield autocomplete" data-options= '{"clearable": "true", "showAllResults": false, "source": "//latest-enterprise.demo.design.infor.com/api/states?term="}' placeholder="Type a search term"/>
+        </div>
+      </div>
+    </div>
+  </section>
+  <nav class="sidebar scrollable">
+    <div class="content">
+      <div id="splitter" class="splitter"></div>
+    </div>
+  </nav>
+</div>
+<script>
+$('#splitter').splitter({
+  attributes: [
+    { name: 'id', value: 'splitter-id-1' },
+    { name: 'data-automation-id', value: 'splitter-automation-id-1' }
+  ]
+});
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[Dropdown]` Fixed disabling of function keys F1 to F12. ([#4976](https://github.com/infor-design/enterprise/issues/4976))
 - `[Dropdown]` Fixed a bug where selecting the first item on the list doesn't trigger the `change` event that will select the value immediately. ([NG#1102](https://github.com/infor-design/enterprise-ng/issues/1102))
 - `[Dropdown]` Fixed an accessibility issue where the error message was unannounced using a screen reader. ([#5130](https://github.com/infor-design/enterprise/issues/5130))
+- `[Popupmenu]` Fixed an not released issue where opening menus limited the ability to click after. ([#5648/#5649](https://github.com/infor-design/enterprise/issues/5648))
 - `[Icons]` Fix sizes on some of the icons in classic mode. ([#5626](https://github.com/infor-design/enterprise/issues/5626))
 - `[Locale]` Fixed an additional case where large numbers cannot be formatted correctly. ([#5605](https://github.com/infor-design/enterprise/issues/5605))
 - `[Locale]` Expanded support from 10 to 20 decimal places. Max number is 21, 20 now. ([#5622](https://github.com/infor-design/enterprise/issues/5622))

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -1023,6 +1023,10 @@ PopupMenu.prototype = {
       self.handleItemClick(e, a);
     });
 
+    this.menu.on(`click.btn-menu.${this.id}`, (e) => {
+      e.preventDefault();
+    });
+
     const excludes = 'li:not(.separator):not(.hidden):not(.heading):not(.group):not(.is-disabled):not(.is-placeholder)';
 
     // Select on Focus
@@ -1281,13 +1285,6 @@ PopupMenu.prototype = {
         }
         return undefined;
       });
-
-      if (!self.element.hasClass('ids-actionsheet-trigger')) {
-        $(document).off(`click.btn-menu.${this.id}`).on(`click.btn-menu.${this.id}`, (e) => {
-          e.preventDefault();
-          return false;
-        });
-      }
     }, 1);
   },
 
@@ -2337,12 +2334,18 @@ PopupMenu.prototype = {
       this.menu.off('click.popupmenu touchend.popupmenu touchcancel.popupmenu dragstart.popupmenu');
     }
 
+    setTimeout(() => {
+      if (this.menu && this.menu.length) {
+        this.menu.off(`click.btn-menu.${this.id}`);
+      }
+    }, 1);
+
     $('iframe').each(function () {
       const frame = $(this);
       try {
         frame.contents().find('body').off('click.popupmenu touchend.popupmenu touchcancel.popupmenu');
       } catch (e) {
-        // Ignore security errors on out of iframe
+        // Ignore security errors on iframes
       }
     });
   },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Reverted the fix on https://github.com/infor-design/enterprise/pull/5617 as it caused #5649 and #5648
A new NG only fix was added to cover it https://github.com/infor-design/enterprise-ng/pull/1134

Added a new example for another bug for later

**Related github/jira issue (required)**:
Fixes #5649
Fixes #5648

**Steps necessary to review your pull request (required)**:
- Go to http://localhost:4000/components/calendar/example-index.html
- Click on Add/"+" on the upper right
- Click on Add Event(Modal)
-  click the the "All day" checkbox -> should work
- go to http://localhost:4000/components/checkboxes/example-checkbox-groups.html
- open the ... menu and pick a color
- click the checkboxes -> should work

**Included in this Pull Request**:
- [x] A note to the change log.
