### PR TITLE
6320 - Tabs Module: Search menu looks off in responsive view

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@
 - `[Slider]` Fixed background color of slider in a modal in new dark theme. ([6211](https://github.com/infor-design/enterprise-ng/issues/6211))
 - `[Swaplist]` Fixed a bug in swaplist where the filter is not behaving correctly on certain key search. ([#6222](https://github.com/infor-design/enterprise/issues/6222))
 - `[SwipeAction]` Fixed scrollbar being visible in firefox. ([#6312](https://github.com/infor-design/enterprise/issues/6312))
+- `[Tabs/Module]` Fixed a bug where a scroll bar appear in search field when in responsive view. ([#6320](https://github.com/infor-design/enterprise/issues/6320))
 - `[TextArea]` Fixed medium size text area when in responsive view. ([#6334](https://github.com/infor-design/enterprise/issues/6334))
 - `[Validation]` Updated example page to include validation event for email field. ([#6296](https://github.com/infor-design/enterprise/issues/6296))
 

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -20,7 +20,7 @@
 .searchfield-wrapper {
   display: inline-block;
   margin-bottom: 20px;
-  position: relative;
+  position: inherit;
 
   @include transition(width 300ms $cubic-ease,
   left 300ms $cubic-ease,

--- a/src/components/toolbar/_toolbar-new.scss
+++ b/src/components/toolbar/_toolbar-new.scss
@@ -26,7 +26,7 @@
   .toolbar {
     .buttonset {
       height: auto;
-      overflow: auto;
+      overflow: hidden;
     }
   }
 }

--- a/src/components/toolbar/_toolbar.scss
+++ b/src/components/toolbar/_toolbar.scss
@@ -359,7 +359,7 @@ $toolbar-buttonset-height: 40px;
   .toolbar {
     .btn,
     .btn-tertiary {
-      padding: 0 5px;
+      padding: 0 -5px;
     }
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug on where a scroll bar appear in search field when in responsive view..

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6320

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go http://localhost:4000/components/tabs-module/example-category-searchfield-go-button-home.html and http://localhost:4000/components/tabs-module/example-category-searchfield.html and http://localhost:4000/components/tabs-module/example-toolbar-with-spillover.html
- Minimize the screen
- Type in search
- Click the search button

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

