### PR TITLE
N/A - Fix unit testing test in accordion

### DIFF
--- a/test/components/accordion/accordion.puppeteer-spec.js
+++ b/test/components/accordion/accordion.puppeteer-spec.js
@@ -42,7 +42,7 @@ describe('Accordion Puppeteer Test', () => {
 
     it('should have ajax data in headers', async () => {
       await page.click('#ajax-accordion .accordion-header button');
-
+      await page.waitForTimeout(100);
       page.waitForSelector('#ajax-accordion .accordion-pane.is-expanded > .accordion-header:first-child', { visible: true });
 
       expect(await page.$eval('#ajax-accordion .accordion-pane.is-expanded > .accordion-header:first-child', el => el.textContent.trim())).toEqual('Apples');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the issue in an accordion test that's failing in the build due to the selector that couldn't find. It just needs to add delay to be able to find the element since accordion has some sort of animation delay.

**Related github/jira issue (required)**:

N/A

**Steps necessary to review your pull request (required)**:
- Build should pass (hopefully)
- Test on local via `npm run e2e:puppeteer accordion`
- Should pass the ajax test

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
