### PR TITLE
6039 - Fix horizontal alignment issue in header flex toolbar

### DIFF
--- a/app/views/components/header/test-flex-toolbar-horizontal.html
+++ b/app/views/components/header/test-flex-toolbar-horizontal.html
@@ -1,0 +1,54 @@
+<header class="header is-personalizable">
+  <div class="flex-toolbar">
+    <div class="toolbar-section">
+      {{> includes/header-appmenu-trigger}}
+    </div>
+    <div class="toolbar-section title">
+      <h1><span class="page-title">Page Title</span></h1>
+    </div>
+
+    <div class="toolbar-section buttonset">
+      <button id="settings-button" class="btn">
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-settings"></use>
+        </svg>
+        <span>Settings</span>
+      </button>
+
+      <button id="delete-button" class="btn">
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-delete"></use>
+        </svg>
+        <span>Delete</span>
+      </button>
+
+      <button id="filter-button" class="btn">
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-filter"></use>
+        </svg>
+        <span>Filter</span>
+      </button>
+    </div>
+
+    <div id="more-button" class="toolbar-section more">
+      <button class="btn-actions" type="button">
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-more"></use>
+        </svg>
+        <span class="audible" data-translate="text">More</span>
+      </button>
+      <ul class="popupmenu">
+        <li><a href="#">Item One</a></li>
+        <li><a href="#">Item Two</a></li>
+        <li class="submenu">
+          <a href="#">Item Three</a>
+          <ul class="popupmenu">
+            <li><a href="#">Sub-Item One</a></li>
+            <li><a href="#">Sub-Item Two</a></li>
+          </ul>
+        </li>
+        <li><a href="#">Item Four</a></li>
+      </ul>
+    </div>
+  </div>
+</header>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `[Field Options]` Fixed UI alignment of close icon button (searchfield) in Field Options. ([#5983](https://github.com/infor-design/enterprise/issues/5983))
 - `[Field Options]` Fixed UI alignment of close icon button (searchfield) in Field Options. ([#5983](https://github.com/infor-design/enterprise/issues/5983))
 - `[General]` Fixed several memory leaks with the attached data object. ([#6020](https://github.com/infor-design/enterprise/issues/6020))
+- `[Header]` Fixed a regression bug where the buttonset was not properly aligned correctly. ([#6039](https://github.com/infor-design/enterprise/issues/6039))
 - `[Listbuilder]` Fix on disable bug: Will not enable on call to enable() after disable() twice. ([#5885](https://github.com/infor-design/enterprise/issues/5885))
 - `[Locale]` Changed the text from Insert Anchor to Insert Hyperlink. Some translations my still reference anchor until updated from the translation team. ([#5987](https://github.com/infor-design/enterprise/issues/5987))
 - `[Modal]` Fixed a regression bug where elements inside of the tab panel were being disabled when its `li` tab is not selected (is-selected class) initially. ([NG#1210](https://github.com/infor-design/enterprise-ng/issues/1210))

--- a/src/components/header/_header-new.scss
+++ b/src/components/header/_header-new.scss
@@ -26,6 +26,16 @@
             }
           }
         }
+
+        .btn.searchfield-category-button {
+          height: 38px;
+          padding-right: 20px;
+
+          @media (min-width: $breakpoint-phone-to-tablet) {
+            height: 34px;
+            padding-right: 10px;
+          }
+        }
       }
 
       .toolbar-searchfield-wrapper {

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -394,20 +394,13 @@ $subheader-height: 60px;
     }
 
     .toolbar-section {
-      &.buttonset,
-      &.title,
-      &.search-categories {
-        display: flex;
-      }
-
       &.search-categories {
         &.search {
           .btn.searchfield-category-button {
-            height: 38px;
+            height: 33px;
             padding-right: 20px;
 
             @media (min-width: $breakpoint-phone-to-tablet) {
-              height: 34px;
               padding-right: 10px;
             }
           }
@@ -415,9 +408,13 @@ $subheader-height: 60px;
           .has-close-icon-button {
             .btn-icon {
               height: auto;
-              right: 7px;
+              right: 40px;
               top: 50%;
               transform: translateY(-50%);
+
+              @media(min-width: $breakpoint-phone-to-tablet) {
+                right: 7px;
+              }
 
               .icon.close {
                 top: 0 !important;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixed a regression bug regarding the alignment issue of the buttonset in the header flex-toolbar. I also fixed the close icon on `example-toolbar-flex-with-categories` test page (mobile viewport).

Bug:
<img width="1540" alt="bug" src="https://user-images.githubusercontent.com/8839327/150314769-beaf2f91-53b8-450c-aa67-e8aee8449a71.png">

Fix
<img width="1541" alt="fix" src="https://user-images.githubusercontent.com/8839327/150314783-bdc0f59d-a52e-4897-8d53-498f210d8f8d.png">

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/6039

**Steps necessary to review your pull request (required)**:
- Pull this branch build and run the app
- Go to http://localhost:4000/components/header/test-flex-toolbar-horizontal
- Buttonset should be on the right section of the header (see screenshot on top)
- Go to http://localhost:4000/components/header/example-toolbar-flex-with-categories.html
- Open it on a smaller viewport (766px and below)
- Type anything in the search field
- Close icon should perfectly be aligned and should be visible
- Test in classic theme

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
