### PR TITLE
5722 - ApplicationMenu: Menu Button Arrow Misaligned in Safari

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## v4.62.0 Fixes
 
+- `[ApplicationMenu]` Remove a Safari-specific style rule the misaligns the button svg arrow. ([#5722](https://github.com/infor-design/enterprise/issues/5722))
 - `[Calendar]` Fix day of the week to show three letters as default in range calendar ([#6193](https://github.com/infor-design/enterprise/issues/6193))
 - `[Datagrid]` Fixed a regression bug where the datepicker icon button and time value upon click were misaligned. ([#6198](https://github.com/infor-design/enterprise/issues/6198))
 - `[Dropdown]` Fixed multiple accessibility issues with multiselect dropdown. ([#6075](https://github.com/infor-design/enterprise/issues/6075))

--- a/src/components/applicationmenu/_applicationmenu-new.scss
+++ b/src/components/applicationmenu/_applicationmenu-new.scss
@@ -817,15 +817,3 @@ html[dir='rtl'] {
     }
   }
 }
-
-.is-safari {
-  .application-menu {
-    .accordion-static-panel {
-      .btn-menu {
-        svg {
-          margin-top: -2px;
-        }
-      }
-    }
-  }
-}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Removes a Safari-specific CSS rule to move down the button svg arrow.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Resolves #5722 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull, build, run
- Visit http://localhost:4000/components/applicationmenu/example-menubutton.html in Safari
- Ensure the arrow is aligned properly

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
