### PR TITLE
6415 - Weekview: Month-Year Label is not changing upon clicking the arrow

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `[Tree]` The expanded event did not fire when source is being used. ([#1294](https://github.com/infor-design/enterprise-ng/issues/1294))
 - `[Typography]` Fixed a bug where the text are overlapping in Firefox. ([#6450](https://github.com/infor-design/enterprise/issues/6450))
 - `[WeekView]` Fixed a bug where 'today' date is not being rendered properly. ([#6260](https://github.com/infor-design/enterprise/issues/6260))
+- `[WeekView]` Fixed a bug where month-year label is not changing upon clicking the arrow button. ([#6415](https://github.com/infor-design/enterprise/issues/6415))
 - `[Validator]` Fixed a bug where toolbar error message still appears after error is removed. ([#6253](https://github.com/infor-design/enterprise/issues/6253))
 
 ## v4.64.0 features

--- a/src/components/week-view/week-view.js
+++ b/src/components/week-view/week-view.js
@@ -658,6 +658,7 @@ WeekView.prototype = {
    */
   addToolbar() {
     // Invoke the toolbar
+    const view = !this.isDayView ? 'week' : 'day';
     this.header = $('<div class="week-view-header"><div class="calendar-toolbar"></div></div>').appendTo(this.element);
     this.calendarToolbarEl = this.header.find('.calendar-toolbar');
     this.calendarToolbarAPI = new CalendarToolbar(this.calendarToolbarEl[0], {
@@ -672,10 +673,10 @@ WeekView.prototype = {
       showViewChanger: this.settings.showViewChanger,
       hitbox: this.settings.hitbox,
       onChangeView: this.settings.onChangeView,
-      viewChangerValue: !this.isDayView ? 'week' : 'day',
+      viewChangerValue: view,
       attributes: this.settings.attributes
     });
-    this.monthField = this.header.find('#monthview-datepicker-field');
+    this.monthField = this.header.find(this.settings.attributes ? `#${this.settings.attributes[0].value}-${view}-view-datepicker` : '#monthview-datepicker-field');
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes the bug where the month-year label does not change which arrow is clicked. 

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6415

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/week-view/example-index.html
- Click on the left/right arrow button

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.