### PR TITLE
6530 - Fix redundant aria-describedby attribute

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## v4.66.0 Fixes
 
+- `[Datagrid]` Fixed redundant aria-describedby attributes at cells. ([#6530](https://github.com/infor-design/enterprise/issues/6530))
+
 ## v4.65.0
 
 ## v4.65.0 Features

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4815,8 +4815,6 @@ Datagrid.prototype = {
         cssClass = cssClass.replace(/^\s+|\s+$/g, '').replace(/\s+/g, ' ');
       }
 
-      const idProp = this.settings.attributes?.filter(a => a.name === 'id');
-      const ariaDescribedby = `aria-describedby="${idProp?.length === 1 ? `${idProp[0].value}-col-${col.id?.toLowerCase()}` : self.uniqueId(`-header-${j}`)}"`;
       let ariaChecked = '';
 
       // Set aria-checkbox attribute
@@ -4836,8 +4834,7 @@ Datagrid.prototype = {
       }
 
       containerHtml[container] += `<td role="gridcell" ${ariaReadonly} aria-colindex="${j + 1}"` +
-          ` ${ariaDescribedby
-          }${ariaChecked
+          ` ${ariaChecked
           }${isSelected ? ' aria-selected="true"' : ''
           }${cssClass ? ` class="${cssClass}"` : ''
           }${colspan ? ` colspan="${colspan}"` : ''

--- a/test/components/datagrid/datagrid-aria.func-spec.js
+++ b/test/components/datagrid/datagrid-aria.func-spec.js
@@ -56,7 +56,6 @@ describe('Datagrid ARIA', () => { //eslint-disable-line
     expect(document.querySelectorAll('.datagrid-wrapper tbody tr')[0].querySelector('td').getAttribute('aria-readonly')).toEqual('true');
     expect(document.querySelectorAll('.datagrid-wrapper tbody tr')[0].querySelector('td').getAttribute('aria-colindex')).toEqual('1');
     expect(document.querySelectorAll('.datagrid-wrapper tbody tr')[0].querySelectorAll('td')[1].getAttribute('aria-colindex')).toEqual('2');
-    expect(document.querySelectorAll('.datagrid-wrapper tbody tr')[0].querySelector('td').getAttribute('aria-describedby')).toBeTruthy();
   });
 
   it('Should set ARIA attributes for selection', () => {

--- a/test/components/datagrid/datagrid.puppeteer-spec.js
+++ b/test/components/datagrid/datagrid.puppeteer-spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable compat/compat */
 const { getConfig, getComputedStyle } = require('../../helpers/e2e-utils.js');
 
 describe('Datagrid Puppeteer Tests', () => {
@@ -216,6 +217,21 @@ describe('Datagrid Puppeteer Tests', () => {
 
       await page.evaluate(() => document.querySelector('.datagrid-expand-btn').getAttribute('class'))
         .then(el => expect(el).toContain('is-expanded'));
+    });
+  });
+
+  describe('Landmark', () => {
+    const url = `${baseUrl}/test-landmark`;
+
+    beforeAll(async () => {
+      await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });
+    });
+
+    it('should not have aria-describedby attribute at cells', async () => {
+      await page.evaluate(async () => {
+        const cells = await document.querySelectorAll('.datagrid body tr td');
+        cells.forEach(cell => expect(cell.getAttribute('aria-describedby')).toBe(null));
+      });
     });
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes redundant `aria-describedby` attribute at cells.

**Related github/jira issue (required)**:

Closes
- #6530 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-landmark.html
- Check the cells
- It should not have `aria-describedby` attribute

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
