### PR TITLE
MISC - update chrome driver that will fix e2e to work

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "e2e:local:debug": "npm run webdriver:update && npx protractor test/protractor.local.debug.conf.js",
     "e2e:puppeteer": "npx --no-install jest --config=test/jest.config.js --runInBand --detectOpenHandles --forceExit",
     "webdriver:clean": "npx webdriver-manager clean",
-    "webdriver:update": "npx webdriver-manager update --versions.chrome 93.0.4577.63 --standalone false --quiet --gecko=false",
+    "webdriver:update": "npx webdriver-manager update --versions.chrome 92.0.4515.43 --standalone false --quiet --gecko=false",
     "zip-dist": "npx grunt zip-dist",
     "documentation": "node ./scripts/deploy-documentation.js",
     "release:dev": "node scripts/publish-nightly-manual",
@@ -79,7 +79,7 @@
     "node-version-check": "npx check-node-version --node 12",
     "node-updates-check": "npx ncu"
   },
-  "chrome-version": "94",
+  "chrome-version": "92",
   "dependencies": {
     "d3": "^5.16.0",
     "jquery": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "e2e:local:debug": "npm run webdriver:update && npx protractor test/protractor.local.debug.conf.js",
     "e2e:puppeteer": "npx --no-install jest --config=test/jest.config.js --runInBand --detectOpenHandles --forceExit",
     "webdriver:clean": "npx webdriver-manager clean",
-    "webdriver:update": "npx webdriver-manager update --standalone false --quiet --gecko=false",
+    "webdriver:update": "npx webdriver-manager update --versions.chrome 93.0.4577.63 --standalone false --quiet --gecko=false",
     "zip-dist": "npx grunt zip-dist",
     "documentation": "node ./scripts/deploy-documentation.js",
     "release:dev": "node scripts/publish-nightly-manual",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "e2e:local:debug": "npm run webdriver:update && npx protractor test/protractor.local.debug.conf.js",
     "e2e:puppeteer": "npx --no-install jest --config=test/jest.config.js --runInBand --detectOpenHandles --forceExit",
     "webdriver:clean": "npx webdriver-manager clean",
-    "webdriver:update": "npx webdriver-manager update --versions.chrome 92.0.4515.43 --standalone false --quiet --gecko=false",
+    "webdriver:update": "npx webdriver-manager update --standalone false --quiet --gecko=false",
     "zip-dist": "npx grunt zip-dist",
     "documentation": "node ./scripts/deploy-documentation.js",
     "release:dev": "node scripts/publish-nightly-manual",
@@ -79,7 +79,7 @@
     "node-version-check": "npx check-node-version --node 12",
     "node-updates-check": "npx ncu"
   },
-  "chrome-version": "92",
+  "chrome-version": "94",
   "dependencies": {
     "d3": "^5.16.0",
     "jquery": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "e2e:local:debug": "npm run webdriver:update && npx protractor test/protractor.local.debug.conf.js",
     "e2e:puppeteer": "npx --no-install jest --config=test/jest.config.js --runInBand --detectOpenHandles --forceExit",
     "webdriver:clean": "npx webdriver-manager clean",
-    "webdriver:update": "npx webdriver-manager update --versions.chrome 92.0.4515.43 --standalone false --quiet --gecko=false",
+    "webdriver:update": "npx webdriver-manager update --versions.chrome 93.0.4577.63 --standalone false --quiet --gecko=false",
     "zip-dist": "npx grunt zip-dist",
     "documentation": "node ./scripts/deploy-documentation.js",
     "release:dev": "node scripts/publish-nightly-manual",
@@ -79,7 +79,7 @@
     "node-version-check": "npx check-node-version --node 12",
     "node-updates-check": "npx ncu"
   },
-  "chrome-version": "92",
+  "chrome-version": "94",
   "dependencies": {
     "d3": "^5.16.0",
     "jquery": "^3.6.0",


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR updates the chrome driver and chrome version to 94. And we noticed that it has an issue when running `e2e:ci`. It's not working for both local and on docker instances even after updating the stable version of chrome.

**Related github/jira issue (required)**:
N/A

**Steps necessary to review your pull request (required)**:
- Pull this branch
- Do `npm i`
- Build then run the app
- Run `npm run e2e:ci` it should work and should not encounter any error regarding ChromeDriver
- Optional: Test also on the docker instances
- Make sure you are on the latest and stable version of Chrome

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
