### PR TITLE
5592 - Fix a bug which clears list format when it's not part of the selected text

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `[Datagrid]` Fixed UI alignment of close icon button on mobile view. ([#5947](https://github.com/infor-design/enterprise/issues/5947))
 - `[Editor]` Changed selector for for image value selction from id to name. ([#5915](https://github.com/infor-design/enterprise/issues/5915))
 - `[Editor]` Fix a bug which changes the approach intended by the user after typing in editor. ([#5937](https://github.com/infor-design/enterprise/issues/5937))
+- `[Editor]` Fix a bug which clears list format when it's not part of the selected text. ([#5592](https://github.com/infor-design/enterprise/issues/5592))
 - `[Field Options]` Fixed UI alignment of close icon button (searchfield) in Field Options. ([#5983](https://github.com/infor-design/enterprise/issues/5983))
 - `[Export]` Added data sanitization in Export to CSV. ([#5982](https://github.com/infor-design/enterprise/issues/5982))
 - `[Field Options]` Fixed UI alignment of close icon button (searchfield) in Field Options. ([#5983](https://github.com/infor-design/enterprise/issues/5983))

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -2534,6 +2534,25 @@ Editor.prototype = {
       }
     };
 
+    // Check if selection contains given node
+    const containsNodeInSelection = (node) => {
+      const sel = window.getSelection();
+      let r = false;
+      if (env.browser.isIE11()) {
+        const rangeAt = sel.getRangeAt(0);
+        const range = document.createRange();
+        range.selectNode(node);
+        const s2s = rangeAt.compareBoundaryPoints(Range.START_TO_END, range);
+        const s2e = rangeAt.compareBoundaryPoints(Range.START_TO_START, range);
+        const e2s = rangeAt.compareBoundaryPoints(Range.END_TO_START, range);
+        const e2e = rangeAt.compareBoundaryPoints(Range.END_TO_END, range);
+        r = ((s2s !== s2e) || (e2s !== e2e) || (s2s !== e2e));
+      } else {
+        r = sel.containsNode(node, true);
+      }
+      return r;
+    };
+
     // Clear all lists belongs to selection area
     const clearLists = () => {
       const normalizeList = (list) => {
@@ -2557,30 +2576,16 @@ Editor.prototype = {
       } else {
         const setEl = () => ($(parentEl).closest('.editor').length ? parentEl.parentNode : null);
         const elem = parentEl.classList.contains('editor') ? parentEl : setEl();
+
         if (elem) {
           const lists = [].slice.call(elem.querySelectorAll('ul, ol'));
-          lists.forEach(list => normalizeList(list));
+          lists.forEach((list) => {
+            if (containsNodeInSelection(list)) {
+              normalizeList(list);
+            }
+          });
         }
       }
-    };
-
-    // Check if selection contains given node
-    const containsNodeInSelection = (node) => {
-      const sel = window.getSelection();
-      let r = false;
-      if (env.browser.isIE11()) {
-        const rangeAt = sel.getRangeAt(0);
-        const range = document.createRange();
-        range.selectNode(node);
-        const s2s = rangeAt.compareBoundaryPoints(Range.START_TO_END, range);
-        const s2e = rangeAt.compareBoundaryPoints(Range.START_TO_START, range);
-        const e2s = rangeAt.compareBoundaryPoints(Range.END_TO_START, range);
-        const e2e = rangeAt.compareBoundaryPoints(Range.END_TO_END, range);
-        r = ((s2s !== s2e) || (e2s !== e2e) || (s2s !== e2e));
-      } else {
-        r = sel.containsNode(node, true);
-      }
-      return r;
     };
 
     // Convert hyperlinks to plain text in selected area.


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Added check to see if list items are selected before clearing format.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #5592 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/editor/test-clear-formatting.html
- Make a bullet list and a numbered list below the existing text.
- Select "Embrace e-commerce action-items, reintermediate, ecologies"
- Click the Clear Formatting icon.

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
