### PR TITLE
NG1273 - Fix for NaN in Datepicker French

### DIFF
--- a/app/views/components/datepicker/test-datepicker-french.html
+++ b/app/views/components/datepicker/test-datepicker-french.html
@@ -1,0 +1,26 @@
+
+<div class="row">
+  <div class="four columns">
+    <div class="field">
+      <label for="range-french" class="label">Range French - Initial value by Element value</label>
+      <input id="range-french" name="range-french" class="datepicker input-md" type="text" value="28/01/2017 - 30/01/2017"/>
+    </div>
+  </div>
+</div>
+
+<script>
+  $(document).ready(function () {
+    $('body').on('initialized', function () {
+    Soho.Locale.set('fr-FR');
+
+    $('#range-french').datepicker({
+      dateFormat: 'dd/MM/yyyy',
+      range: {
+        start: new Date(2021, 0, 24),
+        end: new Date(2021, 0, 25),
+        useRange: true
+      }
+    });
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - `[Accordion]` Fixed the bottom border of the completely disabled accordion in dark mode. ([#6406](https://github.com/infor-design/enterprise/issues/6406))
 - `[ContextualActionPanel]` Fixed a bug where the toolbar searchfield with close icon looks off on mobile viewport. ([#6448](https://github.com/infor-design/enterprise/issues/6448))
+- `[Datepicker]` Fixed a bug where the datepicker is displaying NaN when using french format. ([NG#1273](https://github.com/infor-design/enterprise-ng/issues/1273))
 - `[Listview]` Fixed disabled font color not showing in listview. ([#6391](https://github.com/infor-design/enterprise/issues/6391))
 - `[Page-Patterns]` Fixed a bug where the header disappears when the the last item in the list is clicked and the browser is smaller in Chrome and Edge. ([#6328](https://github.com/infor-design/enterprise/issues/6328))
 - `[Locale]` Added montnly translations. ([#6556](https://github.com/infor-design/enterprise/issues/6556))

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -1470,7 +1470,7 @@ DatePicker.prototype = {
         s.range.first.date = d;
         s.range.second.date = d;
 
-        if (s.range.end) {
+        if (s.range.end && date) {
           if (typeof s.range.end === 'string') {
             s.range.second.date = Locale.parseDate(s.range.end, {
               pattern: this.pattern,


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug where the datepicker is displaying NaN when using french format. (This will also fix for Deutsch)

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1273

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datepicker/test-datepicker-french.html
- Open `Datepicker`

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

