### PR TITLE
6149 - Make tag buttons have a type

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,6 @@
 - `[Swipe-action]` Added a Puppeteer Script for Swipe Container. ([#6129](https://github.com/infor-design/enterprise/issues/6129))
 - `[Tag]` The dismiss button was missing a button type causing the form to submit. ([#6149](https://github.com/infor-design/enterprise/issues/6149))
 
-
 ## v4.61.0 Fixes
 
 - `[Datagrid]` Fix on value not shown in lookup cell in safari. ([#6003](https://github.com/infor-design/enterprise/issues/6003))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,8 @@
 - `[Locale]` Refined some Filipino translations. ([#5864](https://github.com/infor-design/enterprise/issues/5864))
 - `[Locale]` Refined some Japanese translations. ([#6115](https://github.com/infor-design/enterprise/issues/6115))
 - `[Swipe-action]` Added a Puppeteer Script for Swipe Container. ([#6129](https://github.com/infor-design/enterprise/issues/6129))
+- `[Tag]` The dismiss button was missing a button type causing the form to submit. ([#6149](https://github.com/infor-design/enterprise/issues/6149))
+
 
 ## v4.61.0 Fixes
 

--- a/src/components/tag/tag.js
+++ b/src/components/tag/tag.js
@@ -173,7 +173,7 @@ Tag.prototype = {
     let dismissibleBtn = '';
     if (this.settings.dismissible) {
       elemClasses.add('is-dismissible');
-      dismissibleBtn = `<button class="btn-dismissible" focusable="false" tabIndex="-1">
+      dismissibleBtn = `<button class="btn-dismissible" focusable="false" tabindex="-1" type="button">
         ${$.createIcon('close')}
         <span class="audible">${Locale.translate('Close')}</span>
       </button>`;

--- a/test/components/tag/tag.func-spec.js
+++ b/test/components/tag/tag.func-spec.js
@@ -39,6 +39,7 @@ describe('Tag API (as span)', () => {
     });
 
     expect(tagAPI.element.querySelector('.btn-dismissible')).toBeDefined();
+    expect(tagAPI.element.querySelector('.btn-dismissible').getAttribute('type')).toEqual('button');
   });
 
   it('can be a hyperlink if defined with an anchor', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Adds `type="button"` to tag buttons.

**Related github/jira issue (required)**:
Fixes #6149

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/tag/example-index.html
- inspect the dismissible tag -> make sure the button has `type="button"`

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
