### PR TITLE
5927 - Datagrid Leading Spaces not triggering dirty indicator

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - `[Calendar]` Fixed an issue where you could not have more than one in the same page. ([#6042](https://github.com/infor-design/enterprise/issues/6042))
 - `[Column]` Fix a bug where bar size is still showing even the value is zero in column chart. ([#5911](https://github.com/infor-design/enterprise/issues/5911))
+- `[Datagrid]` Fix a bug where leading spaces not triggering dirty indicator in editable data cell. ([#5927](https://github.com/infor-design/enterprise/issues/5927))
 - `[Datagrid]` Fix Edit Input Date Field on medium row height in Datagrid. ([#5955](https://github.com/infor-design/enterprise/issues/5955))
 - `[Datagrid]` Fixed close icon alignment on mobile viewport. ([#6023](https://github.com/infor-design/enterprise/issues/6023))
 - `[Datagrid]` Fixed close icon alignment on mobile viewport, Safari browser. ([#5946](https://github.com/infor-design/enterprise/issues/5946))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -11005,7 +11005,7 @@ Datagrid.prototype = {
     }
 
     if (typeof d.originalVal === 'string' || d.originalVal instanceof String) {
-      if (d.originalVal?.trim() === d.value?.trim()) {
+      if (d?.originalVal === d?.value) {
         this.dirtyArray[row][cell].isDirty = false;
         this.setDirtyIndicator(row, cell, false);
       }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug where leading spaces not triggering dirty indicator in editable data cell.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5927

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-cell-with-leading-space-dirty-indicator.html
- Click on add leading spaces to Compressor in the first cell under the Product Name column
- Tab out of the cell

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

