### PR TITLE
6289 - Datagrid: Datepicker icon visibility when toggling datagrid editable setting

### DIFF
--- a/app/views/components/datagrid/test-toggle-editable.html
+++ b/app/views/components/datagrid/test-toggle-editable.html
@@ -84,7 +84,7 @@
         grid = $('#datagrid').datagrid({
           columns: columns,
           dataset: data,
-          editable: true,
+          editable: false,
           clickToSelect: false,
           selectable: 'multiple',
           toolbar: {keywordFilter: true, results: true}

--- a/app/views/components/datagrid/test-toggle-editable.html
+++ b/app/views/components/datagrid/test-toggle-editable.html
@@ -84,7 +84,7 @@
         grid = $('#datagrid').datagrid({
           columns: columns,
           dataset: data,
-          editable: false,
+          editable: true,
           clickToSelect: false,
           selectable: 'multiple',
           toolbar: {keywordFilter: true, results: true}
@@ -96,7 +96,11 @@
 
   //Add Code for Add and icon-delete
   $('#edit-btn').on('click', function () {
-    gridApi.settings.editable = !gridApi.settings.editable;
+    const settings = {
+      editable: gridApi.settings.editable ? false : true
+    };
+
+    gridApi = gridApi.updated(settings);
   });
 
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1085,6 +1085,7 @@
 ### v4.35.3 Fixes
 
 - `[Datagrid]` Made a fix that when calling applyFilter the lookup checkbox did not update. ([#4693](https://github.com/infor-design/enterprise/issues/4693))
+- `[Datagrid]` Fixed a bug where the datepicker icon is not visible when the datagrid starts as non editable and toggled to editable and is visible when the datagrid starts as editable and toggled to non editable. ([#6289](https://github.com/infor-design/enterprise/issues/6289))
 - `[Dropdown]` Fixed a bug where the tooltips are invoked for each dropdown item. This was slow with a lot of items. ([#4672](https://github.com/infor-design/enterprise/issues/4672))
 - `[Dropdown]` Fixed a bug where mouseup was used rather than click to open the list and this was inconsistent. ([#4638](https://github.com/infor-design/enterprise/issues/4638))
 - `[Lookup]` Added a clear callback function like the click callback that fires when clicking the clear X if enabled. ([#4693](https://github.com/infor-design/enterprise/issues/4693))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[Datagrid]` Fixed row height of extra-small rows on editable datagrid with icon columns. ([#6284](https://github.com/infor-design/enterprise/issues/6284))
 - `[Datagrid]` Added trimSpaces option for leading spaces upon blur. ([#6244](https://github.com/infor-design/enterprise/issues/6244))
 - `[Datagrid]` Fixed header alignment when formatter is ellipsis. ([#6251](https://github.com/infor-design/enterprise/issues/6251))
+- `[Datagrid]` Fixed a bug where the datepicker icon is not visible when the datagrid starts as non editable and toggled to editable and is visible when the datagrid starts as editable and toggled to non editable. ([#6289](https://github.com/infor-design/enterprise/issues/6289))
 - `[Datepicker]` Fixed a bug where selecting a date that's consecutive to the previous range won't select that date. ([#6272](https://github.com/infor-design/enterprise/issues/6272))
 - `[Bar Stacked]` Fixed a bug where chart tooltip total shows 99.999 instead of 100 on 100% Stacked Bar Chart. ([#6236](https://github.com/infor-design/enterprise/issues/6326))
 - `[Flex Toolbar]` Fixed the data automation id to be more reliable for popupmenu and overflowed buttons. ([#6175](https://github.com/infor-design/enterprise/issues/6175))
@@ -1085,7 +1086,6 @@
 ### v4.35.3 Fixes
 
 - `[Datagrid]` Made a fix that when calling applyFilter the lookup checkbox did not update. ([#4693](https://github.com/infor-design/enterprise/issues/4693))
-- `[Datagrid]` Fixed a bug where the datepicker icon is not visible when the datagrid starts as non editable and toggled to editable and is visible when the datagrid starts as editable and toggled to non editable. ([#6289](https://github.com/infor-design/enterprise/issues/6289))
 - `[Dropdown]` Fixed a bug where the tooltips are invoked for each dropdown item. This was slow with a lot of items. ([#4672](https://github.com/infor-design/enterprise/issues/4672))
 - `[Dropdown]` Fixed a bug where mouseup was used rather than click to open the list and this was inconsistent. ([#4638](https://github.com/infor-design/enterprise/issues/4638))
 - `[Lookup]` Added a clear callback function like the click callback that fires when clicking the clear X if enabled. ([#4693](https://github.com/infor-design/enterprise/issues/4693))


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a bug where the datepicker icon is not visible when the datagrid starts as non editable and toggled to editable and is visible when the datagrid starts as editable and toggled to non editable.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6289

**Steps necessary to review your pull request (required)**:
Scenario 1 
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-toggle-editable.html
- Hover over the date cells 
- Click the edit button
- Hover over the date cells 

Scenario 2 
- Pull this branch, build, and run the app
- Set editable: true on initialization in test-toggle-editable.html
- Go to http://localhost:4000/components/datagrid/test-toggle-editable.html
- Hover over the date cells 
- Click the edit button
- Hover over the date cells 

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.