### PR TITLE
5947 - Follow up fix for close icon issue on mobile classic theme

### DIFF
--- a/src/components/datagrid/_datagrid-new.scss
+++ b/src/components/datagrid/_datagrid-new.scss
@@ -413,6 +413,12 @@
   &.medium-rowheight th.text-ellipsis .datagrid-header-text {
     margin: 5px 0 0 !important;
   }
+
+  &:not(.extra-small-rowheight) .datagrid-header {
+    .datagrid-filter-wrapper .dropdown + .icon {
+      top: 1px;
+    }
+  }
 }
 
 .datagrid.small-rowheight tbody tr td.datagrid-trigger-cell .trigger {
@@ -797,6 +803,12 @@ html[dir='rtl'] {
 }
 
 .android.is-firefox {
+  .datagrid-header .datagrid-filter-wrapper {
+    .dropdown + .icon:not(.close) {
+      top: 1px;
+    }
+  }
+
   .dropdown-list > .trigger .icon.close {
     top: 6px;
   }

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -5493,6 +5493,26 @@ html[dir='rtl'] {
   }
 }
 
+.android.is-firefox {
+  .mobile {
+    &.dropdown-list {
+    .trigger {
+      position: absolute;
+
+      .icon.close {
+        top: 6px;
+      }
+    }
+  }
+  }
+
+  .datagrid-header .datagrid-filter-wrapper {
+    .dropdown + .icon:not(.close) {
+      top: -2px;
+    }
+  }
+}
+
 .table-errors {
   display: inline-block;
   height: 35px;

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -5496,19 +5496,19 @@ html[dir='rtl'] {
 .android.is-firefox {
   .mobile {
     &.dropdown-list {
-    .trigger {
-      position: absolute;
+      .trigger {
+        position: absolute;
 
-      .icon.close {
-        top: 6px;
+        .icon.close {
+          top: 6px;
+        }
       }
     }
-  }
   }
 
   .datagrid-header .datagrid-filter-wrapper {
     .dropdown + .icon:not(.close) {
-      top: -2px;
+      top: -1px;
     }
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Follow up fix for close icon position on mobile classic theme.

**Related github/jira issue (required)**:

Closes #5947

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Open in BrowserStack or actual android device then in Firefox browser http://localhost:4000/components/datagrid/example-columnsizing.html?theme=classic&mode=light&colors=2578a9
- Open any dropdown element
- Close icon should be vertically aligned
- Test also in the New theme

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
