### PR TITLE
5588/5566 - Fix title and icon position in RTL and update font size of count xl

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # What's New with Enterprise
 
+## v4.57.0 Fixes
+
+- `[Counts]` Updated the font size of `xl-text` from `50px` to `45px`. ([#5588](https://github.com/infor-design/enterprise/issues/5588))
+- `[Counts]` Fixed title and icon position when in RTL. ([#5566](https://github.com/infor-design/enterprise/issues/5566))
+
 ## v4.56.0 Features
 
 - `[ContextualActionPanel]` Changed the color of the toolbar header in the new theme. ([#5685](https://github.com/infor-design/enterprise/issues/5685))

--- a/src/components/counts/_counts-new.scss
+++ b/src/components/counts/_counts-new.scss
@@ -4,7 +4,6 @@
     border: 1px solid;
     color: $ids-color-font-base;
     height: 80px;
-    line-height: 75px;
     width: 80px;
 
     &[class=count] {
@@ -15,5 +14,16 @@
   svg.icon {
     background: $cardlist-bg-color;
     right: 24px;
+  }
+}
+
+// RTL styles
+html[dir='rtl'] {
+  .instance-count {
+    svg.icon {
+      &.icon-alert {
+        right: 2px;
+      }
+    }
   }
 }

--- a/src/components/counts/_counts.scss
+++ b/src/components/counts/_counts.scss
@@ -82,6 +82,10 @@
     color: inherit;
     display: block;
   }
+
+  .xl-text {
+    @include font-size(45);
+  }
 }
 
 .form-layout-compact {
@@ -99,11 +103,19 @@ html[dir='rtl'] {
       float: right;
     }
 
+    svg.icon {
+      &.icon-alert,
+      &.icon-success {
+        right: 4px;
+      }
+    }
+
     .title {
       float: right;
       padding-left: inherit;
-      padding-right: 11px;
-      text-align: right;
+      padding-right: 0;
+      text-align: center;
+      width: 80px;
     }
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the title and text position of count in RTL and updates the font size of `xl text` from `50px` to `45px`.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/5588 https://github.com/infor-design/enterprise/issues/5566

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/counts/example-index.html
- Inspect the `xl text`, and it should be `45px` now
- Go to http://localhost:4000/components/counts/example-widget-count?&locale=he-IL
- Check the count title, it should be centered and below the counts
- Count icon should properly position upper right
- Test also on classic

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
