### PR TITLE
6042 - Fix calendar to allow more than one in a page

### DIFF
--- a/app/views/components/homepage/example-calendars.html
+++ b/app/views/components/homepage/example-calendars.html
@@ -1,0 +1,97 @@
+<style>
+  .monthview-header  {
+    display: none;
+  }
+</style>
+
+<div class="homepage page-container scrollable" data-init="false" id="maincontent" data-columns="3" role="main">
+  <div class="content">
+
+    <div class="widget">
+      <div class="widget-header">
+        <h2 class="widget-title">No Calendar</h2>
+        <button class="btn-actions" type="button">
+          <span class="audible">Actions</span>
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-more"></use>
+          </svg>
+        </button>
+        <ul class="popupmenu actions top">
+          <li><a href="#">Action One</a></li>
+          <li><a href="#">Action Two</a></li>
+        </ul>
+      </div>
+
+      <div class="widget-content">
+      </div>
+    </div>
+
+    <div class="widget">
+      <div class="widget-header">
+        <h2 class="widget-title">Calendar (Feb 2021)</h2>
+        <button class="btn-actions" type="button">
+          <span class="audible">Actions</span>
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-more"></use>
+          </svg>
+        </button>
+        <ul class="popupmenu actions top">
+          <li><a href="#">Action One</a></li>
+          <li><a href="#">Action Two</a></li>
+        </ul>
+      </div>
+
+      <div class="widget-content">
+        <div class="calendar" data-init="false" id="calendar-one">
+          <div class="calendar-monthview">
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="widget">
+      <div class="widget-header">
+        <h2 class="widget-title">Calendar (March 2022)</h2>
+        <button class="btn-actions" type="button">
+          <span class="audible">Actions</span>
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-more"></use>
+          </svg>
+        </button>
+        <ul class="popupmenu actions top">
+          <li><a href="#">Action One</a></li>
+          <li><a href="#">Action Two</a></li>
+        </ul>
+      </div>
+
+      <div class="widget-content">
+        <div class="calendar" data-init="false" id="calendar-two">
+          <div class="calendar-monthview">
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<script>
+  $('body').on('initialized', function () {
+    $('.homepage').homepage();
+
+    $('#calendar-one').calendar({
+      month: 1,
+      day: 2,
+      year: 2022,
+      showToday: false,
+      showViewChanger: false,
+    });
+    $('#calendar-two').calendar({
+      month: 2,
+      year: 2022,
+      day: 4,
+      showToday: false,
+      showViewChanger: false,
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## v4.60.0 Fixes
 
+- `[Calendar]` Fixed an issue where you could not have more than one in the same page. ([#6042](https://github.com/infor-design/enterprise/issues/6042))
 - `[Datagrid]` Fix Edit Input Date Field on medium row height in Datagrid. ([#5955](https://github.com/infor-design/enterprise/issues/5955))
 - `[Datagrid]` Fixed close icon alignment on mobile viewport. ([#6023](https://github.com/infor-design/enterprise/issues/6023))
 - `[Datagrid]` Fixed close icon alignment on mobile viewport, Safari browser. ([#5946](https://github.com/infor-design/enterprise/issues/5946))

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -244,7 +244,7 @@ Calendar.prototype = {
    * @private
    */
   renderMonthView() {
-    this.monthViewContainer = document.querySelector('.calendar .calendar-monthview');
+    this.monthViewContainer = this.element[0].querySelector('.calendar-monthview');
 
     // Handle changing view
     this.activeView = 'month';


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The calendar component did not work with more than one in the same page. Made this possible to satisfy a t2v use case.

Im not convinced the UI looks very good with it there as its too small but this is what they asked for.

**Related github/jira issue (required)**:
Fixes #6042

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/homepage/example-monthviews.html
- see you can have one in each widget
- go to http://localhost:4000/components/homepage/example-calendars.html
- see you can have one in each 2 out of 3 widgets
- also test http://localhost:4000/components/calendar and http://localhost:4000/components/monthview for any issues

**Included in this Pull Request**:
- [x] A note to the change log.

