### PR TITLE
6218 - Fixed bug where lookup still appears when modal closes

### DIFF
--- a/app/views/components/modal/test-async.html
+++ b/app/views/components/modal/test-async.html
@@ -1,0 +1,81 @@
+<div class="row top-padding">
+	<div class="twelve columns">
+
+		<button class="btn-secondary" type="button" id="show-modal">Show Modal</button><br/><br/>
+
+		<div id="example-modal" class="hidden">
+      <div class="container">
+        <div class="form-responsive row no-indent">
+          <div class="full-width column">
+              <div class="field">
+                <input id="example-lookup" data-init="false" class="lookup" name="example-lookup" type="text"/>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+	</div>
+</div>
+
+<script>
+const modals = {
+    'show-modal': {
+      'id': 'my-id',
+      'content': $('#example-modal')
+    }
+  };
+  
+  let timer, data = [], columns = [];
+
+  columns.push({ id: 'productId', name: 'Product Id', field: 'productId'});
+  columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink});
+  columns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity'});
+  columns.push({ id: 'quantity', filterType: 'text', name: 'Quantity', field: 'quantity'});
+  columns.push({ id: 'price', name: 'Price', field: 'price', formatter: Formatters.Decimal});
+
+  // Some Sample Data
+  data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+  data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+  data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+  data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+  data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+  data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+  data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+
+  function onBeforeShow(api, response) {
+    if (timer) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(function() {
+      response();
+    }, 2000);
+  }
+
+  setModal = function (opt) {
+    opt = $.extend({
+      buttons: [{
+        text: 'Close',
+        click: function(e, modal) {
+          modal.close();
+        }
+      }]
+    }, opt);
+
+    $('body').modal(opt);
+  };
+
+  $('#example-lookup').lookup({
+    beforeShow: onBeforeShow,
+    options: {
+      columns: columns,
+      dataset: data,
+      selectable: 'single',
+      rowNavigation: true
+    }
+  });
+
+  $('#show-modal').on('click', function () {
+    setModal(modals[this.id]);
+  });
+
+</script>

--- a/app/views/components/modal/test-async.html
+++ b/app/views/components/modal/test-async.html
@@ -36,25 +36,25 @@
   data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
 
   const onBeforeShow = (api, response) => {
-    if (timer) {
-      clearTimeout(timer);
-    }
     timer = setTimeout(function() {
       response(); 
     }, 2000);
   };
 
-  
+  lookup = $('#example-lookup').lookup({
+      beforeShow: onBeforeShow,
+      options: {
+        columns: columns,
+        dataset: data,
+        selectable: 'single',
+        rowNavigation: true
+      }
+  }).data('lookup');
+
   $('#show-modal').on('click', function () {
-    lookup = $('#example-lookup').lookup({
-        beforeShow: onBeforeShow,
-        options: {
-          columns: columns,
-          dataset: data,
-          selectable: 'single',
-          rowNavigation: true
-        }
-    }).data('lookup');
+    if (timer) {
+        clearTimeout(timer);
+    }
 
     modal = $('body').modal({
       content: $('#example-modal'),
@@ -67,10 +67,9 @@
     }).data('modal');
 
     modal.element.on('close', () => {
-      if (timer) {
-        clearTimeout(timer);
+      if (lookup) {
+        delete lookup.isOpen;
       }
-    });
+    })
   });
-
 </script>

--- a/app/views/components/modal/test-async.html
+++ b/app/views/components/modal/test-async.html
@@ -18,14 +18,7 @@
 </div>
 
 <script>
-const modals = {
-    'show-modal': {
-      'id': 'my-id',
-      'content': $('#example-modal')
-    }
-  };
-  
-  let timer, data = [], columns = [];
+  let timer, lookup, modal, closeFlag = false, data = [], columns = [];
 
   columns.push({ id: 'productId', name: 'Product Id', field: 'productId'});
   columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink});
@@ -42,40 +35,42 @@ const modals = {
   data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
   data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
 
-  function onBeforeShow(api, response) {
+  const onBeforeShow = (api, response) => {
     if (timer) {
       clearTimeout(timer);
     }
     timer = setTimeout(function() {
-      response();
+      response(); 
     }, 2000);
-  }
+  };
 
-  setModal = function (opt) {
-    opt = $.extend({
+  
+  $('#show-modal').on('click', function () {
+    lookup = $('#example-lookup').lookup({
+        beforeShow: onBeforeShow,
+        options: {
+          columns: columns,
+          dataset: data,
+          selectable: 'single',
+          rowNavigation: true
+        }
+    }).data('lookup');
+
+    modal = $('body').modal({
+      content: $('#example-modal'),
       buttons: [{
         text: 'Close',
         click: function(e, modal) {
           modal.close();
         }
       }]
-    }, opt);
+    }).data('modal');
 
-    $('body').modal(opt);
-  };
-
-  $('#example-lookup').lookup({
-    beforeShow: onBeforeShow,
-    options: {
-      columns: columns,
-      dataset: data,
-      selectable: 'single',
-      rowNavigation: true
-    }
-  });
-
-  $('#show-modal').on('click', function () {
-    setModal(modals[this.id]);
+    modal.element.on('close', () => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    });
   });
 
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[Line Chart]` Fixed a bug where the alignment of focus is overlapping another component. ([#6384](https://github.com/infor-design/enterprise/issues/6384))
 - `[Listview]` Fixed a bug where the search icon is misaligned in Firefox and Safari. ([#6390](https://github.com/infor-design/enterprise/issues/6390))
 - `[Locale]` Fixed incorrect date format for Latvian language. ([#6123](https://github.com/infor-design/enterprise/issues/6123))
+- `[Lookup]` Fixed bug where lookup still appeared when modal closes. ([#6218](https://github.com/infor-design/enterprise/issues/6218))
 - `[WeekView]` Fixed a bug where 'today' date is not being rendered properly. ([#6260](https://github.com/infor-design/enterprise/issues/6260))
 
 ## v4.64.0 features

--- a/src/components/lookup/lookup.js
+++ b/src/components/lookup/lookup.js
@@ -373,11 +373,13 @@ Lookup.prototype = {
 
     if (this.settings.beforeShow) {
       const response = function (grid) {
+        const isVisible = self.element && self.element.is(':visible');
+
         if (grid) {
           self.createGrid(grid);
         }
 
-        if (typeof grid === 'boolean' && grid === false) {
+        if (!isVisible || (typeof grid === 'boolean' && grid === false)) {
           self.isOpen = false;
           return false;
         }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Added check to see if lookup input element is visible before opening lookup. If it's not visible, lookup should not show.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #6218 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/modal/test-async
- Click on Show Modal
- Click on lookup icon
- Lookup should show after around 2 seconds
- Close modal and click on Show Modal again
- Click on lookup icon and either press "Esc" or close the modal right after
- Modal should close, lookup should not show 

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
