### PR TITLE
5173v2 + 5178v2 - Tabs: Go Button Overlaps X Icon in Mobile View

### DIFF
--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -1026,7 +1026,7 @@ html[dir='rtl'] {
     }
   }
 
-  @media (max-width: $breakpoint-phone-to-tablet) {
+  @media (max-width: $breakpoint-phone-to-tablet - 1) {
     right: auto;
     width: 100% !important;
 

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -1028,7 +1028,7 @@ html[dir='rtl'] {
 
   @media (max-width: $breakpoint-phone-to-tablet - 1) {
     right: auto;
-    width: 100% !important;
+    width: 100%;
 
     button.close:not(.is-empty) {
       right: 32px;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Relates to #5173 . Specifically resolves https://github.com/infor-design/enterprise/issues/5173#issuecomment-1134655374
Relates to #5178 . Specifically resolves https://github.com/infor-design/enterprise/issues/5178#issuecomment-1132580265

**Steps necessary to review your pull request (required)**:

- Pull, build, run
- Visit http://llocalhost:4000/components/tabs-module/example-category-searchfield-go-button.html
- Resize browser to 766 width, step increase to 769
- Ensure Close Button is always visible after typing text and Go Button is always visible.

- Visit http://localhost:4000/components/tabs-module/example-category-searchfield-go-button.html
- Resize browser down to a small breakpoint
- Maximize window or quick expand (can't be a drag motion) to full screen size
- Ensure Go Button does not disappear

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
~- [ ] A note to the change log.~
