### PR TITLE
6346 - Fix flex toolbar position when selecting items in the listview [regression bug]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Badges]` Fixed a bug where in badges is not properly aligned in Contrast Mode. ([#6273](https://github.com/infor-design/enterprise/issues/6273))
 - `[Calendar]` Allowed product devs to add custom css class to event labels in Calendar Component. ([#6304](https://github.com/infor-design/enterprise/issues/6304))
+- `[Card]` Fixed a regression bug where the flex toolbar's position was not properly aligned when selecting listview items. ([#6346](https://github.com/infor-design/enterprise/issues/6346)]
 - `[ContextualActionPanel]` Added close CAP function to a demo example. ([#6274](https://github.com/infor-design/enterprise/issues/6274))
 - `[Datagrid]` Fixed a bug where tooltip is not displayed even when settings is turned on in disabled rows. ([#6128](https://github.com/infor-design/enterprise/issues/6128))
 - `[Datagrid]` Fixed misaligned lookup icon button upon click/editing. ([#6233](https://github.com/infor-design/enterprise/issues/6233))

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -1115,7 +1115,8 @@ ListView.prototype = {
         toolbar.trigger('recalculate-buttons').removeClass('is-hidden');
       });
       if (toolbar[0]) {
-        toolbar[0].style.display = 'block';
+        const isContextualToolbar = toolbar[0].classList.contains('contextual-toolbar');
+        toolbar[0].style.display = isContextualToolbar ? 'block' : '';
       }
       // toolbar.animateOpen({distance: 52});
       toolbar.animateOpen({ distance: 40 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the position of the flex toolbar when selecting items in the list view. It was an introduced bug from the PR https://github.com/infor-design/enterprise/pull/6309. Added additional conditions to isolate the fix in the contextual toolbar.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/6346

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/cards/example-group-action.html
- Select any on the list to show the counts
- The elements of the toolbar should not move anywhere
- Test also http://localhost:4000/components/listview/test-multiselect-flex.html
- Select any on the list 
- It should show the contextual toolbar

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
