### PR TITLE
6256 - FieldOptions: compact misaligned in Safari

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[Datagrid]` Fix a bug where tooltip is not displayed even when settings is turned on in disabled rows. ([#6128](https://github.com/infor-design/enterprise/issues/6128))
 - `[Datepicker]` Fix a bug on setValue() when pass an empty string for clearing field. ([#6168](https://github.com/infor-design/enterprise/issues/6168))
 - `[Dropdown]` Fix on keydown events not working when dropdown is nested in label. ([NG#1262](https://github.com/infor-design/enterprise-ng/issues/1262))
+- `[Field-Options]` Fix alignment of field options in the Color Picker when in compact mode in Safari. ([#6256](https://github.com/infor-design/enterprise/issues/6256)) 
 - `[Listview]` Added flex toolbar for multiselect listview. ([NG#1249](https://github.com/infor-design/enterprise-ng/issues/1249))
 - `[Listview]` Adjusted spaces between the search icon and filter wrapper. ([#6007](https://github.com/infor-design/enterprise/issues/6007))
 - `[Listview]` Change the font size of heading, subheading, and micro in Listview Component. ([#4996](https://github.com/infor-design/enterprise/issues/4996))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@
 - `[Datagrid]` Fix a bug where tooltip is not displayed even when settings is turned on in disabled rows. ([#6128](https://github.com/infor-design/enterprise/issues/6128))
 - `[Datepicker]` Fix a bug on setValue() when pass an empty string for clearing field. ([#6168](https://github.com/infor-design/enterprise/issues/6168))
 - `[Dropdown]` Fix on keydown events not working when dropdown is nested in label. ([NG#1262](https://github.com/infor-design/enterprise-ng/issues/1262))
-- `[Field-Options]` Fix alignment of field options in the Color Picker when in compact mode in Safari. ([#6256](https://github.com/infor-design/enterprise/issues/6256)) 
+- `[Field-Options]` Fix alignment of field options in the Color Picker when in compact mode in Safari and alignment of search icon in Clearable Searchfield. ([#6256](https://github.com/infor-design/enterprise/issues/6256))
 - `[Listview]` Added flex toolbar for multiselect listview. ([NG#1249](https://github.com/infor-design/enterprise-ng/issues/1249))
 - `[Listview]` Adjusted spaces between the search icon and filter wrapper. ([#6007](https://github.com/infor-design/enterprise/issues/6007))
 - `[Listview]` Change the font size of heading, subheading, and micro in Listview Component. ([#4996](https://github.com/infor-design/enterprise/issues/4996))

--- a/src/components/field-options/_field-options-new.scss
+++ b/src/components/field-options/_field-options-new.scss
@@ -438,8 +438,7 @@
   .field-short.is-fieldoptions,
   .form-layout-compact .field.is-fieldoptions {
     .field-options ~ .close ~ .btn-actions,
-    input[type='text'][readonly]:not(.fileupload) ~ .btn-actions,
-    .colorpicker-container ~ .btn-actions {
+    input[type='text'][readonly]:not(.fileupload) ~ .btn-actions{
       top: 1px;
     }
   }

--- a/src/components/field-options/_field-options-new.scss
+++ b/src/components/field-options/_field-options-new.scss
@@ -249,7 +249,7 @@
 
     .searchfield-wrapper.has-focus:not(.toolbar-searchfield-wrapper) > .icon:not(.close):not(.icon-error),
     .searchfield-wrapper > .icon:not(.close):not(.icon-error) {
-      top: 9px;
+      top: 14px;
     }
 
     .textarea ~ .btn-actions:not(.is-checkbox) {

--- a/src/components/field-options/_field-options-new.scss
+++ b/src/components/field-options/_field-options-new.scss
@@ -438,7 +438,7 @@
   .field-short.is-fieldoptions,
   .form-layout-compact .field.is-fieldoptions {
     .field-options ~ .close ~ .btn-actions,
-    input[type='text'][readonly]:not(.fileupload) ~ .btn-actions{
+    input[type='text'][readonly]:not(.fileupload) ~ .btn-actions {
       top: 1px;
     }
   }

--- a/src/components/field-options/_field-options.scss
+++ b/src/components/field-options/_field-options.scss
@@ -428,7 +428,7 @@
 
     > .icon:not(.close):not(.icon-error) {
       left: 4px;
-      top: 7px;
+      top: 14px;
     }
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR will fix a bug on the Color Picker Field Options alignment when in compact mode in Safari 

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6256

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/field-options/example-index.html
- Click on compact mode
- Scroll down to color picker
- Click in field to show field options

**Included in this Pull Request**: 
- [ ] An e2e or functional test for the bug or feature. 
- [x] A note to the change log.