### PR TITLE
1327 - Fix CAP teardown error

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,10 +27,11 @@
 - `[Datepicker]` Added listener for calendar monthrendered event and pass along. ([NG#1324](https://github.com/infor-design/enterprise-ng/issues/1324))
 - `[Input]` Fixed a bug where the password does not show or hide in Firefox. ([#6481](https://github.com/infor-design/enterprise/issues/6481))
 - `[Listview]` Fixed disabled font color not showing in listview. ([#6391](https://github.com/infor-design/enterprise/issues/6391))
-- `[Locale]` Added montnly translations. ([#6556](https://github.com/infor-design/enterprise/issues/6556))
+- `[Locale]` Added monthly translations. ([#6556](https://github.com/infor-design/enterprise/issues/6556))
 - `[Lookup]` Fixed a bug where search-list icon, launch icon, and ellipses is misaligned and the table and title overlaps in responsive view. ([#6487](https://github.com/infor-design/enterprise/issues/6487))
 - `[Modal]` Fixed an issue on some monitors where the overlay is too dim. ([#6566](https://github.com/infor-design/enterprise/issues/6566))
 - `[Page-Patterns]` Fixed a bug where the header disappears when the the last item in the list is clicked and the browser is smaller in Chrome and Edge. ([#6328](https://github.com/infor-design/enterprise/issues/6328))
+- `[ToolbarFlex]` Fixed a bug where the teardown might error on situations. ([#1327](https://github.com/infor-design/enterprise/issues/1327))
 - `[Validation]` Fixed a bug where the tooltip would show on the header when the message has actually been removed. ([#6547](https://github.com/infor-design/enterprise/issues/6547)
 
 ## v4.64.0

--- a/src/components/toolbar-flex/toolbar-flex.jquery.js
+++ b/src/components/toolbar-flex/toolbar-flex.jquery.js
@@ -19,7 +19,7 @@ $.fn.toolbarflex = function (settings) {
         if (typeof oldDestroy === 'function') {
           oldDestroy.call(this);
         }
-        $.removeData(this.element, COMPONENT_NAME);
+        if (this.element) $.removeData(this.element, COMPONENT_NAME);
         this.element = undefined;
       };
     }

--- a/src/components/toolbar-flex/toolbar-flex.js
+++ b/src/components/toolbar-flex/toolbar-flex.js
@@ -641,9 +641,9 @@ ToolbarFlex.prototype = {
    */
   teardown() {
     if (!this.settings.allowTabs) {
-      this.element.removeEventListener('keydown', this.keydownListener);
-      this.element.removeEventListener('keyup', this.keyupListener);
-      this.element.removeEventListener('click', this.clickListener);
+      this.element?.removeEventListener('keydown', this.keydownListener);
+      this.element?.removeEventListener('keyup', this.keyupListener);
+      this.element?.removeEventListener('click', this.clickListener);
     }
 
     $(this.element).off(`selected.${COMPONENT_NAME}`);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The angular lifecycle is having some issues tearing down the flex toolbar when its in a Contextual Action Panel. This fixes the issue

**Related github/jira issue (required)**:
Fixes https://github.com/infor-design/enterprise-ng/issues/1327

**Steps necessary to review your pull request (required)**:
- pull this branch and then `npm run build`
- copy the dist folder to an https://github.com/infor-design/enterprise-ng folder (in node_modules/ids-enterprise/dist) and replace it (effectively getting this fix on an NG branch
- run the ng demo app and go to http://localhost:4200/ids-enterprise-ng-demo/contextual-action-panel
- Click "Panel with Searchfield in flex toolbar"
- Click X
- The overlay should close and no errors should be in the console

**Included in this Pull Request**:
- [x] A note to the change log.
