### PR TITLE
6400 -Targeted Achievement: Icon is cut off

### DIFF
--- a/src/components/completion-chart/_completion-chart.scss
+++ b/src/components/completion-chart/_completion-chart.scss
@@ -418,7 +418,7 @@
   }
 
   .label {
-    margin-top: 1px;
+    line-height: 1.6rem;
   }
 
   &.is-mac {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a bug where the icon is cut off in Firefox.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6400

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/targeted-achievement/example-index.html
- Switch to classic theme
- See icon

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.