### PR TITLE
6297 - Tabs: Z-Index conflict between Modal overlay and draggable Module Tabs

### DIFF
--- a/app/views/components/tabs-module/example-sortable.html
+++ b/app/views/components/tabs-module/example-sortable.html
@@ -38,6 +38,9 @@
               <p>First Tab content</p>
               <p>This tab is 1st tab, and will be resized by the Module Tabs algorithm.</p>
             </div>
+            <div class="six columns">
+              <button class="btn-primary" type="button" id="primary-action-two">Open Modal Dialog</button><br/><br/><br/>
+            </div>
           </div>
         </div>
       </div>
@@ -102,3 +105,22 @@
     </div>
 
   </div>
+  
+  <script>
+
+    $("#primary-action-two").click(function() {
+      $('body').message({
+        title: "Z-Index Issue",
+        message: "IDS Modal dialog with overlay",
+        status: "error",
+        buttons: [{
+                text: Locale.translate('Close'),
+                click: function() {
+                  $(this).data('modal').close();
+                },
+                isDefault: true
+            }]		
+      });
+    });
+  </script>
+</body>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@
 - `[Slider]` Fixed background color of slider in a modal in new dark theme. ([6211](https://github.com/infor-design/enterprise-ng/issues/6211))
 - `[Swaplist]` Fixed a bug in swaplist where the filter is not behaving correctly on certain key search. ([#6222](https://github.com/infor-design/enterprise/issues/6222))
 - `[SwipeAction]` Fixed scrollbar being visible in firefox. ([#6312](https://github.com/infor-design/enterprise/issues/6312))
+- `[Tabs]` Fixed Z-index conflict between modal overlay and draggable module tabs. ([#6297](https://github.com/infor-design/enterprise/issues/6297))
 - `[TextArea]` Fixed medium size text area when in responsive view. ([#6334](https://github.com/infor-design/enterprise/issues/6334))
 - `[Validation]` Updated example page to include validation event for email field. ([#6296](https://github.com/infor-design/enterprise/issues/6296))
 

--- a/src/components/drag/_drag.scss
+++ b/src/components/drag/_drag.scss
@@ -17,6 +17,12 @@
   }
 }
 
+.modal-engaged {
+  .draggable {
+    z-index: 500;
+  }
+}
+
 // Resize Styling
 .resize-handle {
   @include no-select;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes the z-index conflict between Modal overlay and draggable module tabs. 

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6297

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/tabs-module/example-sortable.html
- Click the "Open Modal Dialog" button in the first tab

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.