### PR TITLE
6123 - Fix incorrect date format the for the Latvian language

### DIFF
--- a/app/views/components/locale/test-format-date.html
+++ b/app/views/components/locale/test-format-date.html
@@ -20,6 +20,10 @@
       <label for="date-field4" class="label">pt-BR</label>
       <input id="date-field4" />
     </div>
+    <div class="field">
+      <label for="date-field5" class="label">pt-BR</label>
+      <input id="date-field5" />
+    </div>
   </div>
 </div>
 
@@ -63,6 +67,14 @@
       const val = Soho.Locale.formatDate(new Date(2019, 11, 5));
       $('#date-field4').val(val);
       $('#date-field4').prev('label').text(Soho.Locale.currentLocale.dataName + ' (' + Soho.Locale.currentLocale.data.calendars[0].dateFormat.short + ')');
+    });
+
+    var locale = 'lv-LV';
+    Soho.Locale.set(locale).done(function(a) {
+      console.log(Soho.Locale.currentLocale, Soho.Locale.currentLanguage);
+      const val = Soho.Locale.formatDate(new Date(2019, 11, 5));
+      $('#date-field5').val(val);
+      $('#date-field5').prev('label').text(Soho.Locale.currentLocale.dataName + ' (' + Soho.Locale.currentLocale.data.calendars[0].dateFormat.short + ')');
     });
   });
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[Icons]` Fixed the inconsistency between solid and outlined icons. ([#6165](https://github.com/infor-design/enterprise/issues/6165))
 - `[Icons]` Changed the error color to change in themes in some areas. ([#6273](https://github.com/infor-design/enterprise/issues/6273))
 - `[Listview]` Fixed a bug where the search icon is misaligned in Firefox and Safari. ([#6390](https://github.com/infor-design/enterprise/issues/6390))
+- `[Locale]` Fixed incorrect date format for Latvian language. ([#6123](https://github.com/infor-design/enterprise/issues/6123))
 - `[WeekView]` Fixed a bug where 'today' date is not being rendered properly. ([#6260](https://github.com/infor-design/enterprise/issues/6260))
 
 ## v4.63.0

--- a/src/components/locale/cultures/lv-LV.js
+++ b/src/components/locale/cultures/lv-LV.js
@@ -13,7 +13,7 @@ Soho.Locale.addCulture('lv-LV', {
     dateFormat: {
       separator: '.', // Infered
       timeSeparator: ':',
-      short: 'dd.MM.yyyy', // use four digit year
+      short: 'dd.MM.yyyy.', // use four digit year
       medium: 'MMM yyyy',
       long: 'd. MMMM yyyy',
       full: 'EEEE, y. gada d. MMMM',

--- a/test/components/locale/locale.puppeteer-spec.js
+++ b/test/components/locale/locale.puppeteer-spec.js
@@ -1,17 +1,34 @@
 const { getConfig } = require('../../helpers/e2e-utils.js');
 
-describe('Locale visual test for PH - Translation', () => {
-  const url = 'http://localhost:4000/components/locale/test-translations.html?locale=tl-PH';
+describe('Locale', () => {
+  const baseUrl = 'http://localhost:4000/components/locale';
 
-  beforeAll(async () => {
-    await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });
-    await page.setViewport({ width: 1920, height: 1080 });
+  describe('Locale visual test for PH - Translation', () => {
+    const url = `${baseUrl}/test-translations.html?locale=tl-PH`;
+
+    beforeAll(async () => {
+      await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });
+      await page.setViewport({ width: 1920, height: 1080 });
+    });
+
+    it('should run visual test for locale-ph', async () => {
+      await page.waitForSelector('#tabs-2');
+      const img = await page.screenshot();
+      const config = getConfig('locale-ph');
+      expect(img).toMatchImageSnapshot(config);
+    });
   });
 
-  it('should run visual test for locale-ph', async () => {
-    await page.waitForSelector('#tabs-2');
-    const img = await page.screenshot();
-    const config = getConfig('locale-ph');
-    expect(img).toMatchImageSnapshot(config);
+  describe('Locale date format in Latvian tests', () => {
+    const url = `${baseUrl}/test-format-date.html`;
+
+    beforeAll(async () => {
+      await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });
+    });
+
+    it('should show the correct date format for Latvian', async () => {
+      await page.evaluate(() => document.querySelector('#date-field5').value)
+        .then(value => expect(value).toEqual('05.12.2019.'));
+    });
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR corrects the date format for the Latvian language.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/6123

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/locale/test-format-date.html
- Check the last input `lv-LV (dd.MM.yyyy.)`
- The value should be `05.12.2019.`
- It should have a dot at the end of the date

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
