### PR TITLE
5880 - Timepicker Feature Option Limit Hours

### DIFF
--- a/app/views/components/timepicker/example-hour-range.html
+++ b/app/views/components/timepicker/example-hour-range.html
@@ -1,0 +1,33 @@
+<div class="row">
+  <div class="twelve columns">
+    <div class="field">
+      <label for="timepicker-id-1" class="label">Timepicker: 12hr Format</label>
+      <input id="timepicker-id-1" class="timepicker" type="text" data-init="false"/>
+    </div>
+    <div class="field">
+      <label for="timepicker-id-2" class="label">Timepicker: 24hr Format</label>
+      <input id="timepicker-id-2" class="timepicker" type="text" data-init="false"/>
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    $('#timepicker-id-1').timepicker({
+      hourRange: [0, 18],
+      attributes: [
+        { name: 'id', value: 'timepicker-id-1' },
+        { name: 'data-automation-id', value: 'timepicker-automation-id-1' }
+      ]
+    });
+
+    $('#timepicker-id-2').timepicker({
+      hourRange: [0, 14],
+      timeFormat: 'HH:mm',
+      attributes: [
+        { name: 'id', value: 'timepicker-id-2' },
+        { name: 'data-automation-id', value: 'timepicker-automation-id-2' }
+      ]
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[Column]` Added example page for legend colors. ([#5761](https://github.com/infor-design/enterprise/issues/5761))
 - `[Datagrid]` Added datagrid feature using arrow keys to select. ([#5713](https://github.com/infor-design/enterprise/issues/5713))
 - `[Datagrid]` Added exportToCsv option for datagrid toolbar. ([#5786](https://github.com/infor-design/enterprise/issues/5786))
+- `[Timepicker]` Added settings in timepicker to limit the hours that can be selected. ([#5880](https://github.com/infor-design/enterprise/issues/5880))
 
 ## v4.58.1 Fixes
 

--- a/src/components/timepicker/timepicker.js
+++ b/src/components/timepicker/timepicker.js
@@ -29,6 +29,7 @@ const TIMEPICKER_DEFAULTS = function () {
     returnFocus: true,
     attributes: null,
     tabbable: true,
+    hourRange: [0, 24]
   };
 };
 
@@ -51,6 +52,7 @@ const TIMEPICKER_DEFAULTS = function () {
  *  the calling element. It usually should be for accessibility purposes.
  * @param {string} [settings.attributes] Add extra attributes like id's to the toast element. For example `attributes: { name: 'id', value: 'my-unique-id' }`
  * @param {boolean} [settings.tabbable=true] If true, causes the Timepicker's trigger icon to be focusable with the keyboard.
+ * @param {number[]} [settings.hourRange=] Sets the range of hours in the timepicker.
  */
 function TimePicker(element, settings) {
   this.element = $(element);
@@ -444,6 +446,24 @@ TimePicker.prototype = {
     return this;
   },
 
+  getMaxHourRange(initValues, hasDayPeriods, period) {
+    const self = this;
+    let maxValue = 12;
+    let timePeriod = (!period) ? initValues.period : period;
+
+    if (hasDayPeriods) {
+      if (timePeriod === 'AM') {
+        maxValue = (self.settings.hourRange[1] > 12) ? 12 : self.settings.hourRange[1];
+      } else {
+        maxValue = (self.settings.hourRange[1] > 12) ? self.settings.hourRange[1] - 12 : 12;
+      }
+    } else {
+      maxValue = self.settings.hourRange[1];
+    }
+
+    return maxValue;
+  },
+
   /**
    * Constructs all markup and subcomponents needed to build the standard Timepicker popup.
    * @private
@@ -470,6 +490,12 @@ TimePicker.prototype = {
 
     while (hourCounter < maxHourCount) {
       selected = '';
+
+      const maxHourRange = self.getMaxHourRange(this.initValues, hasDayPeriods);
+      if (hourCounter > maxHourRange) {
+        break;
+      }
+
       if (parseInt(self.initValues.hours, 10) === hourCounter) {
         selected = ' selected';
       }
@@ -1042,6 +1068,38 @@ TimePicker.prototype = {
     }
 
     this.popup.find('div.dropdown').first().focus();
+
+    setTimeout(() => {
+      $('select.period.dropdown').on('change', (e) => {
+        var period = $(e.target).find(':checked').val();
+
+        let selected, resetValue = false;
+        this.initValues = self.getTimeFromField();
+        const is24HourFormat = this.is24HourFormat();
+        let hourCounter = is24HourFormat ? 0 : 1
+        const maxHourCount = is24HourFormat ? 24 : 13;
+        const hourSelect = $('select.hours.dropdown');
+        hourSelect.empty();
+
+        while (hourCounter < maxHourCount) {
+          selected = '';
+    
+          const maxHourRange = self.getMaxHourRange(this.initValues, this.hasDayPeriods(), period);
+          if (hourCounter > maxHourRange) {
+            break;
+          }
+
+          if (!resetValue) {
+            selected = ' selected';
+            resetValue = true;
+            $('select.hours.dropdown').siblings('.dropdown-wrapper').find('.dropdown').children('span').html('1');
+          }
+          
+          hourSelect.append($(`<option${selected}>${self.hourText(hourCounter)}</option>`));
+          hourCounter++;
+        }
+      })
+    }, 10);
   },
 
   /**

--- a/src/components/timepicker/timepicker.js
+++ b/src/components/timepicker/timepicker.js
@@ -449,7 +449,7 @@ TimePicker.prototype = {
   getMaxHourRange(initValues, hasDayPeriods, period) {
     const self = this;
     let maxValue = 12;
-    let timePeriod = (!period) ? initValues.period : period;
+    const timePeriod = (!period) ? initValues.period : period;
 
     if (hasDayPeriods) {
       if (timePeriod === 'AM') {
@@ -1071,12 +1071,13 @@ TimePicker.prototype = {
 
     setTimeout(() => {
       $('select.period.dropdown').on('change', (e) => {
-        var period = $(e.target).find(':checked').val();
+        const period = $(e.target).find(':checked').val();
 
-        let selected, resetValue = false;
+        let selected;
+        let resetValue = false;
         this.initValues = self.getTimeFromField();
         const is24HourFormat = this.is24HourFormat();
-        let hourCounter = is24HourFormat ? 0 : 1
+        let hourCounter = is24HourFormat ? 0 : 1;
         const maxHourCount = is24HourFormat ? 24 : 13;
         const hourSelect = $('select.hours.dropdown');
         hourSelect.empty();
@@ -1092,13 +1093,14 @@ TimePicker.prototype = {
           if (!resetValue) {
             selected = ' selected';
             resetValue = true;
-            $('select.hours.dropdown').siblings('.dropdown-wrapper').find('.dropdown').children('span').html('1');
+            $('select.hours.dropdown').siblings('.dropdown-wrapper').find('.dropdown').children('span')
+            .html('1');
           }
           
           hourSelect.append($(`<option${selected}>${self.hourText(hourCounter)}</option>`));
           hourCounter++;
         }
-      })
+      });
     }, 10);
   },
 

--- a/src/components/timepicker/timepicker.js
+++ b/src/components/timepicker/timepicker.js
@@ -1093,8 +1093,11 @@ TimePicker.prototype = {
           if (!resetValue) {
             selected = ' selected';
             resetValue = true;
-            $('select.hours.dropdown').siblings('.dropdown-wrapper')
-              .find('.dropdown').children('span').html('1');
+            $('select.hours.dropdown')
+              .siblings('.dropdown-wrapper')
+              .find('.dropdown')
+              .children('span')
+              .html('1');
           }
           
           hourSelect.append($(`<option${selected}>${self.hourText(hourCounter)}</option>`));

--- a/src/components/timepicker/timepicker.js
+++ b/src/components/timepicker/timepicker.js
@@ -1093,8 +1093,8 @@ TimePicker.prototype = {
           if (!resetValue) {
             selected = ' selected';
             resetValue = true;
-            $('select.hours.dropdown').siblings('.dropdown-wrapper').find('.dropdown').children('span')
-            .html('1');
+            $('select.hours.dropdown').siblings('.dropdown-wrapper')
+              .find('.dropdown').children('span').html('1');
           }
           
           hourSelect.append($(`<option${selected}>${self.hourText(hourCounter)}</option>`));

--- a/test/components/timepicker/timepicker-settings.func-spec.js
+++ b/test/components/timepicker/timepicker-settings.func-spec.js
@@ -37,7 +37,8 @@ describe('TimePicker settings', () => {
       parentElement: null,
       returnFocus: true,
       attributes: null,
-      tabbable: true
+      tabbable: true,
+      hourRange: [0, 24]
     };
 
     expect(timepickerObj.settings).toEqual(settings);
@@ -55,7 +56,8 @@ describe('TimePicker settings', () => {
       parentElement: null,
       returnFocus: true,
       attributes: null,
-      tabbable: true
+      tabbable: true,
+      hourRange: [0, 24]
     };
 
     timepickerObj.updated();
@@ -77,7 +79,8 @@ describe('TimePicker settings', () => {
       parentElement: null,
       returnFocus: true,
       attributes: null,
-      tabbable: true
+      tabbable: true,
+      hourRange: [0, 24]
     };
     timepickerObj.updated(settings);
 

--- a/test/components/timepicker/timepicker.e2e-spec.js
+++ b/test/components/timepicker/timepicker.e2e-spec.js
@@ -216,7 +216,7 @@ describe('Timepicker with seconds example tests', () => {
       await element(by.css('.set-time')).click();
       await browser.driver.sleep(config.sleep);
 
-      expect(await timepickerEl.getAttribute('value')).toEqual('03:10:15 PM');
+      expect(await timepickerEl.getAttribute('value')).toEqual('01:10:15 PM');
     });
   }
 
@@ -264,7 +264,7 @@ describe('Timepicker Intervals tests', () => {
     await browser.driver
       .wait(protractor.ExpectedConditions.invisibilityOf(element(by.id('dropdown-list'))), config.waitsFor);
 
-    expect(await timepickerEl.getAttribute('value')).toEqual('2:10 PM');
+    expect(await timepickerEl.getAttribute('value')).toEqual('1:10 PM');
   });
 
   it('Should rounds minutes to the nearest interval', async () => {

--- a/test/components/timepicker/timepicker.puppeteer-spec.js
+++ b/test/components/timepicker/timepicker.puppeteer-spec.js
@@ -33,6 +33,36 @@ describe('Timepicker Puppeteer Tests', () => {
     });
   });
 
+  describe('Timepicker Example Hour Range Tests', () => {
+    const url = 'http://localhost:4000/components/timepicker/example-hour-range.html';
+
+    beforeAll(async () => {
+      await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });
+    });
+
+    it('should not have errors', async () => {
+      await page.on('error', function (err) {
+        const theTempValue = err.toString();
+        console.log(`Error: ${theTempValue}`);
+      });
+    });
+
+    it('should set the time and period', async () => {
+      const timepickerEl = await page.$('#timepicker-id-1');
+
+      await page.click('#timepicker-id-1-trigger');
+      await page.click('#timepicker-id-1-period');
+      await page.click('#list-option-1');
+      await page.click('#timepicker-id-1-hours');
+
+      // VERIFY IF 7 PM ONWARDS IS NOT AVAILABLE
+      await expect(page).not.toMatchElement('#list-option-6');
+      
+      await page.click('.set-time');
+      expect(await page.evaluate(el => el.value, timepickerEl)).toEqual('1:00 PM');
+    });
+  });
+
   describe('Timepicker Chinese Localization Tests', () => {
     const url = 'http://localhost:4000/components/timepicker/example-index.html?locale=zh-CN';
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will add a setting in timepicker to limit the hours that can be selected.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5880

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/timepicker/example-hour-range.html
- Click the Timepicker in (12hr Format)
- Choose `PM` in `Day Period`
- Check the `Hours`. Can only see till `6PM`

- Click the Timepicker in (24hr Format)
- Check the `Hours`. Can only see till `14:00`

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

