### PR TITLE
1172 NG - Added default values for when there is no data in dataset

### DIFF
--- a/app/views/components/line/example-empty.html
+++ b/app/views/components/line/example-empty.html
@@ -1,0 +1,51 @@
+<div class="row">
+    <div class="two-thirds column">
+        <div class="widget">
+          <div class="widget-header">
+            <h2 class="widget-title">Line Chart Title</h2>
+          </div>
+          <div class="widget-content">
+            <div id="line-example" class="chart-container">
+            </div>
+          </div>
+        </div>
+    </div>
+  </div>
+  
+  <script id="line-script">
+  $('body').on('initialized', function () {
+  
+    var dataset = [{
+      data: [],
+      name: 'Component A',
+      legendShortName: 'Comp A',
+      legendAbbrName: 'A',
+      attributes: [
+       { name: 'id', value: 'line-comp-a' },
+       { name: 'data-automation-id', value: 'automation-id-line-comp-a' }
+     ]
+    }, {
+      data: [],
+      name: 'Component B',
+      legendShortName: 'Comp B',
+      legendAbbrName: 'B',
+      attributes: [
+       { name: 'id', value: 'line-comp-b' },
+       { name: 'data-automation-id', value: 'automation-id-line-comp-b' }
+     ]
+    }, {
+      data: [],
+      name: 'Component C',
+      legendShortName: 'Comp C',
+      legendAbbrName: 'C',
+      attributes: [
+       { name: 'id', value: 'line-comp-c' },
+       { name: 'data-automation-id', value: 'automation-id-line-comp-c' }
+     ]
+    }];
+  
+    $('#line-example').chart({type: 'line', dataset: dataset, yAxis: {ticks: {number: 10, format: 's'} } });
+  
+  });
+  </script>
+  

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `[Datagrid]` Fixed a bug where the maskOptions function is never called when the grid has filtering. ([#5847](https://github.com/infor-design/enterprise/issues/5847))
 - `[Fieldset]` Implemented design improvements. ([#5638](https://github.com/infor-design/enterprise/issues/5638))
 - `[Dropdown]` Clear search matches after an item is selected. ([#5632](https://github.com/infor-design/enterprise/issues/5632))
+- `[Linechart]` Added default values on line width and y-axis when data in dataset is blank. ([#1172](https://github.com/infor-design/enterprise-ng/issues/1172))
 - `[Listview]` Fixed a bug where the alert icons in RTL were missing. ([#5827](https://github.com/infor-design/enterprise/issues/5827))
 - `[Modal]` Fixed a close button overlapped when title is long. ([#5795](https://github.com/infor-design/enterprise/issues/5795))
 - `[Modal]` Modal exits if Escape key is pressed in datagrid. ([#5796](https://github.com/infor-design/enterprise/issues/5796))

--- a/src/components/line/line.js
+++ b/src/components/line/line.js
@@ -138,7 +138,18 @@ Line.prototype = {
     this.element.addClass(cssClass);
 
     // Handle Empty Data Set
-    if (s.dataset.length === 0) {
+    let isEmpty = s.dataset.length === 0;
+    if (!isEmpty) {
+      let count = 0;
+      s.dataset.forEach((set) => {
+        if (set.data.length === 0) {
+          count++;
+        }
+      });
+      isEmpty = count === s.dataset.length;
+    }
+
+    if (isEmpty) {
       self.element.emptymessage(s.emptyMessage);
       return this;
     }
@@ -871,11 +882,14 @@ Line.prototype = {
    * @returns {string} the current y-axis value
    */
   getTransformYAxisValue(str) {
-    const arrayValue = str.split(',');
-    arrayValue.splice(0, 1).join('');
-    const stringOfYAxis = arrayValue.join(',');
+    if (str) {
+      const arrayValue = str.split(',');
+      arrayValue.splice(0, 1).join('');
+      const stringOfYAxis = arrayValue.join(',');
+      return stringOfYAxis.slice(0, -1);
+    }
 
-    return stringOfYAxis.slice(0, -1);
+    return '0';
   },
 
   /**
@@ -940,7 +954,7 @@ Line.prototype = {
     });
 
     yAxis.width = yAxis.el.getBBox().width;
-    line.width = line.el.getBBox().width;
+    line.width = line.el ? line.el.getBBox().width : 0;
     brief.xDiff = yAxis.width - line.width;
 
     if (!this.settings.selectable) {
@@ -1001,7 +1015,7 @@ Line.prototype = {
     if (!isLeftAxis) {
       // Reasign values, could be truncation applied
       yAxis.width = yAxis.el.getBBox().width;
-      line.width = line.el.getBBox().width;
+      line.width = line.el ? line.el.getBBox().width : 0;
       brief.xDiff = yAxis.width - line.width;
       const variations = [
         { min: 0, max: 23, val: 62 },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Added default values on line width and y-axis when data in dataset is blank to fix type error occurring when the data in dataset is an empty array.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Addresses this issue: https://github.com/infor-design/enterprise-ng/issues/1172

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/line/example-empty.html
- Check console, there should be no error 

**Included in this Pull Request**:
- [ ] A note to the change log.
- [ ] An example page

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
