### PR TITLE
6610 - Fix on close button not showing in Firefox

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - `[Fileupload Advanced]` Fix on max fileupload limit. ([#6625](https://github.com/infor-design/enterprise/issues/6625))
 - `[Datagrid]` Fixed redundant aria-describedby attributes at cells. ([#6530](https://github.com/infor-design/enterprise/issues/6530))
+- `[Tabs]` Fix on close button not showing in Firefox. ([#6610](https://github.com/infor-design/enterprise/issues/6610))
 
 ## v4.65.0
 

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -546,7 +546,7 @@
             height: 10px;
             margin-left: -3px;
             margin-top: 2px;
-            padding-right: -1px;
+            padding-right: 0;
             right: -1px;
             top: 1px;
             z-index: 10;

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -546,7 +546,7 @@
             height: 10px;
             margin-left: -3px;
             margin-top: 2px;
-            padding-right: 0;
+            padding-right: -1px;
             right: -1px;
             top: 1px;
             z-index: 10;
@@ -912,6 +912,11 @@ html.is-firefox {
         .icon-info,
         .icon-alert {
           top: 12px;
+        }
+
+        &.dismissible .icon.close {
+          padding-right: 0;
+          right: 0;
         }
       }
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Edited css of close icon in Firefox.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #6610 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- In Firefox, go to: http://localhost:4000/components/tabs-header/example-add-tab-button.html
- Add Tab with + button
- New tab should have close icon

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
