### PR TITLE
6301 - Donut Chart: Legend selected highlight issue

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[Badges]` Fixed a bug where in badges is not properly aligned in Contrast Mode. ([#6273](https://github.com/infor-design/enterprise/issues/6273))
 - `[Calendar]` Allowed product devs to add custom css class to event labels in Calendar Component. ([#6304](https://github.com/infor-design/enterprise/issues/6304))
 - `[Card]` Fixed a regression bug where the flex toolbar's position was not properly aligned when selecting listview items. ([#6346](https://github.com/infor-design/enterprise/issues/6346)]
+- `[Charts]` Fixed the misalignment of the legend and legend color with the highlight of the selected legend. ([#6301](https://github.com/infor-design/enterprise/issues/6301))
 - `[ContextualActionPanel]` Moved notification to appropriate location and trigger redraw of styles. ([#6264](https://github.com/infor-design/enterprise/issues/6264))
 - `[ContextualActionPanel]` Added close CAP function to a demo example. ([#6274](https://github.com/infor-design/enterprise/issues/6274))
 - `[Datagrid]` Fixed misaligned lookup icon button upon click/editing. ([#6233](https://github.com/infor-design/enterprise/issues/6233))

--- a/src/components/charts/_charts.scss
+++ b/src/components/charts/_charts.scss
@@ -260,7 +260,7 @@
 
     &.is-two-column {
       align-items: center;
-      display: inline-flex;
+      display: inline-block;
       float: none;
       margin: 0;
       padding: 0 30px;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes the alignment of the legend and legend color with the highlight of the selected legend

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6301

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/donut/example-legend-bottom-single-widget.html
- Click a legend 

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.