### PR TITLE
5365 - Treemap fix broken footer text on new theme

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@
 - `[Spinbox]` Remove functionality of Home and End buttons on Spinbox. ([#5659](https://github.com/infor-design/enterprise/issues/5659))
 - `[Spinbox]` Fix spinbox misalignment on sample sizes. ([#5733](https://github.com/infor-design/enterprise/issues/5733))
 - `[Tabs]` Fix a bug on vertical tabs scroll on panel containers. ([#5565](https://github.com/infor-design/enterprise/issues/5565))
+- `[Treemap]` Fix Treemap's misaligned footer-text on the new theme. ([#5365](https://github.com/infor-design/enterprise/issues/5365))
 
 ## v4.56.0 Features
 

--- a/scripts/data/expected-files.json
+++ b/scripts/data/expected-files.json
@@ -304,6 +304,7 @@
 	"/dist/sass/src/components/tree/_tree.scss",
 	"/dist/sass/src/components/tree/_tree-new.scss",
 	"/dist/sass/src/components/treemap/_treemap.scss",
+	"/dist/sass/src/components/treemap/_treemap-new.scss",
 	"/dist/sass/src/components/typography/_typography-new.scss",
 	"/dist/sass/src/components/typography/_typography.scss",
 	"/dist/sass/src/components/visibility/_visibility.scss",

--- a/src/components/treemap/_treemap-new.scss
+++ b/src/components/treemap/_treemap-new.scss
@@ -8,6 +8,11 @@
   }
 
   .label {
+    font-size: 1.4rem;
     white-space: nowrap;
+  }
+
+  .text-emphasis {
+    font-size: 1.4rem;
   }
 }

--- a/src/components/treemap/_treemap-new.scss
+++ b/src/components/treemap/_treemap-new.scss
@@ -1,0 +1,13 @@
+.chart-treemap-footer {
+  height: 65px;
+  margin-top: -33px;
+  overflow: hidden;
+
+  .data {
+    line-height: 1em;
+  }
+
+  .label {
+    white-space: nowrap;
+  }
+}

--- a/src/components/treemap/_treemap.scss
+++ b/src/components/treemap/_treemap.scss
@@ -55,4 +55,8 @@
   height: 60px;
   margin-top: -28px;
   overflow: hidden;
+
+  .label {
+    white-space: nowrap;
+  }
 }

--- a/src/components/treemap/_treemap.scss
+++ b/src/components/treemap/_treemap.scss
@@ -59,4 +59,8 @@
   .label {
     white-space: nowrap;
   }
+
+  .text-emphasis {
+    line-height: 1em;
+  }
 }

--- a/src/components/treemap/_treemap.scss
+++ b/src/components/treemap/_treemap.scss
@@ -56,6 +56,10 @@
   margin-top: -28px;
   overflow: hidden;
 
+  .data {
+    white-space: nowrap;
+  }
+
   .label {
     white-space: nowrap;
   }

--- a/src/core/_controls-new.scss
+++ b/src/core/_controls-new.scss
@@ -158,6 +158,7 @@
 @import '../components/radar/radar';
 @import '../components/stepchart/stepchart';
 @import '../components/treemap/treemap';
+@import '../components/treemap/treemap-new';
 @import '../components/line/line';
 
 // Patterns ====/


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
This PR fixes Treemap's misaligned footer-text on the new theme.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise/issues/5365

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build, and run the app
- Go to: http://localhost:4000/components/treemap/example-stats.html?theme=new
- Compare the above to: https://main-enterprise.demo.design.infor.com/components/treemap/example-stats.html?theme=new
- Go to: http://localhost:4000/components/treemap/example-stats.html?theme=classic
- Compare the above to: https://main-enterprise.demo.design.infor.com/components/treemap/example-stats.html?theme=classic

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
