### PR TITLE
6015 - Fix for add hyperlink modal via CTRL-H 

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## v4.61.0 Fixes
 
+- `[Editor]` Fix a bug in editor where CTRL-H (add hyperlink) breaks the interface. ([#6015](https://github.com/infor-design/enterprise/issues/6015))
 - `[Timepicker]` Fix a bug in timepicker where hours reset to 1 when changing period. ([#6049](https://github.com/infor-design/enterprise/issues/6049))
 - `[Timepicker]` Fix a bug in timepicker where hours is not properly created when changing from AM/PM. ([#6104](https://github.com/infor-design/enterprise/issues/6104))
 

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -621,9 +621,12 @@ Editor.prototype = {
     this.textarea.text(xssUtils.sanitizeHTML(this.element.html().toString()));
 
     self.container.on('input.editor keyup.editor', '.editor', debounce((e) => {
-      this.textarea.text(xssUtils.sanitizeHTML(this.element.html().toString()));
-      this.resetEmptyEditor(e);
-      this.element.trigger('change');
+      /// The last savedSelection was always replaced on this section so we need to disabled this event when CTRL+H was used.
+      if (e.keyCode !== 72 && !e.ctrlKey) {
+        this.textarea.text(xssUtils.sanitizeHTML(this.element.html().toString()));
+        this.resetEmptyEditor(e);
+        this.element.trigger('change');
+      }
     }, 400));
 
     $('html').on(`themechanged.${COMPONENT_NAME}`, () => {

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -622,7 +622,7 @@ Editor.prototype = {
 
     self.container.on('input.editor keyup.editor', '.editor', debounce((e) => {
       /// The last savedSelection was always replaced on this section so we need to disabled this event when CTRL+H was used.
-      if (e.keyCode !== 72 && !e.ctrlKey) {
+      if (e.keyCode !== 72 && !e.ctrlKey && $('.modal.is-visible').length < 1) {
         this.textarea.text(xssUtils.sanitizeHTML(this.element.html().toString()));
         this.resetEmptyEditor(e);
         this.element.trigger('change');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug in editor where CTRL-H (add hyperlink) breaks the interface.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6015

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/editor/example-index.html
- Resize the browser window such that the add hyperlink option is not visible
- Press ctrl-H to open the add hyperlink modal
- Attempt to add the hyperlink (press 'insert' button)

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

