### PR TITLE
5796 - Close modal if Escape key is pressed in datagrid

### DIFF
--- a/app/views/components/modal/test-modal-datagrid-escape-closing.html
+++ b/app/views/components/modal/test-modal-datagrid-escape-closing.html
@@ -1,0 +1,127 @@
+<div class="row">
+  <div class="twelve columns">
+    <button class="btn-secondary" type="button" id="open-modal">Open Modal</button><br><br>
+
+    <!-- "Context" Example -->
+    <div id="modal-content" style="display: none;" >
+
+      <form class="form-layout-compact">
+        <div class="toolbar" role="toolbar">
+          <div class="title">
+            Finance Dimension 6
+          </div>
+          <div class="buttonset">
+            <button class="btn" type="button" id="filter">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use href="#icon-filter"></use>
+              </svg>
+            </button>
+          </div>
+
+          <div class="more">
+            <button class="btn-actions" type="button">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use href="#icon-more"></use>
+              </svg>
+              <span class="audible">More Actions</span>
+            </button>
+            <ul class="popupmenu">
+              <li><a data-option="personalize-columns" href="#" data-translate="text">PersonalizeColumns</a></li>
+              <li><a data-option="reset-layout" href="#" data-translate="text">ResetDefault</a></li>
+              <li class="separator"></li>
+              <li class="heading">Filter</li>
+              <li class="show-filter is-toggleable is-checked"><a data-option="show-filter-row" data-translate="text">ShowFilterRow</a></li>
+              <li class="is-indented"><a data-option="run-filter" data-translate="text">RunFilter</a></li>
+              <li class="is-indented"><a data-option="clear-filter" data-translate="text">ClearFilter</a></li>
+              <li class="separator single-selectable-section"></li>
+              <li class="heading">Row Height</li>
+              <li class="is-selectable is-checked"><a data-option="row-extra-small" href="#" data-translate="text">ExtraSmall</a></li>
+              <li class="is-selectable"><a data-option="row-small" href="#" data-translate="text">Small</a></li>
+              <li class="is-selectable"><a data-option="row-medium" href="#" data-translate="text">Medium</a></li>
+              <li class="is-selectable"><a data-option="row-large" href="#" data-translate="text">Large</a></li>
+            </ul>
+          </div>
+        </div>
+        <div id="datagrid">
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<script>
+  var gridApi = null;
+  var modal = null;
+
+  $('body').one('initialized', function () {
+    //Locale.set('en-US').done(function () {
+    var grid,
+      columns = [],
+      data = [];
+
+    // Some Sample Data
+    data.push({ id: 1, productId: 'T100', productName: 'Compressor', phone: '191/2004', activity:  'Assemble Paint', quantity: 1, price: '800.9905673502324', percent: .10, status: 'OK', orderDate: '00000000', action: 'Action', summary: 'Is action oriented and full of energy'});
+    data.push({ id: 2, productId: '200', productName: 'Different Compressor', phone: '(888) 888-8888', activity:  'Inspect and Repair', quantity: '2', percent: .10, price: null, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold', summary: 'Active Server Pages'});
+    data.push({ id: 3, productId: '300', productName: 'Compressor', phone: '(888) 888-8888', activity:  'Inspect and Repair', quantity: 1, price: '120.99', percent: .10, status: null, orderDate: new Date(2014, 6, 3), action: 'Action', summary: 'Analytical Skills'});
+    data.push({ id: 4, productId: 'Z400', productName: 'Another Compressor', phone: '(888) 888-8888', activity:  'Assemble Paint', quantity: 3, price: '2345', percent: .10, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action', summary: 'Is excellent at honest analysis'});
+    data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: '2345', percent: .10, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action', summary: 'Assessment Skills'});
+    data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: '210.99', percent: .10, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold', summary: 'Practices attentive and active listening'});
+    data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: '120.99', percent: .10, status: 'OK', orderDate:new Date(2017, 5, 5), action: 'On Hold', summary: 'Creates a feeling of belonging to and commitment to the team'});
+    data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '123.99', percent: .10, status: 'OK', orderDate: null, action: 'On Hold', summary: 'Brings out the best in people'});
+
+    //Define Columns for the Grid.
+    columns.push({ id: 'productId', name: 'Id', field: 'productId', formatter: Formatters.Text, filterType: 'text'});
+    columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', formatter: Formatters.Text, filterType: 'text', align: 'left' });
+
+    //Init and get the api for the grid
+    grid = $('#datagrid').datagrid({
+      columns: columns,
+      dataset: data,
+      columnSizing: 'data',
+      saveColumns: false,
+      actionableMode: true,
+      cellNavigation: false,
+      editable: false,
+      enableTooltips: true,
+      filterWhenTyping: false,
+      redrawOnResize: false,
+      rowHeight: 'short',
+      selectable: 'single',
+      showDirty: false,
+      filterable: true,
+      toolbar: {title: 'Select Compressor', actions: true, rowHeight: true, personalize: true}
+    }).on('selected', function (e, args) {
+      // Return the selected item and close the modal
+      console.log('selected', args);
+      modal.close();
+    });
+
+    gridApi = $('#datagrid').data('datagrid');
+
+    var modals = {
+        'open-modal': {
+          'title': 'Escape Not Always Close',
+          'content': $('#modal-content')
+        }
+      },
+
+      setModal = function (opt) {
+        opt = $.extend({
+          autoFocus: false,
+          showCloseBtn: true,
+        }, opt);
+
+        // modal = $('body').modal(opt);
+        modal = $('body').modal(opt).data('modal');
+
+        setTimeout(function ()  {
+          // Set focus to the first row
+          gridApi.setActiveCell(0, 0);
+        }, 300);
+      };
+
+    $('#open-modal').on('click', function () {
+      setModal(modals[this.id]);
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `[Colorpicker]` Fixed a bug where the red diagonal line that goes beyond its border when field-short/form-layout-compact is used. ([#5744](https://github.com/infor-design/enterprise/issues/5744))
 - `[Dropdown]` Clear search matches after an item is selected. ([#5632](https://github.com/infor-design/enterprise/issues/5632))
 - `[Listview]` Fixed a bug where the alert icons in RTL were missing. ([#5827](https://github.com/infor-design/enterprise/issues/5827))
+- `[Modal]` Modal exits if Escape key is pressed in datagrid. ([#5796](https://github.com/infor-design/enterprise/issues/5796))
 - `[Searchfield]` Fixed a bug where the close button icon is overlapping with the search icon in RTL. ([#5807](https://github.com/infor-design/enterprise/issues/5807))
 - `[Spinbox]` Fixed a bug where the spinbox controls still show the ripple effect even it's disabled. ([#5719](https://github.com/infor-design/enterprise/issues/5719))
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9134,6 +9134,7 @@ Datagrid.prototype = {
         return;
       }
 
+
       // Enter or Space
       if (key === 13 || key === 32) {
         triggerEl = (self.settings.selectable === 'multiple' && index === 0) ? $('.datagrid-checkbox', th) : th;
@@ -9217,6 +9218,13 @@ Datagrid.prototype = {
       if (key === 113 && !this.inlineMode) {
         self.settings.actionableMode = !self.settings.actionableMode;
         handled = true;
+      }
+
+      // If datagrid is in modal, close modal on Escape key
+      const modalParent = self.element.parents('.modal');
+      if (key === 27 && modalParent.length !== 0) {
+        const modalApi = modalParent.data().modal;
+        modalApi.close();
       }
 
       if (handled) {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9134,7 +9134,6 @@ Datagrid.prototype = {
         return;
       }
 
-
       // Enter or Space
       if (key === 13 || key === 32) {
         triggerEl = (self.settings.selectable === 'multiple' && index === 0) ? $('.datagrid-checkbox', th) : th;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Modal will close when Escape key is pressed in datagrid.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #5796 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/modal/test-modal-datagrid-escape-closing.html
- Focus on filter row input fields
- Press Escape
- Modal should close

**Included in this Pull Request**:
- [x] An example page.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
