### PR TITLE
5875 - Fix on Modal Focus with Hidden Display None

### DIFF
--- a/app/views/components/modal/example-hidden-field.html
+++ b/app/views/components/modal/example-hidden-field.html
@@ -1,0 +1,86 @@
+<div class="row">
+	<div class="twelve columns">
+
+		<button class="btn-secondary" type="button" id="add-context">Show Modal</button><br/><br/>
+
+    <button class="btn-secondary" type="button" id="suppress-key">Show Modal (Suppressed Enter)</button>
+
+		<!-- Modal Example -->
+		<div id="modal-add-context" class="hidden">
+      <div class="field">
+				<label for="hidden">Hidden Field</label>
+				<input type="text" style="display: none;" id="hidden" name="subject"/>
+			</div>
+
+			<div class="field">
+				<label for="subject">Problem</label>
+				<input type="text" id="subject" name="subject"/>
+			</div>
+
+      <div class="field">
+        <label for="location" class="label">Location</label>
+        <select id="location" name="location" class="dropdown">
+          <option value="N">North</option>
+          <option value="S">South</option>
+          <option value="E">East</option>
+          <option value="W">West</option>
+        </select>
+      </div>
+
+			<div class="field">
+				<label for="notes-max">Notes (maxlength)</label>
+				<textarea id="notes-max" class="textarea" maxlength="90" name="notes-max">Line One</textarea>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<script>
+var modals = {
+    'add-context': {
+      'title': 'Add Context',
+      'id': 'my-id',
+      'content': $('#modal-add-context')
+    },
+    'suppress-key': {
+      'title': 'Suppress Key',
+      'id': 'my-id',
+      'content': $('#modal-add-context'),
+      'suppressEnterKey': true
+    }
+  },
+
+  setModal = function (opt) {
+    opt = $.extend({
+      buttons: [{
+        text: 'Cancel',
+      //  id: 'modal-button-1',
+        click: function(e, modal) {
+          modal.close();
+        }
+      }, {
+        text: 'Save',
+      //  id: 'modal-button-2',
+        click: function(e, modal) {
+          modal.close();
+        },
+        validate: false,
+        isDefault: true
+      }]
+    }, opt);
+
+    $('body').modal(opt);
+  };
+
+  $('#add-context').on('click', function () {
+		$(this).focus();
+    setModal(modals[this.id]);
+  });
+
+  $('#suppress-key').on('click', function () {
+		$(this).focus();
+    setModal(modals[this.id]);
+  });
+
+</script>

--- a/app/views/components/modal/example-index.html
+++ b/app/views/components/modal/example-index.html
@@ -7,6 +7,11 @@
 
 		<!-- Modal Example -->
 		<div id="modal-add-context" class="hidden">
+      <div class="field">
+				<label for="hidden">Hidden Field</label>
+				<input type="text" style="display: none;" id="hidden" name="subject"/>
+			</div>
+
 			<div class="field">
 				<label for="subject">Problem</label>
 				<input type="text" id="subject" name="subject"/>

--- a/app/views/components/modal/example-index.html
+++ b/app/views/components/modal/example-index.html
@@ -7,11 +7,6 @@
 
 		<!-- Modal Example -->
 		<div id="modal-add-context" class="hidden">
-      <div class="field">
-				<label for="hidden">Hidden Field</label>
-				<input type="text" style="display: none;" id="hidden" name="subject"/>
-			</div>
-
 			<div class="field">
 				<label for="subject">Problem</label>
 				<input type="text" id="subject" name="subject"/>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Locale]` Added missing translations for font picker. ([#5784](https://github.com/infor-design/enterprise/issues/5784))
 - `[Modal]` Fixed a close button overlapped when title is long. ([#5795](https://github.com/infor-design/enterprise/issues/5795))
 - `[Modal]` Modal exits if Escape key is pressed in datagrid. ([#5796](https://github.com/infor-design/enterprise/issues/5796))
+- `[Modal]` Fixed modal focus issues with inline display none. ([#5875](https://github.com/infor-design/enterprise/issues/5875))
 - `[Searchfield]` Fixed a bug where the close button icon is overlapping with the search icon in RTL. ([#5807](https://github.com/infor-design/enterprise/issues/5807))
 - `[Spinbox]` Fixed a bug where the spinbox controls still show the ripple effect even it's disabled. ([#5719](https://github.com/infor-design/enterprise/issues/5719))
 - `[Toolbar]` Fixed an issue where things in the page get scrambled if you have a button with undefined ids. ([#1194](https://github.com/infor-design/enterprise-ng/issues/1194))

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1040,7 +1040,7 @@ Modal.prototype = {
       self.setFocusableElems();
 
       let focusElem = $(self.focusableElems).not('.modal-header .searchfield')
-        .not('[style*="display: none"]').first();
+        .not(':hidden').first();
       if (focusElem.length === 0) {
         focusElem = thisElem.element.find('.btn-modal-primary');
       }

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1039,7 +1039,8 @@ Modal.prototype = {
       self.changeObserver.observe(self.element[0], { childList: true, subtree: true });
       self.setFocusableElems();
 
-      let focusElem = $(self.focusableElems).not('.modal-header .searchfield').first();
+      let focusElem = $(self.focusableElems).not('.modal-header .searchfield')
+        .not('[style*="display: none"]').first();
       if (focusElem.length === 0) {
         focusElem = thisElem.element.find('.btn-modal-primary');
       }

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1039,8 +1039,9 @@ Modal.prototype = {
       self.changeObserver.observe(self.element[0], { childList: true, subtree: true });
       self.setFocusableElems();
 
-      let focusElem = $(self.focusableElems).not('.modal-header .searchfield')
-        .not(':hidden').first();
+      const focusableElements = $(self.focusableElems).not('.modal-header .searchfield');
+      focusableElements.not(':visible').attr('disabled', 'disabled');
+      let focusElem = focusableElements.not(':hidden').first();
       if (focusElem.length === 0) {
         focusElem = thisElem.element.find('.btn-modal-primary');
       }

--- a/test/components/modal/modal.puppeteer-spec.js
+++ b/test/components/modal/modal.puppeteer-spec.js
@@ -38,7 +38,7 @@ describe('Modal open example-modal tests on click', () => {
   });
 });
 
-fdescribe('Modal with hidden field tests on click', () => {
+describe('Modal with hidden field tests on click', () => {
   const url = 'http://localhost:4000/components/modal/example-hidden-field';
   beforeEach(async () => {
     await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });

--- a/test/components/modal/modal.puppeteer-spec.js
+++ b/test/components/modal/modal.puppeteer-spec.js
@@ -38,6 +38,22 @@ describe('Modal open example-modal tests on click', () => {
   });
 });
 
+fdescribe('Modal with hidden field tests on click', () => {
+  const url = 'http://localhost:4000/components/modal/example-hidden-field';
+  beforeEach(async () => {
+    await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });
+    await page.waitForSelector('#add-context');
+    await page.click('#add-context');
+    await page.waitForSelector('.overlay');
+  });
+
+  it('Should open modal on click', async () => {
+    expect(await page.waitForSelector('.modal, is-visible')).toBeTruthy();
+    const subjectEl = await page.evaluateHandle(() => document.activeElement);
+    await subjectEl.type('input#subject');
+  });
+});
+
 describe('Modal example-close-btn tests', () => {
   const url = 'http://localhost:4000/components/modal/example-close-btn';
   beforeEach(async () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix modal focus issues with inline display none.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5875 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/modal/example-hidden-field.html
- Click `Show Modal`
- Tab around the modal - should skip the hidden field

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

