### PR TITLE
5173 - Go Button Disappears on Entering Long Text in Responsive Vi…

### DIFF
--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -1021,6 +1021,10 @@ html[dir='rtl'] {
     top: 50%;
     transform: translateY(-50%);
 
+    @media (min-width: $breakpoint-tablet-reduced) {
+      right: 15%;
+    }
+
     svg.close {
       display: block;
       top: 0 !important;
@@ -1037,6 +1041,16 @@ html[dir='rtl'] {
 
     button.close:not(.is-empty) {
       right: 32px;
+    }
+  }
+
+  @media (min-width: $breakpoint-tablet-reduced) {
+    &.has-go-button.has-text {
+      width: auto !important;
+
+      .searchfield {
+        width: auto !important;
+      }
     }
   }
 }


### PR DESCRIPTION
…ew and then Quickly Maximizing Window

**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
There is an extreme edge case issue where if you reduce window size to around a mobile width, enter a long text string in the searchfield and then maximize your window quickly to full screen size, the Go Button disappears.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Resolves #5173 , specifically https://github.com/infor-design/enterprise/issues/5173#issuecomment-1145705994

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull, build, run
- Visit http://localhost:4000/components/tabs-module/example-category-searchfield-go-button.html
- Reduce window size to around mobile width
- Enter a long string of text in the toolbar searchfield
- Maximize your browser quickly with the maximize button or by forcing full screen (this must be done quickly to effectively test this edge case bug)
- Notice the Go Button is still visible

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
~- [ ] A note to the change log.~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
