### PR TITLE
NG1210 - Fix elements getting disabled in Tabs CAP [regression bug]

### DIFF
--- a/app/views/components/contextualactionpanel/example-cap-tabs-vertical-scroll.html
+++ b/app/views/components/contextualactionpanel/example-cap-tabs-vertical-scroll.html
@@ -21,10 +21,10 @@
           </div>
 
           <ul class="tab-list">
-            <li class="tab is-selected">
+            <li class="tab">
               <a id="tab-test-info-a" data-automation-id="tab-test-info-a" href="#test-info">Test Information</a>
             </li>
-            <li class="tab">
+            <li class="tab is-selected">
               <a id="tab-product-level-a" data-automation-id="tab-product-level-a" href="#product-level">Product
                 Level</a>
             </li>
@@ -94,7 +94,12 @@
 
       <div class="tab-panel-container scrollable-y">
         <div id="test-info" class="tab-panel">
-          <h3>Test Information</h3>
+          <h3 class="section-title">Test Information</h3>
+          <div class="field">
+            <label for="first-name">Insert Text</label>
+            <input type="text" id="insert-text"  name="insert-text" placeholder="Normal text Field"/>
+            <button class="btn-primary" type="button" id="insert-text-btn">Action</button>
+          </div>
           <p>Back-end interactive supply-chains, enterprise sticky user-contributed robust platforms innovative; harness
             frictionless incentivize optimize? Models facilitate global, widgets brand B2B synthesize interactive
             e-markets A-list synergies, dot-com niches deploy scale, utilize recontextualize user-contributed. Visionary

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[General]` Fixed several memory leaks with the attached data object. ([#6020](https://github.com/infor-design/enterprise/issues/6020))
 - `[Listbuilder]` Fix on disable bug: Will not enable on call to enable() after disable() twice. ([#5885](https://github.com/infor-design/enterprise/issues/5885))
 - `[Locale]` Changed the text from Insert Anchor to Insert Hyperlink. Some translations my still reference anchor until updated from the translation team. ([#5987](https://github.com/infor-design/enterprise/issues/5987))
+- `[Modal]` Fixed a regression bug where elements inside of the tab panel were being disabled when its `li` tab is not selected (is-selected class) initially. ([NG#1210](https://github.com/infor-design/enterprise-ng/issues/1210))
 - `[Searchfield]` Fixed UI alignment of close icon button (searchfield) in Datagrid. ([#5954](https://github.com/infor-design/enterprise/issues/5954))
 - `[Tabs Module]` Fixed UI alignment of close icon button on mobile view([#5951](https://github.com/infor-design/enterprise/issues/5951))
 

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1040,8 +1040,14 @@ Modal.prototype = {
       self.setFocusableElems();
 
       const focusableElements = $(self.focusableElems).not('.modal-header .searchfield');
-      focusableElements.not(':visible').attr('disabled', 'disabled');
+
+      // The element/s will be disabled if detects that it has inline display: none; style.
+      if (focusableElements.css('display') === 'none') {
+        focusableElements.not(':visible').attr('disabled', 'disabled');
+      }
+
       let focusElem = focusableElements.not(':hidden').first();
+
       if (focusElem.length === 0) {
         focusElem = thisElem.element.find('.btn-modal-primary');
       }

--- a/test/components/contextualactionpanel/contextualactionpanel.puppeteer-spec.js
+++ b/test/components/contextualactionpanel/contextualactionpanel.puppeteer-spec.js
@@ -1,0 +1,28 @@
+describe('Contextual Action Panel Puppeteer Tests', () => {
+  const baseUrl = 'http://localhost:4000/components/contextualactionpanel';
+  const capTrigger = '#cap-trigger';
+
+  describe('CAP Tabs Vertical tests', () => {
+    const url = `${baseUrl}/example-cap-tabs-vertical-scroll`;
+
+    beforeAll(async () => {
+      await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });
+    });
+
+    it('should not disable the elements inside of the tab panel when the li is not initially selected', async () => {
+      await page.click(`${capTrigger}`);
+
+      await page.waitForSelector('.modal-engaged', { visible: true });
+
+      await page.click('#tab-test-info-a');
+
+      await page.click('#insert-text');
+      await page.evaluate(() => document.querySelector('#insert-text').getAttribute('disabled'))
+        .then(disabledValue => expect(disabledValue).toEqual(null));
+
+      await page.keyboard.press('Tab');
+      await page.evaluate(() => document.querySelector('#insert-text-btn').getAttribute('disabled'))
+        .then(disabledValue => expect(disabledValue).toEqual(null));
+    });
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes a regression bug where the elements in Tabs (inside of Contextual Action Panel) were getting disabled. I noticed that this bug occurs if the `li` element doesn't have `is-selected` initially. It has something to do with the fix [here](https://github.com/infor-design/enterprise/issues/5875) related to a modal. Added a condition that will not affect those elements that haven't been visible prior to opening a modal.

The issue has been raised in the NG version.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise-ng/issues/1210

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app

1.) Original Bug
- Go to http://localhost:4000/components/contextualactionpanel/example-cap-tabs-vertical-scroll.html
- Click the `CAP - Tabs Vertical` button
- Then click the `Test Information` tab
- Input and button elements should not be disabled

2.) Related Issue that needs to test also [PR](https://github.com/infor-design/enterprise/pull/5979) & [Issue](https://github.com/infor-design/enterprise/issues/5875) links to check
- Go to http://localhost:4000/components/modal/example-hidden-field.html
- Click `Show Modal`
- Tab around the modal - should skip the hidden field
- Check the element in Hidden Field
- The input field should be disabled

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
