### PR TITLE
5126 - Field Filter short: text is not displayed in dropdown

### DIFF
--- a/src/components/field-filter/_field-filter.scss
+++ b/src/components/field-filter/_field-filter.scss
@@ -23,6 +23,7 @@ $dd-width: 55px;
 
         span {
           position: static;
+          width: 0px;
         }
 
         > .listoption-icon {

--- a/src/components/field-filter/_field-filter.scss
+++ b/src/components/field-filter/_field-filter.scss
@@ -23,7 +23,7 @@ $dd-width: 55px;
 
         span {
           position: static;
-          width: 0px;
+          width: 1px;
         }
 
         > .listoption-icon {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR will fix a bug on field filter short that the text does not displayed in dropdown and the label/text appearing on the dropdown-wrapper when in classic mode in Firefox.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5126

**Steps necessary to review your pull request (required)**:
1st Issue 
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/field-filter/example-short.html
- Click on the dropdown and select an item

2nd Issue 
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/field-filter/example-short.html?theme=classic&mode=light&colors=2578a9
- Click on the dropdown and select an item

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.