### PR TITLE
6618 - Fix border style of searchfield in category when active

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,8 +9,9 @@
 
 ## v4.66.0 Fixes
 
-- `[Fileupload Advanced]` Fix on max fileupload limit. ([#6625](https://github.com/infor-design/enterprise/issues/6625))
 - `[Datagrid]` Fixed redundant aria-describedby attributes at cells. ([#6530](https://github.com/infor-design/enterprise/issues/6530))
+- `[Fileupload Advanced]` Fixed on max fileupload limit. ([#6625](https://github.com/infor-design/enterprise/issues/6625))
+- `[Tabs Module]` Fixed category border when focusing the searchfield. ([#6618](https://github.com/infor-design/enterprise/issues/6618)) 
 
 ## v4.65.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - `[Datagrid]` Fixed redundant aria-describedby attributes at cells. ([#6530](https://github.com/infor-design/enterprise/issues/6530))
 - `[Fileupload Advanced]` Fixed on max fileupload limit. ([#6625](https://github.com/infor-design/enterprise/issues/6625))
-- `[Tabs Module]` Fixed category border when focusing the searchfield. ([#6618](https://github.com/infor-design/enterprise/issues/6618)) 
+- `[Tabs Module]` Fixed category border when focusing the searchfield. ([#6618](https://github.com/infor-design/enterprise/issues/6618))
 
 ## v4.65.0
 

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -319,8 +319,7 @@ $toolbarsearchfield-category-empty-width: 51px;
       &.toolbar-searchfield-wrapper {
         &.has-categories {
           .searchfield {
-            border-bottom-color: rgba($searchfield-border-color, 1);
-            box-shadow: $focus-box-shadow-input;
+            border-left: 1px solid;
 
             &:focus {
               border-color: $header-searchfield-input-border-color;
@@ -427,6 +426,9 @@ $toolbarsearchfield-category-empty-width: 51px;
     &.searchfield-wrapper.show-category {
       .searchfield {
         border-left-color: $header-searchfield-input-border-color !important;
+        border-bottom: 0;
+        border-top: 0;
+        border-right: 0;
       }
     }
   }
@@ -610,6 +612,15 @@ $toolbarsearchfield-category-empty-width: 51px;
     }
 
     .searchfield-category-button {
+      border-bottom-left-radius: 2px;
+      border-top-left-radius: 2px;
+      border-top: 0;
+      border-bottom: 0;
+
+      .category {
+        color: $header-flex-toolbar-input-searchfield-color;
+      }
+
       &.btn {
         background-color: $searchfield-header-bg-color;
         border-bottom-color: rgba($searchfield-header-border-color, 0.7);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the styling of the toolbar searchfield category when active.

**Related github/jira issue (required)**:

Closes
- https://github.com/infor-design/enterprise/issues/6618

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/tabs-module/example-category-searchfield-go-button.html
- Click on the searchfield
- Searchfield border should be visible and should look correct
- Select any value in the category button
- Text should be visible

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
