### PR TITLE
6434 - Follow-up fix for expanding the treegrid via keyboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "e2e:puppeteer": "npx --no-install jest --config=test/jest.config.js --runInBand --detectOpenHandles --forceExit",
     "e2e:update-imagesnapshots": "npx --no-install jest --config=test/jest.config.js --updateSnapshot --runInBand --detectOpenHandles --forceExit",
     "webdriver:clean": "npx webdriver-manager clean",
-    "webdriver:update": "npx webdriver-manager update --versions.chrome=101.0.4951.64 --standalone false --quiet --gecko=false",
+    "webdriver:update": "npx webdriver-manager update --versions.chrome=103.0.5060.53 --standalone false --quiet --gecko=false",
     "zip-dist": "npx grunt zip-dist",
     "documentation": "node ./scripts/deploy-documentation.js",
     "release:dev": "node scripts/publish-nightly-manual",
@@ -80,7 +80,7 @@
     "node-version-check": "npx check-node-version --node 14",
     "node-updates-check": "npx ncu"
   },
-  "chrome-version": "101",
+  "chrome-version": "103",
   "dependencies": {
     "d3": "^5.16.0",
     "ids-identity": "4.11.9",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "e2e:puppeteer": "npx --no-install jest --config=test/jest.config.js --runInBand --detectOpenHandles --forceExit",
     "e2e:update-imagesnapshots": "npx --no-install jest --config=test/jest.config.js --updateSnapshot --runInBand --detectOpenHandles --forceExit",
     "webdriver:clean": "npx webdriver-manager clean",
-    "webdriver:update": "npx webdriver-manager update --versions.chrome=103.0.5060.53 --standalone false --quiet --gecko=false",
+    "webdriver:update": "npx webdriver-manager update --versions.chrome=102.0.5005.115 --standalone false --quiet --gecko=false",
     "zip-dist": "npx grunt zip-dist",
     "documentation": "node ./scripts/deploy-documentation.js",
     "release:dev": "node scripts/publish-nightly-manual",
@@ -80,7 +80,7 @@
     "node-version-check": "npx check-node-version --node 14",
     "node-updates-check": "npx ncu"
   },
-  "chrome-version": "103",
+  "chrome-version": "102",
   "dependencies": {
     "d3": "^5.16.0",
     "ids-identity": "4.11.9",

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9675,7 +9675,7 @@ Datagrid.prototype = {
         // Toggle datagrid-expand with Space press
         const btn = target.find('.datagrid-expand-btn, .datagrid-drilldown');
         if (btn && btn.length) {
-          btn.trigger('click.datagrid');
+          btn.trigger('click');
           e.preventDefault();
           return;
         }
@@ -9692,7 +9692,7 @@ Datagrid.prototype = {
       if (self.settings.editable && key === 32) {
         const btnExpand = target?.find('.datagrid-expand-btn');
         if (btnExpand) {
-          btnExpand.trigger('click.datagrid');
+          btnExpand.trigger('click');
           e.preventDefault(); // This will prevent scrolling down when the list is overflowing.
         }
 

--- a/test/components/datagrid/datagrid.puppeteer-spec.js
+++ b/test/components/datagrid/datagrid.puppeteer-spec.js
@@ -163,7 +163,7 @@ describe('Datagrid Puppeteer Tests', () => {
     });
   });
 
-  describe('Datagrid', () => {
+  describe('Datagrid update column', () => {
     const url = `${baseUrl}/test-update-column.html`;
     beforeAll(async () => {
       await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });
@@ -177,27 +177,45 @@ describe('Datagrid Puppeteer Tests', () => {
       expect(firstValue).not.toEqual(secondValue);
     });
   });
-});
 
-describe('Datagrid test to have a method to make cell editable', () => {
-  const url = 'http://localhost:4000/components/datagrid/test-addrow-selected.html';
-  beforeAll(async () => {
-    await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });
+  describe('Datagrid test to have a method to make cell editable', () => {
+    const url = `${baseUrl}/test-addrow-selected.html`;
+    beforeAll(async () => {
+      await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });
+    });
+
+    it('should have method for cell editing for new row added', async () => {
+      await page.waitForSelector('#add-row-button');
+      await page.click('#add-row-button');
+
+      const focusedEl = await page.evaluateHandle(() => document.activeElement);
+      await focusedEl.type('ttest', { delay: 1000 });
+      await page.waitForTimeout(200);
+      await page.keyboard.press('Tab');
+      await page.waitForTimeout(200);
+
+      const input = await page.$('.datagrid-row:nth-child(1) > .has-editor:nth-child(2) > .datagrid-cell-wrapper');
+      await page.waitForTimeout(200);
+      const value = await page.evaluate(el => el.textContent, input);
+      expect(value).toContain('test');
+    });
   });
 
-  it('should have method for cell editing for new row added', async () => {
-    await page.waitForSelector('#add-row-button');
-    await page.click('#add-row-button');
+  describe('Test with tree checkbox', () => {
+    const url = `${baseUrl}/test-tree-with-checkbox.html`;
+    beforeAll(async () => {
+      await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });
+    });
 
-    const focusedEl = await page.evaluateHandle(() => document.activeElement);
-    await focusedEl.type('ttest', { delay: 1000 });
-    await page.waitForTimeout(200);
-    await page.keyboard.press('Tab');
-    await page.waitForTimeout(200);
+    it('should expand the treegrid via keyboard whenn editable is set to true', async () => {
+      // Tab three times to focus on the expand button
+      for (let i = 0; i < 3; i++) {
+        page.keyboard.press('Tab');
+      }
+      await page.keyboard.press('Space');
 
-    const input = await page.$('.datagrid-row:nth-child(1) > .has-editor:nth-child(2) > .datagrid-cell-wrapper');
-    await page.waitForTimeout(200);
-    const value = await page.evaluate(el => el.textContent, input);
-    expect(value).toContain('test');
+      await page.evaluate(() => document.querySelector('.datagrid-expand-btn').getAttribute('class'))
+        .then(el => expect(el).toContain('is-expanded'));
+    });
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR is a follow-up fix for expanding the treegrid via keyboard and added e2e to capture the functionality.

**Related github/jira issue (required)**:

Closes
- #6434 

Related PR
- https://github.com/infor-design/enterprise/pull/6578

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-tree-with-checkbox.html
- Focus on the cell with the expand button
- Hit space
- It should expand the row of treegrid

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
