### PR TITLE
Adjust translation string for better translation

### DIFF
--- a/app/www/test/js/sv-SE.f0r73571n6purp0537051mul473h45h.js
+++ b/app/www/test/js/sv-SE.f0r73571n6purp0537051mul473h45h.js
@@ -200,7 +200,6 @@ Soho.Locale.addCulture('sv-SE', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Informationsmeddelanden på sidan', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Pågår', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Infoga', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Infoga fästpunktslänk', comment: 'Insert Acnhor (link) in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Infoga bild', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Infoga länk', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Infoga URL', comment: 'Insert a Url in an editor' },

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -1049,7 +1049,7 @@ Editor.prototype = {
 
       separator: '<div class="separator"></div>',
 
-      anchor: `<button type="button" class="btn btn-editor" title="${Locale.translate('InsertAnchor')}" data-action="anchor" data-modal="modal-url-${this.id}" data-element="a">${buttonLabels.anchor}</button>`,
+      anchor: `<button type="button" class="btn btn-editor" title="${Locale.translate('InsertHyperlink')}" data-action="anchor" data-modal="modal-url-${this.id}" data-element="a">${buttonLabels.anchor}</button>`,
 
       image: `<button type="button" class="btn btn-editor" title="${Locale.translate('InsertImage')}" data-action="image" data-modal="modal-image-${this.id}" data-element="img">${buttonLabels.image}</button>`,
 
@@ -1094,7 +1094,7 @@ Editor.prototype = {
       strikethrough: this.getIcon('StrikeThrough', 'strike-through'),
       foreColor: this.getIcon('TextColor', 'fore-color'),
       backColor: this.getIcon('BackgroundColor', 'back-color'),
-      anchor: this.getIcon('InsertAnchor', 'link'),
+      anchor: this.getIcon('InsertHyperlink', 'link'),
       image: this.getIcon('InsertImage', 'insert-image'),
       header1: this.getIcon('ToggleH3', 'h3'),
       header2: this.getIcon('ToggleH4', 'h4'),
@@ -1312,7 +1312,7 @@ Editor.prototype = {
     const output = $(`<div class="modal editor-modal-url" id="modal-url-${this.id}"></div>`)
       .html(`<div class="modal-content">
         <div class="modal-header">
-          <h1 class="modal-title">${Locale.translate('InsertAnchor')}</h1>
+          <h1 class="modal-title">${Locale.translate('InsertHyperlink')}</h1>
         </div>
         <div class="modal-body">
           <div class="field">

--- a/src/components/locale/cultures/af-ZA.js
+++ b/src/components/locale/cultures/af-ZA.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('af-ZA', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Inligtingsboodskap(pe) op bladsy', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Tans aan die gang', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Voeg in', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Voer anker in', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Voer anker in', comment: 'Insert a hyperlink (synonymous with link or anchor tag) into an editor' },
     InsertImage: { id: 'InsertImage', value: 'Voeg prent in', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Voeg skakel in', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Voeg URL in', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/ar-EG.js
+++ b/src/components/locale/cultures/ar-EG.js
@@ -493,7 +493,7 @@ Soho.Locale.addCulture('ar-EG', {
     InfoOnPage: { id: 'InfoOnPage', value: 'رسالة(رسائل) المعلومات موجودة على الصفحة', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'قيد التنفيذ', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'إدراج', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'إدراج ارتساء', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'إدراج ارتساء', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'إدراج صورة', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'إدراج رابط', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'إدراج عنوان Url', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/bg-BG.js
+++ b/src/components/locale/cultures/bg-BG.js
@@ -254,7 +254,7 @@ Soho.Locale.addCulture('bg-BG', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Информационно(и) съобщение(я) на страница', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'В ход...', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Вмъкване', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Вмъкване на котва', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Вмъкване на котва', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Вмъкване на изображение', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Вмъкване на връзка', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Вмъкване на Url', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/cs-CZ.js
+++ b/src/components/locale/cultures/cs-CZ.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('cs-CZ', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Informační zprávy na stránce', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Probíhá', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Vložit', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Vložit odkaz', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Vložit odkaz', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Vložit obrázek', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Vložit propojení', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Vložit URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/da-DK.js
+++ b/src/components/locale/cultures/da-DK.js
@@ -254,7 +254,7 @@ Soho.Locale.addCulture('da-DK', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Informationsmeddelelse(r) på side', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'I gang', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Indsæt', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Indsæt anker', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Indsæt anker', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Indsæt billede', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Indsæt link', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Indsæt Url', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/de-DE.js
+++ b/src/components/locale/cultures/de-DE.js
@@ -255,7 +255,7 @@ Soho.Locale.addCulture('de-DE', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Informationsmeldung(en) auf Seite', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'In Bearbeitung', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Einfügen', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Textmarke einfügen', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Textmarke einfügen', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Bild einfügen', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Link einfügen', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'URL einfügen', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/el-GR.js
+++ b/src/components/locale/cultures/el-GR.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('el-GR', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Μήνυμα(τα) ενημέρωσης στη σελίδα', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Σε εξέλιξη', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Εισαγωγή', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Εισαγωγή αγκύρωσης', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Εισαγωγή αγκύρωσης', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Εισαγωγή εικόνας', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Εισαγωγή σύνδεσης', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Εισαγωγή Url', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/en-US.js
+++ b/src/components/locale/cultures/en-US.js
@@ -232,7 +232,7 @@ Soho.Locale.addCulture('en-US', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Information message(s) on page', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'In Progress', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Insert', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Insert Anchor', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Insert Hyperlink', comment: 'Insert a hyperlink (synonymous with link or anchor tag) into an editor. Please recheck this as it was renamed from anchor.' },
     InsertImage: { id: 'InsertImage', value: 'Insert Image', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Insert Link', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Insert Url', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/es-ES.js
+++ b/src/components/locale/cultures/es-ES.js
@@ -254,7 +254,7 @@ Soho.Locale.addCulture('es-ES', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Mensajes de información en la página', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'En curso', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Insertar', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Insertar delimitador', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Insertar delimitador', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Insertar imagen', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Insertar vínculo', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Insertar URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/et-EE.js
+++ b/src/components/locale/cultures/et-EE.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('et-EE', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Infoteated leheküljel', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Pooleli', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Lisa', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Lisa ankur', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Lisa ankur', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Lisa pilt', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Lisa link', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Lisa URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/fi-FI.js
+++ b/src/components/locale/cultures/fi-FI.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('fi-FI', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Tietoviesti tai -viestejä sivulla', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Käynnissä', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Lisää', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Lisää ankkuri', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Lisää ankkuri', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Lisää kuva', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Lisää linkki', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Lisää URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/fr-CA.js
+++ b/src/components/locale/cultures/fr-CA.js
@@ -252,7 +252,7 @@ Soho.Locale.addCulture('fr-CA', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Message(s) d\'information sur page', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'En cours', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Insérer', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Insérer point d\'ancrage', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Insérer point d\'ancrage', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Insérer image', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Insérer lien', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Insérer URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/fr-FR.js
+++ b/src/components/locale/cultures/fr-FR.js
@@ -254,7 +254,7 @@ Soho.Locale.addCulture('fr-FR', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Message(s) d\'information sur page', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'En cours', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Insérer', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Insérer point d\'ancrage', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Insérer point d\'ancrage', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Insérer image', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Insérer lien', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Insérer URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/he-IL.js
+++ b/src/components/locale/cultures/he-IL.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('he-IL', {
     InfoOnPage: { id: 'InfoOnPage', value: 'הודע(ו)ת מידע בדף', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'מתבצע...', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'הוסף', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'הכנס עוגן', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'הכנס עוגן', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'הכנס תמונה', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'הוסף קישור', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'הוסף כתובת URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/hi-IN.js
+++ b/src/components/locale/cultures/hi-IN.js
@@ -254,7 +254,7 @@ Soho.Locale.addCulture('hi-IN', {
     InfoOnPage: { id: 'InfoOnPage', value: 'पृष्ठ पर जानकारी संदेश', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'प्रगति में', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'सम्मिलित करें', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'एंकर सम्मिलित करें', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'एंकर सम्मिलित करें', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'छवि सम्मिलित करें', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'लिंक सम्मिलित करें', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Url सम्मिलित करें', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/hr-HR.js
+++ b/src/components/locale/cultures/hr-HR.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('hr-HR', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Informativne poruke na stranici', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'U tijeku', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Umetni', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Umetni sidrenu oznaku', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Umetni sidrenu oznaku', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Umetni sliku', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Umetni vezu', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Umetni Url', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/hu-HU.js
+++ b/src/components/locale/cultures/hu-HU.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('hu-HU', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Tájékoztató üzenet(ek) ezen az oldalon:', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Folyamatban', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Beszúrás', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Horgony beszúrása', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Horgony beszúrása', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Kép beszúrása', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Hivatkozás beszúrása', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'URL-cím beszúrása', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/id-ID.js
+++ b/src/components/locale/cultures/id-ID.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('id-ID', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Pesan informasi pada halaman', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Pencarian berlangsung', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Sisipkan', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Sisipkan Jangkar', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Sisipkan Jangkar', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Sisipkan Gambar', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Sisipkan Tautan', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Sisipkan Url', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/it-IT.js
+++ b/src/components/locale/cultures/it-IT.js
@@ -254,7 +254,7 @@ Soho.Locale.addCulture('it-IT', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Messaggi informativi nella pagina', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'In corso', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Inserisci', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Inserisci ancoraggio', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Inserisci ancoraggio', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Inserisci immagine', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Inserisci collegamento', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Inserisci URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/ja-JP.js
+++ b/src/components/locale/cultures/ja-JP.js
@@ -254,7 +254,7 @@ Soho.Locale.addCulture('ja-JP', {
     InfoOnPage: { id: 'InfoOnPage', value: 'ページの情報メッセージ', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: '処理中', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: '挿入', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'アンカーの挿入', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'アンカーの挿入', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: '画像の挿入', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'リンクの挿入', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'URL の挿入', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/ko-KR.js
+++ b/src/components/locale/cultures/ko-KR.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('ko-KR', {
     InfoOnPage: { id: 'InfoOnPage', value: '페이지에서 정보 메시지 표시', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: '진행 중', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: '삽입', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: '기준 위치 삽입', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: '기준 위치 삽입', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: '이미지 삽입', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: '링크 삽입', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'URL 삽입', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/la-IT.js
+++ b/src/components/locale/cultures/la-IT.js
@@ -195,7 +195,7 @@ Soho.Locale.addCulture('la-IT', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Information nuntius (s) on page', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'In corso', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Inserere', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Insert ceratas ancora puppes,', comment: 'Insert Acnhor (link) in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Insert ceratas ancora puppes,', comment: 'Insert Acnhor (link) in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Insert imago', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Insert collegamento', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Insert URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/lt-LT.js
+++ b/src/components/locale/cultures/lt-LT.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('lt-LT', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Informacinis (-iai) pranešimas (-ai) puslapyje', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Vykdoma', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Įterpti', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Įterpti prieraišą', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Įterpti prieraišą', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Įterpti atvaizdą', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Įterpti nuorodą', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Įterpti URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/lv-LV.js
+++ b/src/components/locale/cultures/lv-LV.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('lv-LV', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Informācijas ziņojums(-i) lapā', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Notiekošs', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Ievietot', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Ievietot hipersaiti', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Ievietot hipersaiti', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Ievietot attēlu', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Ievietot saiti', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Ievietot vietrādi URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/ms-bn.js
+++ b/src/components/locale/cultures/ms-bn.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('ms-bn', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Mesej maklumat pada halaman', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Sedang Berjalan', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Sisip', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Sisipkan Sauh', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Sisipkan Sauh', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Sisipkan Imej', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Sisipkan Pautan', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Sisipkan Url', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/nl-NL.js
+++ b/src/components/locale/cultures/nl-NL.js
@@ -254,7 +254,7 @@ Soho.Locale.addCulture('nl-NL', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Informatiebericht(en) op pagina', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'In uitvoering', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Invoegen', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Anker invoegen', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Anker invoegen', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Afbeelding invoegen', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Koppeling invoegen', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'URL invoegen', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/no-NO.js
+++ b/src/components/locale/cultures/no-NO.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('no-NO', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Informasjonsmelding(er) på side', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Pågår', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Sett inn', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Sett inn kobling', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Sett inn kobling', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Sett inn bilde', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Sett inn kobling', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Sett inn URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/pl-PL.js
+++ b/src/components/locale/cultures/pl-PL.js
@@ -254,7 +254,7 @@ Soho.Locale.addCulture('pl-PL', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Komunikaty informacyjne na stronie', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'W toku', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Wstaw', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Wstaw kotwicę', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Wstaw kotwicę', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Wstaw obraz', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Wstaw łącze', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Wstaw adres URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/pt-BR.js
+++ b/src/components/locale/cultures/pt-BR.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('pt-BR', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Mensagens de informações na página', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Em andamento', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Inserir', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Inserir âncora', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Inserir âncora', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Inserir imagem', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Inserir link', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Inserir Url', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/pt-PT.js
+++ b/src/components/locale/cultures/pt-PT.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('pt-PT', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Mensagens de informação na página', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Em curso', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Inserir', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Inserir âncora', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Inserir âncora', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Inserir imagem', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Inserir ligação', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Inserir URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/ro-RO.js
+++ b/src/components/locale/cultures/ro-RO.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('ro-RO', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Mesaj(e) de informare pe pagină', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'În curs...', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Inserare', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Inserare ancoră', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Inserare ancoră', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Inserare imagine', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Inserare legătură', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Inserare URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/ru-RU.js
+++ b/src/components/locale/cultures/ru-RU.js
@@ -254,7 +254,7 @@ Soho.Locale.addCulture('ru-RU', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Информационные сообщения на странице', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Выполняется', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Вставить', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Вставить привязку', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Вставить привязку', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Вставить изображение', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Вставить ссылку', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Вставить URL-адрес', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/sk-SK.js
+++ b/src/components/locale/cultures/sk-SK.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('sk-SK', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Informačné správy na stránke', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Prebieha', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Vložiť', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Vložiť ukotvenie', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Vložiť ukotvenie', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Vložiť obrázok', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Vložiť prepojenie', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Vložiť adresu URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/sl-SI.js
+++ b/src/components/locale/cultures/sl-SI.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('sl-SI', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Informacijsko(-a) sporočilo(-a) na strani', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Poteka', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Vstavi', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Vstavi povezavo', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Vstavi povezavo', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Vstavi sliko', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Vstavi povezavo', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Vstavi URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/sv-SE.js
+++ b/src/components/locale/cultures/sv-SE.js
@@ -254,7 +254,7 @@ Soho.Locale.addCulture('sv-SE', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Informationsmeddelanden på sidan', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Pågår', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Infoga', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Infoga fästpunktslänk', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Infoga fästpunktslänk', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Infoga bild', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Infoga länk', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Infoga URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/th-TH.js
+++ b/src/components/locale/cultures/th-TH.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('th-TH', {
     InfoOnPage: { id: 'InfoOnPage', value: 'ข้อความข้อมูลในหน้า', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'กำลังดำเนินการ', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'แทรก', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'แทรกจุดยึด', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'แทรกจุดยึด', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'แทรกรูปภาพ', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'แทรกลิงก์', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'แทรก Url', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/tl-PH.js
+++ b/src/components/locale/cultures/tl-PH.js
@@ -254,7 +254,7 @@ Soho.Locale.addCulture('tl-PH', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Impormasyon ng (mga) mensahe sa pahina', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Isinasagawa', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Isingit', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Isingit ang Anchor', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Isingit ang Anchor', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Isingit ang Imahe', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Isingit ang Link', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Isingit ang Url', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/tr-TR.js
+++ b/src/components/locale/cultures/tr-TR.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('tr-TR', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Sayfada bilgi mesajları', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Devam Ediyor', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Ekle', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Bağlayıcı Ekle', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Bağlayıcı Ekle', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Görüntü Ekle', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Bağlantı Ekle', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Url Ekle', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/uk-UA.js
+++ b/src/components/locale/cultures/uk-UA.js
@@ -254,7 +254,7 @@ Soho.Locale.addCulture('uk-UA', {
     InfoOnPage: { id: 'InfoOnPage', value: 'Інформаційні повідомлення на сторінці', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Виконується', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Вставити', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Вставити прив\'язку', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Вставити прив\'язку', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Вставити зображення', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Вставити посилання', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Вставити URL-адресу', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/vi-VN.js
+++ b/src/components/locale/cultures/vi-VN.js
@@ -253,7 +253,7 @@ Soho.Locale.addCulture('vi-VN', {
     InfoOnPage: { id: 'InfoOnPage', value: '(Các) tin nhắn thông tin trên trang', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: 'Đang tiến hành', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: 'Chèn', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: 'Chèn ký tự liên kết', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: 'Chèn ký tự liên kết', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: 'Chèn hình ảnh', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: 'Chèn liên kết', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: 'Chèn Url', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/zh-CN.js
+++ b/src/components/locale/cultures/zh-CN.js
@@ -254,7 +254,7 @@ Soho.Locale.addCulture('zh-CN', {
     InfoOnPage: { id: 'InfoOnPage', value: '页面的信息性消息', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: '进行中', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: '插入', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: '插入定位标记', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: '插入定位标记', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: '插入图像', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: '插入链接', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: '插入 URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/zh-Hans.js
+++ b/src/components/locale/cultures/zh-Hans.js
@@ -254,7 +254,7 @@ Soho.Locale.addCulture('zh-Hans', {
     InfoOnPage: { id: 'InfoOnPage', value: '页面的信息性消息', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: '进行中', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: '插入', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: '插入定位标记', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: '插入定位标记', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: '插入图像', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: '插入链接', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: '插入 URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/zh-Hant.js
+++ b/src/components/locale/cultures/zh-Hant.js
@@ -254,7 +254,7 @@ Soho.Locale.addCulture('zh-Hant', {
     InfoOnPage: { id: 'InfoOnPage', value: '資訊訊息，頁面', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: '進行中', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: '插入', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: '插入錨點', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: '插入錨點', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: '插入影像', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: '插入連結', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: '插入 URL', comment: 'Insert a Url in an editor' },

--- a/src/components/locale/cultures/zh-TW.js
+++ b/src/components/locale/cultures/zh-TW.js
@@ -254,7 +254,7 @@ Soho.Locale.addCulture('zh-TW', {
     InfoOnPage: { id: 'InfoOnPage', value: '資訊訊息，頁面', comment: 'Information message(s) on page n' },
     InProgress: { id: 'In Progress', value: '進行中', comment: 'Info tooltip that an action is in progress' },
     Insert: { id: 'Insert', value: '插入', comment: 'Insert Modal Dialog Button' },
-    InsertAnchor: { id: 'InsertAnchor', value: '插入錨點', comment: 'Insert a hyperlink in an editor' },
+    InsertHyperlink: { id: 'InsertHyperlink', value: '插入錨點', comment: 'Insert a hyperlink in an editor' },
     InsertImage: { id: 'InsertImage', value: '插入影像', comment: 'Insert Image in an editor' },
     InsertLink: { id: 'InsertLink', value: '插入連結', comment: 'Insert Link in an editor' },
     InsertUrl: { id: 'InsertUrl', value: '插入 URL', comment: 'Insert a Url in an editor' },

--- a/test/components/locale/locale.func-spec.js
+++ b/test/components/locale/locale.func-spec.js
@@ -2208,6 +2208,6 @@ describe('Locale API', () => {
     Locale.set('zh-CN');
 
     expect(Locale.translate('StrikeThrough')).toEqual('穿透');
-    expect(Locale.translate('InsertAnchor')).toEqual('插入定位标记');
+    expect(Locale.translate('InsertHyperlink')).toEqual('插入定位标记');
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Changing the string from anchor to hyperlink for easier translation. As per #5987 

**Related github/jira issue (required)**:
Relates to #5987

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/editor/example-index.html and click the link icon. The modal text is now Insert Hyperlink
- try http://localhost:4000/components/editor/example-index.html?locale=de-DE - the translations may still be mixed between translating anchor and link until we get back but at least the old translation is there.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.