### PR TITLE
NG1232 - Fix on editor changing text in another editor

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[Datagrid]` Fixed a regression bug where the datepicker icon button and time value upon click were misaligned. ([#6198](https://github.com/infor-design/enterprise/issues/6198))
 - `[Dropdown]` Fixed multiple accessibility issues with multiselect dropdown. ([#6075](https://github.com/infor-design/enterprise/issues/6075))
 - `[Dropdown]` Fixed an overflow issue on Windows 10 Chrome. ([#4940](https://github.com/infor-design/enterprise/issues/4940))
+- `[Editor]` Fix on editor changing text in another editor. ([NG#1232](https://github.com/infor-design/enterprise-ng/issues/1232))
 - `[FileUploadAdvanced]` Fixed a missing link in french locale. ([#6226](https://github.com/infor-design/enterprise/issues/6226))
 - `[Homepage]` Fixed instability of the visual tests. ([#6179](https://github.com/infor-design/enterprise/issues/6179))
 - `[Modal]` Updated close method that will close even if there are subcomponents opened. ([#6048](https://github.com/infor-design/enterprise/issues/6048))

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -2291,7 +2291,6 @@ Editor.prototype = {
   // Run the CE action.
   execAction(action) {
     const currentElement = this.getCurrentElement();
-
     // Visual Mode
     if (currentElement === this.element) {
       if (action.indexOf('append-') > -1) {
@@ -2771,6 +2770,11 @@ Editor.prototype = {
     }
 
     if (!this.selection || !(this.selection instanceof Selection)) {
+      return;
+    }
+
+    // Check if selected text is in current editor
+    if (this.element.get(0) !== $(this.selection.anchorNode.parentNode).parent().get(0)) {
       return;
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Added a check before executing format change. If selected text is not in current editor, formatting is not executed.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Addresses this issue: https://github.com/infor-design/enterprise-ng/issues/1232

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/editor/test-several-on-page.html
- Select text in the first editor and change to Header 1
- Do not press inside the text area of the second editor, only select Header 2 from the dropdown
- The text from the first editor will change to Header 2

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
