### PR TITLE
6591 - ListView: Any toolbar-flex gets a "selection title" if it wrapped under widget class with soho-listview as a sibling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `[Datepicker]` Added listener for calendar `monthrendered` event and pass along. ([NG#1324](https://github.com/infor-design/enterprise-ng/issues/1324))
 - `[Input]` Fixed a bug where the password does not show or hide in Firefox. ([#6481](https://github.com/infor-design/enterprise/issues/6481))
 - `[Listview]` Fixed disabled font color not showing in listview. ([#6391](https://github.com/infor-design/enterprise/issues/6391))
+- `[Listview]` Changed toolbar-flex to contextual-toolbar for multiselect listview. ([#6591](https://github.com/infor-design/enterprise/issues/6591))
 - `[Locale]` Added monthly translations. ([#6556](https://github.com/infor-design/enterprise/issues/6556))
 - `[Lookup]` Fixed a bug where search-list icon, launch icon, and ellipses is misaligned and the table and title overlaps in responsive view. ([#6487](https://github.com/infor-design/enterprise/issues/6487))
 - `[Modal]` Fixed an issue on some monitors where the overlay is too dim. ([#6566](https://github.com/infor-design/enterprise/issues/6566))

--- a/src/components/listview/listview.js
+++ b/src/components/listview/listview.js
@@ -404,7 +404,7 @@ ListView.prototype = {
         self.element.addClass('is-multiselect');
 
         // Create a Toolbar for the "Selected Items" area
-        const selectedToolbar = self.element.prevAll('.toolbar, .flex-toolbar');
+        const selectedToolbar = self.element.prevAll('.toolbar, .contextual-toolbar');
         if (selectedToolbar.length && selectedToolbar.data('toolbar')) {
           selectedToolbar.data('toolbar').toggleMoreMenu();
         }
@@ -1101,7 +1101,7 @@ ListView.prototype = {
       parent = this.element.parent();
     }
 
-    const toolbar = parent.find('.listview-toolbar, .contextual-toolbar, .flex-toolbar');
+    const toolbar = parent.find('.listview-toolbar, .contextual-toolbar');
     const toolbarControl = toolbar.data('toolbar');
 
     if (self.selectedItems.length > 0) {
@@ -1123,7 +1123,7 @@ ListView.prototype = {
 
       let title = toolbar.find('.title, .selection-count');
       if (!title || !title.length) {
-        title = $(toolbar.hasClass('flex-toolbar') ? '<div class="toolbar-section title selection-count"></div>' : '<div class="title selection-count"></div>');
+        title = $(toolbar.hasClass('contextual-toolbar') ? '<div class="toolbar-section title selection-count"></div>' : '<div class="title selection-count"></div>');
         toolbar.prepend(title);
       }
       title.text(`${self.selectedItems.length} ${Locale ? Locale.translate('Selected') : 'Selected'}`);

--- a/src/components/toolbar-flex/_toolbar-flex.scss
+++ b/src/components/toolbar-flex/_toolbar-flex.scss
@@ -19,60 +19,6 @@
   flex-flow: row nowrap;
   justify-content: space-between;
 
-  &.contextual-toolbar {
-    font-size: 0;
-    position: relative;
-    text-align: left;
-    -webkit-touch-callout: none;
-    padding: 0 15px;
-
-    .toolbar-section {
-      @include enable-select();
-
-      height: 40px;
-      overflow: hidden;
-      position: relative;
-      text-align: left;
-      text-overflow: ellipsis;
-      top: 0;
-      white-space: nowrap;
-      width: 45%; // Overridden by sizing calculation.
-
-      &.title {
-        -webkit-font-smoothing: antialiased;
-        color: $contextual-toolbar-color;
-        font-size: $ids-size-font-base;
-        height: 42px;
-
-        &::before {
-          @include vertical-alignment-spacer;
-        }
-      }
-
-      &.buttonset {
-        width: calc(55% - 1px);
-        height: 42px;
-        user-select: none;
-        overflow: hidden;
-        padding-left: 1px;
-
-        > * {
-          margin: -1px 0 0 2px;
-          vertical-align: top;
-        }
-      }
-
-      [class^='btn'] {
-        color: $contextual-toolbar-button-color;
-      }
-    }
-
-    > * {
-      display: inline-block;
-      vertical-align: middle;
-    }
-  }
-
   .toolbar-section {
     &.title {
       padding: 1px 0;
@@ -101,6 +47,60 @@
         }
       }
     }
+  }
+}
+
+.contextual-toolbar {
+  font-size: 0;
+  position: relative;
+  text-align: left;
+  -webkit-touch-callout: none;
+  padding: 0 15px;
+
+  .toolbar-section {
+    @include enable-select();
+
+    height: 40px;
+    overflow: hidden;
+    position: relative;
+    text-align: left;
+    text-overflow: ellipsis;
+    top: 0;
+    white-space: nowrap;
+    width: 45%; // Overridden by sizing calculation.
+
+    &.title {
+      -webkit-font-smoothing: antialiased;
+      color: $contextual-toolbar-color;
+      font-size: $ids-size-font-base;
+      height: 42px;
+
+      &::before {
+        @include vertical-alignment-spacer;
+      }
+    }
+
+    &.buttonset {
+      width: calc(55% - 1px);
+      height: 42px;
+      user-select: none;
+      overflow: hidden;
+      padding-left: 1px;
+
+      > * {
+        margin: -1px 0 0 2px;
+        vertical-align: top;
+      }
+    }
+
+    [class^='btn'] {
+      color: $contextual-toolbar-button-color;
+    }
+  }
+
+  > * {
+    display: inline-block;
+    vertical-align: middle;
   }
 }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR changes the target to a contextual toolbar when adding selection text. 

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6591

**Steps necessary to review your pull request (required)**:
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/listview/test-multiselect-flex.html
- Select items
- Contextual toolbar should appear

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.