### PR TITLE
6375 - Follow-up fix for close icon in datagrid column dialog

### DIFF
--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -5625,6 +5625,14 @@ html[dir='rtl'] {
     .listview.alternate-bg {
       background-color: $listview-bg-color;
     }
+
+    .listview-search {
+      .icon.close {
+        height: 18px;
+        top: 50%;
+        transform: translateY(-50%);
+      }
+    }
   }
 
   // Modal Lists
@@ -5639,6 +5647,7 @@ html[dir='rtl'] {
     width: -webkit-fill-available;
     width: stretch;
   }
+  
 }
 
 // Popup Adjustments

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -5647,7 +5647,6 @@ html[dir='rtl'] {
     width: -webkit-fill-available;
     width: stretch;
   }
-  
 }
 
 // Popup Adjustments


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Follow-up fix for the close icon in Datagrid column dialog. I also adjusted the height to `18px`.

**Related github/jira issue (required)**:

Closes #6375

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/example-index
- Click the `...` button and select `Personalize Columns`
- Type anything in the searchfield
- Close icon should show in a vertically aligned position
- Test in New and Classic

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
