### PR TITLE
5827 - Fix the alert icon position in RTL

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v4.59.0 Fixes
 
 - `[Colorpicker]` Fixed a bug where the red diagonal line that goes beyond its border when field-short/form-layout-compact is used. ([#5744](https://github.com/infor-design/enterprise/issues/5744))
+- `[Listview]` Fixed a bug where the alert icons in RTL were missing. ([#5827](https://github.com/infor-design/enterprise/issues/5827))
 - `[Searchfield]` Fixed a bug where the close button icon is overlapping with the search icon in RTL. ([#5807](https://github.com/infor-design/enterprise/issues/5807))
 
 ## v4.58.0 Features

--- a/src/components/listview/_listview-new.scss
+++ b/src/components/listview/_listview-new.scss
@@ -51,6 +51,12 @@ html.is-firefox {
 }
 
 html[dir='rtl'] {
+  .listview ul li {
+    .alert-text::before {
+      margin-right: 28px;
+    }
+  }
+
   .listview-search {
     .searchfield-wrapper {
       .icon:not(.close):not(.icon-error) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the position of the alert icon in RTL.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/5827

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/listview/example-status.html?locale=he-IL
- Alert dot icon should be visible and it should be seen beside the alert text
- Test in classic mode

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
