### PR TITLE
6244- Datagrid: Leading spaces are visible upon blur 

### DIFF
--- a/app/views/components/datagrid/example-editable.html
+++ b/app/views/components/datagrid/example-editable.html
@@ -110,7 +110,7 @@
       showNewRowIndicator: false,
       clickToSelect: false,
       selectable: 'multiple',
-      toolbar: {title: 'Data Grid Header Title', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: true,  collapsibleFilter: true},
+      toolbar: {title: 'Data Grid Header Title', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: true,  collapsibleFilter: true, trimSpaces: true},
       paging: true,
       pagesize: 5,
       pagesizes: [2, 5, 6]

--- a/app/views/components/datagrid/example-editable.html
+++ b/app/views/components/datagrid/example-editable.html
@@ -110,10 +110,11 @@
       showNewRowIndicator: false,
       clickToSelect: false,
       selectable: 'multiple',
-      toolbar: {title: 'Data Grid Header Title', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: true,  collapsibleFilter: true, trimSpaces: true},
+      toolbar: {title: 'Data Grid Header Title', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: true,  collapsibleFilter: true},
       paging: true,
       pagesize: 5,
-      pagesizes: [2, 5, 6]
+      pagesizes: [2, 5, 6],
+      trimSpaces: true,
     }).on('cellchange', function (e, args) {
       console.log('cellchange', args);
     }).on('rowadd', function (e, args) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[Datagrid]` Fixed misaligned lookup icon button upon click/editing. ([#6233](https://github.com/infor-design/enterprise/issues/6233))
 - `[Datagrid]` Fixed a bug where tooltip is not displayed even when settings is turned on in disabled rows. ([#6128](https://github.com/infor-design/enterprise/issues/6128))
 - `[Datagrid]` Fixed misaligned lookup icon button upon click/editing. ([#6233](https://github.com/infor-design/enterprise/issues/6233))
+- `[Datagrid]` Added trimSpaces option for leading spaces upon blur. ([#6244](https://github.com/infor-design/enterprise/issues/6244))
 - `[Datepicker]` Fixed a bug on setValue() when pass an empty string for clearing field. ([#6168](https://github.com/infor-design/enterprise/issues/6168))
 - `[Datepicker]` Fixed a bug on datepicker not clearing in angular version. ([NG#1256](https://github.com/infor-design/enterprise-ng/issues/1256))
 - `[Dropdown]` Fixed on keydown events not working when dropdown is nested in label. ([NG#1262](https://github.com/infor-design/enterprise-ng/issues/1262))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10871,7 +10871,12 @@ Datagrid.prototype = {
     // Adjust leading/trailing spaces as `&nbsp;`
     const adj = (thisVal, regx) => {
       const r = (typeof thisVal === 'string' ? thisVal.match(regx) : ['']) || [''];
-      return r[0].replace(/\s/g, '&nbsp;');
+
+      if (!this.settings.toolbar.trimSpaces) {
+        return r[0].replace(/\s/g, '&nbsp;');
+      } else {
+        return r; 
+      }
     };
 
     // update cell value

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10870,13 +10870,12 @@ Datagrid.prototype = {
 
     // Adjust leading/trailing spaces as `&nbsp;`
     const adj = (thisVal, regx) => {
-      const r = (typeof thisVal === 'string' ? thisVal.match(regx) : ['']) || [''];
+      let r = (typeof thisVal === 'string' ? thisVal.match(regx) : ['']) || [''];
 
       if (!this.settings.toolbar.trimSpaces) {
-        return r[0].replace(/\s/g, '&nbsp;');
-      } else {
-        return r; 
-      }
+        r = r[0].replace(/\s/g, '&nbsp;');
+      } 
+      return r; 
     };
 
     // update cell value

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10872,7 +10872,7 @@ Datagrid.prototype = {
     const adj = (thisVal, regx) => {
       let r = (typeof thisVal === 'string' ? thisVal.match(regx) : ['']) || [''];
 
-      if (!this.settings.toolbar.trimSpaces) {
+      if (!this.settings.trimSpaces) {
         r = r[0].replace(/\s/g, '&nbsp;');
       } 
       return r; 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds a trimSpaces option for leading spaces upon blur. 

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6244

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/example-editable.html
- Click on the "Assemble Paint" cell 
- Add leading Spaces 
- Click away from the cell
- Click on the "Assemble Paint" cell 

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.