### PR TITLE
3706 - Fix on pagesize selector being hidden

### DIFF
--- a/app/views/components/datagrid/test-count-in-select-all-current-page-setting.html
+++ b/app/views/components/datagrid/test-count-in-select-all-current-page-setting.html
@@ -30,10 +30,11 @@
         columns: columns,
         selectable: 'multiple',
         selectAllCurrentPage: true,
+        hidePagerOnOnePage: true,
         toolbar: {title: 'Data Grid Header Title', results: true, selectCount: true},
         paging: true,
         pagesize: 10,
-        pagesizes: [5, 10, 25, 50]
+        pagesizes: [5, 10, 25, 50, 100]
       }).on('selected', function (e, args) {
         console.log(args);
       });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[ApplicationMenu]` Remove a Safari-specific style rule the misaligns the button svg arrow. ([#5722](https://github.com/infor-design/enterprise/issues/5722))
 - `[Calendar]` Fix day of the week to show three letters as default in range calendar ([#6193](https://github.com/infor-design/enterprise/issues/6193))
 - `[Datagrid]` Fixed a regression bug where the datepicker icon button and time value upon click were misaligned. ([#6198](https://github.com/infor-design/enterprise/issues/6198))
+- `[Datagrid]` Show pagesize selector even in hidePagerOnOnePage mode ([#3706](https://github.com/infor-design/enterprise/issues/3706))
 - `[Dropdown]` Fixed multiple accessibility issues with multiselect dropdown. ([#6075](https://github.com/infor-design/enterprise/issues/6075))
 - `[Dropdown]` Fixed an overflow issue on Windows 10 Chrome. ([#4940](https://github.com/infor-design/enterprise/issues/4940))
 - `[Homepage]` Fixed instability of the visual tests. ([#6179](https://github.com/infor-design/enterprise/issues/6179))

--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -1251,10 +1251,25 @@ Pager.prototype = {
     }
 
     const classList = this.pagerBar[0] ? this.pagerBar[0].classList : null;
-    if (this.hidePagerBar(pagingInfo) && classList) {
+    const pagerClassList = ['.pager-first', '.pager-prev', '.pager-next', '.pager-last', '.pager-count'];
+
+    const toggleHide = (classNames = [], addHide = true) => {
+      classNames.forEach((className) => {
+        if (addHide) {
+          self.pagerBar.find(className).addClass('hidden');
+        } else {
+          self.pagerBar.find(className).removeClass('hidden');
+        }
+      });
+    };
+
+    if (this.settings.hideOnOnePage && pagingInfo.total <= pagingInfo.pagesize) {
+      toggleHide(pagerClassList);
+    } else if (this.hidePagerBar(pagingInfo) && classList) {
       classList.add('hidden');
     } else if (this.settings.hideOnOnePage && classList && classList.contains('hidden')) {
       classList.remove('hidden');
+      toggleHide(pagerClassList, false);
     }
 
     this.initTabIndexes();
@@ -1529,10 +1544,6 @@ Pager.prototype = {
    * @returns {void}
    */
   hidePagerBar(pagingInfo) {
-    if (this.settings.hideOnOnePage && pagingInfo.total <= pagingInfo.pagesize) {
-      return true;
-    }
-
     if (pagingInfo && (pagingInfo.firstPage === true && pagingInfo.lastPage === true) &&
       pagingInfo.hideDisabledPagers) {
       return true;

--- a/test/components/datagrid/datagrid.e2e-spec.js
+++ b/test/components/datagrid/datagrid.e2e-spec.js
@@ -4725,7 +4725,13 @@ describe('Datagrid hide pager on one page tests', () => {
     await filterOpt.click();
     await browser.driver.sleep(config.sleep);
 
-    expect(await pagerBar.getAttribute('class')).toContain('hidden');
+    const pagerClassList = ['.pager-first', '.pager-prev', '.pager-next', '.pager-last', '.pager-count'];
+
+    pagerClassList.forEach(async (pagerClass) => {
+      const pe = await pagerBar.all(by.css(pagerClass)).first();
+      expect(await pe.getAttribute('class')).toContain('hidden');
+    });
+
     expect(await element.all(by.css(selector.rows)).count()).toEqual(2);
     await filterOpt.click();
     await browser.driver.sleep(config.sleep);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Updated check on hiding pager. If the pagesize selected is greater than the records and hide pager on one mode is set to true, hide only the pager and not the pagesize selector.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #3706 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to http://localhost:4000/components/datagrid/test-count-in-select-all-current-page-setting.html
- Select pagesize to 100
- Pagesize selector should still be visible

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
