### PR TITLE
5972 - Datagrid TargetedAchievement colors not displaying correctly on other locales

### DIFF
--- a/app/views/components/datagrid/test-targeted-achievement-with-locale.html
+++ b/app/views/components/datagrid/test-targeted-achievement-with-locale.html
@@ -1,0 +1,60 @@
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+
+  var gridApi = null;
+
+  $('body').one('initialized', function () {
+
+    Locale.set('fr-FR').done(function () {
+      var grid,
+        data = [],
+        columns = [];
+
+      //Define Columns for the Grid.
+      columns.push({id: 'manufacturerName', name: 'Manufacturer Name', field: 'manufacturerName', filterType: 'text'});
+      columns.push({id: 'inventoryValue', name: 'Inventory', field: 'inventoryValue', width: 100});
+      columns.push({ id: 'customerSatisfaction', name: 'With Primary Color', field: 'customerSatisfaction', formatter: Formatters.TargetedAchievement, showPercentText: true , width: 200, numberFormat: { minimumFractionDigits: 3, maximumFractionDigits: 3} });
+      columns.push({
+        id: 'customerSatisfaction2',
+        name: 'With Alert Colors',
+        field: 'customerSatisfaction',
+        formatter: Formatters.TargetedAchievement,
+        showPercentText: true,
+        ranges: [{'min': 0, 'max': 20, 'classes': 'error-color'}, {
+          'min': 21,
+          'max': 40,
+          'classes': 'alert-yellow'
+        }, {'min': 41, 'max': 80, 'classes': 'good'}],
+        width: 200
+      });
+      columns.push({ id: 'customerSatisfaction3', name: 'To a Target', field: 'customerSatisfaction', formatter: Formatters.TargetedAchievement, target: 80, width: 200});
+      columns.push({ id: 'customerSatisfaction3', name: 'Custom Text', field: 'customerSatisfaction', formatter: Formatters.TargetedAchievement, text: 'Custom Text <% percent %>', tooltip: 'Custom Tooltip', width: 200});
+      columns.push({id: 'gap', name: ''});
+
+      //Get some data via ajax
+      var url = '{{basepath}}api/bikes';
+
+      $.getJSON(url, function (res) {
+
+        $('#datagrid').datagrid({
+          columns: columns,
+          dataset: res,
+          paging: true,
+          pagesize: 10,
+          enableTooltips: true,
+          frozenColumns: {
+            left: ['manufacturerName', 'inventoryValue'],
+          },
+          toolbar: {title: 'Bike Dealers', results: true, personalize: true, actions: true, rowHeight: true}
+        });
+      });
+    });
+  });
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - `[Calendar]` Fixed an issue where you could not have more than one in the same page. ([#6042](https://github.com/infor-design/enterprise/issues/6042))
 - `[Column]` Fix a bug where bar size is still showing even the value is zero in column chart. ([#5911](https://github.com/infor-design/enterprise/issues/5911))
+- `[Datagrid]` Fix a bug where targeted achievement colors are not displaying correctly when using other locales. ([#5972](https://github.com/infor-design/enterprise/issues/5972))
 - `[Datagrid]` Fix a bug where leading spaces not triggering dirty indicator in editable data cell. ([#5927](https://github.com/infor-design/enterprise/issues/5927))
 - `[Datagrid]` Fix Edit Input Date Field on medium row height in Datagrid. ([#5955](https://github.com/infor-design/enterprise/issues/5955))
 - `[Datagrid]` Fixed close icon alignment on mobile viewport. ([#6023](https://github.com/infor-design/enterprise/issues/6023))

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -805,8 +805,10 @@ const formatters = {
       col.numberFormat || { minimumFractionDigits: 2, maximumFractionDigits: 2 }
     );
 
+    const en_perc = perc.replace(',', '.');
+
     let text = `${perc}%`;
-    const ranges = formatters.ClassRange(row, cell, perc, col);
+    const ranges = formatters.ClassRange(row, cell, en_perc, col);
     const target = col.target;
 
     if (col.text) {
@@ -825,7 +827,7 @@ const formatters = {
     const barClass = (col.ranges && ranges.classes ? ranges.classes : 'primary');
     return `<div class="total bar chart-completion-target chart-targeted-achievement">
               <div class="target remaining bar" style="width: ${(target || 0)}%;"></div>
-              <div class="completed bar ${barClass}" style="width: ${perc}%;"></div>
+              <div class="completed bar ${barClass}" style="width: ${en_perc}%;"></div>
               ${(col.showPercentText ? `<div class="chart-targeted-text l-center">${text}</div>
             </div>` : `<div class="audible">${perc}%</div>`)}`;
   },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug where targeted achievement colors are not displaying correctly when using other locales.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5972

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-targeted-achievement.html?locale=de-DE
- See the percentages.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

