### PR TITLE
6131 - Fix wrong disabled

### DIFF
--- a/app/views/components/modal/test-focusable-elements.html
+++ b/app/views/components/modal/test-focusable-elements.html
@@ -6,7 +6,7 @@
 		<!-- Modal Example -->
 		<div id="modal-add-context" class="hidden">
 			<div class="field">
-				<label for="testtab"  class="label is-disabled">Test Tab Index -1</label>
+				<label for="testtab" class="label">Test Tab Index -1</label>
 				<input type="text" id="testtab" name="testtab" tabindex="-1"/>
 			</div>
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Following up fix. QA identified the first field isnt disabled but the label was made disabled.

**Related github/jira issue (required)**:
Fixes #6131

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/modal/test-focusable-elements.html
- the first field has no tabindex - it is not disabled so it shouldnt have a disabled label
