### PR TITLE
5659: Spinbox Home and End Keys Set the Max and Min value

### DIFF
--- a/src/components/spinbox/spinbox.js
+++ b/src/components/spinbox/spinbox.js
@@ -323,7 +323,7 @@ Spinbox.prototype = {
    */
   handleKeyDown(e, self) {
     const key = e.which;
-    const validKeycodes = [35, 36, 37, 38, 39, 40];
+    const validKeycodes = [37, 38, 39, 40];
 
     if ($.inArray(key, validKeycodes) === -1) {
       return;
@@ -333,14 +333,8 @@ Spinbox.prototype = {
       return;
     }
 
-    // If the keycode got this far, it's an arrow key, HOME, or END.
+    // If the keycode got this far, it's an arrow key.
     switch (key) {
-      case 35: // End key sets the spinbox to its minimum value
-        if (self.element.attr('min')) { self.element.val(self.element.attr('min')); }
-        break;
-      case 36: // Home key sets the spinbox to its maximum value
-        if (self.element.attr('max')) { self.element.val(self.element.attr('max')); }
-        break;
       case 38: // Up increases the spinbox value
         self.addButtonStyle(self.buttons.up);
         self.increaseValue();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Home and End keys (on Mac: Fn + Left Arrow, Fn + Right Arrow) increase or decrease spinbox to maximum or minimum value.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Fixes #5659 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull branch, run app
- Visit spinbox example index
- Notice when spinbox is focused that max and min values are not applied.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
