### PR TITLE
6198 - Fix UI alignment issues in datagrid datepicker & timepicker when is-editing [regression bug]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## v4.62.0 Fixes
 
 - `[Calendar]` Fix day of the week to show three letters as default in range calendar ([#6193](https://github.com/infor-design/enterprise/issues/6193))
+- `[Datagrid]` Fixed a regression bug where the datepicker icon button and time value upon click were misaligned when is in editing mode. ([#6198](https://github.com/infor-design/enterprise/issues/6198))
 - `[Homepage]` Fixed instability of the visual tests. ([#6179](https://github.com/infor-design/enterprise/issues/6179))
 - `[Widget]` Fix on drag image including the overflow area. ([NG#1216](https://github.com/infor-design/enterprise-ng/issues/1216))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## v4.62.0 Fixes
 
 - `[Calendar]` Fix day of the week to show three letters as default in range calendar ([#6193](https://github.com/infor-design/enterprise/issues/6193))
-- `[Datagrid]` Fixed a regression bug where the datepicker icon button and time value upon click were misaligned when is in editing mode. ([#6198](https://github.com/infor-design/enterprise/issues/6198))
+- `[Datagrid]` Fixed a regression bug where the datepicker icon button and time value upon click were misaligned. ([#6198](https://github.com/infor-design/enterprise/issues/6198))
 - `[Homepage]` Fixed instability of the visual tests. ([#6179](https://github.com/infor-design/enterprise/issues/6179))
 - `[Widget]` Fix on drag image including the overflow area. ([NG#1216](https://github.com/infor-design/enterprise-ng/issues/1216))
 

--- a/src/components/datagrid/_datagrid-new.scss
+++ b/src/components/datagrid/_datagrid-new.scss
@@ -540,6 +540,12 @@
     top: -2px;
   }
 
+  .datagrid {
+    .datagrid-trigger-cell .icon.icon-clock {
+      top: -2px;
+    }
+  }
+
   // Main Grid for firefox
   .datagrid {
     td {

--- a/src/components/datagrid/_datagrid-new.scss
+++ b/src/components/datagrid/_datagrid-new.scss
@@ -152,8 +152,6 @@
 
     input.timepicker {
       margin-top: 2px;
-      padding-left: 14px;
-      padding-top: 6px;
 
       ~ .trigger {
         margin-left: -7px;
@@ -161,8 +159,8 @@
       }
 
       + .btn-icon.trigger {
-        margin-left: -7px !important;
-        margin-top: 13px !important;
+        margin-left: -2px;
+        margin-top: 9px;
       }
     }
   }
@@ -320,9 +318,9 @@
       }
 
       input.timepicker {
-        + .trigger {
+        + .btn-icon.trigger {
           margin-left: -3px !important;
-          margin-top: 7px !important;
+          margin-top: 3px !important;
         }
       }
     }
@@ -658,7 +656,6 @@
 }
 
 .datagrid.medium-rowheight td.is-editing input.timepicker {
-  padding: 15px !important;
   margin-top: 3px !important;
 
   ~ .icon {
@@ -684,7 +681,7 @@
 
         + .btn-icon.trigger {
           margin-left: 5px !important;
-          margin-top: 0 !important;
+          margin-top: 1px !important;
         }
       }
     }
@@ -701,12 +698,13 @@
 
     td.is-editing {
       .timepicker {
-        margin-left: 1px !important;
+        margin-left: 0 !important;
         padding: unset !important;
+        width: calc(100% - 25px);
 
         + .btn-icon.trigger {
           margin-left: 4px !important;
-          margin-top: -1px !important;
+          margin-top: 0;
         }
       }
     }

--- a/src/components/datagrid/_datagrid-new.scss
+++ b/src/components/datagrid/_datagrid-new.scss
@@ -459,10 +459,6 @@
   }
 }
 
-.datagrid-trigger-cell.is-editing .datagrid-cell-wrapper {
-  padding: 0 !important;
-}
-
 // Fix header alignment
 .datagrid-container {
   th.text-ellipsis .datagrid-header-text {
@@ -673,6 +669,14 @@
 
 .datagrid {
   &.extra-small-rowheight {
+    tbody tr {
+      td.is-editing {
+        .datepicker + .btn-icon.trigger {
+          margin-top: 3px;
+        }
+      }
+    }
+
     td.is-editing {
       .timepicker {
         margin: 0 !important;
@@ -687,6 +691,14 @@
   }
 
   &.small-rowheight {
+    tbody tr {
+      td.is-editing {
+        .datepicker {
+          height: 2rem;
+        }
+      }
+    }
+
     td.is-editing {
       .timepicker {
         margin-left: 1px !important;

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -2455,13 +2455,12 @@ $datagrid-small-row-height: 25px;
       }
 
       .datepicker {
-        margin-left: -7px !important;
         margin-top: unset !important;
         padding: unset !important;
 
         + .btn-icon.trigger {
           margin-top: 2px;
-          margin-left: 26px;
+          margin-left: 11px;
         }
       }
     }
@@ -3026,7 +3025,7 @@ $datagrid-small-row-height: 25px;
           margin-top: 13px;
 
           .icon {
-            top: -2px;
+            top: -1px;
           }
         }
 
@@ -4158,10 +4157,6 @@ td .btn-actions {
   &.is-editing {
     padding: 0;
 
-    .datagrid-cell-wrapper {
-      padding: 0;
-    }
-
     .dropdown-wrapper {
       height: inherit;
       margin-bottom: 0;
@@ -4400,6 +4395,20 @@ td .btn-actions {
     tbody tr.arrange-dragging td {
       font-size: $ids-size-font-base;
       height: $datagrid-row-height;
+    }
+  }
+
+  .datagrid {
+    &.small-rowheight {
+      tbody tr td.is-editing {
+        .datepicker {
+          height: 2rem;
+
+          + .btn-icon.trigger {
+            margin-top: 0;
+          }
+        }
+      }
     }
   }
 }

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -4303,6 +4303,18 @@ td .btn-actions {
     }
   }
 
+  .datagrid {
+    &.medium-rowheight {
+      .datagrid-trigger-cell .icon.icon-clock {
+        top: 0;
+      }
+    }
+
+    .datagrid-trigger-cell .icon.icon-clock {
+      top: 0;
+    }
+  }
+
   .datagrid-expand-btn {
     line-height: 27px !important;
   }
@@ -4333,8 +4345,6 @@ td .btn-actions {
       }
 
       .timepicker {
-        margin-top: 17px;
-
         ~ .icon {
           top: calc(50% - 16px);
         }
@@ -4360,8 +4370,6 @@ td .btn-actions {
         }
 
         .timepicker {
-          margin-top: 12px;
-
           ~ .icon {
             top: calc(50% - 16px);
           }
@@ -4379,8 +4387,6 @@ td .btn-actions {
         }
 
         .timepicker {
-          margin-top: 7px;
-
           ~ .icon {
             top: calc(50% - 15px);
           }

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1221,9 +1221,7 @@ $datagrid-small-row-height: 25px;
             }
 
             &.timepicker {
-              margin-top: 3px;
-              padding: 0 15px;
-              width: calc(100% - 26px);
+              width: calc(100% - 10px);
 
               ~ .icon {
                 left: auto;
@@ -1627,7 +1625,7 @@ $datagrid-small-row-height: 25px;
 
           .timepicker {
             margin-top: 0;
-            padding: 0 8px;
+            padding-left: 8px;
 
             + .icon {
               margin-left: 1px;
@@ -2425,7 +2423,7 @@ $datagrid-small-row-height: 25px;
         margin-top: 0;
 
         + .btn-icon.trigger {
-          margin-top: 9px;
+          margin-top: 6px;
           margin-left: 0;
         }
       }
@@ -2445,12 +2443,11 @@ $datagrid-small-row-height: 25px;
   &.small-rowheight {
     td.is-editing {
       .timepicker {
-        padding: 14px 15px !important;
         margin-left: -8px !important;
 
         + .btn-icon.trigger {
           margin-top: 3px;
-          margin-left: 8px;
+          margin-left: 4px;
         }
       }
 
@@ -2470,9 +2467,10 @@ $datagrid-small-row-height: 25px;
     td.is-editing {
       .timepicker {
         padding: unset !important;
+        width: calc(100% - 26px);
 
         + .btn-icon.trigger {
-          margin-top: 1px;
+          margin-top: 2px;
           margin-left: 8px;
         }
       }
@@ -2880,13 +2878,11 @@ $datagrid-small-row-height: 25px;
         }
 
         &.timepicker {
-          margin-top: 7px;
-          padding: 0 15px;
-          width: calc(100% - 26px);
+          width: calc(100% - 15px);
 
           + .btn-icon.trigger {
-            margin-left: -5px;
-            margin-top: 13px;
+            margin-left: 0;
+            margin-top: 10px;
           }
 
           + .trigger {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR addresses UI issues of the datepicker icon trigger and time value when it's in editing mode.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/6198

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app

1.) Datagrid with Datepicker
- Go to http://localhost:4000/components/datagrid/test-editable-datetime.html
- Click on any Date cells or datepicker icons
- No alignment issues should be found
- Test in Classic mode and in different browsers (Firefox, Edge, Safari)

2.) Datagrid with Timepicker
- Go to http://localhost:4000/components/datagrid/test-timepicker-24.html
- Click on any Date cells or timepicker icons
- No alignment issues should be found
- Test in Classic mode and in different browsers (Firefox, Edge, Safari)

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
