### PR TITLE
6020 - Fix memory leaks on data removal

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -3,6 +3,7 @@
     "stylelint-scss"
   ],
   "extends": ["stylelint-config-standard-scss"],
+  "ignoreFiles": ["**/*.js", "**/*.md", "**/*.MD", "**/*.html"],
   "rules": {
     "alpha-value-notation": "number",
     "at-rule-empty-line-before": [

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## v4.60.0 Fixes
 
 - `[Field Options]` Fixed UI alignment of close icon button (searchfield) in Field Options. ([#5983](https://github.com/infor-design/enterprise/issues/5983))
+- `[General]` Fixed several memory leaks with the attached data object. ([#6020](https://github.com/infor-design/enterprise/issues/6020))
 - `[Searchfield]` Fixed UI alignment of close icon button (searchfield) in Datagrid. ([#5954](https://github.com/infor-design/enterprise/issues/5954))
 - `[Locale]` Changed the text from Insert Anchor to Insert Hyperlink. Some translations my still reference anchor until updated from the translation team. ([#5987](https://github.com/infor-design/enterprise/issues/5987))
 

--- a/src/components/hyperlinks/hyperlinks.jquery.js
+++ b/src/components/hyperlinks/hyperlinks.jquery.js
@@ -14,7 +14,8 @@ $.fn.hyperlink = function (settings) {
       instance = $.data(this, COMPONENT_NAME, new Hyperlink(this, settings));
       instance.destroy = function destroy() {
         this.teardown();
-        $.removeData(this, COMPONENT_NAME);
+        $.removeData(this.element, COMPONENT_NAME);
+        $.removeData(this.element, 'hidefocus');
       };
     }
   });

--- a/src/components/list-detail/list-detail.jquery.js
+++ b/src/components/list-detail/list-detail.jquery.js
@@ -14,7 +14,8 @@ $.fn.listdetail = function (settings) {
       instance = $.data(this, COMPONENT_NAME, new ListDetail(this, settings));
       instance.destroy = function destroy() {
         this.teardown();
-        $.removeData(this, COMPONENT_NAME);
+        $.removeData(this.element, COMPONENT_NAME);
+        $.removeData(this.element, 'options');
       };
     }
   });

--- a/src/components/stepchart/stepchart.jquery.js
+++ b/src/components/stepchart/stepchart.jquery.js
@@ -14,7 +14,8 @@ $.fn.stepchart = function (settings) {
       instance = $.data(this, COMPONENT_NAME, new StepChart(this, settings));
       instance.destroy = function destroy() {
         this.teardown();
-        $.removeData(this, COMPONENT_NAME);
+        $.removeData(this.element, COMPONENT_NAME);
+        $.removeData(this.element, 'options');
       };
     }
   });

--- a/src/components/stepchart/stepchart.js
+++ b/src/components/stepchart/stepchart.js
@@ -174,11 +174,20 @@ StepChart.prototype = {
    * Tear down and remove.
    * @returns {this} component instance
    */
-  destroy() {
+  teardown() {
     this.element.empty();
     this.settings = null;
     $.removeData(this.element[0], COMPONENT_NAME);
 
+    return this;
+  },
+
+  /**
+   * Tear down and remove.
+   * @returns {this} component instance
+   */
+  destroy() {
+    this.teardown();
     return this;
   }
 };

--- a/src/components/toolbar-flex/toolbar-flex.item.jquery.js
+++ b/src/components/toolbar-flex/toolbar-flex.item.jquery.js
@@ -19,7 +19,7 @@ $.fn.toolbarflexitem = function (settings) {
         if (typeof oldDestroy === 'function') {
           oldDestroy.call(this);
         }
-        $.removeData(this, COMPONENT_NAME);
+        $.removeData(this.element, COMPONENT_NAME);
       };
     }
   });

--- a/src/components/toolbar-flex/toolbar-flex.item.jquery.js
+++ b/src/components/toolbar-flex/toolbar-flex.item.jquery.js
@@ -19,7 +19,7 @@ $.fn.toolbarflexitem = function (settings) {
         if (typeof oldDestroy === 'function') {
           oldDestroy.call(this);
         }
-        $.removeData(this.element, COMPONENT_NAME);
+        $.removeData(this, COMPONENT_NAME);
       };
     }
   });

--- a/src/components/toolbar-flex/toolbar-flex.jquery.js
+++ b/src/components/toolbar-flex/toolbar-flex.jquery.js
@@ -19,7 +19,7 @@ $.fn.toolbarflex = function (settings) {
         if (typeof oldDestroy === 'function') {
           oldDestroy.call(this);
         }
-        $.removeData(this, COMPONENT_NAME);
+        $.removeData(this.element, COMPONENT_NAME);
       };
     }
   });

--- a/src/components/week-view/week-view.js
+++ b/src/components/week-view/week-view.js
@@ -910,6 +910,8 @@ WeekView.prototype = {
     this.teardown();
     this.element.empty();
     $.removeData(this.element[0], COMPONENT_NAME);
+    $.removeData(this.element[0], 'init');
+    $.removeData(this.element[0], 'automationId');
     return this;
   }
 };

--- a/test/components/datagrid/datagrid.puppeteer-spec.js
+++ b/test/components/datagrid/datagrid.puppeteer-spec.js
@@ -34,6 +34,7 @@ describe('Datagrid Puppeteer Tests', () => {
       expect(await page.evaluate(el => el.value, dateFilter)).toEqual(`${testDate.getFullYear()}${testMonth}${testDay}`);
     });
   });
+
   describe('Datagrid Filter Custom Filter Conditions', () => {
     const url = 'http://localhost:4000/components/datagrid/example-custom-filter-conditions-and-defaults.html';
 
@@ -90,7 +91,7 @@ describe('Datagrid example-key-row-select tests', () => {
     await page.click('tr.datagrid-row');
     const row1 = await page.$eval('tr.datagrid-row.is-selected', element => element.getAttribute('class'));
     expect(row1).toEqual('datagrid-row is-hover-row is-clickable is-active-row is-selected');
-    
+
     await page.keyboard.press('ArrowDown');
     const row2 = await page.$eval('tr.datagrid-row.is-selected', element => element.getAttribute('class'));
     expect(row2).toEqual('datagrid-row is-active-row is-selected');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Some components with destroy in the jquery wrapper had memory leaks. Checked for them all and fixed.
Also added ignore to stylelint for some files and fixed a lint warning

**Related github/jira issue (required)**:
Fixes #6020 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/toolbar-flex/example-more-actions-predefined.html
- in the console type:
```
$('#flex-toolbar').data() 
// should return data
$('#flex-toolbar').data('toolbar-flex').destroy()
// no error
$('#flex-toolbar').data() 
// should be empty now
```
- test any other components similarly like this...

**Included in this Pull Request**:
- [x] A note to the change log.
