### PR TITLE
1452 - Fix activated event fires on closing a tab

### DIFF
--- a/app/views/components/tabs/example-dismissible-tabs.html
+++ b/app/views/components/tabs/example-dismissible-tabs.html
@@ -48,3 +48,7 @@
 
   </div>
 </div>
+
+<script>
+  $('#tabs-dismissible').on('activated close', console.log);
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `[Searchfield]` Fix on searchfield clear button not working in Safari. ([6185](https://github.com/infor-design/enterprise-ng/issues/6185))
 - `[Slider]` Fixed background color of slider in a modal in new dark theme. ([6211](https://github.com/infor-design/enterprise-ng/issues/6211))
 - `[SwipeAction]` Fixed scrollbar being visible in firefox. ([#6312](https://github.com/infor-design/enterprise/issues/6312))
+- `[Tabs]` Fixed a bug where the tab activated events are fired on closing a tab. ([#1452](https://github.com/infor-design/enterprise/issues/1452))
 - `[TextArea]` Fixed medium size text area when in responsive view. ([#6334](https://github.com/infor-design/enterprise/issues/6334))
 - `[Validation]` Updated example page to include validation event for email field. ([#6296](https://github.com/infor-design/enterprise/issues/6296))
 

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -796,7 +796,7 @@ Tabs.prototype = {
         }
 
         // let right click pass through
-        if (e.which !== 3) {
+        if (e.which !== 3 && !$(e.target).hasClass('close')) {
           return self.handleTabClick(e, $(this));
         }
         return false;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the firing of the activated event on closing a tab.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/1452

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/tabs/example-dismissible-tabs.html
- Open the console in debugger tool
- Close any tab via clicking `x` icon
- Afer closing a tab, it should only fire the close event

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
