### PR TITLE
6663 - Fix visiblity of datagrid alert icon in datagrid trigger cell

### DIFF
--- a/app/views/components/datagrid/test-editable-alerts.html
+++ b/app/views/components/datagrid/test-editable-alerts.html
@@ -13,6 +13,13 @@
         columns = [],
         data = [];
 
+
+      var myCustom = function (row, cell, value, col) {
+
+        return '<svg class="icon datagrid-alert-icon icon-error" focusable="false" aria-hidden="true" role="presentation"><use xlink:href="#icon-error"></use></svg><span class="datagrid-alert-text">On Hold</span>'
+
+      };
+
       // Some Sample Data
       data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
       data.push({ id: 2, productId: 2241202, productName: '1 Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
@@ -32,6 +39,8 @@
       columns.push({ id: 'quantity', name: 'Badge', field: 'quantity', align: 'center', formatter: Formatters.Badge, editor: Editors.Input, sortable: false, ranges: [{'min': 0, 'max': 2, 'classes': 'error'}, {'value': 41, 'classes': 'good'}]});
       columns.push({ id: 'price3', name: 'Tag', field: 'price', align: 'center', formatter: Formatters.Tag, editor: Editors.Input, ranges: [{'min': 151, 'max': 9999, 'classes': 'info'}]});
       columns.push({ id: 'price5', name: 'Price', field: 'price', editor: Editors.Input, formatter: Formatters.Decimal});
+      columns.push({ id: 'action', name: 'Action', field: 'action', formatter: myCustom, editor: Editors.Dropdown,
+        options: [{id: '', label: '', value: -1}, {id: 'oh1', label: 'On Hold', value: 1}, {id: 'sh1', label: 'Shipped', value: 2} , {id: 'ac1', label: 'Action', value: 3}, {id: 'pen', label: 'Pending', value: 4}, {id: 'bk1', label: 'Backorder', value: 5}, {id: 'can', label: 'Cancelled', value: 6}, {id: 'pro', label: 'Processing', value: 7}]});;
       columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', editor: Editors.Input, formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
 
       // Init and get the api for the grid

--- a/app/views/components/datagrid/test-editable-alerts.html
+++ b/app/views/components/datagrid/test-editable-alerts.html
@@ -33,7 +33,7 @@
       columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Readonly});
       columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink, href: 'http://www.google.com' });
       columns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity'});
-      columns.push({ id: 'alert', name: 'Alert w Text', field: 'quantity', formatter: Formatters.Alert, editor: Editors.Input, ranges: [{'min': 0, 'max': 8, 'classes': 'info', 'text': ' Alert Text'}, {'min': 9, 'max': 1000, 'classes': 'error', 'text': ' Alert Text'}]});
+      columns.push({ id: 'alert', name: 'Alert w Text', field: 'quantity', formatter: Formatters.Alert, editor: Editors.Input, ranges: [{'min': 0, 'max': 8, 'classes': 'info', 'text': 'Alert Text'}, {'min': 9, 'max': 1000, 'classes': 'error', 'text': 'Alert Text'}]});
       columns.push({ id: 'price', name: 'Alert Choose Header', field: 'price', formatter: Formatters.Alert, editor: Editors.Input, ranges: [{'min': 0, 'max': 150, 'classes': 'success', text: ' '}, {'min': 151, 'max': 9999, 'classes': 'error', text: ' '}]});
       columns.push({ id: 'price2', name: 'Alert', field: 'price', align: 'center', formatter: Formatters.Alert, editor: Editors.Input, ranges: [{'min': 0, 'max': 150, 'classes': 'success', text: ' '}, {'min': 151, 'max': 9999, 'classes': 'alert', text: ' '}]});
       columns.push({ id: 'quantity', name: 'Badge', field: 'quantity', align: 'center', formatter: Formatters.Badge, editor: Editors.Input, sortable: false, ranges: [{'min': 0, 'max': 2, 'classes': 'error'}, {'value': 41, 'classes': 'good'}]});

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## v4.66.0 Fixes
 
+- `[Datagrid]` Fixed the datagrid alert icon was not visible and the trigger cell moves when hovering over when editor has trigger icon. ([#6663](https://github.com/infor-design/enterprise/issues/6663))
 - `[Datagrid]` Fixed redundant aria-describedby attributes at cells. ([#6530](https://github.com/infor-design/enterprise/issues/6530))
 - `[Datagrid]` Updated filter phrases for datepicker. ([#6587](https://github.com/infor-design/enterprise/issues/6587))
 - `[Datagrid]` Fixed the overflowing of the multiselect dropdown on the page and pushes the container near the screen's edge. ([#6580](https://github.com/infor-design/enterprise/issues/6580))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -4073,7 +4073,7 @@ td .btn-actions {
     }
   }
 
-  .icon {
+  .icon:not(.datagrid-alert-icon) {
     @include trigger-icon-background($datagrid-cell-bg-color);
 
     color: $trigger-icon-fill-color;

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1366,7 +1366,7 @@ $datagrid-small-row-height: 25px;
     }
 
     .datagrid-trigger-cell {
-      .icon {
+      .icon:not(.datagrid-alert-icon) {
         left: 3px;
         top: 5px;
 
@@ -1541,7 +1541,7 @@ $datagrid-small-row-height: 25px;
             }
           }
 
-          .icon {
+          .icon:not(.datagrid-alert-icon) {
             height: 16px;
             top: 4px;
 
@@ -2014,7 +2014,7 @@ $datagrid-small-row-height: 25px;
 
     .datagrid-trigger-cell.has-editor:not(.is-readonly):hover,
     .datagrid-trigger-cell.has-editor:not(.is-readonly):focus {
-      .icon {
+      .icon:not(.datagrid-alert-icon) {
         &.icon-error {
           margin-left: -45px !important;
         }
@@ -2262,6 +2262,7 @@ $datagrid-small-row-height: 25px;
       line-height: 25px;
       margin-right: -8px;
       padding-left: 8px;
+      position: relative;
       text-align: left;
       width: inherit;
     }
@@ -4080,6 +4081,10 @@ td .btn-actions {
     top: 4px;
     visibility: hidden;
 
+    &.datagrid-alert-icon {
+      visibility: visible;
+    }
+
     &.icon-search-list {
       left: -1px;
       top: 4px;
@@ -4161,7 +4166,9 @@ td .btn-actions {
       .icon-error,
       .icon-info,
       .icon-alert {
+        &:not(.datagrid-alert-icon) {
         margin-left: -48px !important;
+        }
       }
     }
   }

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -4167,7 +4167,7 @@ td .btn-actions {
       .icon-info,
       .icon-alert {
         &:not(.datagrid-alert-icon) {
-        margin-left: -48px !important;
+          margin-left: -48px !important;
         }
       }
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the visibility of datagrid alert icon when the trigger cell is active and moving cell content when hovering over.

**Related github/jira issue (required)**:

Closes
- #6663 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-editable-alerts
- Check the `Action` Column
- Alert icon should be visible
- Hover on the cell
- It should not move when hovering over
- Test on different row heights

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
