### PR TITLE
NG1298 - rowData for grouping tooltip callback

### DIFF
--- a/app/views/components/datagrid/test-datagrid-grouping-tooltip.html
+++ b/app/views/components/datagrid/test-datagrid-grouping-tooltip.html
@@ -1,0 +1,44 @@
+<div class="row">
+  <div class="twelve columns">
+
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+
+    Locale.set('en-US').done(function () {
+        var grid,
+          columns = [],
+          data = [];
+
+        // Define Some Sample Data
+        data.push({ id: 1, warehouse: 'ABC', itemDescription: 'A bundle of wands'});
+        data.push({ id: 2, warehouse: 'ABC', itemDescription: 'A bundle of rods'});
+        data.push({ id: 2, warehouse: 'XYZ', itemDescription: 'Some other items'});
+
+        //Define Columns for the Grid.
+        var callback = function(rowIdx, cell, value, col, rowData, grid) {
+          console.log('row:', rowIdx);
+          console.log('rowData:', rowData);
+
+          return `${rowData.itemDescription}`
+        }
+
+        columns.push({ width: 30, id: 'warehouse', field: 'warehouse', name: 'Warehouse', resizable: false, sortable: false});
+        columns.push({ width: 75, id: 'itemDescription', field: 'itemDescription', name: 'Item Description', resizable: true, sortable: true, contentTooltip: true, tooltip: callback});
+
+        //Init the grid
+        $('#datagrid').datagrid({
+          columns: columns,
+          dataset: data,
+          selectable: 'single',
+          groupable: { fields: ['warehouse'], aggregator: '' },
+          enableTooltips: true
+        });
+    });
+  });
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Fileupload Advanced]` Fix on max fileupload limit. ([#6625](https://github.com/infor-design/enterprise/issues/6625))
 - `[Datagrid]` Fixed redundant aria-describedby attributes at cells. ([#6530](https://github.com/infor-design/enterprise/issues/6530))
 - `[Datagrid]` Fixed the overflowing of the multiselect dropdown on the page and pushes the container near the screen's edge. ([#6580](https://github.com/infor-design/enterprise/issues/6580))
+- `[Datagrid]` Fixed incorrect rowData for grouping tooltip callback. ([NG#1298](https://github.com/infor-design/enterprise-ng/issues/1298))
 
 ## v4.65.0
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -12713,7 +12713,7 @@ Datagrid.prototype = {
           rowData = this.settings.treeDepth[rowIdx].node;
         } else {
           rowIdx = this.dataRowIndex(rowElem);
-          rowData = this.settings.dataset[rowIdx];
+          rowData = this.rowData(rowIdx);
         }
 
         const value = this.fieldValue(rowData, col.field);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix incorrect rowData for grouping tooltip callback.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1298

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-datagrid-grouping-tooltip.html
- Open `Developer Console`
- `Hover` each of the rows to display the `tooltip`
- See the `rowData` correctly displaying in the `Console`

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

