### PR TITLE
NG1282- Fix typo class name (tertiary)

### DIFF
--- a/src/components/button/_button-new.scss
+++ b/src/components/button/_button-new.scss
@@ -5,7 +5,7 @@
 [class^='btn'],
 .btn-primary,
 .btn-secondary,
-.btn-teritary {
+.btn-tertiary {
   height: auto;
   line-height: normal;
   min-height: 34px;
@@ -43,7 +43,7 @@
   [class^='btn'],
   .btn-primary,
   .btn-secondary,
-  .btn-teritary {
+  .btn-tertiary {
     > .icon {
       vertical-align: -20%;
     }
@@ -57,7 +57,7 @@
   [class^='btn'],
   .btn-primary,
   .btn-secondary,
-  .btn-teritary {
+  .btn-tertiary {
     > .icon {
       margin-top: -2px;
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Follow-up fix for https://github.com/infor-design/enterprise-ng/issues/1282. Typo on `teritary` should be `tertiary`.

**Related github/jira issue (required)**:

Related PR https://github.com/infor-design/enterprise/pull/6492
Fixes https://github.com/infor-design/enterprise-ng/issues/1282

**Steps necessary to review your pull request (required)**:
- Check the class name `tertiary` and not `teritary`
- In `_button-new.scss` Lines: 8, 46 and 60.

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
