### PR TITLE
6312 - Fix visible scroll bar in FF

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Listview]` Adjusted spaces between the search icon and filter wrapper. ([#6007](https://github.com/infor-design/enterprise/issues/6007))
 - `[Listview]` Change the font size of heading, subheading, and micro in Listview Component. ([#4996](https://github.com/infor-design/enterprise/issues/4996))
 - `[Modal]` Fix on too wide minimum width when close button is enabled. ([NG#1240](https://github.com/infor-design/enterprise-ng/issues/1240))
+- `[SwipeAction]` Fixed scrollbar being visible in firefox. ([#6312](https://github.com/infor-design/enterprise/issues/6312))
 - `[Validation]` Update example page to include validation event for email field. ([#6296](https://github.com/infor-design/enterprise/issues/6296))
 
 ## v4.63.0 Features

--- a/src/components/swipe-action/_swipe-action.scss
+++ b/src/components/swipe-action/_swipe-action.scss
@@ -55,6 +55,11 @@
   display: none;
 }
 
+// Hide scroll bar in Firefox
+.swipe-container {
+  scrollbar-width: none;
+}
+
 // Snaps into view
 .swipe-element {
   align-items: center;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The swipe action component was missing css to hide the scroll bar in FF. This fixes it

**Related github/jira issue (required)**:
Fixes #6312 

**Steps necessary to review your pull request (required)**:
- pull, build, run
- go to http://localhost:4000/components/swipe-action/example-index.html
- in Firefox and Chrome and compare
- Should be no visible scrollbar in firefox now

**Included in this Pull Request**:
- [x] A note to the change log.
