### PR TITLE
6464 - Tabs Focus Indicator Classic

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@
 - `[Modal]` Fixed an issue on some monitors where the overlay is too dim. ([#6566](https://github.com/infor-design/enterprise/issues/6566))
 - `[Page-Patterns]` Fixed a bug where the header disappears when the the last item in the list is clicked and the browser is smaller in Chrome and Edge. ([#6328](https://github.com/infor-design/enterprise/issues/6328))
 - `[ToolbarFlex]` Fixed a bug where the teardown might error on situations. ([#1327](https://github.com/infor-design/enterprise/issues/1327))
+- `[Tabs]` Fixed a bug where tabs focus indicator is not fixed on Classic Theme. ([#6464](https://github.com/infor-design/enterprise/issues/6464))
 - `[Validation]` Fixed a bug where the tooltip would show on the header when the message has actually been removed. ([#6547](https://github.com/infor-design/enterprise/issues/6547)
 
 ## v4.64.2 Fixes

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -3809,6 +3809,7 @@ Tabs.prototype = {
     const parentContainer = this.element;
     const scrollingTablist = this.tablistContainer;
     const hasCompositeForm = parentContainer.parents('.composite-form').length;
+    const hasHeader = parentContainer.parents('.header.has-tabs').length;
     const accountForPadding = scrollingTablist && this.focusState.parent().is(scrollingTablist);
     const widthPercentage = target[0].getBoundingClientRect().width / target[0].offsetWidth * 100;
 
@@ -3844,7 +3845,7 @@ Tabs.prototype = {
         }
 
         // Composite Form has additional padding on the right
-        if (hasCompositeForm) {
+        if (isRTL && hasCompositeForm && !hasHeader) {
           targetRectObj.right -= 42;
 
           if (isRTL) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug where tab focus indicator is not aligned properly in RTL composite forms.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6464

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/tabs/example-composite-form-on-side.html?locale=ar-sa
- Focus on the tabs
- Go to http://localhost:4000/components/tabs/example-desktop-breakpoint.html?theme=classic&mode=light&colors=2578a9&locale=ar-SA
- Focus on the tabs

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

