### PR TITLE
5734 - Tab key doesn't go to next cells if cellNavigation is false

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## v4.58.0 Fixes
 
+- `[Datagrid]` Tab doesn't go to cells if cellNavigation is false. ([#5734](https://github.com/infor-design/enterprise/issues/5734))
 - `[Searchfield]` Save input value when searchfield collapses but is not cleared via button click or key. ([#5792](https://github.com/infor-design/enterprise/issues/5792))
 - `[Tabs-Vertical]` Fixed on Tabs Vertical Aria and Roles. ([#5712](https://github.com/infor-design/enterprise/issues/5712))
 - `[Toolbar Searchfield]` Fixed the height the collapse button on a smaller viewport (`766px` and below). ([#5791](https://github.com/infor-design/enterprise/issues/5791))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9318,7 +9318,7 @@ Datagrid.prototype = {
 
       // Tab, Left and Right arrow keys.
       if ([9, 37, 39].indexOf(key) !== -1) {
-        if (key === 9 && !self.settings.actionableMode) {
+        if (key === 9 && !self.settings.actionableMode || !self.settings.cellNavigation) {
           return;
         }
 
@@ -9339,7 +9339,7 @@ Datagrid.prototype = {
             }
           }
 
-          if (cell === -1 && !self.settings.actionableMode) {
+          if (cell === -1 && !self.settings.actionableMode || !self.settings.cellNavigation) {
             return;
           }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
If cellNavigation is false, tabbing will skip the cells.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #5734

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datagrid/test-editable-paging-validation.html
- Press the tab key several times
- Should not focus on the cells

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
