### PR TITLE
6421 -  datepicker clear pptr test

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@
 - `[Bar]` Added the ability to set axis labels on different positions (top, right, bottom, left). ([#5382](https://github.com/infor-design/enterprise/issues/5382))
 - `[Blockgrid]` Converted protractor tests to puppeteer. ([#6327](https://github.com/infor-design/enterprise/issues/6327))
 - `[Datagrid]` Added a new method for cell editing for new row added. ([#6338](https://github.com/infor-design/enterprise/issues/6338))
+- `[Datepicker]` Added puppeteer script for datepicker clear (empty string) test . ([#6421](https://github.com/infor-design/enterprise/issues/6421))
 - `[Modal]` Added an ability to add icon in title section of the modal. ([#5905](https://github.com/infor-design/enterprise/issues/5905))
 
 ## v4.63.2 Fixes

--- a/test/components/datepicker/datepicker.puppeteer-spec.js
+++ b/test/components/datepicker/datepicker.puppeteer-spec.js
@@ -1,0 +1,21 @@
+describe('datefield clear test', () => {
+  const url = 'http://localhost:4000/components/datepicker/test-input-datefield-clear.html';
+  beforeAll(async () => {
+    await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });
+  });
+
+  it('should clear the date field', async () => {
+    await page.click('[data-automation-id="custom-automation-id-trigger"]');
+    await page.waitForTimeout(500);
+
+    await page.click('tbody > tr:nth-child(2) > td:nth-child(1) > .day-container > .day-text');
+    await page.click('tbody > tr:nth-child(2) > td:nth-child(5) > .day-container > .day-text');
+    await page.click('#primary-action-two');
+
+    const inputField = await page.$eval('#date-field-normal', el => el.value);
+    await page.waitForTimeout(500);
+
+    expect(inputField).toBe('');
+    expect(inputField).not.toContain('Nan');
+  });
+});

--- a/test/components/datepicker/datepicker.puppeteer-spec.js
+++ b/test/components/datepicker/datepicker.puppeteer-spec.js
@@ -1,4 +1,4 @@
-describe('datefield clear test', () => {
+describe('Datepicker clear test', () => {
   const url = 'http://localhost:4000/components/datepicker/test-input-datefield-clear.html';
   beforeAll(async () => {
     await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->

**Related github/jira issue (required)**:
closes https://github.com/infor-design/enterprise/issues/6421
related to https://github.com/infor-design/enterprise-ng/issues/1256
**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

1. pull this branch
2. build and run the app
3. run npm run e2e:puppeteer Datepicker
4. It should pass.


Given I’m on[ 'http://localhost:4000/components/datepicker/test-input-datefield-clear.html'](http://localhost:4000/components/datepicker/test-input-datefield-clear.html)
When Select start and end date in range2 field (label is Date with Range (set via range))
And Press clear button.
Then range2 value should be cleared.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
