### PR TITLE
4696 - Change width of searchfield when parent container becomes smaller

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `[Lookup]` Fix an uncentered lookup icon in composite form. ([#5657](https://github.com/infor-design/enterprise/issues/5657))
 - `[Searchfield]` Fix on uneven searchfield in firefox. ([#5620](https://github.com/infor-design/enterprise/issues/5620))
 - `[Searchfield]` Fix on uneven searchfield in firefox. ([#5695](https://github.com/infor-design/enterprise/issues/5695))
+- `[Searchfield]` Change width when parent container becomes smaller. ([#4696](https://github.com/infor-design/enterprise/issues/4696))
 - `[Spinbox]` Remove functionality of Home and End buttons on Spinbox. ([#5659](https://github.com/infor-design/enterprise/issues/5659))
 - `[Spinbox]` Fix spinbox misalignment on sample sizes. ([#5733](https://github.com/infor-design/enterprise/issues/5733))
 - `[Tabs]` Fix a bug on vertical tabs scroll on panel containers. ([#5565](https://github.com/infor-design/enterprise/issues/5565))

--- a/src/components/searchfield/searchfield.js
+++ b/src/components/searchfield/searchfield.js
@@ -1811,6 +1811,7 @@ SearchField.prototype = {
       }
 
       self.isCollapsing = true;
+
       self.wrapper.removeAttr('style');
 
       // Puts the input wrapper back where it should be if it's been moved due to small form factors.

--- a/src/components/searchfield/searchfield.js
+++ b/src/components/searchfield/searchfield.js
@@ -466,17 +466,27 @@ SearchField.prototype = {
     });
     renderLoop.register(resizeTimer);
 
+    let wrapperWidth = 0;
+
     // when the window size changes, searchfield
     // should calculate its width so that the input
     // does not overflow the buttons/icons contained
     // in it
     $('body').on(`resize.${this.id}`, () => {
+      if (self.wrapper.width() >= self.wrapper.parent().width() ||
+      (self.wrapper.width() !== wrapperWidth && wrapperWidth >= self.wrapper.parent().width())) {
+        self.wrapper.width(`${self.wrapper.parent().width() - (self.wrapper.parent().width() * 0.1)}px`);
+      } else {
+        self.wrapper.css('width', '');
+      }
       self.calculateSearchfieldWidth();
     });
 
     if (this.settings.collapsible === false) {
       this.expand(true);
     }
+
+    wrapperWidth = self.wrapper.width();
 
     return this;
   },
@@ -1801,7 +1811,6 @@ SearchField.prototype = {
       }
 
       self.isCollapsing = true;
-
       self.wrapper.removeAttr('style');
 
       // Puts the input wrapper back where it should be if it's been moved due to small form factors.

--- a/src/components/searchfield/searchfield.js
+++ b/src/components/searchfield/searchfield.js
@@ -473,11 +473,13 @@ SearchField.prototype = {
     // does not overflow the buttons/icons contained
     // in it
     $('body').on(`resize.${this.id}`, () => {
-      if (self.wrapper.width() >= self.wrapper.parent().width() ||
-      (self.wrapper.width() !== wrapperWidth && wrapperWidth >= self.wrapper.parent().width())) {
-        self.wrapper.width(`${self.wrapper.parent().width() - (self.wrapper.parent().width() * 0.1)}px`);
-      } else {
-        self.wrapper.css('width', '');
+      // searchfield wrapper only changes width if it's in a splitter container
+      if (self.wrapper.parents('.splitter-container').length > 0) {
+        if (self.wrapper.width() >= self.wrapper.parent().width() || wrapperWidth >= self.wrapper.parent().width()) {
+          self.wrapper.width(`${self.wrapper.parent().width() - (self.wrapper.parent().width() * 0.1)}px`);
+        } else {
+          self.wrapper.css('width', '');
+        }
       }
       self.calculateSearchfieldWidth();
     });

--- a/src/components/splitter/_splitter.scss
+++ b/src/components/splitter/_splitter.scss
@@ -35,6 +35,13 @@
   .content {
     height: 100%;
   }
+
+  .searchfield-wrapper {
+    @include transition(
+    left 300ms $cubic-ease,
+    right 300ms $cubic-ease,
+    box-shadow 300ms $cubic-ease);
+  }
 }
 
 .splitter {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Searchfield will change width is splitter moves and the splitter container becomes smaller.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #4696 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/splitter/example-searchfield.html
- Move splitter
- Searchfield should change width when splitter gets closer to it

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
