### PR TITLE
6233 - Follow up fix for datagrid border td when editing in firefox

### DIFF
--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -4332,6 +4332,16 @@ td .btn-actions {
     padding: 1px 0 2px 5px !important;
   }
 
+  .extra-small-rowheight {
+    .datagrid-trigger-cell.text-ellipsis.has-editor span.trigger {
+      padding-top: 2px;
+    }
+  }
+
+  .datagrid.extra-small-rowheight tbody tr td.is-editing .lookup-wrapper {
+    padding-top: 1px;
+  }
+
   .small-rowheight,
   .extra-small-rowheight {
     .datagrid tbody tr.arrange-dragging td {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This is a follow-up fix for the previous PR https://github.com/infor-design/enterprise/pull/6310. QA found a minor issue on extra small row height in firefox.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/6233

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/example-list-lookup.html?theme=classic&mode=contrast&colors=133c59 open in firefox
- Change the row height to extra small
- Click on any `Product Id` cells
- There should be no cut off border on top of the cell when is-editing

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
