### PR TITLE
6566 - Fix modal overlay on chrome

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,8 @@
 - `[Datepicker]` Fixed a bug where the datepicker is displaying NaN when using french format. ([NG#1273](https://github.com/infor-design/enterprise-ng/issues/1273))
 - `[Listview]` Fixed disabled font color not showing in listview. ([#6391](https://github.com/infor-design/enterprise/issues/6391))
 - `[Page-Patterns]` Fixed a bug where the header disappears when the the last item in the list is clicked and the browser is smaller in Chrome and Edge. ([#6328](https://github.com/infor-design/enterprise/issues/6328))
-- `[Locale]` Added montnly translations. ([#6556](https://github.com/infor-design/enterprise/issues/6556))
+- `[Locale]` Added monthly translations. ([#6556](https://github.com/infor-design/enterprise/issues/6556))
+- `[Modal]` Fixed an issue on some monitors where the overlay is too dim. ([#6566](https://github.com/infor-design/enterprise/issues/6566))
 
 ## v4.64.0
 

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -325,10 +325,9 @@
 .overlay {
   @include css3(transition, all 0.2s);
 
-  background: $ids-color-palette-black;
+  background: rgba(0, 0, 0, 0.7);
   height: 100%;
   left: 0;
-  opacity: 0;
   position: fixed;
   top: 0;
   visibility: hidden;
@@ -339,7 +338,6 @@
 // Body tag is notified when a modal is present in the page.
 body.modal-engaged {
   .overlay {
-    opacity: 0.7;
     visibility: visible;
   }
 }

--- a/src/components/modal/modal.manager.js
+++ b/src/components/modal/modal.manager.js
@@ -205,7 +205,7 @@ ModalManager.prototype = {
       opacity = this.currentlyActive.settings.overlayOpacity;
     }
 
-    this.overlayElem.style.opacity = opacity ? `${opacity}` : '';
+    this.overlayElem.style.background = `rgba(0, 0, 0, ${opacity ? `${opacity}` : ''})`;
   },
 
   /**

--- a/test/components/message/message.puppeteer-spec.js
+++ b/test/components/message/message.puppeteer-spec.js
@@ -307,8 +307,8 @@ describe('Message overlay opacity tests', () => {
     const divOverlay = await page.evaluate(() => !!document.querySelector('.overlay'));
     expect(divOverlay).toBe(true);
     await page.waitForTimeout(100);
-    const everlayEl = await page.evaluate(() => document.querySelector('.overlay').style.opacity);
-    expect(everlayEl).toBe('0.1');
+    const everlayEl = await page.evaluate(() => document.querySelector('.overlay').style.background);
+    expect(everlayEl).toContain('rgba(0, 0, 0, 0.1)');
     await page.click('.btn-modal');
   });
 });

--- a/test/components/modal/modal.e2e-spec.js
+++ b/test/components/modal/modal.e2e-spec.js
@@ -240,7 +240,7 @@ describe('Modal overlay opacity tests', () => {
     await browser.driver.sleep(config.sleep);
     const overlayEl = await element(by.css('.overlay'));
 
-    expect(await overlayEl.getCssValue('opacity')).toBe('0.3');
+    expect(await overlayEl.getCssValue('background')).toContain('rgba(0, 0, 0, 0.3)');
   });
 });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes a bug with the overlay in chrome. By using RGBA the issue goes away.

**Related github/jira issue (required)**:
Fixes #6566 

**Steps necessary to review your pull request (required)**:
- open http://localhost:4000/components/modal/example-index.html
- click the button. should not be too dark
- make sure this page still works http://localhost:4000/components/modal/test-overlay-opacity.html
- as does this one http://localhost:4000/components/message/test-overlay-opacity.html

**Included in this Pull Request**:
- [x] A note to the change log.
