### PR TITLE
6474 - Removed automatic legend bottom placement

### DIFF
--- a/app/views/components/donut/example-legend-bottom.html
+++ b/app/views/components/donut/example-legend-bottom.html
@@ -1,6 +1,6 @@
 
 <div class="row">
-  <div class="two-thirds column" style="min-width: 300px !important; max-width: 400px !important;">
+  <div class="two-thirds column" style="min-width: 200px !important; max-width: 300px !important;">
       <div class="widget auto-height">
         <div class="widget-header">
           <h2 class="widget-title">Pie Chart</h2>
@@ -10,13 +10,15 @@
           </div>
         </div>
       </div>
+      <button class="btn-primary" type="button" id="toggle-legend">Toggle Legend</button>
   </div>
 </div>
 
 <script>
 $('body').on('initialized', function () {
+  let isBottom = false;
 
-  var pieData = [{
+  const pieData = [{
   centerLabel: '<tspan x="0" dy="-0.4em">Total Hours</tspan> <tspan x="0" dy="1.4em">265</tspan>',
   data: [{
       name: 'Reg',
@@ -49,12 +51,15 @@ $('body').on('initialized', function () {
     }]
   }];
 
-  $('#pie-chart-example').chart({
+  const pieApi = $('#pie-chart-example').chart({
     type: 'donut',
     dataset: pieData,
     showLegend: true,
-    legendPlacement: 'bottom'
-  });
+  }).data('pie')
 
+  $('#toggle-legend').on('click', () => {
+    pieApi.updated({ legendPlacement: isBottom ? 'right' : 'bottom' });
+    isBottom = !isBottom;
+  });
 });
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - `[Accordion]` Fixed the bottom border of the completely disabled accordion in dark mode. ([#6406](https://github.com/infor-design/enterprise/issues/6406))
 - `[ContextualActionPanel]` Fixed a bug where the toolbar searchfield with close icon looks off on mobile viewport. ([#6448](https://github.com/infor-design/enterprise/issues/6448))
+- `[Chart]` Removed automatic legend bottom placement when reaching a minimum width. ([#6474](https://github.com/infor-design/enterprise/issues/6474))
 - `[Listview]` Fixed disabled font color not showing in listview. ([#6391](https://github.com/infor-design/enterprise/issues/6391))
 - `[Page-Patterns]` Fixed a bug where the header disappears when the the last item in the list is clicked and the browser is smaller in Chrome and Edge. ([#6328](https://github.com/infor-design/enterprise/issues/6328))
 - `[Locale]` Added montnly translations. ([#6556](https://github.com/infor-design/enterprise/issues/6556))

--- a/src/components/charts/charts.js
+++ b/src/components/charts/charts.js
@@ -330,8 +330,7 @@ charts.addLegend = function (series, chartType, settings, container) {
   let width = 0;
   let currentWidth;
   let totalWidth = 0;
-
-  let maxLength = series.length;
+  let maxLength;
 
   let currentTotalWidthPercent;
   for (i = 0; i < series.length; i++) {
@@ -348,10 +347,9 @@ charts.addLegend = function (series, chartType, settings, container) {
   width += 55;
   const widthPercent = width / $(container).width() * 100;
   const exceedsMaxWidth = widthPercent > 45;
+  const isBottom = series[0].placement && series[0].placement === 'bottom';
 
-  const isBottom = exceedsMaxWidth || (series[0].placement && series[0].placement === 'bottom');
-
-  if (!exceedsMaxWidth) {
+  if (!(isBottom && exceedsMaxWidth)) {
     maxLength = series.length;
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Chart will do bottom legend placement only when specified in settings.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #6474 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/donut/example-legend-bottom
- Legends should be in right placement
- Click Toggle Legend
- Legends should be in bottom placement

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
