### PR TITLE
5954 - Follow up fix for icon alignment in firefox

### DIFF
--- a/src/components/searchfield/_searchfield-new.scss
+++ b/src/components/searchfield/_searchfield-new.scss
@@ -135,10 +135,6 @@ html.is-firefox {
       .icon:not(.close) {
         top: 8px;
       }
-
-      .icon.close {
-        top: 11px;
-      }
     }
 
     .collapse-button {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Follow up fix for close icon alignment in firefox.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/5954

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Open Firefox browser and navigate to http://localhost:4000/components/datagrid/example-custom-toolbar.html
- Make the browser smaller or toggle the Responsive Design Mode (firefox)
- Click the search icon and type anything to show the close icon
- It should be vertically aligned

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
