### PR TITLE
5721 - Ability to add axis labels in column-grouped chart

### DIFF
--- a/app/views/components/column-grouped/example-axis-labels.html
+++ b/app/views/components/column-grouped/example-axis-labels.html
@@ -1,0 +1,168 @@
+
+<div class="row">
+  <div class="two-thirds column">
+      <div class="widget">
+        <div class="widget-header">
+          <h2 class="widget-title">Grouped Column Chart - Axis Labels</h2>
+        </div>
+        <div class="widget-content">
+          <div id="column-grouped-example" class="chart-container">
+          </div>
+        </div>
+      </div>
+  </div>
+</div>
+
+<script>
+$('body').on('initialized', function () {
+
+    var dataset = [{
+        data: [{
+            name: 'Jan',
+            value: 12,
+            attributes: [
+             { name: 'id', value: 'columngrouped-c1-jan' },
+             { name: 'data-automation-id', value: 'automation-id-columngrouped-c1-jan' }
+           ]
+        }, {
+            name: 'Feb',
+            value: 11,
+            attributes: [
+             { name: 'id', value: 'columngrouped-c1-feb' },
+             { name: 'data-automation-id', value: 'automation-id-columngrouped-c1-feb' }
+           ]
+        }, {
+            name: 'Mar',
+            value: 14,
+            attributes: [
+             { name: 'id', value: 'columngrouped-c1-mar' },
+             { name: 'data-automation-id', value: 'automation-id-columngrouped-c1-mar' }
+           ]
+        }, {
+            name: 'Apr',
+            value: 10,
+            attributes: [
+             { name: 'id', value: 'columngrouped-c1-apr' },
+             { name: 'data-automation-id', value: 'automation-id-columngrouped-c1-apr' }
+           ]
+        }, {
+            name: 'May',
+            value: 14,
+            attributes: [
+             { name: 'id', value: 'columngrouped-c1-may' },
+             { name: 'data-automation-id', value: 'automation-id-columngrouped-c1-may' }
+           ]
+        }, {
+            name: 'Jun',
+            value: 8,
+            attributes: [
+             { name: 'id', value: 'columngrouped-c1-jun' },
+             { name: 'data-automation-id', value: 'automation-id-columngrouped-c1-jun' }
+           ]
+        }],
+        name: 'Component A'
+      }, {
+        data: [{
+            name: 'Jan',
+            value: 22,
+            attributes: [
+             { name: 'id', value: 'columngrouped-c2-jan' },
+             { name: 'data-automation-id', value: 'automation-id-columngrouped-c2-jan' }
+           ]
+        }, {
+            name: 'Feb',
+            value: 21,
+            attributes: [
+             { name: 'id', value: 'columngrouped-c2-feb' },
+             { name: 'data-automation-id', value: 'automation-id-columngrouped-c2-feb' }
+           ]
+        }, {
+            name: 'Mar',
+            value: 24,
+            attributes: [
+             { name: 'id', value: 'columngrouped-c2-mar' },
+             { name: 'data-automation-id', value: 'automation-id-columngrouped-c2-mar' }
+           ]
+        }, {
+            name: 'Apr',
+            value: 20,
+            attributes: [
+             { name: 'id', value: 'columngrouped-c2-apr' },
+             { name: 'data-automation-id', value: 'automation-id-columngrouped-c2-apr' }
+           ]
+        }, {
+            name: 'May',
+            value: 24,
+            attributes: [
+             { name: 'id', value: 'columngrouped-c2-may' },
+             { name: 'data-automation-id', value: 'automation-id-columngrouped-c2-may' }
+           ]
+        }, {
+            name: 'Jun',
+            value: 28,
+            attributes: [
+             { name: 'id', value: 'columngrouped-c2-jun' },
+             { name: 'data-automation-id', value: 'automation-id-columngrouped-c2-jun' }
+           ]
+        }],
+        name: 'Component B'
+      }, {
+        data: [{
+            name: 'Jan',
+            value: 32,
+            attributes: [
+             { name: 'id', value: 'columngrouped-c3-jan' },
+             { name: 'data-automation-id', value: 'automation-id-columngrouped-c3-jan' }
+           ]
+        }, {
+            name: 'Feb',
+            value: 31,
+            attributes: [
+             { name: 'id', value: 'columngrouped-c3-feb' },
+             { name: 'data-automation-id', value: 'automation-id-columngrouped-c3-feb' }
+           ]
+        }, {
+            name: 'Mar',
+            value: 34,
+            attributes: [
+             { name: 'id', value: 'columngrouped-c3-mar' },
+             { name: 'data-automation-id', value: 'automation-id-columngrouped-c3-mar' }
+           ]
+        }, {
+            name: 'Apr',
+            value: 30,
+            attributes: [
+             { name: 'id', value: 'columngrouped-c3-apr' },
+             { name: 'data-automation-id', value: 'automation-id-columngrouped-c3-apr' }
+           ]
+        }, {
+            name: 'May',
+            value: 34,
+            attributes: [
+             { name: 'id', value: 'columngrouped-c3-may' },
+             { name: 'data-automation-id', value: 'automation-id-columngrouped-c3-may' }
+           ]
+        }, {
+            name: 'Jun',
+            value: 38,
+            attributes: [
+             { name: 'id', value: 'columngrouped-c3-jun' },
+             { name: 'data-automation-id', value: 'automation-id-columngrouped-c3-jun' }
+           ]
+        }],
+        name: 'Component C'
+      }];
+
+  $('#column-grouped-example').chart({
+    type: 'column-grouped',
+    dataset: dataset,
+    axisLabels: {
+      left: 'Left axis label',
+      top: 'Top axis label',
+      right: 'Right axis label',
+      bottom: 'Bottom axis label'
+    }
+    });
+
+});
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[Column]` Added support to add a line chart in column-grouped. ([#4598](https://github.com/infor-design/enterprise/issues/4598))
 - `[Column]` Added feature to rotate labels. ([#5773](https://github.com/infor-design/enterprise/issues/5773))
+- `[Column Chart]` Added the ability to add axis labels in column-grouped chart. ([#5721](https://github.com/infor-design/enterprise/issues/5721))
 
 ## v4.58.0 Fixes
 

--- a/src/components/column/column.js
+++ b/src/components/column/column.js
@@ -414,7 +414,8 @@ Column.prototype = {
       .attr('width', width + margin.left + margin.right)
       .attr('height', height + margin.top + margin.bottom + (isAxisLabels.atLeastOne ? 12 : 0))
       .append('g')
-      .attr('transform', `translate(${isAxisLabels.atLeastOne ? margin.left + 11 : margin.left},${margin.top - (isAxisLabels.atLeastOne ? 5 : 0)})`);
+      .attr('transform', `translate(${isRTL ? margin.left + 5 : (isAxisLabels.atLeastOne ? margin.left + 11 : margin.left)}
+        ,${margin.top - (isAxisLabels.atLeastOne ? 5 : 0)})`);
 
     this.svg = svg;
 
@@ -522,9 +523,9 @@ Column.prototype = {
 
       const placeStyle = {
         top: `rotate(0deg) scaleX(-1) translate(-${widthAxisLabel / 2}px, ${-10}px)`,
-        right: `rotate(90deg) scaleX(-1) translate(-${(height / 2) + 5}px, -${widthAxisLabel + 28}px)`,
-        bottom: `rotate(0deg) scaleX(-1) translate(-${widthAxisLabel / 2}px, ${height + 40}px)`,
-        left: `rotate(90deg) scaleX(-1) translate(-${(height / 2 - 5)}px, ${55}px)`
+        right: `rotate(90deg) scaleX(-1) translate(-${(height / 2) + 5}px, -${widthAxisLabel + (isRTL ? 55 : 28)}px)`,
+        bottom: `rotate(0deg) scaleX(-1) translate(-${widthAxisLabel / 2}px, ${height + 47}px)`,
+        left: `rotate(90deg) scaleX(-1) translate(-${(height / 2 - 5)}px, ${isRTL ? 35 : 55}px)`
       };
 
       const addAxis = (pos) => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR adds the ability to attach axis labels `(top, right, bottom, left)` in the column-grouped chart. It also supports the RTL position.

You can set this using `axisLabels` setting e.g.

```javascript
axisLabels: {
      left: 'Left axis label',
      top: 'Top axis label',
      right: 'Right axis label',
      bottom: 'Bottom axis label'
    }
```

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/5721

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/column-grouped/example-axis-labels
- On the example page, you will see labels on different positions in the column-grouped chart
- Test in classic theme
- Test in RTL http://localhost:4000/components/column-grouped/example-axis-labels?locale=ar-EG
- Check the alignment of the axis labels
- Test in classic theme

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
