### PR TITLE
5178 v3 - Tabs: Go Button Overlaps X Icon in Mobile View

### DIFF
--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -1028,7 +1028,11 @@ html[dir='rtl'] {
 
   @media (max-width: $breakpoint-phone-to-tablet - 1) {
     right: auto;
-    width: 100%;
+    width: 100% !important;
+
+    .searchfield {
+      width: auto;
+    }
 
     button.close:not(.is-empty) {
       right: 32px;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Searchfield was overflowing to a scroll bar on mobile devices.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Resolves #5178 , specifically https://github.com/infor-design/enterprise/issues/5178#issuecomment-1138517525

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull, build, run
- Visit http://localhost:4000/components/tabs-module/example-category-searchfield-go-button.html
- Refresh at mobile size and ensure there is no overflow and the issue is resolved.

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
~- [ ] A note to the change log.~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
