### PR TITLE
NG1272 - Fixed bug where popup goes behind modal when in application menu in resizable mode

### DIFF
--- a/app/views/components/applicationmenu/test-app-menu.html
+++ b/app/views/components/applicationmenu/test-app-menu.html
@@ -1,0 +1,254 @@
+{{> includes/head}}
+
+<body class="no-scroll">
+ <a href="#maincontent" class="skip-link" data-translate="text">SkipToMain</a>
+  {{> includes/svg-inline-refs}}
+
+  <div class="my-app-wrapper">
+    {{> ../../src/components/icons/svg}}
+
+    <nav id="application-menu" class="application-menu" data-options='{"resizable": true}'>
+
+      <div class="accordion panel inverse">
+        <div class="accordion-header">
+          <a href="#"><span>Header 1</span></a>
+        </div>
+
+        <div class="accordion-header">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-home"></use>
+          </svg>
+          <a href="#"><span>Header 2</span></a>
+        </div>
+
+        <!-- Level 1 -->
+        <div class="accordion-header">
+          <a href="#"><span>Header 3</span></a>
+        </div>
+        <div class="accordion-pane">
+
+          <!-- Level 2 -->
+          <div class="accordion-header">
+            <a href="#"><span>Level 2</span></a>
+          </div>
+          <div class="accordion-pane">
+
+            <!-- Level 3 -->
+            <div class="accordion-header">
+              <a href="#"><span>Level 3</span></a>
+            </div>
+            <div class="accordion-pane">
+
+              <!-- Level 4 -->
+              <div class="accordion-header">
+                <a href="#"><span>Level 4</span></a>
+              </div>
+              <div class="accordion-pane">
+
+                <!-- Level 5 -->
+                <div class="accordion-header">
+                  <a href="#"><span>Level 5</span></a>
+                </div>
+                <div class="accordion-pane">
+
+                  <!-- Level 6 -->
+                  <div class="accordion-header">
+                    <a href="#"><span>Level 6</span></a>
+                  </div>
+                  <div class="accordion-pane">
+                    <div class="accordion-content">
+                      <h3>You've reached the bottom</h3>
+                      <p>Nice work</p>
+                    </div>
+                  </div>
+
+                  <div class="accordion-header">
+                    <a href="#"><span>Level 6 Header Only</span></a>
+                  </div>
+
+                </div>
+
+                <!-- Level 5 -->
+                <div class="accordion-header">
+                  <a href="#"><span>Level 5 Content</span></a>
+                </div>
+                <div class="accordion-pane">
+                  <div class="accordion-content">
+                    <h3>Level 5 Content Pane</h3>
+                    <p>Nothing to see here</p>
+                  </div>
+                </div>
+
+                <div class="accordion-header">
+                  <a href="#"><span>Level 5 Header Only</span></a>
+                </div>
+
+              </div>
+
+              <!-- Level 4 -->
+              <div class="accordion-header">
+                <a href="#"><span>Level 4 Content</span></a>
+              </div>
+              <div class="accordion-pane">
+                <div class="accordion-content">
+                  <h3>Level 4 Content Pane</h3>
+                  <p>Nothing to see here</p>
+                </div>
+              </div>
+
+              <div class="accordion-header">
+                <a href="#"><span>Level 4 Header Only</span></a>
+              </div>
+
+            </div>
+
+            <!-- Level 3 -->
+            <div class="accordion-header">
+              <a href="#"><span>Level 3 Content</span></a>
+            </div>
+            <div class="accordion-pane">
+              <div class="accordion-content">
+                <h3>Level 3 Content Pane</h3>
+                <p>Nothing to see here</p>
+              </div>
+            </div>
+
+            <div class="accordion-header">
+              <a href="#"><span>Level 3 Header Only</span></a>
+            </div>
+
+          </div>
+
+          <!-- Level 2 -->
+          <div class="accordion-header">
+            <a href="#"><span>Level 2 Content</span></a>
+          </div>
+          <div class="accordion-pane">
+            <div class="accordion-content">
+              <h3>Level 2 Content Pane</h3>
+              <p>Nothing to see here</p>
+            </div>
+          </div>
+
+          <div class="accordion-header">
+            <a href="#"><span>Level 2 Header Only</span></a>
+          </div>
+
+        </div>
+
+
+      </div>
+
+      <div class="branding">
+        <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-logo"></use>
+        </svg>
+      </div>
+
+    </nav>
+
+    <div class="page-container no-scroll">
+        <div class="my-header-wrapper">
+          <header class="header is-personalizable" id="maincontent">
+
+            <div class="toolbar">
+              <div class="title">
+                {{> includes/header-appmenu-trigger}}
+                {{> includes/page-title}}
+              </div>
+
+              <div class="buttonset">
+              </div>
+
+              {{> includes/header-actionbutton}}
+            </div>
+
+          </header>
+
+        </div>
+        <div class="my-content-wrapper">
+          <div class="content-container-header" role="main">
+            <div class="row">
+              <div class="twelve columns">
+
+                <h2>Notes About How This Test Works</h2>
+                <p>
+                  This is to test if components with popups will show over the modal.
+                </p>
+                <button class="btn-secondary" type="button" id="show-modal">Show Modal</button><br/><br/>
+              </div>
+            </div>
+
+          </div>
+        </div>
+    </div>
+
+    <!-- Modal Example -->
+		<div id="modal-example" class="hidden">
+      <div class="field">
+        <label for="test-timepicker" class="label">Timepicker</label>
+        <input id="test-timepicker" class="timepicker" type="text" data-init="false"/>
+      </div>
+      <div class="field">
+        <label for="test-datepicker" class="label">Date Field</label>
+        <input id="test-datepicker" data-automation-id="custom-automation-id" class="datepicker" name="date-field" type="text" data-init="false"/>
+      </div>
+    </div>
+	</div>
+  </div>
+
+  {{> includes/footer}}
+
+</body>
+<script>
+  const modals = {
+      'show-modal': {
+        'title': 'Test Popup',
+        'id': 'my-id',
+        'content': $('#modal-example')
+      }
+    },
+  
+    setModal = function (opt) {
+      opt = $.extend({
+        buttons: [{
+          text: 'Cancel',
+        //  id: 'modal-button-1',
+          click: function(e, modal) {
+            modal.close();
+          }
+        }, {
+          text: 'Save',
+        //  id: 'modal-button-2',
+          click: function(e, modal) {
+            modal.close();
+          },
+          validate: false,
+          isDefault: true
+        }]
+      }, opt);
+  
+      $('body').modal(opt);
+    };
+
+    $('#show-modal').on('click', function () {
+      $(this).focus();
+      setModal(modals[this.id]);
+    });
+  
+    $('body').one('initialized', function () {
+      $('#test-timepicker').timepicker({
+        attributes: [
+          { name: 'id', value: 'test-timepicker' },
+          { name: 'data-automation-id', value: 'timepicker-automation-id-1' }
+        ]
+      });
+      
+      $('#test-datepicker').datepicker({
+        attributes: [
+          { name: 'id', value: 'custom-id' },
+          { name: 'data-automation-id', value: 'custom-automation-id' }
+      ]});
+  });
+</script>
+</html>

