### PR TITLE
1296- Chart: Wrong interfaces of SohoChartSelectEvent

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - `[Accordion]` Fixed the bottom border of the completely disabled accordion in dark mode. ([#6406](https://github.com/infor-design/enterprise/issues/6406))
 - `[Chart]` Removed automatic legend bottom placement when reaching a minimum width. ([#6474](https://github.com/infor-design/enterprise/issues/6474))
+- `[Chart]` Fixed the result logged in console to be same as the Soho Interfaces. ([NG#1296](https://github.com/infor-design/enterprise-ng/issues/1296))
 - `[ContextualActionPanel]` Fixed a bug where the toolbar searchfield with close icon looks off on mobile viewport. ([#6448](https://github.com/infor-design/enterprise/issues/6448))
 - `[Datagrid]` Fixed a bug in datagrid where focus is not behaving properly when inlineEditor is set to true. ([NG#1300](https://github.com/infor-design/enterprise-ng/issues/1300))
 - `[Datagrid]` Fixed a bug where treegrid doesn't expand a row via keyboard when editable is set to true. ([#6434](https://github.com/infor-design/enterprise/issues/6434))

--- a/src/components/charts/charts.js
+++ b/src/components/charts/charts.js
@@ -831,7 +831,7 @@ charts.setSelectedElement = function (o) {
           if (bar.classed('is-selected')) {
             const data = dataset ? dataset[i] : d;
             data.selected = true;
-            selectedBars.push({ elem: bar.node(), data });
+            selectedBars.push({ elem: bar.nodes(), data, index: i });
           }
         });
         if (isGrouped) {
@@ -862,7 +862,7 @@ charts.setSelectedElement = function (o) {
             dataset[i][o.i] : dataset[i].data[o.i];
         }
         data.selected = true;
-        selectedBars.push({ elem: bar.node(), data });
+        selectedBars.push({ elem: bar.nodes(), data, index: o.i });
       });
       triggerData = selectedBars;
     } else if (isTypePie) { // Pie


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes the bug where the result logged in the console is not the same as the Soho Interfaces.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1296

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app

Case 1: 
- Go to http://localhost:4000/components/bar/test-selected?theme=uplift&variant=light
- Click on any bar 
- See the result that is logged in the console 

Case 2: 
- Go to http://localhost:4000/components/column-grouped/example-get-selected?theme=uplift&variant=light
- Click on any column 
- See the result that is logged in the console 

Case 3: 
- Go to http://localhost:4200/ids-enterprise-ng-demo/bar
- Click on any bar 
- See the result that is logged in the console 

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.