### PR TITLE
1274 - Datagrid: Shift-click on the always selects the first row

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@
 - `[Datagrid]` Fixed a bug where the search icon and x icon are misaligned across datagrid and removed extra margin space in modal in Firefox. ([#6418](https://github.com/infor-design/enterprise/issues/6418))
 - `[Datagrid]` Fixed a bug where page changed to one on removing a row in datagrid. ([#6475](https://github.com/infor-design/enterprise/issues/6475))
 - `[Datagrid]` Header is rerendered when calling updated method, also added paging info settings. ([#6476](https://github.com/infor-design/enterprise/issues/6476))
+- `[Datagrid]` Fixed a bug where using shift-click to multiselect on datagrid with treeGrid setting = true selects from the first row until bottom row. ([NG#1274](https://github.com/infor-design/enterprise-ng/issues/1274))
 - `[Datepicker]` Fixed a bug where the datepicker is displaying NaN when using french format. ([NG#1273](https://github.com/infor-design/enterprise-ng/issues/1273))
 - `[Datepicker]` Added listener for calendar monthrendered event and pass along. ([NG#1324](https://github.com/infor-design/enterprise-ng/issues/1324))
 - `[Input]` Fixed a bug where the password does not show or hide in Firefox. ([#6481](https://github.com/infor-design/enterprise/issues/6481))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -8281,6 +8281,7 @@ Datagrid.prototype = {
           self.selectNode(rowNode, idx, rowData);
         }
         self.setNodeStatus(rowNode);
+        self.lastSelectedRow = idx;
       } else {
         rowData = s.dataset[dataRowIndex];
         if (s.groupable) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes the bug where using shift-click to multi-select on Datagrid with treeGrid setting = true selects from the first row until the bottom row.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1274

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app

Case 1: 
- Go to http://localhost:4000/components/datagrid/test-tree-select-multiple.html
- Click on the row with id = 4
- Do a shift-click on the row with Id=8

Case 2:
- Go to http://localhost:4200/ids-enterprise-ng-demo/datagrid-treegrid-lazy
- Click on the row with id = 11
- Do a shift-click on the row with Id=14

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.