### PR TITLE
1194 - Fix a bug with undefined ids on buttons

### DIFF
--- a/app/views/components/contextualactionpanel/test-undefined-button.html
+++ b/app/views/components/contextualactionpanel/test-undefined-button.html
@@ -1,0 +1,103 @@
+<div class="row">
+  <div class="six columns">
+    <p><b>NOTE: </b>In this example, the markup must be re-generated before the Contextual Action Panel is re-invoked.</p>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="six columns">
+    <div class="field">
+      <button type="button" id="undefined" class="btn-secondary">
+        Open Markup-Based Contextual Action Panel
+      </button>
+    </div>
+  </div>
+</div>
+
+<script id="cap-template" type="text/html">
+  <div style="display:none">
+    <div class="row">
+      <div class="six columns">
+        <div class="field">
+          <label for="expense-type">Expense Type</label>
+          <select id="expense-type" class="dropdown">
+            <option selected>Meal</option>
+            <option>Flight</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="purchase-form">Purchase Form</label>
+          <select id="purchase-form" name="purchase-form" class="dropdown">
+            <option value=""></option>
+            <option value="3567" selected>3567</option>
+            <option value="3568">3568</option>
+            <option value="3569">3569</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="template">Template</label>
+          <select id="template" name="template" class="dropdown">
+            <option value="" selected>None</option>
+            <option value="1">Template #1</option>
+            <option value="2">Template #2</option>
+          </select>
+        </div>
+      </div>
+      <div class="six columns">
+        <div class="field">
+          <label for="notes">Notes</label>
+          <textarea id="notes" name="notes"></textarea>
+        </div>
+      </div>
+    </div>
+  </div>
+</script>
+
+<script id="test-script">
+  var count = 0;
+
+  function openPanel() {
+    const panelHTML = $($('#cap-template')[0].innerHTML).attr('id', 'panel-'+count);
+    panelHTML.insertAfter('#undefined');
+    count++;
+
+    $('body').contextualactionpanel({
+      title: 'Expenses: $50,000.00',
+      content: panelHTML,
+      trigger: 'immediate',
+      buttons: [
+        {
+          type: 'input',
+          text: 'Keyword',
+          id: 'filter',
+          name: 'filter',
+          cssClass: 'searchfield',
+          searchfieldSettings: {
+            clearable: true,
+            collapsible: true
+          }
+        },
+        {
+          cssClass: 'separator'
+        },
+        {
+          text: 'Close',
+          cssClass: 'btn-icon',
+          audible: true,
+          icon: '#icon-close',
+          click: function() {
+            var api = $(this).data('modal');
+            api.close();
+          }
+        }
+      ]
+    }).one('close', function () {
+      console.log('Close Fired');
+    });
+  };
+
+  $('#undefined').on('click', function () {
+    openPanel();
+  });
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[Modal]` Modal exits if Escape key is pressed in datagrid. ([#5796](https://github.com/infor-design/enterprise/issues/5796))
 - `[Searchfield]` Fixed a bug where the close button icon is overlapping with the search icon in RTL. ([#5807](https://github.com/infor-design/enterprise/issues/5807))
 - `[Spinbox]` Fixed a bug where the spinbox controls still show the ripple effect even it's disabled. ([#5719](https://github.com/infor-design/enterprise/issues/5719))
+- `[Toolbar]` Fixed an issue where things in the page get scrambled if you have a button with undefined ids. ([#1194](https://github.com/infor-design/enterprise-ng/issues/1194))
 
 ## v4.59.0 Features
 

--- a/src/components/emptymessage/emptymessage.js
+++ b/src/components/emptymessage/emptymessage.js
@@ -81,7 +81,7 @@ EmptyMessage.prototype = {
 
     if (opts.button && !isHeightSmall) {
       const buttonMarkup = `<div class="empty-actions">
-          <button type="button" class="${opts.button.isPrimary ? 'btn-primary' : 'btn-secondary'} ${opts.button.cssClass} hide-focus" id="${opts.button.id}">
+          <button type="button" class="${opts.button.isPrimary ? 'btn-primary' : 'btn-secondary'} ${opts.button.cssClass} hide-focus" ${opts.button.id ? `id="${opts.button.id}"` : ''}>
             <span>${opts.button.text}</span>
           </button>
         </div>`;

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -220,7 +220,7 @@ Toolbar.prototype = {
 
     if (!popupMenuInstance) {
       this.moreMenu = $(`#${moreAriaAttr}`);
-      if (!this.moreMenu.length) {
+      if (!this.moreMenu.length || moreAriaAttr === undefined) {
         this.moreMenu = this.more.next('.popupmenu, .popupmenu-wrapper');
       }
       if (!this.moreMenu.length) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Due to faulty logic when the toolbar is initialized it is pulling in any buttons with `id="undefined"` when there is a more button with no `aria-controls` on it. This addresses this issue.

TO BE PATCHED in 4.58 once merged

**Related github/jira issue (required)**:
Fixes https://github.com/infor-design/enterprise-ng/issues/1194

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/contextualactionpanel/test-undefined-button
- the page should work as normal - before the button would be moved into the toolbar menu automatically

**Included in this Pull Request**:
- [x] A note to the change log.