### PR TITLE
6290 - datagrid toolbar visible after fixing error/validation

### DIFF
--- a/app/views/components/datagrid/test-editable-paging-validation-toolbar-on-error.html
+++ b/app/views/components/datagrid/test-editable-paging-validation-toolbar-on-error.html
@@ -1,0 +1,100 @@
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+
+    </div>
+  </div>
+</div>
+
+<script>
+  var gridApi = null;
+
+  $(function() {
+    $.fn.validation.rules.customErrorRule = {
+          check: function (value) {
+
+            return (value !== '');
+          },
+          message: 'Custom Error',
+          type: 'error'
+    };
+
+    $.fn.validation.rules.customWarningRule = {
+          check: function (value) {
+
+            return (value !== '');
+          },
+          message: 'Custom Warning',
+          type: 'alert'
+    };
+
+    $.fn.validation.rules.customInformationRule = {
+          check: function (value) {
+
+            return (value !== '');
+          },
+          message: 'Custom Information',
+          type: 'info'
+    };
+
+  });
+
+  $('body').one('initialized', function () {
+         var grid,
+          columns = [],
+          data = [];
+
+        //Define Columns for the Grid.
+        columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
+        columns.push({ id: 'id', name: 'Row Id', field: 'id', formatter: Formatters.Readonly, filterType: 'text'});
+        columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink, required: true,validate: 'required', editor: Editors.Input, filterType: 'text'});
+        columns.push({ id: 'activity', name: 'Activity', field: 'activity', validate: 'customWarningRule', editor: Editors.Input, filterType: 'text'});
+
+        var url = '{{basepath}}api/compressors?pageNum=1&pageSize=100';
+
+        $.getJSON(url, function(res) {
+
+            //Init and get the api for the grid
+            grid = $('#datagrid').datagrid({
+              dataset: res.data,
+              columns: columns,
+              editable: true,
+              clickToSelect: false,
+              actionableMode: true,
+              filterable: true,
+              selectable: 'multiple',
+              columnReorder: true,
+              cellNavigation: false,
+              saveColumns: false,
+              paging: true,
+              pagesize: 10,
+              pagesizes: [5, 10, 25, 50]
+            });
+
+            $('#datagrid').on('page', function(e, pi) {
+              var gridApi = $(this).data('datagrid');
+              var self = $(this).data('datagrid');
+              if (pi && pi.type === 'next' || pi.type === 'prev') {
+                var offet = pi.pagesize;
+                if (pi.type === 'prev') {
+                  offet = -offet;
+                }
+                self.tableBody.find('tr').toArray().forEach(function (visibleRow) {
+                  var row = self.dataRowIndex($(visibleRow));
+                  for (var i = 0; i < self.settings.columns.length; i++) {
+                    self.validateCell(row, i);
+                    if ((row - offet) >= 0 && (row - offet) < self.settings.dataset.length) {
+                      self.validateCell(row - offet, i);
+                    }
+                  }
+                });
+              } else {
+                self.validateAll();
+              }
+            });
+
+        });
+
+  });
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[ContextMenu]` Fixed a bug in context menu where it is not indented properly. ([#6223](https://github.com/infor-design/enterprise/issues/6223))
 - `[Button]` Fixed a bug where changing from primary to secondary disrupts the css styling. ([#6223](https://github.com/infor-design/enterprise-ng/issues/1282))
+- `[Datagrid]` Fixed a bug where toolbar is still visible even no buttons, title and errors appended. ([#6290](https://github.com/infor-design/enterprise/issues/6290))
 - `[Datagrid]` Added setting for color change in active checkbox selection. ([#6303](https://github.com/infor-design/enterprise/issues/6303))
 - `[Datagrid]` Set changed cell to active when update is finished. ([#6317](https://github.com/infor-design/enterprise/issues/6317))
 - `[Datagrid]` Fixed row height of extra-small rows on editable datagrid with icon columns. ([#6284](https://github.com/infor-design/enterprise/issues/6284))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10277,6 +10277,7 @@ Datagrid.prototype = {
       if (this.toolbar && this.toolbar.parent().find('.table-errors').length === 1) {
         this.toolbar.parent().find('.table-errors').remove();
       }
+      this.removeToolbar();
     } else {
       // process via type
       for (const props in $.fn.validation.ValidationTypes) {  // eslint-disable-line
@@ -10284,6 +10285,19 @@ Datagrid.prototype = {
         const errors = $.grep(this.nonVisibleCellErrors, error => error.type === validationType);
         this.showNonVisibleCellErrorType(errors, validationType);
       }
+    }
+  },
+
+  /**
+   * Removes the toolbar if there are no buttonset, title or errors appended
+   * @private
+   * @returns {void}
+   */
+  removeToolbar() {
+    if (this.toolbar.find('.buttonset').children().length < 1 && this.toolbar.find('.title').text().trim().length < 1) {
+      this.toolbar.destroy();
+      this.toolbar.remove();
+      delete this.toolbar;
     }
   },
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug where toolbar is still visible even no buttons, title and errors appended.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6290

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-editable-paging-validation-toolbar-on-error.html
- Enter invalid data, notice the cell is marked with an error icon but there is no toolbar
- Move to page 2, notice there is now a toolbar on the top with an error icon indicating there is an error on page 1
- Move back to page 1, notice the toolbar still there with an error icon
- Fix the error and the cell error icon disappeared, the toolbar is cleared from the error but the white space remains.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

