### PR TITLE
6580 - Fix overflowing of dropdown in datagrid when at edge of the screen

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@
 ## v4.66.0 Fixes
 
 - `[Datagrid]` Fixed redundant aria-describedby attributes at cells. ([#6530](https://github.com/infor-design/enterprise/issues/6530))
-- `[Datagrid]` Fixed overflowing of the multiselect dropdown in the page and push container that is near to the edge of the screen. ([#6580](https://github.com/infor-design/enterprise/issues/6580))
+- `[Datagrid]` Fixed the overflowing of the multiselect dropdown on the page and pushes the container near the screen's edge. ([#6580](https://github.com/infor-design/enterprise/issues/6580))
 
 ## v4.65.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## v4.66.0 Fixes
 
 - `[Datagrid]` Fixed redundant aria-describedby attributes at cells. ([#6530](https://github.com/infor-design/enterprise/issues/6530))
+- `[Datagrid]` Fixed overflowing of the multiselect dropdown in the page and push container that is near to the edge of the screen. ([#6580](https://github.com/infor-design/enterprise/issues/6580))
 
 ## v4.65.0
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -564,7 +564,7 @@ Datagrid.prototype = {
         self.pagerAPI.setActivePage(newActivePage, false, operationType);
         self.pagerAPI.triggerPagingEvents(self.pagerAPI.currentPage);
       }
-    } 
+    }
 
     if (!self.settings.paging && !self.settings.groupable) {
       if (location !== 'bottom') {

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -2041,14 +2041,18 @@ Dropdown.prototype = {
     // It adjust the position of datagrid filter dropdown
     // if the element goes out of the datagrid's container
     if (this.list.hasClass('datagrid-filter-dropdown')) {
-      const gridContainerPos = document.querySelector('.datagrid-container').getBoundingClientRect().right;
-      const gridFilterDropdownPos = document.querySelector('.datagrid-filter-dropdown').getBoundingClientRect().right;
-      const pageContainerPos = document.querySelector('.page-container').getBoundingClientRect().right;
-      const adjustedPosition = pageContainerPos - gridContainerPos;
+      const gridContainerPos = document.querySelector('.datagrid-container').getBoundingClientRect();
+      const gridFilterDropdownPos = document.querySelector('.datagrid-filter-dropdown').getBoundingClientRect();
+      const pageContainerPos = document.querySelector('[role="main"]').getBoundingClientRect().right;
+      const adjustedPosition = pageContainerPos - gridContainerPos.right;
 
-      if (gridContainerPos < gridFilterDropdownPos) {
+      if (gridContainerPos.right < gridFilterDropdownPos.right) {
         this.list[0].style.right = `${adjustedPosition}px`;
         this.list[0].style.left = '';
+      }
+
+      if (Locale.isRTL() && gridFilterDropdownPos.left < 0) {
+        this.list[0].style.left = `${gridContainerPos.left}px`;
       }
     }
 

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -2043,9 +2043,11 @@ Dropdown.prototype = {
     if (this.list.hasClass('datagrid-filter-dropdown')) {
       const gridContainerPos = document.querySelector('.datagrid-container').getBoundingClientRect().right;
       const gridFilterDropdownPos = document.querySelector('.datagrid-filter-dropdown').getBoundingClientRect().right;
+      const pageContainerPos = document.querySelector('.page-container').getBoundingClientRect().right;
+      const adjustedPosition = pageContainerPos - gridContainerPos;
 
       if (gridContainerPos < gridFilterDropdownPos) {
-        this.list[0].style.right = '0';
+        this.list[0].style.right = `${adjustedPosition}px`;
         this.list[0].style.left = '';
       }
     }

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -2038,6 +2038,18 @@ Dropdown.prototype = {
 
     this.position();
 
+    // It adjust the position of datagrid filter dropdown
+    // if the element goes out of the datagrid's container
+    if (this.list.hasClass('datagrid-filter-dropdown')) {
+      const gridContainerPos = document.querySelector('.datagrid-container').getBoundingClientRect().right;
+      const gridFilterDropdownPos = document.querySelector('.datagrid-filter-dropdown').getBoundingClientRect().right;
+
+      if (gridContainerPos < gridFilterDropdownPos) {
+        this.list[0].style.right = '0';
+        this.list[0].style.left = '';
+      }
+    }
+
     if (this.settings.virtualScroll) {
       let selectedIndex = -1;
       let selectedElem = null;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the overflowing of the multiselect dropdown on the page and pushes the container near the screen's edge.

**Related github/jira issue (required)**:

Closes
- #6580 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/example-filter.html
- Shrink the screen width so that "Activity" or "Activity (Multi)" is near the right edge of the screen
- Click open the dropdown
- Dropdown should be placed inside of the datagrid container and the page should not add white space
- Test in RTL position too http://localhost:4000/components/datagrid/example-filter?theme=new&mode=light&colors=0066D4&locale=ar-SA

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
