### PR TITLE
Fix link to code in documentation

### DIFF
--- a/src/components/grid/readme.md
+++ b/src/components/grid/readme.md
@@ -85,7 +85,7 @@ There are 7 breakpoint sizes you can target to tailor your layout to the specifi
 - `breakpoint-tablet-to-desktop`
 - `breakpoint-desktop-to-extralarge`
 
-See [`sass/_config.scss`](src/core/_config.scss) and search for "breakpoint sizes".
+See [`src/core/_config.scss`](https://github.com/infor-design/enterprise/blob/main/src/core/_config.scss#L945-L954) and search for "breakpoint sizes".
 
 For guidance on how to use the breakpoints to tailor your layout for different device sizes, see the [Grid & Breakpoints guidelines](https://design.infor.com/guidelines/layout/grid)
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Per [this comment](https://teams.microsoft.com/l/message/19:2b0c9ce520b0481a9ce115f0ca4a326f@thread.skype/1637679462321?tenantId=457d5685-0467-4d05-b23b-8f817adda47c&groupId=4f50ef7d-e88d-4ccb-98ca-65f26e57fe35&parentMessageId=1637678727395&teamName=IDS%20Enterprise%20Development&channelName=General&createdTime=1637679462321) on Teams, fixing a bad link to the codebase in the site documentation

**Related github/jira issue (required)**:
N/A

**Steps necessary to review your pull request (required)**:
On the readme, make sure the link inside the Breakpoints section that points to the SASS file correctly points to a Github code page on specific lines: https://github.com/infor-design/enterprise/tree/docs-update/src/components/grid#breakpoints
