### PR TITLE
NG1188 - fix rendering of renderRootElems method in SPA

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## v4.60.0 Fixes
 
+- `[Actionsheet]` Fixed an Angular issue where the `renderRootElems` method was not re-rendered when going to other action sheet test pages due to SPA routing concept. ([NG#1188](https://github.com/infor-design/enterprise-ng/issues/1188))
 - `[Calendar]` Fixed an issue where you could not have more than one in the same page. ([#6042](https://github.com/infor-design/enterprise/issues/6042))
 - `[Column]` Fix a bug where bar size is still showing even the value is zero in column chart. ([#5911](https://github.com/infor-design/enterprise/issues/5911))
 - `[Datagrid]` Fix a bug where targeted achievement colors are not displaying correctly when using other locales. ([#5972](https://github.com/infor-design/enterprise/issues/5972))

--- a/src/components/actionsheet/actionsheet.js
+++ b/src/components/actionsheet/actionsheet.js
@@ -51,11 +51,8 @@ ActionSheet.prototype = {
    * @returns {void}
    */
   render() {
-    // Render root elements, if needed
-    const hasRoot = document.querySelector(`#${ROOT_ELEM_ID}`);
-    if (!hasRoot) {
-      this.renderRootElems();
-    }
+    // Render root elements
+    this.renderRootElems();
 
     // Decorate trigger element
     const el = this.element[0];

--- a/src/components/actionsheet/actionsheet.js
+++ b/src/components/actionsheet/actionsheet.js
@@ -127,8 +127,6 @@ ActionSheet.prototype = {
       // Add tray element
       if (this.settings.tray) {
         this.renderTrayElement();
-      } else if ($('.ids-actionsheet-tray-container') && !this.settings.tray) {
-        $('.ids-actionsheet-tray-container').remove();
       }
     }
   },

--- a/src/components/actionsheet/actionsheet.js
+++ b/src/components/actionsheet/actionsheet.js
@@ -51,7 +51,7 @@ ActionSheet.prototype = {
    * @returns {void}
    */
   render() {
-    // Render root elements
+    // Render root elements, if needed
     const hasRoot = document.querySelector(`#${ROOT_ELEM_ID}`);
 
     if (!hasRoot) {

--- a/src/components/actionsheet/actionsheet.js
+++ b/src/components/actionsheet/actionsheet.js
@@ -113,6 +113,8 @@ ActionSheet.prototype = {
       // Add tray element
       if (this.settings.tray) {
         this.renderTrayElement();
+      } else if ($('.ids-actionsheet-tray-container') && !this.settings.tray) {
+        $('.ids-actionsheet-tray-container').remove();
       }
     }
   },

--- a/src/components/actionsheet/actionsheet.js
+++ b/src/components/actionsheet/actionsheet.js
@@ -52,7 +52,21 @@ ActionSheet.prototype = {
    */
   render() {
     // Render root elements
-    this.renderRootElems();
+    const hasRoot = document.querySelector(`#${ROOT_ELEM_ID}`);
+
+    if (!hasRoot) {
+      this.renderRootElems();
+    }
+
+    if (hasRoot && this.rootElem === undefined) {
+      const rootElem = document.getElementById('ids-actionsheet-root');
+
+      // Eliminate duplication of actionsheet root
+      rootElem.remove();
+
+      // Re-initialize the root elements after removing it
+      this.renderRootElems();
+    }
 
     // Decorate trigger element
     const el = this.element[0];


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This is a follow-up fix in Angular wrapper (implementing Actionsheet in NG) where the `renderRootElems` method doesn't re-rendered when going to other action sheet test pages (due to SPA routing concept).

**Related github/jira issue (required)**:

Closes & Relates https://github.com/infor-design/enterprise-ng/issues/1188

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Get the dist file of the app and go to the NG version
- Test the dist in this PR https://github.com/infor-design/enterprise-ng/pull/1219
- Follow the instructions in that PR and navigate to different action sheet test page

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
