### PR TITLE
6065 - CAP: Remove Markup Injection from Example

### DIFF
--- a/app/views/components/contextualactionpanel/example-markup.html
+++ b/app/views/components/contextualactionpanel/example-markup.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div id="cap-template" style="display:none">
+<div id="cap-template" style="display: none;">
   <div class="row">
     <div class="six columns">
       <div class="field">
@@ -52,12 +52,8 @@
 </div>
 
 <script id="test-script">
-  var count = 0;
-
   function openPanel() {
-    const panelHTML = $($('#cap-template')[0].innerHTML).attr('id', 'panel-' + count);
-    panelHTML.insertAfter('#trigger-1');
-    count++;
+    const panelHTML = $($('#cap-template')[0].innerHTML);
 
     $('body').contextualactionpanel({
       content: panelHTML,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[Arrange]` Fix an alignment issue in the demo app. ([#5281](https://github.com/infor-design/enterprise/issues/5281))
 - `[Calendar]` Fix day of the week to show three letters as default in range calendar. ([#6193](https://github.com/infor-design/enterprise/issues/6193))
 - `[ContextualActionPanel]` Fix an issue with the example page where the Contextual Action Panel is not initialized on open. ([#6065](https://github.com/infor-design/enterprise/issues/6065))
+- `[ContextualActionPanel]` Remove unnecessary markup injection behavior from example. ([#6065](https://github.com/infor-design/enterprise/issues/6065))
 - `[Datagrid]` Fixed a regression bug where the datepicker icon button and time value upon click were misaligned. ([#6198](https://github.com/infor-design/enterprise/issues/6198))
 - `[Datagrid]` Show pagesize selector even in hidePagerOnOnePage mode ([#3706](https://github.com/infor-design/enterprise/issues/3706))
 - `[Datagrid]` Corrected a filter type in a demo app page. ([#5497](https://github.com/infor-design/enterprise/issues/5497))


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Versions of the CAP markup are added to the DOM under the trigger button. These injections are not necessary to demonstrate that the example works (can take markup from the page and put it into the CAP). As this markup injection behavior is confusing, we are removing it.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Relates to #6065 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull, build, run
- Visit http://localhost:4000/components/contextualactionpanel/example-markup.html
- Notice no markup is added to the page after clicking open the CAP multiple times in any theme.

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
