### PR TITLE
6069 - Dropdown: Typing Capital Letters in an Open NoSearch Dropdown …

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `[Datagrid]` Fix a bug in datagrid where text is align right when using mask options in filter. ([#5999](https://github.com/infor-design/enterprise/issues/5999))
 - `[Datagrid]` Fix a bug in datagrid where datepicker range having an exception when having values before changing to range type. ([#6008](https://github.com/infor-design/enterprise/issues/6008))
 - `[Datepicker]` Fix on the flickering behavior when range datepicker is shown. ([#6098](https://github.com/infor-design/enterprise/issues/6098))
+- `[Dropdown]` Fix an issue specific to Windows 10 and Chrome where entering a capital letter (Shift + T, e.g.) after opening the dropdown does not focus the entry associated with the letter pressed. ([#6069](https://github.com/infor-design/enterprise/issues/6069))
 - `[Dropdown]` Fix on dropdown multiselect where change event is not triggered when clicking X. ([#6098](https://github.com/infor-design/enterprise/issues/6098))
 - `[Editor]` Fix a bug in editor where CTRL-H (add hyperlink) breaks the interface. ([#6015](https://github.com/infor-design/enterprise/issues/6015))
 - `[Spinbox]` Spinbox should update to correct value when Enter is pressed. ([#6036](https://github.com/infor-design/enterprise/issues/6036))

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1626,7 +1626,7 @@ Dropdown.prototype = {
         }
         self.toggle();
       }
-    } else if (this.settings.noSearch === true) {
+    } else if (this.settings.noSearch === true && !self.isControl(key)) {
       // In `noSearch` mode, this enables typeahead while the list is opened
       this.handleAutoComplete(e);
     }

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -1467,6 +1467,20 @@ Dropdown.prototype = {
           selectedIndex = index;
         }
       });
+
+      // Mac OSX: "backspace" delete key
+      // Everything else: DEL key (numpad, control keys)
+      const isOSX = env.os.name === 'mac';
+      if (((!isOSX && e.key === 'Delete') || (isOSX && e.key === 'Backspace') || e.key === 'Backspace') && this.settings.noSearch) {
+        const first = $(options[0]);
+        this.highlightOption(first);
+
+        // Stop the backspace key from navigating back a page
+        if (e.key === 'Backspace') {
+          e.stopPropagation();
+          e.preventDefault();
+        }
+      }
     }
 
     switch (key) {  //eslint-disable-line


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

In Windows10, using Chrome, some users are reporting that upon initial open of the dropdown and then immediately pressing 'Shift + T', the T input is not focused/selected.

**Related github/jira issue (required)**:
Fixes #6069 

**Steps necessary to review your pull request (required)**:
Visit on Windows10 and Chrome http://localhost:4000/components/dropdown/example-no-search-lsf.html
Click the noSearch dropdown to open (the first/top one)
Press Shift + T
The T entry should be focused.

**Included in this Pull Request**:
- [x] A note to the change log.

