### PR TITLE
5751 - follow up fix for datepicker icon position in classic mode

### DIFF
--- a/src/components/datepicker/_datepicker-new.scss
+++ b/src/components/datepicker/_datepicker-new.scss
@@ -70,3 +70,12 @@ html[dir='rtl'] {
     }
   }
 }
+
+html.is-safari {
+  .field-short,
+  .form-layout-compact {
+    .datepicker + .trigger {
+      top: 2px;
+    }
+  }
+}

--- a/src/components/datepicker/_datepicker.scss
+++ b/src/components/datepicker/_datepicker.scss
@@ -256,15 +256,6 @@ html.is-safari {
   }
 }
 
-html.is-safari {
-  .field-short,
-  .form-layout-compact {
-    .datepicker + .trigger {
-      top: 2px;
-    }
-  }
-}
-
 @include respond-to(tabletdown) {
   .monthview-popup.popover .monthview {
     min-width: 310px;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Follow up fix for datepicker trigger position in class theme.

Was not tested thoroughly. Just need to move the CSS rules to the `New` Mode file.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/5751

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Open in Safari and go to http://localhost:4000/components/form/example-compact-mode.html
- Check the position of datepicker trigger button
- Toggle Compact Mode
- It should position correctly
- Test in Classic
- Check the position of datepicker trigger button
- Toggle Compact Mode
- It should position correctly

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
