### PR TITLE
6526 - Fix overlapping border focus

### DIFF
--- a/src/components/tabs-module/_tabs-module.scss
+++ b/src/components/tabs-module/_tabs-module.scss
@@ -317,8 +317,9 @@
       }
     }
 
-    .more {
-      height: 34px;
+    .more,
+    .more .btn-actions {
+      height: 32px;
     }
 
     [class^='btn'],


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This is a follow-up fix of the overlapping border focus in tabs module.

**Related github/jira issue (required)**:

Closes
- #6526 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/tabs-module/example-category-searchfield.html
- Hit tab until you reach the `btn-action` (ellipsis button)
- Border should not overlap

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
