### PR TITLE
5818 - Fix breaking of shared menu if a datagrid present

### DIFF
--- a/app/views/components/popupmenu/test-contextmenu-with-datagrid.html
+++ b/app/views/components/popupmenu/test-contextmenu-with-datagrid.html
@@ -1,0 +1,124 @@
+<div class="row">
+  <div class="twelve columns">
+    <button id="popup-destroy-1" class="btn-secondary" type="button">
+      <span>Destroy 1st Field</span>
+    </button>
+
+    <button id="popup-destroy-2" class="btn-secondary" type="button">
+      <span>Destroy 2nd Field</span>
+    </button>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+
+    <div class="field" id="field1">
+      <label for="input-menu">Label</label>
+      <input type="text" value="Right Click Me" id="input-menu"/>
+    </div>
+
+    <div class="field" id="field2">
+      <label for="input-menu2">Label2</label>
+      <input type="text" value="Right Click Me" id="input-menu2"/>
+    </div>
+
+    <ul id="action-popupmenu" class="popupmenu">
+      <li><a href="#">Cut</a></li>
+      <li><a href="#">Copy</a></li>
+      <li><a href="#">Paste</a></li>
+      <li>
+        <a href="#">Paste Special</a>
+        <ul class="popupmenu">
+          <li><a href="#">Sub Menu 1</a></li>
+          <li><a href="#">Sub Menu 2</a></li>
+          <li class="separator"></li>
+          <li>
+            <a href="#">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use href="#icon-settings"></use>
+              </svg>
+              Settings
+            </a>
+          </li>
+        </ul>
+      </li>
+      <li class="separator"></li>
+      <li><a href="#">Name and project range</a></li>
+      <li class="is-disabled"><a id='x' href="#" disabled>Insert comment</a></li>
+      <li class="is-disabled"><a href="#" disabled>Insert note</a></li>
+      <li><a href="#">Clear notes</a></li>
+      <li class="separator single-selectable-section"></li>
+      <li class="heading">Additional Options</li>
+      <li class="is-selectable is-checked"><a href="#">Conditional formatting</a></li>
+      <li class="is-selectable"><a href="#">Data validation</a></li>
+      <li class="separator"></li>
+      <li>
+        <a href="#">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-settings"></use>
+          </svg>
+          Settings
+        </a>
+      </li>
+    </ul>
+
+  </div>
+
+  <script>
+    // Like Angular
+    const input1 = $('#input-menu');
+    input1.popupmenu({trigger:'rightClick', menu: "action-popupmenu" })
+    const inputAPI1 = input1.data('popupmenu');
+
+    const input2 = $('#input-menu2')
+    input2.popupmenu({trigger:'rightClick', menu: "action-popupmenu" });
+    const inputAPI2 = input2.data('popupmenu');
+
+    $('#popup-destroy-1').click(function() {
+      input1.off();
+      inputAPI1.destroy();
+      input1.parent().remove();
+    });
+
+    $('#popup-destroy-2').click(function () {
+      input2.off();
+      inputAPI2.destroy();
+      input2.parent().remove();
+    });
+  </script>
+
+</div>
+
+<div class="row">
+  <div id="datagrid" data-automation-id="datagrid-automation-id" class="datagrid"></div>
+</div>
+
+<script id="datagrid-script">
+  $('body').one('initialized', function () {
+
+      var columns = [];
+
+      $.getJSON('{{basepath}}api/datagrid-sample-data', function(res) {
+
+        // Define Columns for the Grid.
+        columns.push({ id: 'productId', hideable: false, name: 'Id', field: 'productId', formatter: Formatters.Text });
+        columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink, click: function(e) { console.log('Click Fired') } });
+        columns.push({ id: 'activity', name: 'Activity', field: 'activity'});
+        columns.push({ id: 'hidden', hidden: true, name: 'Hidden', field: 'hidden'});
+        columns.push({ id: 'price', align: 'right', name: 'Actual Price', field: 'price', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'currency', currencySign: '$'}});
+        columns.push({ id: 'percent', align: 'right', name: 'Actual %', field: 'percent', formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'percent'}});
+        columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
+        columns.push({ id: 'phone', name: 'Phone', field: 'phone', formatter: Formatters.Text});
+
+        // Init and get the api for the grid
+        $('#datagrid').datagrid({
+          columns: columns,
+          dataset: res,
+          saveColumns: false,
+          attributes: [{ name: 'id', value: 'custom-id' }, { name: 'data-automation-id', value: 'custom-automation-id' } ],
+          toolbar: {title: 'Compressors', results: true, actions: true, rowHeight: true, personalize: true}
+        });
+      });
+ });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## v4.58.0 Fixes
 
 - `[Calendar]` Fix the header days where it should be seen when scrolled down. ([#5742](https://github.com/infor-design/enterprise/issues/5742))
+- `[Contextmenu/Popupmenu]` Fixed breaking of shared menu if a datagrid is present on the page. ([#5818](https://github.com/infor-design/enterprise/issues/5818))
 - `[Datagrid]` Tab doesn't go to cells if cellNavigation is false. ([#5734](https://github.com/infor-design/enterprise/issues/5734))
 - `[Locale]` Fix issue in parsing date when AM/PM comes first before Hours (a:hh:mm). ([#5129](https://github.com/infor-design/enterprise/issues/5129))
 - `[Modal]` Added option to disable primary trigger on field. ([#5728](https://github.com/infor-design/enterprise/issues/5728))

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -2517,10 +2517,8 @@ PopupMenu.prototype = {
     // Only unwrap/move this menu if there are no other menus attempting to control it (shared instance)
     const menuId = this.menu[0]?.id;
     const otherTriggers = $(`[aria-controls="${menuId}"]`).not(this.element);
-    // Needs to check to unwrap and wrap the menu in datagrid
-    const datagridFilterWrapper = $('.datagrid-filter-wrapper');
 
-    if (!otherTriggers.length || datagridFilterWrapper.length > 0) {
+    if (!otherTriggers.length) {
       const parentNode = this.menu.parent();
       parentNode.find('.arrow').remove();
       parentNode.off('contextmenu.popupmenu');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes breaking of the shared menu if a Datagrid is present. It looks like that the issue from datagrid paging (unable to reopen filter options after paging) has been resolved even without the condition for datagrid filter wrapper in popupmenu.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/5818

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/popupmenu/test-contextmenu-with-datagrid.html
- Click the `Destroy 1st Field` button
- Right click the remaining input field
- Popupmenu should be shown correctly

Another thing to test
- Go to http://localhost:4000/components/datagrid/test-filter-paging-client-side.html and http://localhost:4000/components/datagrid/test-filter-paging-server-side.html
- Click on any filter options dropdown
- Move to other page / last page
- Click again the filter option
- It should reopen the filter option

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
