### PR TITLE
6406 - Accordion: bottom borders missing in dark mode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## v4.65.0 Features
 
-## v4.64.0 Fixes
+## v4.65.0 Fixes
 
 - `[Accordion]` Fixed the bottom border of the completely disabled accordion in dark mode. ([#6406](https://github.com/infor-design/enterprise/issues/6406))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # What's New with Enterprise
 
+## v4.65.0
+
+### v4.65.0 Important Notes
+
+## v4.65.0 Features
+
+## v4.64.0 Fixes
+
+- `[Accordion]` Fixed the bottom border of the completely disabled accordion in dark mode. ([#6406](https://github.com/infor-design/enterprise/issues/6406))
+
 ## v4.64.0
 
 ### v4.64.0 Important Notes

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -279,7 +279,7 @@
           border-bottom-color: $accordion-panel-border-color;
         }
       }
-      
+
       .accordion-header {
         border-bottom-color: $accordion-alternate-border-color;
 

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -274,6 +274,12 @@
     &.alternate {
       background-color: $accordion-alternate-bg-color;
 
+      &.is-disabled {
+        .accordion-header {
+          border-bottom-color: $accordion-panel-border-color;
+        }
+      }
+      
       .accordion-header {
         border-bottom-color: $accordion-alternate-border-color;
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes the bug where the bottom borders are missing in dark mode for the completely disabled accordion.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6406

**Steps necessary to review your pull request (required)**:
- Go to http://localhost:4000/components/accordion/example-disabled.html?theme=new&mode=dark&colors=0066D4

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.