### PR TITLE
5813 - Remove the version from the OS on about

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # What's New with Enterprise
 
+## v4.59.0 Markup Changes
+
+- `[About]` Changed the OS Version to not show the version. This is because this information is incorrect and the correct information is no longer given by the browser. Also using the userAgent is deprecated in newer browsers. ([#5813](https://github.com/infor-design/enterprise/issues/5813))
+
 ## v4.59.0 Fixes
 
 - `[Calendar]` Added an option to configure month label to use abbreviation and changed month label to display on the first day of the months rendered in calendar. ([#5941](https://github.com/infor-design/enterprise/issues/5941))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v4.59.0 Markup Changes
 
-- `[About]` Changed the OS Version to not show the version. This is because this information is incorrect and the correct information is no longer given by the browser. Also using the userAgent is deprecated in newer browsers. ([#5813](https://github.com/infor-design/enterprise/issues/5813))
+- `[About]` Changed the OS Version to not show the version. This is because this information is incorrect and the correct information is no longer given by newer versions of Operating systems in any browser. or this reason the version is removed from the OS field on the about dialog. ([#5813](https://github.com/infor-design/enterprise/issues/5813))
 
 ## v4.59.0 Fixes
 

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1690,7 +1690,7 @@ Dropdown.prototype = {
 
     // Mac OSX: "backspace" delete key
     // Everything else: DEL key (numpad, control keys)
-    const isOSX = env.os.name === 'Mac OS X';
+    const isOSX = env.os.name === 'mac';
     if ((!isOSX && key === 'Delete') || (isOSX && key === 'Backspace') || key === 'Backspace' && this.settings.noSearch) {
       this.selectBlank();
 

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -857,7 +857,7 @@ Editor.prototype = {
     // Open link in new windows/tab, if clicked with command-key(for mac) or ctrl-key(for windows)
     this.element.on('mousedown.editor', 'a', function (e) {
       const href = $(this).attr('href');
-      if (env.browser.name !== 'firefox' && (env.os.name === 'Mac OS X' && (e.metaKey || e.ctrlKey))) {
+      if (env.browser.name !== 'firefox' && (env.os.name === 'mac' && (e.metaKey || e.ctrlKey))) {
         window.open(href, '_blank');
         e.preventDefault();
       }

--- a/src/utils/environment.js
+++ b/src/utils/environment.js
@@ -89,7 +89,7 @@ const Environment = {
     const macosPlatforms = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'];
     if (macosPlatforms.indexOf(platform) > -1 && !/Linux/.test(platform)) {
       cssClasses += 'is-mac ';
-      this.os.name = 'Mac OS X';
+      this.os.name = 'mac';
     }
 
     if (ua.indexOf('Firefox') > 0) {
@@ -256,8 +256,14 @@ const Environment = {
     }
 
     switch (os) { //eslint-disable-line
+      case 'Windows 10':
+        osVersion = '';
+        os = 'Windows';
+        break;
+
       case 'Mac OS X':
-        osVersion = /Mac OS X ([1-9][0-9][\.\_\d]+)/.exec(nUAgent)[1].replace(/\_/g, '.'); //eslint-disable-line
+        osVersion = '';
+        os = 'Mac OS';
         break;
 
       case 'Android':


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Because using the userAgent is deprecated the last few browser/os versions do not update this information. So the version can no longer be obtained. For this reason the version is removed from the OS field on the about dialog

**Related github/jira issue (required)**:
Fixes #5813
Fixes #5803 

**Steps necessary to review your pull request (required)**:
- pull/build
- go to http://localhost:4000/components/about/example-index.html
- look at the OS and platform for windows and mac there is no no version shown

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
