### PR TITLE
NG1240 - Fix on too wide minimum width when close button is enabled

### DIFF
--- a/app/views/components/modal/example-close-btn.html
+++ b/app/views/components/modal/example-close-btn.html
@@ -28,6 +28,33 @@
 			</div>
 		</div>
 
+    <!-- Modal Full Example -->
+    <div id="modal-add-context-full" class="hidden">
+      <div class="form-responsive row">
+        <div class="full column">
+          <div class="field">
+            <label for="subject">Problem</label>
+            <input type="text" id="subject-full" name="subject" />
+          </div>
+          
+          <div class="field">
+            <label for="location" class="label">Location</label>
+            <select id="location-full" name="location" class="dropdown">
+              <option value="N">North</option>
+              <option value="S">South</option>
+              <option value="E">East</option>
+              <option value="W">West</option>
+            </select>
+          </div>
+    
+          <div class="field">
+            <label for="notes-max">Notes (maxlength)</label>
+            <textarea id="notes-max-full" class="textarea" maxlength="90" name="notes-max">Line One</textarea>
+          </div>
+        </div>
+      </div>
+		</div>
+
 	</div>
 </div>
 
@@ -42,11 +69,11 @@ var modals = {
       attributes: [ { name: 'id', value: 'add-context-modal' }, { name: 'data-automation-id', value: 'add-context-modal-auto' } ],
     },
     'add-context-full': {
-      'title': 'Add Context',
+      'title': 'Add Context Full',
       'id': 'my-id',
-      'content': $('#modal-add-context'),
+      'content': $('#modal-add-context-full'),
       'showCloseBtn': true,
-			'triggerButton': $('#add-context'),
+			'triggerButton': $('#add-context-full'),
       fullsize: 'responsive',
       attributes: [ { name: 'id', value: 'add-context-modal' }, { name: 'data-automation-id', value: 'add-context-modal-auto' } ],
     },

--- a/app/views/components/modal/example-close-btn.html
+++ b/app/views/components/modal/example-close-btn.html
@@ -3,6 +3,8 @@
 
 		<button class="btn-secondary" type="button" id="add-context">Show Modal</button><br/><br/>
 
+    <button class="btn-secondary" type="button" id="add-context-full">Show Modal (Full)</button><br/><br/>
+
 		<!-- Modal Example -->
 		<div id="modal-add-context" class="hidden">
 			<div class="field">
@@ -39,6 +41,15 @@ var modals = {
 			'triggerButton': $('#add-context'),
       attributes: [ { name: 'id', value: 'add-context-modal' }, { name: 'data-automation-id', value: 'add-context-modal-auto' } ],
     },
+    'add-context-full': {
+      'title': 'Add Context',
+      'id': 'my-id',
+      'content': $('#modal-add-context'),
+      'showCloseBtn': true,
+			'triggerButton': $('#add-context'),
+      fullsize: 'responsive',
+      attributes: [ { name: 'id', value: 'add-context-modal' }, { name: 'data-automation-id', value: 'add-context-modal-auto' } ],
+    },
   },
 
   setModal = function (opt) {
@@ -64,6 +75,10 @@ var modals = {
   };
 
   $('#add-context').on('click', function () {
+    setModal(modals[this.id]);
+  });
+
+  $('#add-context-full').on('click', function () {
     setModal(modals[this.id]);
   });
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v4.63.0 Fixes
 
 - `[Datepicker]` Fix a bug on setValue() when pass an empty string for clearing field. ([#6168](https://github.com/infor-design/enterprise/issues/6168))
+- `[Modal]` Fix on too wide minimum width when close button is enabled. ([NG#1240](https://github.com/infor-design/enterprise-ng/issues/1240))
 
 ## v4.63.0 Features
 

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1210,6 +1210,14 @@ Modal.prototype = {
       }
     }
 
+    if (this.settings.showCloseBtn && !this.isCAP) {
+      if ($(window).width() < 400 && this.element.hasClass('has-close-btn')) {
+        this.element.removeClass('has-close-btn');
+      } else if ($(window).width() >= 400 && !this.element.hasClass('has-close-btn')) {
+        this.element.addClass('has-close-btn');
+      }
+    }
+
     const toolbars = this.element.find('.toolbar');
     if (toolbars.length) {
       toolbars.triggerHandler('recalculate-buttons');

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -322,7 +322,11 @@ Modal.prototype = {
           <span class="audible">${Locale.translate('Close')}</span>
         </button>
       `);
-      this.element.addClass('has-close-btn');
+
+      if ($(window).width() >= 400) {
+        this.element.addClass('has-close-btn');
+      }
+
       this.element.find('.modal-content').append(closeBtn);
       closeBtn.on(`click.${this.namespace}`, () => this.close()).tooltip();
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Change minimum width only if screen size is greater than 400.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Addresses issue in: https://github.com/infor-design/enterprise-ng/issues/1240

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Use any device with screen width more narrow than 400 pixels. Or Inspect element and switch to mobile
- Go to: http://localhost:4000/components/modal/example-close-btn.html
- Click Show Modal (Full)
- Content should fit in screen

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
