### PR TITLE
5632 - Fix on noSearch dropdown not clearing previous search matches

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `[Calendar]` Fix the header days where it should be seen when scrolled down. ([#5742](https://github.com/infor-design/enterprise/issues/5742))
 - `[Datagrid]` Tab doesn't go to cells if cellNavigation is false. ([#5734](https://github.com/infor-design/enterprise/issues/5734))
+- `[Dropdown]` Clear search matches after an item is selected. ([#5632](https://github.com/infor-design/enterprise/issues/5632))
 - `[Locale]` Fix issue in parsing date when AM/PM comes first before Hours (a:hh:mm). ([#5129](https://github.com/infor-design/enterprise/issues/5129))
 - `[Modal]` Added option to disable primary trigger on field. ([#5728](https://github.com/infor-design/enterprise/issues/5728))
 - `[Searchfield]` Save input value when searchfield collapses but is not cleared via button click or key. ([#5792](https://github.com/infor-design/enterprise/issues/5792))

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -3235,6 +3235,10 @@ Dropdown.prototype = {
       }
     }
 
+    if (this.settings.noSearch) {
+      delete this.searchMatches;
+    }
+
     return elem.options[newIdx]; //eslint-disable-line
   },
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
The searchMatches aren't cleared after an option is selected, added line of code that deletes current searchMatches if dropdown is noSearch.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #5632 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/dropdown/example-no-search.html
- Type "t" to select "Two"
- Use the mouse to select "Five" or use $('#nosearch-dropdown').val('15').trigger('updated') to do it programmatically
- Type "t"
- "Two" should be highlighted

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
