### PR TITLE
6207 Follow up - X Button Focus Fix

### DIFF
--- a/src/components/tabs-module/_tabs-module.scss
+++ b/src/components/tabs-module/_tabs-module.scss
@@ -842,8 +842,20 @@ html[dir='rtl'] {
 .tab-container > .toolbar > .buttonset {
   > .searchfield-wrapper.toolbar-searchfield-wrapper > .btn-icon.close {
     height: 24px; // matches min-height declaration of button.close in input.scss
-    top: 50%;
+    top: 50% !important;
     transform: translateY(-50%);
-    width: 18px;
+    width: 24px;
+  }
+}
+
+html[class*='theme-new-'] .tab-container > .toolbar > .buttonset {
+  > .searchfield-wrapper.toolbar-searchfield-wrapper > .btn-icon.close {
+    height: 28px;
+    margin-top: -1px;
+    width: 28px;
+
+    .icon.close {
+      margin-top: 1px;
+    }
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Focus state is off on close "X" button in searchfield.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Relates to #6207 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull, build, run
- Visit http://localhost:4000/components/tabs-module/example-toolbar-with-spillover.html?theme=new&mode=light
- Focus X button after typing in searchfield and notice color and position.

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
~- [ ] A note to the change log.~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
