### PR TITLE
6272 - Datepicker consecutive range date bugfix

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## v4.64.0 Fixes
 
+- `[Datepicker]` Fixed a bug where selecting a date that's consecutive to the previous range won't select that date. ([#6272](https://github.com/infor-design/enterprise/issues/6272))
 - `[WeekView]` Fixed a bug where 'today' date is not being rendered properly. ([#6260](https://github.com/infor-design/enterprise/issues/6260))
 
 ## v4.63.0

--- a/src/components/monthview/_monthview.scss
+++ b/src/components/monthview/_monthview.scss
@@ -401,7 +401,7 @@
           height: 36px;
           left: 100%;
           position: absolute;
-          width: 43px;
+          width: 25px;
           z-index: -1;
           margin-left: -1px;
         }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Shortened the width of the range block so that any consecutive dates clicked will be detected.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #6272 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datepicker/example-range.html
- Select a range that does not exceed a whole week
- Reopen datepicker
- Select a range a day after the previous range
- Date should be selected

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
