### PR TITLE
NG1225 - Searchfield in header should not be full width if collapsible

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[Datepicker]` Fix on the flickering behavior when range datepicker is shown. ([#6098](https://github.com/infor-design/enterprise/issues/6098))
 - `[Dropdown]` Fix on dropdown multiselect where change event is not triggered when clicking X. ([#6098](https://github.com/infor-design/enterprise/issues/6098))
 - `[Editor]` Fix a bug in editor where CTRL-H (add hyperlink) breaks the interface. ([#6015](https://github.com/infor-design/enterprise/issues/6015))
+- `[Searchfield]` Fix a bug in NG where searchfield is in full width even when it's collapsible. ([NG#1225](https://github.com/infor-design/enterprise-ng/issues/1225))
 - `[Spinbox]` Spinbox should update to correct value when Enter is pressed. ([#6036](https://github.com/infor-design/enterprise/issues/6036))
 - `[Timepicker]` Fix a bug in timepicker where hours reset to 1 when changing period. ([#6049](https://github.com/infor-design/enterprise/issues/6049))
 - `[Timepicker]` Fix a bug in timepicker where hours is not properly created when changing from AM/PM. ([#6104](https://github.com/infor-design/enterprise/issues/6104))

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -254,7 +254,7 @@ $subheader-height: 60px;
   }
 
   .toolbar-section.search {
-    .searchfield-wrapper.toolbar-searchfield-wrapper {
+    .searchfield-wrapper.toolbar-searchfield-wrapper:not(.has-collapse-button) {
       width: 100%;
     }
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Searchfield should not be at full width if it's collapsible.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Addresses one of the issues mentioned here: https://github.com/infor-design/enterprise-ng/issues/1225

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch and build
- In NG, pull this branch: https://github.com/infor-design/enterprise-ng/tree/1225-flextoolbar
- Use this IDS version and build NG
- Go to: http://localhost:4200/ids-enterprise-ng-demo/searchfield-header
- Searchfield should be collapsed 

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
