### PR TITLE
6193 - Calendar: use abbreviated letter as default

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ## v4.62.0 Fixes
 
+- `[Calendar]` Fix day of the week to show three letters as default in range calendar ([#6193](https://github.com/infor-design/enterprise/issues/6193))
 - `[Homepage]` Fixed instability of the visual tests. ([#6179](https://github.com/infor-design/enterprise/issues/6179))
 - `[Widget]` Fix on drag image including the overflow area. ([NG#1216](https://github.com/infor-design/enterprise-ng/issues/1216))
-- `[Calendar]` Fix day of the week to show three letters as default in range calendar
 
 ## v4.61.0 Features
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - `[Homepage]` Fixed instability of the visual tests. ([#6179](https://github.com/infor-design/enterprise/issues/6179))
 - `[Widget]` Fix on drag image including the overflow area. ([NG#1216](https://github.com/infor-design/enterprise-ng/issues/1216))
-- `[Calendar]` Fix day of the week to show 3 letters as default in range calendar
+- `[Calendar]` Fix day of the week to show three letters as default in range calendar
 
 ## v4.61.0 Features
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Homepage]` Fixed instability of the visual tests. ([#6179](https://github.com/infor-design/enterprise/issues/6179))
 - `[Widget]` Fix on drag image including the overflow area. ([NG#1216](https://github.com/infor-design/enterprise-ng/issues/1216))
+- `[Calendar]` Fix day of the week to show 3 letters as default in range calendar
 
 ## v4.61.0 Features
 

--- a/src/components/monthview/monthview.js
+++ b/src/components/monthview/monthview.js
@@ -523,7 +523,7 @@ MonthView.prototype = {
     now.setHours(0);
     now.setMinutes(0);
     now.setSeconds(0);
-    
+
     let elementDate;
     if (this.isIslamic) {
       elementDate = s.activeDate || Locale.gregorianToUmalqura(now);
@@ -849,8 +849,7 @@ MonthView.prototype = {
       );
     }
 
-    let days = this.currentCalendar.days.narrow;
-    days = days || this.currentCalendar.days.abbreviated;
+    const days = this.currentCalendar.days.abbreviated;
 
     // Set the Days of the week
     let firstDayofWeek = (this.currentCalendar.firstDayofWeek || 0);

--- a/src/components/monthview/monthview.js
+++ b/src/components/monthview/monthview.js
@@ -849,7 +849,12 @@ MonthView.prototype = {
       );
     }
 
-    const days = this.currentCalendar.days.abbreviated;
+    let days = this.currentCalendar.days.narrow;
+    days = days || this.currentCalendar.days.abbreviated;
+
+    if (!(s.isPopup || s.inPage)) {
+      days = this.currentCalendar.days.abbreviated;
+    }
 
     // Set the Days of the week
     let firstDayofWeek = (this.currentCalendar.firstDayofWeek || 0);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->

Current default is to use 1 letter to show day of the week, however, based on the IDS design pattern, looks like for calendar in page view, 3 letter should be the default. 

**Related github/jira issue (required)**:
Fixes https://github.com/infor-design/enterprise/issues/6193

**Steps necessary to review your pull request (required)**:
- compare http://localhost:4000/components/calendar/test-range-in-month.html  -> https://main-enterprise.demo.design.infor.com/calendar/test-range-in-month.html 

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
