### PR TITLE
fix: Set this.element  to undefined on jquery destroy

### DIFF
--- a/src/components/toolbar-flex/toolbar-flex.item.jquery.js
+++ b/src/components/toolbar-flex/toolbar-flex.item.jquery.js
@@ -20,6 +20,7 @@ $.fn.toolbarflexitem = function (settings) {
           oldDestroy.call(this);
         }
         $.removeData(this, COMPONENT_NAME);
+        this.element = undefined;
       };
     }
   });

--- a/src/components/toolbar-flex/toolbar-flex.jquery.js
+++ b/src/components/toolbar-flex/toolbar-flex.jquery.js
@@ -20,6 +20,7 @@ $.fn.toolbarflex = function (settings) {
           oldDestroy.call(this);
         }
         $.removeData(this.element, COMPONENT_NAME);
+        this.element = undefined;
       };
     }
   });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fix leak caused by this.element on toolbar-flex and toolbar-flex-item
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
