### PR TITLE
6632 - Datepicker Increment/Decrement Settings

### DIFF
--- a/app/views/components/datepicker/test-datepicker-today-increment-key.html
+++ b/app/views/components/datepicker/test-datepicker-today-increment-key.html
@@ -15,6 +15,7 @@
   $('body').on('initialized', function() {
     $('#date-field-normal')
       .datepicker({
+        todayWithKeyboard: true,
         incrementWithKeyboard: true,
         attributes: [
           { name: 'id', value: 'custom-id' },

--- a/app/views/components/datepicker/test-increment-decrement-day.html
+++ b/app/views/components/datepicker/test-increment-decrement-day.html
@@ -1,0 +1,28 @@
+
+<div class="row">
+  <div class="four columns">
+
+    <div class="field">
+      <label for="date-field-normal" class="label">Date Field</label>
+      <input id="date-field-normal" data-automation-id="custom-automation-id" class="datepicker" name="date-field" type="text" data-init="false"/>
+    </div>
+
+  </div>
+
+</div>
+
+<script>
+  $('body').on('initialized', function() {
+    $('#date-field-normal')
+      .datepicker({
+        updateWithKeyboard: true,
+        attributes: [
+          { name: 'id', value: 'custom-id' },
+          { name: 'data-automation-id', value: 'custom-automation-id' }
+      ]})
+      .on('change', function () {
+        console.log('Change Event Fired')
+      });
+  });
+
+</script>

--- a/app/views/components/datepicker/test-increment-decrement-day.html
+++ b/app/views/components/datepicker/test-increment-decrement-day.html
@@ -15,7 +15,7 @@
   $('body').on('initialized', function() {
     $('#date-field-normal')
       .datepicker({
-        updateWithKeyboard: true,
+        incrementWithKeyboard: true,
         attributes: [
           { name: 'id', value: 'custom-id' },
           { name: 'data-automation-id', value: 'custom-automation-id' }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## v4.66.0 Features
 
 - `[Busyindicator]` Converted protractor tests to puppeteer. ([#6623](https://github.com/infor-design/enterprise/issues/6623))
+- `[Datepicker]` Added setting for adjusting day using +/- in datepicker. ([#6632](https://github.com/infor-design/enterprise/issues/6632))
 - `[Textarea]` Converted protractor tests to puppeteer. ([#6629](https://github.com/infor-design/enterprise/issues/6629))
 
 ## v4.66.0 Fixes

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -90,7 +90,7 @@ const COMPONENT_NAME = 'datepicker';
  * @param {string} [settings.attributes] Add extra attributes like id's to the element. For example `attributes: { name: 'id', value: 'my-unique-id' }`
  * @param {string} [settings.autocompleteAttribute="off"] Allows prevention of built-in browser typeahead by changing/removing an `autocomplete` attribute to the field.
  * @param {boolean} [settings.tabbable=true] If true, causes the Datepicker's trigger icon to be focusable with the keyboard.
- * @param {boolean} [settings.updateWithKeyboard=true] If true, enables increment/decrement of day by using +/- in the keyboard.
+ * @param {boolean} [settings.updateWithKeyboard=false] If true, enables increment/decrement of day by using +/- in the keyboard.
 */
 const LEGEND_DEFAULTS = [
   { name: 'Public Holiday', color: 'azure06', dates: [] },

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -149,7 +149,8 @@ const DATEPICKER_DEFAULTS = {
   autocompleteAttribute: 'off',
   useMask: true,
   tabbable: true,
-  incrementWithKeyboard: false
+  incrementWithKeyboard: false,
+  todayWithKeyboard: false
 };
 
 function DatePicker(element, settings) {
@@ -426,7 +427,7 @@ DatePicker.prototype = {
       }
 
       // 't' selects today
-      if (key === 84) {
+      if (key === 84 && this.settings.todayWithKeyboard) {
         handled = true;
         this.setToday();
       }

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -90,7 +90,7 @@ const COMPONENT_NAME = 'datepicker';
  * @param {string} [settings.attributes] Add extra attributes like id's to the element. For example `attributes: { name: 'id', value: 'my-unique-id' }`
  * @param {string} [settings.autocompleteAttribute="off"] Allows prevention of built-in browser typeahead by changing/removing an `autocomplete` attribute to the field.
  * @param {boolean} [settings.tabbable=true] If true, causes the Datepicker's trigger icon to be focusable with the keyboard.
- * @param {boolean} [settings.updateWithKeyboard=false] If true, enables increment/decrement of day by using +/- in the keyboard.
+ * @param {boolean} [settings.incrementWithKeyboard=false] If true, enables increment/decrement of day by using +/- in the keyboard.
 */
 const LEGEND_DEFAULTS = [
   { name: 'Public Holiday', color: 'azure06', dates: [] },
@@ -149,7 +149,7 @@ const DATEPICKER_DEFAULTS = {
   autocompleteAttribute: 'off',
   useMask: true,
   tabbable: true,
-  updateWithKeyboard: false
+  incrementWithKeyboard: false
 };
 
 function DatePicker(element, settings) {
@@ -431,7 +431,7 @@ DatePicker.prototype = {
         this.setToday();
       }
 
-      if (!hasMinusPattern && this.settings.updateWithKeyboard) {
+      if (!hasMinusPattern && this.settings.incrementWithKeyboard) {
         // get input value
         const inputVal = $(e.currentTarget).val();
 

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -90,6 +90,7 @@ const COMPONENT_NAME = 'datepicker';
  * @param {string} [settings.attributes] Add extra attributes like id's to the element. For example `attributes: { name: 'id', value: 'my-unique-id' }`
  * @param {string} [settings.autocompleteAttribute="off"] Allows prevention of built-in browser typeahead by changing/removing an `autocomplete` attribute to the field.
  * @param {boolean} [settings.tabbable=true] If true, causes the Datepicker's trigger icon to be focusable with the keyboard.
+ * @param {boolean} [settings.updateWithKeyboard=true] If true, enables increment/decrement of day by using +/- in the keyboard.
 */
 const LEGEND_DEFAULTS = [
   { name: 'Public Holiday', color: 'azure06', dates: [] },
@@ -147,7 +148,8 @@ const DATEPICKER_DEFAULTS = {
   attributes: null,
   autocompleteAttribute: 'off',
   useMask: true,
-  tabbable: true
+  tabbable: true,
+  updateWithKeyboard: false
 };
 
 function DatePicker(element, settings) {
@@ -429,7 +431,7 @@ DatePicker.prototype = {
         this.setToday();
       }
 
-      if (!hasMinusPattern) {
+      if (!hasMinusPattern && this.settings.updateWithKeyboard) {
         // get input value
         const inputVal = $(e.currentTarget).val();
 

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -84,9 +84,7 @@ describe('Datepicker example-index tests', () => {
     await element(by.css('.btn-icon.prev')).click();
 
     expect(await element.all(by.css('#monthview-popup td.is-selected')).count()).toEqual(1);
-  });
-
-  
+  });  
 
   it('Should be able to set id/automation id', async () => {
     const datepickerEl = await element(by.id('date-field-normal'));

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -86,19 +86,7 @@ describe('Datepicker example-index tests', () => {
     expect(await element.all(by.css('#monthview-popup td.is-selected')).count()).toEqual(1);
   });
 
-  it('Should advance on +/-', async () => {
-    await element(by.id('date-field-normal')).sendKeys('7/4/2020');
-
-    expect(await element(by.id('date-field-normal')).getAttribute('value')).toEqual('7/4/2020');
-
-    await element(by.id('date-field-normal')).sendKeys(protractor.Key.ADD);
-
-    expect(await element(by.id('date-field-normal')).getAttribute('value')).toEqual('7/5/2020');
-
-    await element(by.id('date-field-normal')).sendKeys(protractor.Key.SUBTRACT);
-
-    expect(await element(by.id('date-field-normal')).getAttribute('value')).toEqual('7/4/2020');
-  });
+  
 
   it('Should be able to set id/automation id', async () => {
     const datepickerEl = await element(by.id('date-field-normal'));
@@ -2180,3 +2168,28 @@ describe('Datepicker translation tests', () => {
     expect(await element(by.css('.monthview-table thead')).getText()).toBe('一 二 三 四 五 六 日');
   });
 });
+
+describe('Datepicker Increment/Decrement tests', () => {
+  beforeEach(async () => {
+    await utils.setPage('/components/datepicker/test-increment-decrement-day?theme=classic&layout=nofrills');
+  });
+
+  it('Should not have errors', async () => {
+    await utils.checkForErrors();
+  });
+
+  it('Should advance on +/-', async () => {
+    await element(by.id('date-field-normal')).sendKeys('7/4/2020');
+
+    expect(await element(by.id('date-field-normal')).getAttribute('value')).toEqual('7/4/2020');
+
+    await element(by.id('date-field-normal')).sendKeys(protractor.Key.ADD);
+
+    expect(await element(by.id('date-field-normal')).getAttribute('value')).toEqual('7/5/2020');
+
+    await element(by.id('date-field-normal')).sendKeys(protractor.Key.SUBTRACT);
+
+    expect(await element(by.id('date-field-normal')).getAttribute('value')).toEqual('7/4/2020');
+  });
+});
+

--- a/test/components/datepicker/datepicker.e2e-spec.js
+++ b/test/components/datepicker/datepicker.e2e-spec.js
@@ -2169,7 +2169,7 @@ describe('Datepicker translation tests', () => {
 
 describe('Datepicker Increment/Decrement tests', () => {
   beforeEach(async () => {
-    await utils.setPage('/components/datepicker/test-increment-decrement-day?theme=classic&layout=nofrills');
+    await utils.setPage('/components/datepicker/test-datepicker-today-increment-key?theme=classic&layout=nofrills');
   });
 
   it('Should not have errors', async () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will add a setting for to allow keyboard hotkeys for increment and decrement of days in datepicker.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6632
Closes https://github.com/infor-design/enterprise/issues/6653

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datepicker/test-datepicker-today-increment-key.html
- In the first date field, press `t` to enter todays date
- While in the date field, press the `+` key
- The date should be incremented
- While in the date field, press the `-` key
- The date should be decremented

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

