### PR TITLE
5847 - Fix an issue with maskOptions functions on grids with filtering

### DIFF
--- a/app/views/components/datagrid/test-dynamic-mask-with-filter.html
+++ b/app/views/components/datagrid/test-dynamic-mask-with-filter.html
@@ -1,0 +1,71 @@
+<div class="row">
+  <div class="twelve columns">
+    <br />
+    <h3>Grid Example: Customization</h3>
+    <p>
+    Shows you can dynamically set a mask on different cells.
+    In this example the last row (Gold Pieces) allows decimals in the quantity column.
+    The other cells allow just integer values (no decimal).
+    </p>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+    <div id="readonly-datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+    $('body').on('initialized', function () {
+     //Locale.set('en-US').done(function () {
+      var grid,
+        columns = [],
+        data = [];
+
+      // Some Sample Data
+      data.push({ id: 1, productId: 2142201, productName: 'Camera', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action', ordered: 1});
+      data.push({ id: 2, productId: 2241202, productName: 'Camera', activity:  'Inspect and Repair', quantity: 1, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+      data.push({ id: 3, productId: 2342203, productName: 'Phone', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action', });
+      data.push({ id: 4, productId: 2445204, productName: 'Gold Pieces', activity:  'Assemble Paint', quantity: 9.25, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action', pieces: true});
+
+      var maskFormatter = function (row, cell, value, column, item) {
+        console.log('maskFormatter is called');
+
+        var defaults = {
+          patternOptions: {allowNegative: true,
+          allowDecimal: item.pieces ? true : false,
+          allowThousandsSeparator: false,
+          integerLimit: 4, decimalLimit: item.pieces ? 2 : 0,
+          symbols: {
+            thousands: ',',
+            decimal: '.',
+            negative: '-'
+          }},
+          process: 'number'
+        };
+
+        return defaults;
+      };
+
+      //Define Columns for the Grid.
+      columns.push({ id: 'productId', name: 'Product Id', field: 'productId', filterType: 'integer', editor: Editors.Input});
+      columns.push({ id: 'productDesc', name: 'Product Desc', sortable: false, field: 'productName', filterType: 'text', editor: Editors.Input});
+      columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', maskOptions: maskFormatter, filterType: 'decimal', editor: Editors.Input,
+        filterMaskOptions: {process: 'number', patternOptions: {allowDecimal: true, allowNegative: true, allowLeadingZeros: true, allowThousandsSeparator: false, integerLimit: 4, decimalLimit: 3}}});
+      columns.push({ id: 'activity', name: 'Activity', field: 'activity', filterType: 'text', editor: Editors.Input});
+
+      //Init and get the api for the grid
+      $('#readonly-datagrid').datagrid({
+        columns: columns,
+        dataset: data,
+        editable: true,
+        clickToSelect: false,
+        filterable: true,
+        filterWhenTyping: false,
+        selectable: 'multiple',
+      });
+    });
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `[Calendar]` Added an option to configure month label to use abbreviation and changed month label to display on the first day of the months rendered in calendar. ([#5941](https://github.com/infor-design/enterprise/issues/5941))
 - `[Cards]` Added focus state on selected cards. ([#5684](https://github.com/infor-design/enterprise/issues/5684))
 - `[Colorpicker]` Fixed a bug where the red diagonal line that goes beyond its border when field-short/form-layout-compact is used. ([#5744](https://github.com/infor-design/enterprise/issues/5744))
+- `[Datagrid]` Fixed a bug where the maskOptions function is never called when the grid has filtering. ([#5847](https://github.com/infor-design/enterprise/issues/5847))
 - `[Fieldset]` Implemented design improvements. ([#5638](https://github.com/infor-design/enterprise/issues/5638))
 - `[Dropdown]` Clear search matches after an item is selected. ([#5632](https://github.com/infor-design/enterprise/issues/5632))
 - `[Listview]` Fixed a bug where the alert icons in RTL were missing. ([#5827](https://github.com/infor-design/enterprise/issues/5827))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1578,7 +1578,7 @@ Datagrid.prototype = {
               col.filterMaskOptions = utils.extend(true, {}, decimalDefaults, col.filterMaskOptions);
             }
 
-            if (col.maskOptions && typeof col.maskOptions != 'function') {
+            if (col.maskOptions && typeof col.maskOptions !== 'function') {
               col.maskOptions = utils.extend(true, {}, decimalDefaults, col.maskOptions);
             }
           }

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1574,11 +1574,11 @@ Datagrid.prototype = {
               );
             }
           } else {
-            if (col.filterMaskOptions) {
+            if (col.filterMaskOptions && typeof col.filterMaskOptions !== 'function') {
               col.filterMaskOptions = utils.extend(true, {}, decimalDefaults, col.filterMaskOptions);
             }
 
-            if (col.maskOptions) {
+            if (col.maskOptions && typeof col.maskOptions != 'function') {
               col.maskOptions = utils.extend(true, {}, decimalDefaults, col.maskOptions);
             }
           }
@@ -6584,7 +6584,7 @@ Datagrid.prototype = {
         if (!self.settings.cellNavigation && self.settings.rowNavigation) {
           const rowNodes = self.rowNodes($(this));
 
-          if (!rowNodes.hasClass('is-active-row')) { 
+          if (!rowNodes.hasClass('is-active-row')) {
             rowNodes.addClass('is-active-row');
             const index = self.actualRowIndex(rowNodes);
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
A column's maskOptions function was never called when the datagrid also has a filter row. This is a fix.

**Related github/jira issue (required)**:
Fixes #5847

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-dynamic-mask-with-filter.html
- edit in the quanity column
- the first 3 rows allow no decimals
- the last row does allow it
- also see the console to confirm the dynamic function is being called

**Included in this Pull Request**:
- [x] A note to the change log.
