### PR TITLE
6279 - file-upload failed status puppeteer script 

### DIFF
--- a/test/components/fileupload/fileupload-advanced.puppeteer-spec.js
+++ b/test/components/fileupload/fileupload-advanced.puppeteer-spec.js
@@ -50,4 +50,54 @@ describe('File Upload Advanced Puppeteer Tests', () => {
         .then(progress => expect(progress).toBeDefined());
     });
   });
+
+  describe('File example failed status', () => {
+    const testFile = 'testfile.pdf';
+    const url = `${baseUrl}/example-failed.html`;
+    const filePath = path.resolve(__dirname, testFile);
+
+    beforeEach(async () => {
+      await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle2'] });
+    });
+
+    it('should upload a file and show progress bar', async () => {
+      const [fileChooser] = await Promise.all([
+        page.waitForFileChooser(),
+        page.click('.hyperlink')
+      ]);
+
+      await fileChooser.accept([filePath]);
+
+      // Progress bar
+      await page.waitForSelector('.progress-row', { visible: true })
+        .then(element => element.$('.progress'))
+        .then(progress => expect(progress).toBeDefined());
+    });
+
+    it('should set failed status ', async () => {
+      // click on Select File
+      // file upload should pop up
+      const [fileChooser] = await Promise.all([
+        page.waitForFileChooser(),
+        page.click('.hyperlink')
+      ]);
+
+      await fileChooser.accept([filePath]);
+
+      await page.click('#set-failed');
+
+      // File failed error message
+      await page.waitForSelector('.msg', { visible: true })
+        .then(async (element) => {
+          const errorMessage = await element.$eval('.msg > p', e => e.textContent);
+          expect(errorMessage).toContain('File failed error message');
+        });
+      // Toast
+      await page.waitForSelector('.toast-message', { visible: true })
+        .then(async (element) => {
+          const errorMessage = await element.evaluate(e => e.textContent);
+          expect(errorMessage).toContain('File failed error message');
+        });
+    });
+  });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->

**Related github/jira issue (required)**:
closes #6279 
related to #5671 

**Steps necessary to review your pull request (required)**:

1. pull this branch
2. build and run the app
3. run npm run e2e:puppeteer file upload-advance
4. It should pass.

Steps
Given user is on [https://main-enterprise.demo.design.infor.com//components/fileupload-advanced/example-failed.html](https://main-enterprise.demo.design.infor.com/components/fileupload-advanced/example-failed.html)
When I Upload a file
Then it should be able to upload the file
When I click Set Failed button
Then it should stop the upload progress
And show error message in toast and in file container

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.
- [ ] a 10mb file is added to catch the upload progress

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
