### PR TITLE
6063 - Fix stretch column last

### DIFF
--- a/app/views/components/datagrid/test-stretch-last-column.html
+++ b/app/views/components/datagrid/test-stretch-last-column.html
@@ -39,7 +39,7 @@
         columns: columns,
         dataset: data,
         selectable: 'single',
-        stretchColumn: columns[columns.length -1].id, // 'last' used to work see #6063
+        stretchColumn: 'last', // 'last' used to work see #6063
         toolbar: {title: 'Data Grid Header Title', collapsibleFilter: true, results: true, keywordFilter: true, actions: true, rowHeight: true}
       });
     });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[Calendar]` Fixed an issue where you could not have more than one in the same page. ([#6042](https://github.com/infor-design/enterprise/issues/6042))
 - `[Column]` Fix a bug where bar size is still showing even the value is zero in column chart. ([#5911](https://github.com/infor-design/enterprise/issues/5911))
 - `[Datagrid]` Fix a bug in datagrid where filterable headers cannot be tab through in modal. ([#5735](https://github.com/infor-design/enterprise/issues/5735))
+- `[Datagrid]` Fix a bug in datagrid where stretch column last broke and the resize would loose the last column. ([#6063](https://github.com/infor-design/enterprise/issues/6063))
 - `[Datagrid]` Fix a bug where leading spaces not triggering dirty indicator in editable data cell. ([#5927](https://github.com/infor-design/enterprise/issues/5927))
 - `[Datagrid]` Fix Edit Input Date Field on medium row height in Datagrid. ([#5955](https://github.com/infor-design/enterprise/issues/5955))
 - `[Datagrid]` Fixed close icon alignment on mobile viewport. ([#6023](https://github.com/infor-design/enterprise/issues/6023))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5191,8 +5191,8 @@ Datagrid.prototype = {
         if (diff < colWidth) {
           this.stretchColumnWidth = colWidth;
         } else {
+          colWidth = diff;
           this.stretchColumnDiff = colWidth;
-          this.stretchColumnDiff = diff;
         }
       }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
I tried to fix a lint error but fixed the chained assignment in the wrong order so the values were off.

**Related github/jira issue (required)**:
fixes #6063

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4000/components/datagrid/test-stretch-last-column.html
- resize the last column to the right -> make sure you can still see it and scroll to it
- resize the next column to it to the left -> make sure you can still scroll right and see it 

See https://user-images.githubusercontent.com/76002134/151219770-0710ad8b-2655-4c9b-965b-49c97605b5fe.gif for clarification if needed

**Included in this Pull Request**:
- [x] A note to the change log.
