### PR TITLE
6405 - Toolbar: Search icon misaligned in Firefox

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[Listview]` Fixed a bug where the search icon is misaligned in Firefox and Safari. ([#6390](https://github.com/infor-design/enterprise/issues/6390))
 - `[Locale]` Fixed incorrect date format for Latvian language. ([#6123](https://github.com/infor-design/enterprise/issues/6123))
 - `[Targeted-Achievement]` Fixed a bug where the icon is cut off in Firefox. ([#6400](https://github.com/infor-design/enterprise/issues/6400))
+- `[Toolbar]` Fixed a bug where the search icon is misaligned in Firefox. ([#6405](https://github.com/infor-design/enterprise/issues/6405))
 - `[WeekView]` Fixed a bug where 'today' date is not being rendered properly. ([#6260](https://github.com/infor-design/enterprise/issues/6260))
 
 ## v4.64.0 features

--- a/src/components/searchfield/_searchfield-new.scss
+++ b/src/components/searchfield/_searchfield-new.scss
@@ -77,10 +77,6 @@ html.is-firefox {
       height: 38px;
     }
 
-    > .icon {
-      top: 10px;
-    }
-
     .searchfield-category-button {
       height: inherit;
     }
@@ -100,10 +96,6 @@ html.is-firefox {
         padding-bottom: 5px;
         padding-top: 7px;
       }
-
-      .icon:not(.close) {
-        top: 8px;
-      }
     }
 
     .collapse-button {
@@ -111,8 +103,6 @@ html.is-firefox {
     }
 
     > .icon {
-      top: 10px;
-
       &.close {
         top: 18px;
 

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -703,12 +703,6 @@ $toolbarsearchfield-category-empty-width: 51px;
 // Help out firefox a bit
 html.is-firefox {
   .toolbar-searchfield-wrapper {
-    &:not(.is-open):not(.non-collapsible) {
-      .icon:not(.close) {
-        top: 8px;
-      }
-    }
-
     &.is-open,
     &.non-collapsible {
       .searchfield {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a bug where the search icon is misaligned in Firefox.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6405

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/toolbar/example-index.html
- Click to edit searchfield 

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.