--- a/app/views/components/applicationmenu/test-app-menu.html
+++ b/app/views/components/applicationmenu/test-app-menu.html
@@ -15,128 +15,8 @@
         </div>
 
         <div class="accordion-header">
-          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-            <use href="#icon-home"></use>
-          </svg>
           <a href="#"><span>Header 2</span></a>
         </div>
-
-        <!-- Level 1 -->
-        <div class="accordion-header">
-          <a href="#"><span>Header 3</span></a>
-        </div>
-        <div class="accordion-pane">
-
-          <!-- Level 2 -->
-          <div class="accordion-header">
-            <a href="#"><span>Level 2</span></a>
-          </div>
-          <div class="accordion-pane">
-
-            <!-- Level 3 -->
-            <div class="accordion-header">
-              <a href="#"><span>Level 3</span></a>
-            </div>
-            <div class="accordion-pane">
-
-              <!-- Level 4 -->
-              <div class="accordion-header">
-                <a href="#"><span>Level 4</span></a>
-              </div>
-              <div class="accordion-pane">
-
-                <!-- Level 5 -->
-                <div class="accordion-header">
-                  <a href="#"><span>Level 5</span></a>
-                </div>
-                <div class="accordion-pane">
-
-                  <!-- Level 6 -->
-                  <div class="accordion-header">
-                    <a href="#"><span>Level 6</span></a>
-                  </div>
-                  <div class="accordion-pane">
-                    <div class="accordion-content">
-                      <h3>You've reached the bottom</h3>
-                      <p>Nice work</p>
-                    </div>
-                  </div>
-
-                  <div class="accordion-header">
-                    <a href="#"><span>Level 6 Header Only</span></a>
-                  </div>
-
-                </div>
-
-                <!-- Level 5 -->
-                <div class="accordion-header">
-                  <a href="#"><span>Level 5 Content</span></a>
-                </div>
-                <div class="accordion-pane">
-                  <div class="accordion-content">
-                    <h3>Level 5 Content Pane</h3>
-                    <p>Nothing to see here</p>
-                  </div>
-                </div>
-
-                <div class="accordion-header">
-                  <a href="#"><span>Level 5 Header Only</span></a>
-                </div>
-
-              </div>
-
-              <!-- Level 4 -->
-              <div class="accordion-header">
-                <a href="#"><span>Level 4 Content</span></a>
-              </div>
-              <div class="accordion-pane">
-                <div class="accordion-content">
-                  <h3>Level 4 Content Pane</h3>
-                  <p>Nothing to see here</p>
-                </div>
-              </div>
-
-              <div class="accordion-header">
-                <a href="#"><span>Level 4 Header Only</span></a>
-              </div>
-
-            </div>
-
-            <!-- Level 3 -->
-            <div class="accordion-header">
-              <a href="#"><span>Level 3 Content</span></a>
-            </div>
-            <div class="accordion-pane">
-              <div class="accordion-content">
-                <h3>Level 3 Content Pane</h3>
-                <p>Nothing to see here</p>
-              </div>
-            </div>
-
-            <div class="accordion-header">
-              <a href="#"><span>Level 3 Header Only</span></a>
-            </div>
-
-          </div>
-
-          <!-- Level 2 -->
-          <div class="accordion-header">
-            <a href="#"><span>Level 2 Content</span></a>
-          </div>
-          <div class="accordion-pane">
-            <div class="accordion-content">
-              <h3>Level 2 Content Pane</h3>
-              <p>Nothing to see here</p>
-            </div>
-          </div>
-
-          <div class="accordion-header">
-            <a href="#"><span>Level 2 Header Only</span></a>
-          </div>
-
-        </div>
-
-
       </div>
 
       <div class="branding">
