### PR TITLE
6592 - Fix app menu eventing and default

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,15 +17,16 @@
 ## v4.65.0 Fixes
 
 - `[Accordion]` Fixed the bottom border of the completely disabled accordion in dark mode. ([#6406](https://github.com/infor-design/enterprise/issues/6406))
+- `[AppMenu]` Fixed a bug where events are added to the wrong elements for filtering. Also fixed an issue where if no accordion is added the app menu will error. ([#6592](https://github.com/infor-design/enterprise/issues/6592))
 - `[Chart]` Removed automatic legend bottom placement when reaching a minimum width. ([#6474](https://github.com/infor-design/enterprise/issues/6474))
 - `[ContextualActionPanel]` Fixed a bug where the toolbar searchfield with close icon looks off on mobile viewport. ([#6448](https://github.com/infor-design/enterprise/issues/6448))
 - `[Datagrid]` Fixed a bug in datagrid where focus is not behaving properly when inlineEditor is set to true. ([NG#1300](https://github.com/infor-design/enterprise-ng/issues/1300))
-- `[Datagrid]` Fixed a bug where treegrid doesn't expand a row via keyboard when editable is set to true. ([#6434](https://github.com/infor-design/enterprise/issues/6434))
+- `[Datagrid]` Fixed a bug where `treegrid` doesn't expand a row via keyboard when editable is set to true. ([#6434](https://github.com/infor-design/enterprise/issues/6434))
 - `[Datagrid]` Fixed a bug where the search icon and x icon are misaligned across datagrid and removed extra margin space in modal in Firefox. ([#6418](https://github.com/infor-design/enterprise/issues/6418))
 - `[Datagrid]` Fixed a bug where page changed to one on removing a row in datagrid. ([#6475](https://github.com/infor-design/enterprise/issues/6475))
 - `[Datagrid]` Header is rerendered when calling updated method, also added paging info settings. ([#6476](https://github.com/infor-design/enterprise/issues/6476))
 - `[Datepicker]` Fixed a bug where the datepicker is displaying NaN when using french format. ([NG#1273](https://github.com/infor-design/enterprise-ng/issues/1273))
-- `[Datepicker]` Added listener for calendar monthrendered event and pass along. ([NG#1324](https://github.com/infor-design/enterprise-ng/issues/1324))
+- `[Datepicker]` Added listener for calendar `monthrendered` event and pass along. ([NG#1324](https://github.com/infor-design/enterprise-ng/issues/1324))
 - `[Input]` Fixed a bug where the password does not show or hide in Firefox. ([#6481](https://github.com/infor-design/enterprise/issues/6481))
 - `[Listview]` Fixed disabled font color not showing in listview. ([#6391](https://github.com/infor-design/enterprise/issues/6391))
 - `[Locale]` Added monthly translations. ([#6556](https://github.com/infor-design/enterprise/issues/6556))

--- a/src/components/applicationmenu/applicationmenu.js
+++ b/src/components/applicationmenu/applicationmenu.js
@@ -146,7 +146,7 @@ ApplicationMenu.prototype = {
         clearable: true,
         filterMode: this.settings.filterMode,
         source(term, done, args) {
-          done(term, self.accordion.data('accordion').toData(true, true), args);
+          done(term, self.accordion?.data('accordion')?.toData(true, true), args);
         },
         searchableTextCallback(item) {
           return item.text || item.contentText || '';
@@ -157,7 +157,7 @@ ApplicationMenu.prototype = {
         },
         clearResultsCallback() {
           if (self.searchfieldAPI && !self.searchfieldAPI.isFocused) {
-            self.accordionAPI.unfilter();
+            self.accordionAPI?.unfilter();
           }
         },
         displayResultsCallback(results, done, term) {
@@ -166,7 +166,7 @@ ApplicationMenu.prototype = {
       });
 
       this.searchfield.on(`cleared.${COMPONENT_NAME}`, () => {
-        self.accordionAPI.unfilter(null, true);
+        self.accordionAPI?.unfilter(null, true);
       });
     }
 
@@ -239,11 +239,11 @@ ApplicationMenu.prototype = {
       this.triggers.off('click.applicationmenu').on('click.applicationmenu', triggerClickHandler);
     }
 
-    $(document).on('keydown.applicationmenu', (e) => {
+    this.element.find('.searchfield').on('keydown.applicationmenu', (e) => {
       self.handleKeyDown(e);
     });
 
-    $(document).on('input.applicationmenu', () => {
+    this.element.find('.searchfield').on('input.applicationmenu', () => {
       self.handleInput();
     });
   },
@@ -254,9 +254,9 @@ ApplicationMenu.prototype = {
    */
   handleInput() {
     if (!this.element.find('.searchfield').val() && !this.element.find('.searchfield').val()?.length) {
-      this.accordionAPI.unfilter(null, true);
+      this.accordionAPI?.unfilter(null, true);
     } else {
-      this.accordionAPI.unfilter(null);
+      this.accordionAPI?.unfilter(null);
     }
 
     return true;
@@ -748,13 +748,13 @@ ApplicationMenu.prototype = {
    */
   filterResultsCallback(results, done) {
     if (!results) {
-      this.accordionAPI.unfilter();
+      this.accordionAPI?.unfilter();
       done();
       return;
     }
 
     const targets = $(results.map(item => item.element));
-    this.accordionAPI.filter(targets, true);
+    this.accordionAPI?.filter(targets, true);
 
     this.element.triggerHandler('filtered', [results]);
     done();
@@ -773,9 +773,9 @@ ApplicationMenu.prototype = {
 
     if (!val || val === '') {
       const filteredParentHeaders = this.accordion.find('.has-filtered-children');
-      this.accordionAPI.headers.removeClass('filtered has-filtered-children');
-      this.accordionAPI.collapse(filteredParentHeaders);
-      this.accordionAPI.updated();
+      this.accordionAPI?.headers.removeClass('filtered has-filtered-children');
+      this.accordionAPI?.collapse(filteredParentHeaders);
+      this.accordionAPI?.updated();
       this.element.triggerHandler('filtered', [[]]);
     }
   },
@@ -854,11 +854,11 @@ ApplicationMenu.prototype = {
 
     this.element.find('.application-menu-toolbar').off(`click.${COMPONENT_NAME}`);
 
-    if (this.accordionAPI && typeof this.accordionAPI.destroy === 'function') {
+    if (this.accordionAPI && typeof this.accordionAPI?.destroy === 'function') {
       if (this.isFiltered) {
-        this.accordionAPI.collapse();
+        this.accordionAPI?.collapse();
       }
-      this.accordionAPI.destroy();
+      this.accordionAPI?.destroy();
     }
 
     if (this.switcherPanel) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The app menu had some events that attached to every input in the page. Also fixed an issue where if the accordion was missing then you would get a lot of errors in the app menu.

**Related github/jira issue (required)**:
Fixes #6592 

**Steps necessary to review your pull request (required)**:
1. Clone https://github.com/infor-design/enterprise-ng-quickstart
1. build this branch and copy it over
1. npm run start
1. go to http://localhost:4200/ and open app menu
1. type anything in the filter
1. should not see any errors

Also:
1. run this branch
2. test filtering still works http://localhost:4000/components/applicationmenu/example-filterable.html
3. test other examples on http://localhost:4000/components/applicationmenu

**Included in this Pull Request**:
- [x] A note to the change log.
