### PR TITLE
5867 - Fix tabs not working in modal [regression bug 4.57.x]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Locale]` Fix issue in parsing date when AM/PM comes first before Hours (a:hh:mm). ([#5129](https://github.com/infor-design/enterprise/issues/5129))
 - `[Modal]` Added option to disable primary trigger on field. ([#5728](https://github.com/infor-design/enterprise/issues/5728))
 - `[Searchfield]` Save input value when searchfield collapses but is not cleared via button click or key. ([#5792](https://github.com/infor-design/enterprise/issues/5792))
+- `[Tabs]` Fixed regression bug where tabs are no longer working inside the modal. ([#5867](https://github.com/infor-design/enterprise/issues/5867))
 - `[Tabs]` Fix focus indicator in Sink Page. ([#5714](https://github.com/infor-design/enterprise/issues/5714))
 - `[Tabs-Vertical]` Fixed on Tabs Vertical Aria and Roles. ([#5712](https://github.com/infor-design/enterprise/issues/5712))
 - `[Toolbar Searchfield]` Fixed the height the collapse button on a smaller viewport (`766px` and below). ([#5791](https://github.com/infor-design/enterprise/issues/5791))

--- a/src/components/tabs-vertical/_tabs-vertical.scss
+++ b/src/components/tabs-vertical/_tabs-vertical.scss
@@ -75,6 +75,11 @@
 
     .tab-container.vertical {
       z-index: 3;
+
+      .tab-list-container > .tab-focus-indicator.is-visible {
+        border-color: transparent;
+        box-shadow: none;
+      }
     }
 
     .tab-panel-container {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -610,17 +610,14 @@ Tabs.prototype = {
    * @returns {this} component instance
    */
   renderHelperMarkup() {
-    const self = this;
     let auxilaryButtonLocation = this.tablistContainer || this.tablist;
     if (this.isModuleTabs()) {
       auxilaryButtonLocation = this.tablist;
     }
 
-    if (!self.element.parents('.modal-content').length) {
-      this.focusState = this.element.find('.tab-focus-indicator');
-      if (!this.focusState.length) {
-        this.focusState = $('<div class="tab-focus-indicator" role="presentation"></div>').insertBefore(this.tablist);
-      }
+    this.focusState = this.element.find('.tab-focus-indicator');
+    if (!this.focusState.length) {
+      this.focusState = $('<div class="tab-focus-indicator" role="presentation"></div>').insertBefore(this.tablist);
     }
 
     // Add the markup for the "More" button if it doesn't exist.
@@ -3868,18 +3865,16 @@ Tabs.prototype = {
 
     // Adjust the values one more time if we have tabs contained inside of a
     // page-container, or some other scrollable container.
-    if (!self.element.parents('.modal-content').length) {
-      targetPos = adjustForParentContainer(targetPos, parentContainer, scrollingTablist, widthPercentage);
+    targetPos = adjustForParentContainer(targetPos, parentContainer, scrollingTablist, widthPercentage);
 
-      let targetPosString = '';
-      Object.keys(targetPos).forEach((key) => {
-        if (targetPosString.length) {
-          targetPosString += ' ';
-        }
-        targetPosString += `${key}: ${targetPos[key]}px;`;
-      });
-      focusStateElem.style.cssText = targetPosString;
-    }
+    let targetPosString = '';
+    Object.keys(targetPos).forEach((key) => {
+      if (targetPosString.length) {
+        targetPosString += ' ';
+      }
+      targetPosString += `${key}: ${targetPos[key]}px;`;
+    });
+    focusStateElem.style.cssText = targetPosString;
 
     // build CSS string containing each prop and set it:
 

--- a/test/components/tabs/tabs.puppeteer-spec.js
+++ b/test/components/tabs/tabs.puppeteer-spec.js
@@ -1,0 +1,13 @@
+
+const utils = require('../../helpers/e2e-utils.js');
+
+describe('Tabs modal test-modal-error tests', () => {
+  const url = 'http://localhost:4000/components/tabs/test-modal-error.html';
+  beforeAll(async () => {
+    await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });
+  });
+
+  it('should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the regression bug where tabs are not working inside of modal. The issue has something to do with the vertical tabs in the modal. Reverting back to the original script and fixing the floating border indicator via CSS only.

Added unit testing for catching log errors in case we encounter the same issue.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/5867

Related/Affected PR https://github.com/infor-design/enterprise/pull/5725

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/tabs/test-modal-error.html
- Check the logs if there's an error
- Shouldn't have any errors
- Open the modal to check the tabs, and it should be working
- Go to http://localhost:4000/components/contextualactionpanel/example-cap-tabs-vertical-scroll.html
- Open the `CAP - Vertical Tabs`
- Click any of the tabs
- Then play around by scrolling up and down
- There should be no floating white border indicator

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
