### PR TITLE
6272 - Shorten width of range block on end date

### DIFF
--- a/src/components/monthview/_monthview.scss
+++ b/src/components/monthview/_monthview.scss
@@ -407,6 +407,10 @@
         }
       }
 
+      &.end-date .day-text::before {
+        width: 0;
+      }
+
       &:hover {
         .day-text {
           background-color: $datepicker-selected-bg-color;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Shorten width of range block on end date to be able to click on the next date.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #6272 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datepicker/example-range.html
- Select a range that does not exceed a whole week
- Reopen datepicker
- Select a range a day after the previous range
- Date should be selected

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
