### PR TITLE
5719 - Remove ripple effect in spinbox control when it's disabled

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[Colorpicker]` Fixed a bug where the red diagonal line that goes beyond its border when field-short/form-layout-compact is used. ([#5744](https://github.com/infor-design/enterprise/issues/5744))
 - `[Searchfield]` Fixed a bug where the close button icon is overlapping with the search icon in RTL. ([#5807](https://github.com/infor-design/enterprise/issues/5807))
+- `[Spinbox]` Fixed a bug where the spinbox controls still show the ripple effect even it's disabled. ([#5719](https://github.com/infor-design/enterprise/issues/5719))
 
 ## v4.58.0 Features
 

--- a/src/components/spinbox/_spinbox.scss
+++ b/src/components/spinbox/_spinbox.scss
@@ -94,6 +94,7 @@ input::-webkit-inner-spin-button {
     border-color: $input-color-disabled-border;
     color: $spinbox-disabled-icon-color;
     cursor: default;
+    pointer-events: none;
   }
 }
 

--- a/src/components/spinbox/_spinbox.scss
+++ b/src/components/spinbox/_spinbox.scss
@@ -94,7 +94,6 @@ input::-webkit-inner-spin-button {
     border-color: $input-color-disabled-border;
     color: $spinbox-disabled-icon-color;
     cursor: default;
-    pointer-events: none;
   }
 }
 

--- a/src/components/spinbox/spinbox.js
+++ b/src/components/spinbox/spinbox.js
@@ -644,6 +644,7 @@ Spinbox.prototype = {
     this.buttons.up.off('click.spinbox mousedown.spinbox');
     this.buttons.up.remove();
     this.buttons.down.off('click.spinbox mousedown.spinbox');
+    this.buttons.up.add(this.buttons.down).off('click.spinbox-control');
     this.buttons.down.remove();
     this.element.off('focus.spinbox blur.spinbox keydown.spinbox keyup.spinbox');
     this.element.unwrap();

--- a/src/components/spinbox/spinbox.js
+++ b/src/components/spinbox/spinbox.js
@@ -608,6 +608,7 @@ Spinbox.prototype = {
       !((!isDisabled || isDisabled === 'enable'));
 
     button[isDisabled ? 'addClass' : 'removeClass']('is-disabled');
+    button[0].disabled = isDisabled;
   },
 
   /**
@@ -744,6 +745,12 @@ Spinbox.prototype = {
           preventClick = false;
           self.element.focus();
         });
+      }
+    });
+
+    buttons.on('click.spinbox-control', () => {
+      if (buttons.hasClass('is-disabled')) {
+        $('svg.ripple-effect').remove();
       }
     });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR removes the ripple effect in spinbox control when it's being disabled, also added a disabled property to it.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/5719

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app.
- Go to http://localhost:4000/components/spinbox/example-range-limits.
- Click on - or + tabs to reach a minimum or maximum value.
- As we reach the min or max value, - or + sections are disabled.
- Clicking the disabled button should not show the ripple effect.
- Ripple effect will only show if the button is not disabled.

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
