### PR TITLE
6120 - Fix addMenuElementLinks incorrectly executed when having multi-level submenus

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[Listview]` Fixed a bug where the search icon is misaligned in Firefox and Safari. ([#6390](https://github.com/infor-design/enterprise/issues/6390))
 - `[Locale]` Fixed incorrect date format for Latvian language. ([#6123](https://github.com/infor-design/enterprise/issues/6123))
 - `[Targeted-Achievement]` Fixed a bug where the icon is cut off in Firefox. ([#6400](https://github.com/infor-design/enterprise/issues/6400))
+- `[Toolbar Flex]` Fixed a bug where the `addMenuElementLinks` function execute incorrectly when menu item has multi-level submenus. ([#6120](https://github.com/infor-design/enterprise/issues/6120))
 - `[WeekView]` Fixed a bug where 'today' date is not being rendered properly. ([#6260](https://github.com/infor-design/enterprise/issues/6260))
 
 ## v4.64.0 features

--- a/src/components/toolbar-flex/toolbar-flex.item.js
+++ b/src/components/toolbar-flex/toolbar-flex.item.js
@@ -815,7 +815,7 @@ ToolbarFlexItem.prototype = {
     }
 
     function addMenuElementLinks(menu, data) {
-      const elems = menu.querySelectorAll('li:not(.heading)');
+      const elems = menu.querySelectorAll(':scope > li:not(.heading)');
       data.forEach((item, i) => {
         item.elementLink = elems[i];
         if (item.submenu) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the `addMenuElementLinks` function incorrectly executed when the menu item has multi-level submenus.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/6120

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/toolbar-flex/example-more-actions-predefined
- Need to open the js file of `toolbar-flex-item.js` and add this `console.log('item '+ i + ' : ' + elems[i].innerText + ' linked');` in line 821 after `item.elementLink = elems[i];`
- Build the app again and go to the page
- You should be able to see `item 3 : Menu Button Item #4 linked` at the last part and not `item 3 : Menu Button Item One linked`
<img width="319" alt="Screen Shot 2022-05-18 at 7 51 40 PM" src="https://user-images.githubusercontent.com/8839327/169032516-7df98cf0-206b-4b40-a726-23a377225601.png">

- Then run this in the console `$('.flex-toolbar').data('toolbar-flex').toPopupmenuData()`
- You should be able to see the same result

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
