### PR TITLE
5442 - Fix image callback

### DIFF
--- a/app/views/components/datagrid/test-images-error.html
+++ b/app/views/components/datagrid/test-images-error.html
@@ -1,5 +1,17 @@
 <div class="row">
   <div class="twelve columns">
+    <div role="toolbar" class="toolbar">
+
+      <div class="title">
+        Example illustrates selected row issue with Save and New.
+       </div>
+
+      <div class="buttonset">
+        <button type="button" id="add-row-button" class="btn">
+          <span>Add Row</span>
+        </button>
+      </div>
+    </div>
     <div id="readonly-datagrid">
     </div>
   </div>
@@ -30,9 +42,13 @@
       columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity'});
 
       //Init and get the api for the grid
-      $('#readonly-datagrid').datagrid({
+      var gridApi = $('#readonly-datagrid').datagrid({
         columns: columns,
         dataset: data
+      }).data('datagrid');
+
+      $('#add-row-button').on('click', function () {
+        gridApi.addRow({ productName: '', productId: '0', image: imgExample }, 0);
       });
     });
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `[ApplicationMenu]` Converted protractor test suites to puppeteer. ([#5835](https://github.com/infor-design/enterprise/issues/5835))
 - `[ContextualActionPanel]` Added setting for cssClass option. ([#1215](https://github.com/infor-design/enterprise-ng/issues/1215))
 - `[Datagrid]` Added visual test for responsive view with puppeteer. ([#5844](https://github.com/infor-design/enterprise/issues/5844))
+- `[Datagrid]` Changed where image events are added. ([#5442](https://github.com/infor-design/enterprise/issues/5442))
 - `[Datepicker]` Added setting in datepicker where you can disable masking input. ([#6080](https://github.com/infor-design/enterprise/issues/6080))
 - `[Card]` Fix a memory leak on events. ([#6155](https://github.com/infor-design/enterprise/issues/6155))
 - `[General]` Added jest image snapshot for visual regression testing with puppeteer. ([#6105](https://github.com/infor-design/enterprise/issues/6105))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1452,12 +1452,12 @@ Datagrid.prototype = {
         const columnId = input.parents('th').attr('data-column-id');
         const defaultDateFormat = 'MM/dd/yyyy';
         const dateFormat = this.columnById(columnId)[0].dateFormat;
-        const dateVal = dateFormat === defaultDateFormat ? 
-          Locale.formatDate(new Date(input.val()), { pattern: dateFormat }) : 
+        const dateVal = dateFormat === defaultDateFormat ?
+          Locale.formatDate(new Date(input.val()), { pattern: dateFormat }) :
           Locale.formatDate(input.val(), { pattern: dateFormat });
 
         input.val(`${dateVal} - ${dateVal}`);
-        options.range = { 
+        options.range = {
           useRange: true,
           start: dateVal,
           end: dateVal
@@ -4054,6 +4054,14 @@ Datagrid.prototype = {
       const currentCol = this.bodyColGroup.find('col').eq(self.getStretchColumnIdx())[0];
       currentCol.style.width = `${this.stretchColumnWidth}px`;
     }
+
+    this.element.find('.datagrid-img').off('error.datagrid').on('error.datagrid', (e) => {
+      const targetEl = $(e.target);
+      const parentEl = targetEl.parent();
+
+      parentEl.append(`<svg class="icon" focusable="false" aria-hidden="true" role="presentation"><use href="#icon-${this.settings.fallbackImage}"></use></svg>`);
+      targetEl.remove();
+    });
 
     /**
     * Fires after the entire grid is rendered.
@@ -7188,14 +7196,6 @@ Datagrid.prototype = {
       if (self.editor && self.editor.input) {
         self.commitCellEdit();
       }
-    });
-
-    this.element.find('.datagrid-img').off('error.datagrid').on('error.datagrid', (e) => {
-      const targetEl = $(e.target);
-      const parentEl = targetEl.parent();
-
-      parentEl.append(`<svg class="icon" focusable="false" aria-hidden="true" role="presentation"><use href="#icon-${this.settings.fallbackImage}"></use></svg>`);
-      targetEl.remove();
     });
   },
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
In some cases the event for image errors did not fire at the right time (like addRow). Moved the event handler

**Related github/jira issue (required)**:
Fixes #5442 again 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-images-error.html
- press add row
- all image placeholders should still be working

**Included in this Pull Request**:
- [x] A note to the change log.
