### PR TITLE
6032 - dirty indicator editor fix

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 # What's New with Enterprise
 
 ## v4.62.0 Features
+
 - `[Editor]` Fix a bug where dirty tracker is not reset when using lots of new line in Edge. ([#6032](https://github.com/infor-design/enterprise/issues/6032))
 
 ## v4.61.0 Features

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # What's New with Enterprise
 
+## v4.62.0 Features
+- `[Editor]` Fix a bug where dirty tracker is not reset when using lots of new line in Edge. ([#6032](https://github.com/infor-design/enterprise/issues/6032))
+
 ## v4.61.0 Features
 
 - `[ApplicationMenu]` Converted protractor test suites to puppeteer. ([#5835](https://github.com/infor-design/enterprise/issues/5835))

--- a/src/components/trackdirty/trackdirty.js
+++ b/src/components/trackdirty/trackdirty.js
@@ -252,6 +252,11 @@ Trackdirty.prototype = {
           current = this.trimEditorText(current);
         }
 
+        // Edge Issue in #6032
+        if (current.indexOf('&nbsp;') > -1) {
+          current = current.replaceAll('&nbsp;', ' ');
+        }
+
         if (current === original || (input.attr('multiple') && utils.equals(current, original))) {
           input.removeClass('dirty');
           $('.icon-dirty, .msg-dirty', field).add(d.icon).add(d.msg).remove();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug where dirty tracker is not reset when using lots of new line in Edge.

**Related github/jira issue (required)**:
Closes #6032 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/editor/test-dirty-tracking-reset.html
- Edit the text on the RTE and use multiple page breaks (return) as much as possible. (see screenshots)
    - put the mouse cursor at the end of the first word of the first line and press enter
    - put the mouse cursor at the end of the first word of the second line and press enter
    - put the mouse cursor at the end of the first word of the third line and press enter
    - repeat on each line with at least 10 page breaks (enter key) 
- Click `Reset Dirty` button

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

