### PR TITLE
5586 - Fix for Application Menu in Safari

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v4.57.0 Fixes
 
+- `[ApplicationMenu]` Fix for broken UI in Safari when hiding and expanding the navigation menu. ([#5620](https://github.com/infor-design/enterprise/issues/5620))
 - `[Datepicker]` Fix on default legends being shown regardless if settings have custom legends. ([#5683](https://github.com/infor-design/enterprise/issues/5683))
 - `[Searchfield]` Fix on uneven searchfield in firefox. ([#5620](https://github.com/infor-design/enterprise/issues/5620))
 

--- a/src/components/applicationmenu/applicationmenu.js
+++ b/src/components/applicationmenu/applicationmenu.js
@@ -470,6 +470,11 @@ ApplicationMenu.prototype = {
         tabPanel.css('width', `calc(100% - ${localStorage.navMenuWidth})`);
       }
     }
+
+    // For some reason, the fix will not work if used in scss style.
+    if ($('html.is-safari')) {
+      $('.resize-app-menu-container').css('display', 'flex');
+    }
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix the broken UI in Safari when hiding and expanding the navigation menu.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5586

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/applicationmenu/example-resizable-menu.html
- Resize the Application Menu to any size
- Click on the hamburger button to hide then click it again to expand

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

