### PR TITLE
6083 - Tabs: 'x' icon is not aligned in responsive view

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Datagrid]` Fix a will add a setting in column to toggle the clearing of cells. ([#5849](https://github.com/infor-design/enterprise/issues/5849))
 - `[Dropdown]` Create a Puppeteer Script for Enter key opens dropdown list, when it should only be used to select items within an open list. ([#5842](https://github.com/infor-design/enterprise/issues/5842))
 - `[Fileupload]` Added puppeteer test to check that progress bar is present when uploading a file. ([#5808](https://github.com/infor-design/enterprise/issues/5808))
+- `[Popupmenu]` Correctly position dismissible close icon inside popupmenu. ([#6083](https://github.com/infor-design/enterprise/issues/6083))
 - `[Swipe Container]` Added mobile enhancements and style changes. ([#5615](https://github.com/infor-design/enterprise/issues/5615))
 - `[Tooltip]` Converted the tooltip protractor test suites to puppeteer. ([#5830](https://github.com/infor-design/enterprise/issues/5830))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,10 @@
 - `[Searchfield]` Fixed UI alignment of close icon button (searchfield) in Datagrid. ([#5954](https://github.com/infor-design/enterprise/issues/5954))
 - `[Tabs Module]` Fixed UI alignment of close icon button on mobile view([#5951](https://github.com/infor-design/enterprise/issues/5951))
 
+## v4.59.3 Fixes
+
+- `[Modal]` Fixed a bug on hidden elements not focusable when it is turned visible. ([#6086](https://github.com/infor-design/enterprise/issues/6086))
+
 ## v4.59.2 Fixes
 
 - `[Calendar]` Fixed an issue where you could not have more than one in the same page. ([#6042](https://github.com/infor-design/enterprise/issues/6042))

--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -116,7 +116,7 @@
               padding-right: 6px;
               position: absolute;
               right: 1px;
-              top: 0;
+              top: 1px;
               transform: translateY(50%);
             }
           }

--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -112,12 +112,12 @@
           .icon {
             &.close {
               height: 15px;
-              margin-top: -7.5px;
               padding-left: 6px;
               padding-right: 6px;
               position: absolute;
-              right: 0;
-              top: 50%;
+              right: 1px;
+              top: 0;
+              transform: translateY(50%);
             }
           }
         }

--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -112,11 +112,12 @@
           .icon {
             &.close {
               height: 15px;
+              margin-top: -7.5px;
               padding-left: 6px;
               padding-right: 6px;
               position: absolute;
-              right: 17px;
-              top: 2px;
+              right: 0;
+              top: 50%;
             }
           }
         }

--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -762,6 +762,23 @@ html[dir='rtl'] {
     }
   }
 
+  .popupmenu-wrapper {
+    &.bottom {
+      .popupmenu {
+        &.has-submenu {
+          .dismissible {
+            .icon {
+              &.close {
+                left: 1px;
+                right: auto;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   .popup-footer {
     button {
       margin-left: inherit;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
This is an issue with the popupmenu associated with tabs overflow.
Close icon should be properly aligned in the popupmenu.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
#6083 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull, build, run
- Visit http://localhost:4000/components/tabs/example-enable-disable.html?theme=classic&mode=light&colors=2578a9
- Emulate a responsive environment
- Pull down dropdown (popupmenu) with tab overflow and notice "Dismissible" close icon is vertically centered and right aligned.

**Included in this Pull Request**:
- [ ] ~An e2e or functional test for the bug or feature.~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