@@ -170,15 +50,12 @@
           <div class="content-container-header" role="main">
             <div class="row">
               <div class="twelve columns">
-
-                <h2>Notes About How This Test Works</h2>
                 <p>
                   This is to test if components with popups will show over the modal.
                 </p>
                 <button class="btn-secondary" type="button" id="show-modal">Show Modal</button><br/><br/>
               </div>
             </div>
-
           </div>
         </div>
     </div>
@@ -195,60 +72,29 @@
       </div>
     </div>
 	</div>
-  </div>
 
   {{> includes/footer}}
 
 </body>
-<script>
-  const modals = {
-      'show-modal': {
-        'title': 'Test Popup',
-        'id': 'my-id',
-        'content': $('#modal-example')
-      }
-    },
-  
-    setModal = function (opt) {
-      opt = $.extend({
-        buttons: [{
-          text: 'Cancel',
-        //  id: 'modal-button-1',
-          click: function(e, modal) {
-            modal.close();
-          }
-        }, {
-          text: 'Save',
-        //  id: 'modal-button-2',
-          click: function(e, modal) {
-            modal.close();
-          },
-          validate: false,
-          isDefault: true
-        }]
-      }, opt);
-  
-      $('body').modal(opt);
-    };
 
-    $('#show-modal').on('click', function () {
-      $(this).focus();
-      setModal(modals[this.id]);
-    });
-  
-    $('body').one('initialized', function () {
-      $('#test-timepicker').timepicker({
-        attributes: [
-          { name: 'id', value: 'test-timepicker' },
-          { name: 'data-automation-id', value: 'timepicker-automation-id-1' }
-        ]
-      });
+<script>
+  $('body').one('initialized', function () {
+      $('#test-timepicker').timepicker();
       
-      $('#test-datepicker').datepicker({
-        attributes: [
-          { name: 'id', value: 'custom-id' },
-          { name: 'data-automation-id', value: 'custom-automation-id' }
-      ]});
+      $('#test-datepicker').datepicker();
+
+      $('#show-modal').on('click', function () {
+        $(this).focus();
+        $('body').modal({
+          title: 'Test Popup',
+          content: $('#modal-example'),
+          buttons: [{
+            text: 'Close',
+            click: function(e, modal) {
+              modal.close();
+            }
+          }]
+        });
+      });
   });
 </script>
-</html>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Locale]` Fixed incorrect date format for Latvian language. ([#6123](https://github.com/infor-design/enterprise/issues/6123))
 - `[Locale]` Fixed incorrect data in ms-my, nn-No and nb-NO. ([#6472](https://github.com/infor-design/enterprise/issues/6472))
 - `[Lookup]` Fixed bug where lookup still appeared when modal closes. ([#6218](https://github.com/infor-design/enterprise/issues/6218))
+- `[Modal]` Fixed bug where popup goes behind modal when in application menu in resizable mode. ([NG#1272](https://github.com/infor-design/enterprise-ng/issues/1272))
 - `[Personalization]` Fixed bug where the dark mode header color was not correct in the tokens and caused the personalization dropdown to be incorrect. ([#6446](https://github.com/infor-design/enterprise/issues/6446))
 - `[Targeted-Achievement]` Fixed a bug where the icon is cut off in Firefox. ([#6400](https://github.com/infor-design/enterprise/issues/6400))
 - `[Toolbar]` Fixed a bug where the search icon is misaligned in Firefox. ([#6405](https://github.com/infor-design/enterprise/issues/6405))

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -944,7 +944,7 @@ Modal.prototype = {
     }
 
     // check if page has an application menu in resizable mode
-    const resizeContainer = $('.resize-app-menu-container:first-child');
+    const resizeContainer = $('.resize-app-menu-container');
 
     if (resizeContainer.length > 0) {
       resizeContainer.append(this.root);

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -872,7 +872,6 @@ Modal.prototype = {
   open(ajaxReturn) {
     let messageArea = null;
     let elemCanOpen = true;
-
     // close any active tooltips
     $('#validation-errors, #tooltip, #validation-tooltip').addClass('is-hidden');
 
@@ -942,6 +941,13 @@ Modal.prototype = {
       if (this.settings.beforeShow) {
         return;
       }
+    }
+
+    // check if page has an application menu in resizable mode
+    const resizeContainer = $('.resize-app-menu-container:first-child');
+
+    if (resizeContainer.length > 0) {
+      resizeContainer.append(this.root);
     }
 
     // Tell the modal manager that this instance is active


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
App menus with resizable set to true will wrap page containers in a resizable container, changing the layering of popups (popups get nested deeper). Modals are not included in it. Added check in modal where if the resizable container exists, place the modal in the resizable container to bring back the original layering of modal and page containers.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Addresses issue in: https://github.com/infor-design/enterprise-ng/issues/1272

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/applicationmenu/test-app-menu.html
- Click on "Show Modal"
- Click on timepicker
- Timepicker should be in front of modal
- Click on datepicker
- Datepicker should be in front of modal

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
