### PR TITLE
6086 - Improve change of tabindex when Modal subcomponents are displayed/hidden

### DIFF
--- a/app/views/components/modal/test-toggle-disabled.html
+++ b/app/views/components/modal/test-toggle-disabled.html
@@ -13,7 +13,7 @@
 			<div class="field">
 				<input type="text" id="subject" name="subject" class="is-hidden" />
 			</div>
-      <button id="test">Test</button>
+      <button class="btn-secondary" type="button" id="test-btn">Test</button>
 		</div>
 
 	</div>
@@ -61,7 +61,7 @@ var modals = {
     setModal(modals[this.id]);
   });
 
-  $('#test').on('click', function () {
+  $('#test-btn').on('click', function () {
     if ($('#subject').hasClass('is-hidden')) {
       $('#subject').removeClass('is-hidden');
       $('#subject').addClass('is-visible');

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "e2e:local:debug": "npm run webdriver:update && npx protractor test/protractor.local.debug.conf.js",
     "e2e:puppeteer": "npx --no-install jest --config=test/jest.config.js --runInBand --detectOpenHandles --forceExit",
     "webdriver:clean": "npx webdriver-manager clean",
-    "webdriver:update": "npx webdriver-manager update --standalone false --quiet --gecko=false",
+    "webdriver:update": "npx webdriver-manager update --versions.chrome=97.0.4692.99 --standalone false --quiet --gecko=false",
     "zip-dist": "npx grunt zip-dist",
     "documentation": "node ./scripts/deploy-documentation.js",
     "release:dev": "node scripts/publish-nightly-manual",

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1045,11 +1045,11 @@ Modal.prototype = {
             updateFocusableElems = true;
           } else {
             const mutationTarget = $(mutation.target);
-              if (hiddenFieldTagNames.includes(mutation.target.tagName)) {
-                if (mutationTarget.is(':visible')) {
-                  mutationTarget.attr('tabindex', '0');
-                } else {
-                  mutationTarget.attr('tabindex', '-1');
+            if (hiddenFieldTagNames.includes(mutation.target.tagName)) {
+              if (mutationTarget.is(':visible')) {
+                mutationTarget.attr('tabindex', '0');
+              } else {
+                mutationTarget.attr('tabindex', '-1');
               }
             }
           }

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1033,23 +1033,31 @@ Modal.prototype = {
 
       self.setFocusableElems();
       const focusableElements = $(self.focusableElems).not('.modal-header .searchfield');
+      const hiddenFieldTagNames = ['INPUT', 'BUTTON'];
 
       // When changes happen within the subtree on the Modal, rebuilds the internal hash of
       // tabbable elements used for retaining focus.
       self.changeObserver = new MutationObserver((mutationsList) => {
+        let updateFocusableElems = false;
+
         mutationsList.forEach((mutation) => {
           if (['childList', 'subtree'].includes(mutation.type)) {
-            self.setFocusableElems();
-          }
-          if (self.focusableElems.includes(mutation.target)) {
+            updateFocusableElems = true;
+          } else {
             const mutationTarget = $(mutation.target);
-            if (mutationTarget.is(':visible')) {
-              mutationTarget.attr('tabindex', '0');
-            } else {
-              mutationTarget.attr('tabindex', '-1');
+              if (hiddenFieldTagNames.includes(mutation.target.tagName)) {
+                if (mutationTarget.is(':visible')) {
+                  mutationTarget.attr('tabindex', '0');
+                } else {
+                  mutationTarget.attr('tabindex', '-1');
+              }
             }
           }
         });
+
+        if (updateFocusableElems) {
+          self.setFocusableElems();
+        }
       });
       self.changeObserver.observe(self.element[0], {
         attributes: true,
@@ -1325,6 +1333,13 @@ Modal.prototype = {
     const ignoredSelectors = [
       'option'
     ];
+
+    // Pre-configure some element types that can be visually-hidden when the Modal opens
+    // to make it impossible to become focused while hidden (see infor-design/enterprise#6806)
+    const nonFocusableElems = $(this.element).find('input:hidden');
+    nonFocusableElems.each((i, elem) => {
+      elem.tabIndex = -1;
+    });
 
     const elems = DOM.focusableElems(this.element[0], extraSelectors, ignoredSelectors);
     this.focusableElems = elems;

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1031,39 +1031,32 @@ Modal.prototype = {
         return;
       }
 
-      // When changes happen within the subtree on the Modal, rebuilds the internal hash of
-      // tabbable elements used for retaining focus.
-      self.changeObserver = new MutationObserver(() => {
-        self.setFocusableElems();
-      });
-      self.changeObserver.observe(self.element[0], { childList: true, subtree: true });
       self.setFocusableElems();
-
       const focusableElements = $(self.focusableElems).not('.modal-header .searchfield');
 
-      // The element/s will be disabled if detects that it has inline display: none; style.
-      if (focusableElements.css('display') === 'none') {
-        // Added MutationObserver for tabbing issue on display none styles instead of using disabled attribute (#5875 and #6086)
-        const observer = new MutationObserver((mutationList) => {
-          mutationList.forEach((mutation) => {
+      // When changes happen within the subtree on the Modal, rebuilds the internal hash of
+      // tabbable elements used for retaining focus.
+      self.changeObserver = new MutationObserver((mutationsList) => {
+        mutationsList.forEach((mutation) => {
+          if (['childList', 'subtree'].includes(mutation.type)) {
+            self.setFocusableElems();
+          }
+          if (self.focusableElems.includes(mutation.target)) {
             const mutationTarget = $(mutation.target);
             if (mutationTarget.is(':visible')) {
               mutationTarget.attr('tabindex', '0');
             } else {
               mutationTarget.attr('tabindex', '-1');
             }
-          });
+          }
         });
-
-        const hiddenElements = focusableElements.not(':visible');
-        hiddenElements.attr('tabindex', '-1');
-        hiddenElements.each((index, val) => {
-          observer.observe(val, {
-            attributes: true, 
-            attributeFilter: ['class', 'style']
-          });
-        });
-      }
+      });
+      self.changeObserver.observe(self.element[0], {
+        attributes: true,
+        attributeFilter: ['class', 'style'],
+        childList: true,
+        subtree: true,
+      });
 
       let focusElem = focusableElements.not(':hidden').first();
 

--- a/test/components/modal/modal.e2e-spec.js
+++ b/test/components/modal/modal.e2e-spec.js
@@ -505,3 +505,22 @@ describe('Modal focusable elements tests', () => {
     expect(focusedElem.getAttribute('class')).toContain('dropdown');
   });
 });
+
+describe('Modal inner element visibility tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/modal/test-toggle-disabled?layout=nofrills');
+    const buttonEl = await element(by.id('add-context'));
+    await browser.driver
+      .wait(protractor.ExpectedConditions.presenceOf(buttonEl), config.waitsFor);
+    await buttonEl.click();
+    await browser.driver.sleep(config.sleep);
+  });
+
+  it('Should adjust tabindex of fields that change visiblity after the modal opens', async () => {
+    const testBtn = await element(by.id('test-btn'));
+    await testBtn.click();
+    await browser.driver.sleep(config.sleep);
+
+    expect(await element(by.id('subject')).getAttribute('tabindex')).toBe('0');
+  });
+});


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR is a followup to #6088 that does the following:
- Reduces use of `MutationObserver` so only one is used (scoped to the Modal and its focusable elements)
- Fixes a minor tabbing bug that was recently introduced where sometimes focus could be placed on elements outside the Modal
- Adds a test

**Related github/jira issue (required)**:
- Closes #6086
- Related to #6088

**Steps necessary to review your pull request (required)**:
- Pull/Build/Run
- Open http://localhost:4000/components/modal/test-toggle-disabled.html
- Open the Modal and click the "test" button to display a previously-hidden input
- Use Shift + Tab to focus the input.  Focus should not escape the modal, should skip the hidden input, and should be placed on the last element inside the Modal (in this case, the Save button)

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.

