### PR TITLE
5640 - Fix line position when all values are zero

### DIFF
--- a/app/views/components/line/test-all-data-points-are-zero-look.html
+++ b/app/views/components/line/test-all-data-points-are-zero-look.html
@@ -1,0 +1,41 @@
+<div class="row">
+    <div class="two-thirds column">
+        <div class="widget">
+          <div class="widget-header">
+            <h2 class="widget-title">Line Chart: Zero Value</h2>
+          </div>
+          <div class="widget-content">
+            <div id="line-example" class="chart-container">
+            </div>
+          </div>
+        </div>
+    </div>
+  </div>
+  
+  <script>
+  $('body').on('initialized', function () {
+  
+      var dataset = [{
+        "data":[
+          {"name":"test 1","value": 0},
+          {"name":"test 2","value": 0},
+          {"name":"test 3","value": 0},
+          {"name":"test 4","value": 0},
+          {"name":"test 5","value": 0}],
+        name: 'Component C'
+      }];
+  
+    $('#line-example').chart({
+      type: 'line',
+      dataset: dataset,
+      yAxis: {
+        ticks: {
+          number: 5,
+          format: 's'
+        }
+      }
+    });
+  
+  });
+  </script>
+  

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,13 @@
 - `[Locale]` Fixed an additional case where large numbers cannot be formatted correctly. ([#5605](https://github.com/infor-design/enterprise/issues/5605))
 - `[Locale]` Expanded support from 10 to 20 decimal places. Max number is 21, 20 now. ([#5622](https://github.com/infor-design/enterprise/issues/5622))
 
+## v4.55.3 Fixes
+
+- `[Datagrid]` Fixed an issue where the selection idx was not updating after append/update data to child nodes for tree. ([#5631](https://github.com/infor-design/enterprise/issues/5631))
+- `[Locale]` Fixed a bug where very large numbers would get a zero added. ([#5308](https://github.com/infor-design/enterprise/issues/5308))
+- `[Locale]` Fixed a bug where very large numbers with negative added an extra zero in formatNumber. ([#5318](https://github.com/infor-design/enterprise/issues/5318))
+- `[Locale]` Expanded support from 10 to 20 decimal places. Max number is 21, 20 now. ([#5622](https://github.com/infor-design/enterprise/issues/5622))
+
 ## v4.55.2 Fixes
 
 - `[Icons]` Fix sizes on some of the icons in classic mode. ([#5626](https://github.com/infor-design/enterprise/issues/5626))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[Dropdown]` Fixed a bug where selecting the first item on the list doesn't trigger the `change` event that will select the value immediately. ([NG#1102](https://github.com/infor-design/enterprise-ng/issues/1102))
 - `[Dropdown]` Fixed an accessibility issue where the error message was unannounced using a screen reader. ([#5130](https://github.com/infor-design/enterprise/issues/5130))
 - `[Icons]` Fix sizes on some of the icons in classic mode. ([#5626](https://github.com/infor-design/enterprise/issues/5626))
+- `[Line Chart]` Fixed a bug where the line chart was not positioned correctly when all the values were zero. ([#5640](https://github.com/infor-design/enterprise/issues/5640))
 - `[Locale]` Fixed an additional case where large numbers cannot be formatted correctly. ([#5605](https://github.com/infor-design/enterprise/issues/5605))
 - `[Locale]` Expanded support from 10 to 20 decimal places. Max number is 21, 20 now. ([#5622](https://github.com/infor-design/enterprise/issues/5622))
 

--- a/src/components/line/line.js
+++ b/src/components/line/line.js
@@ -841,6 +841,21 @@ Line.prototype = {
       }
     };
 
+    // By default, if the all the values are zero, the line-group will be centered
+    // With this, it will be more consistent in terms of look even if it has only one y-axis tick
+    // It should be positioned close contact with the names
+    self.svg._groups.forEach((gLine) => {
+      gLine.forEach((g) => {
+        const tickLength = $(g).find('g.y.axis .tick').length;
+        const gLineGroup = $(g).find('g.line-group');
+        const gYAxis = $(g).find('g.y.axis');
+
+        if (tickLength < 2) {
+          gYAxis.add(gLineGroup).css('transform', 'translateY(38%)');
+        }
+      });
+    });
+
     this.setInitialSelected();
     this.setTextValues();
     this.element.trigger('rendered');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the position of the line chart when all values are zeros. The line chart should not be centered and it should be close to the names.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/5640

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/line/test-all-data-points-are-zero-look.html
- The line chart should be close below with the names and not be centered

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
