### PR TITLE
6464 - Tabs Focus Indicator

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[Lookup]` Fixed bug where lookup still appeared when modal closes. ([#6218](https://github.com/infor-design/enterprise/issues/6218))
 - `[Modal]` Fixed bug where popup goes behind modal when in application menu in resizable mode. ([NG#1272](https://github.com/infor-design/enterprise-ng/issues/1272))
 - `[Personalization]` Fixed bug where the dark mode header color was not correct in the tokens and caused the personalization dropdown to be incorrect. ([#6446](https://github.com/infor-design/enterprise/issues/6446))
+- `[Tabs]` Fixed a bug where tab focus indicator is not aligned properly in RTL composite forms. ([#6464](https://github.com/infor-design/enterprise/issues/6464))
 - `[Targeted-Achievement]` Fixed a bug where the icon is cut off in Firefox. ([#6400](https://github.com/infor-design/enterprise/issues/6400))
 - `[Toolbar]` Fixed a bug where the search icon is misaligned in Firefox. ([#6405](https://github.com/infor-design/enterprise/issues/6405))
 - `[Toolbar Flex]` Fixed a bug where the `addMenuElementLinks` function execute incorrectly when menu item has multi-level submenus. ([#6120](https://github.com/infor-design/enterprise/issues/6120))

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -3842,9 +3842,12 @@ Tabs.prototype = {
         }
 
         // Composite Form has additional padding on the right
-        if (!isRTL && hasCompositeForm) {
+        if (hasCompositeForm) {
           targetRectObj.right -= 42;
-          targetRectObj.width -= 1;
+
+          if (isRTL) {
+            targetRectObj.width += 1;
+          }
         }
 
         // Scaling


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug where tab focus indicator is not aligned properly in RTL composite forms.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6464

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/tabs/example-composite-form-on-side.html?locale=ar-sa
- Focus on the tabs

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

