### PR TITLE
5735 - datagrid modal unable to tab fields

### DIFF
--- a/app/views/components/datagrid/example-modal-datagrid-tabbing.html
+++ b/app/views/components/datagrid/example-modal-datagrid-tabbing.html
@@ -1,0 +1,128 @@
+<div class="row">
+  <div class="twelve columns">
+    <button class="btn-secondary" type="button" id="open-modal">Open Modal</button><br><br>
+
+    <!-- "Context" Example -->
+    <div id="modal-content" style="display: none;" >
+
+      <form class="form-layout-compact">
+        <div class="toolbar" role="toolbar">
+          <div class="title">
+            Compressors
+          </div>
+          <div class="buttonset">
+            <button class="btn" type="button" id="filter">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use href="#icon-filter"></use>
+              </svg>
+            </button>
+          </div>
+
+          <div class="more">
+            <button class="btn-actions" type="button">
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use href="#icon-more"></use>
+              </svg>
+              <span class="audible">More Actions</span>
+            </button>
+            <ul class="popupmenu">
+              <li><a data-option="personalize-columns" href="#" data-translate="text">PersonalizeColumns</a></li>
+              <li><a data-option="reset-layout" href="#" data-translate="text">ResetDefault</a></li>
+              <li class="separator"></li>
+              <li class="heading">Filter</li>
+              <li class="show-filter is-toggleable is-checked"><a data-option="show-filter-row" data-translate="text">ShowFilterRow</a></li>
+              <li class="is-indented"><a data-option="run-filter" data-translate="text">RunFilter</a></li>
+              <li class="is-indented"><a data-option="clear-filter" data-translate="text">ClearFilter</a></li>
+              <li class="separator single-selectable-section"></li>
+              <li class="heading">Row Height</li>
+              <li class="is-selectable is-checked"><a data-option="row-extra-small" href="#" data-translate="text">ExtraSmall</a></li>
+              <li class="is-selectable"><a data-option="row-small" href="#" data-translate="text">Small</a></li>
+              <li class="is-selectable"><a data-option="row-medium" href="#" data-translate="text">Medium</a></li>
+              <li class="is-selectable"><a data-option="row-large" href="#" data-translate="text">Large</a></li>
+            </ul>
+
+          </div>
+        </div>
+        <div id="datagrid">
+        </div>
+      </form>
+  </div>
+</div>
+
+<script>
+  var gridApi = null;
+  var modal = null;
+
+  $('body').one('initialized', function () {
+    //Locale.set('en-US').done(function () {
+    var grid,
+    columns = [],
+    data = [];
+
+    // Some Sample Data
+    data.push({ id: 1, productId: 'T100', productName: 'Compressor', phone: '191/2004', activity:  'Assemble Paint', quantity: 1, price: '800.9905673502324', percent: .10, status: 'OK', orderDate: '00000000', action: 'Action', summary: 'Is action oriented and full of energy'});
+    data.push({ id: 2, productId: '200', productName: 'Different Compressor', phone: '(888) 888-8888', activity:  'Inspect and Repair', quantity: '2', percent: .10, price: null, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold', summary: 'Active Server Pages'});
+    data.push({ id: 3, productId: '300', productName: 'Compressor', phone: '(888) 888-8888', activity:  'Inspect and Repair', quantity: 1, price: '120.99', percent: .10, status: null, orderDate: new Date(2014, 6, 3), action: 'Action', summary: 'Analytical Skills'});
+    data.push({ id: 4, productId: 'Z400', productName: 'Another Compressor', phone: '(888) 888-8888', activity:  'Assemble Paint', quantity: 3, price: '2345', percent: .10, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action', summary: 'Is excellent at honest analysis'});
+    data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: '2345', percent: .10, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action', summary: 'Assessment Skills'});
+    data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: '210.99', percent: .10, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold', summary: 'Practices attentive and active listening'});
+    data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: '120.99', percent: .10, status: 'OK', orderDate:new Date(2017, 5, 5), action: 'On Hold', summary: 'Creates a feeling of belonging to and commitment to the team'});
+    data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '123.99', percent: .10, status: 'OK', orderDate: null, action: 'On Hold', summary: 'Brings out the best in people'});
+
+    //Define Columns for the Grid.
+    columns.push({ id: 'productId', name: 'Id', field: 'productId', formatter: Formatters.Text, filterType: 'text'});
+    columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', formatter: Formatters.Text, filterType: 'text', align: 'left' });
+
+    //Init and get the api for the grid
+    grid = $('#datagrid').datagrid({
+      columns: columns,
+      dataset: data,
+      saveColumns: false,
+      paging: true,
+      pagesize: 10,
+      actionableMode: true,
+      cellNavigation: false,
+      editable: false,
+      enableTooltips: true,
+      filterWhenTyping: false,
+      redrawOnResize: false,
+      rowHeight: 'short',
+      selectable: 'single',
+      showDirty: false,
+      filterable: true,
+      toolbar: {title: 'Select Compressor', actions: true, rowHeight: true, personalize: true}
+    }).on('selected', function (e, args) {
+      // Return the selected item and close the modal
+      console.log('selected', args);
+      modal.close();
+    });
+
+    gridApi = $('#datagrid').data('datagrid');
+
+    var modals = {
+      'open-modal': {
+        'title': 'Open Modal',
+        'content': $('#modal-content')
+      }
+    },
+
+    setModal = function (opt) {
+      opt = $.extend({
+        autoFocus: false,
+        showCloseBtn: true,
+      }, opt);
+
+      // modal = $('body').modal(opt);
+      modal = $('body').modal(opt).data('modal');
+
+      setTimeout(function ()  {
+        // Set focus to the first row
+        gridApi.setActiveCell(0, 0);
+      }, 300);
+    };
+
+    $('#open-modal').on('click', function () {
+      setModal(modals[this.id]);
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - `[Calendar]` Fixed an issue where you could not have more than one in the same page. ([#6042](https://github.com/infor-design/enterprise/issues/6042))
 - `[Column]` Fix a bug where bar size is still showing even the value is zero in column chart. ([#5911](https://github.com/infor-design/enterprise/issues/5911))
+- `[Datagrid]` Fix a bug in datagrid where filterable headers cannot be tab through in modal. ([#5735](https://github.com/infor-design/enterprise/issues/5735))
 - `[Datagrid]` Fix a bug where leading spaces not triggering dirty indicator in editable data cell. ([#5927](https://github.com/infor-design/enterprise/issues/5927))
 - `[Datagrid]` Fix Edit Input Date Field on medium row height in Datagrid. ([#5955](https://github.com/infor-design/enterprise/issues/5955))
 - `[Datagrid]` Fixed close icon alignment on mobile viewport. ([#6023](https://github.com/infor-design/enterprise/issues/6023))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9228,18 +9228,13 @@ Datagrid.prototype = {
       }
 
       // Button Filter Tabbing Issue #5735
-      if (key === 9) {
-        if (targetJq.parents('.modal').length > 0 && targetJq.hasClass('btn-filter')) {
-          e.preventDefault();
-          targetJq.siblings('input').trigger('focus');
-        }
-      }
-
-      // Button Filter Tabbing Issue #5735
-      if (e.shiftKey && key === 9) {
-        if (targetJq.parents('.modal').length > 0 && targetJq.hasClass('btn-filter')) {
+      if (targetJq.parents('.modal').length > 0 && targetJq.hasClass('btn-filter')) {
+        if (e.shiftKey && key === 9) {
           e.preventDefault();
           targetJq.parents('th').prev('th').find('input').trigger('focus');
+        } else if (key === 9) {
+          e.preventDefault();
+          targetJq.siblings('input').trigger('focus');
         }
       }
     });

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9227,11 +9227,19 @@ Datagrid.prototype = {
         e.preventDefault();
       }
 
-      // Button Filters Tabbing Issue #5735
+      // Button Filter Tabbing Issue #5735
       if (key === 9) {
         if (targetJq.parents('.modal').length > 0 && targetJq.hasClass('btn-filter')) {
           e.preventDefault();
           targetJq.siblings('input').trigger('focus');
+        }
+      }
+
+      // Button Filter Tabbing Issue #5735
+      if (e.shiftKey && key === 9) {
+        if (targetJq.parents('.modal').length > 0 && targetJq.hasClass('btn-filter')) {
+          e.preventDefault();
+          targetJq.parents('th').prev('th').find('input').trigger('focus');
         }
       }
     });

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1975,7 +1975,7 @@ Datagrid.prototype = {
     const attrs = utils.stringAttributes(this, this.settings.attributes, `btn-filter-${col.id?.toLowerCase()}`);
 
     const renderButton = function (defaultValue, extraClass) {
-      return `<button type="button" ${attrs} class="btn-menu btn-filter${extraClass ? ` ${extraClass}` : ''}" data-init="false" ${isDisabled ? ' disabled' : ''}${defaultValue ? ` data-default="${defaultValue}"` : ''} type="button"><span class="audible">Filter</span>` +
+      return `<button type="button" ${attrs} class="btn-menu btn-filter${extraClass ? ` ${extraClass}` : ''}" data-init="false" ${isDisabled ? ' disabled' : ''}${defaultValue ? ` data-default="${defaultValue}"` : ''} tabindex="0" type="button"><span class="audible">Filter</span>` +
       `<svg class="icon-dropdown icon" focusable="false" aria-hidden="true" role="presentation"><use href="#icon-filter-{{icon}}"></use></svg>${
         $.createIcon({ icon: 'dropdown', classes: 'icon-dropdown' })
       }</button><ul class="popupmenu has-icons is-translatable is-selectable">`;
@@ -9225,6 +9225,14 @@ Datagrid.prototype = {
         th.removeAttr('tabindex');
         self.activeCell.node = self.cellNode(0, self.settings.groupable ? 0 : self.activeCell.cell).attr('tabindex', '0').focus();
         e.preventDefault();
+      }
+
+      // Button Filters Tabbing Issue #5735
+      if (key === 9) {
+        if (targetJq.parents('.modal').length > 0 && targetJq.hasClass('btn-filter')) {
+          e.preventDefault();
+          targetJq.siblings('input').trigger('focus');
+        }
       }
     });
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1622,7 +1622,7 @@ Datagrid.prototype = {
           filterMarkup += `<input ${col.filterDisabled ? ' disabled' : ''} type="text" class="lookup" ${attrs} >`;
           break;
         default:
-          filterMarkup += `<input${col.filterDisabled ? ' disabled' : ''} type="text" ${attrs}/>`;
+          filterMarkup += `<input${col.filterDisabled ? ' disabled' : ''} tabindex="0" type="text" ${attrs}/>`;
           break;
       }
 
@@ -9230,8 +9230,14 @@ Datagrid.prototype = {
       // Button Filter Tabbing Issue #5735
       if (targetJq.parents('.modal').length > 0 && targetJq.hasClass('btn-filter')) {
         if (e.shiftKey && key === 9) {
-          e.preventDefault();
-          targetJq.parents('th').prev('th').find('input').trigger('focus');
+          if (targetJq.parents('th').prev('th').length > 0) {
+            e.preventDefault();
+            targetJq.parents('th').prev('th').find('[tabindex=0]').trigger('focus');
+          } else if (targetJq.parents('.modal-content').find('.toolbar').length > 0) {
+            e.preventDefault();
+            e.stopPropagation();
+            targetJq.parents('.modal-content').find('.toolbar').find('button[tabindex=0]').trigger('focus');
+          }
         } else if (key === 9) {
           e.preventDefault();
           targetJq.siblings('input').trigger('focus');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug in datagrid where filterable headers cannot be tab through in modal.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5735 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/example-modal-datagrid-tabbing.html
- Click `Open Modal`
- Perform a shift-tab (or tab) until focus is on a field in the filter row

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

