### PR TITLE
5657: Composite Form: Lookup Icon Not Centered in Firefox

### DIFF
--- a/src/components/lookup/_lookup-new.scss
+++ b/src/components/lookup/_lookup-new.scss
@@ -45,15 +45,6 @@
 }
 
 html.is-firefox {
-  .lookup-wrapper {
-    .trigger {
-      .icon {
-        top: 0;
-        margin-top: -10px !important;
-      }
-    }
-  }
-
   .field-short,
   .form-layout-compact .field {
     .lookup-wrapper {
@@ -62,7 +53,6 @@ html.is-firefox {
       }
     }
   }
-
 }
 
 html.is-safari {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Lookup icon is not centered vertically in Firefox.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
#5657

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
Pull branch, run app
Visit http://localhost:4000/components/compositeform/example-index.html or http://localhost:4000/components/compositeform/example-no-summary.html
Notice lookup icon is now centered

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
