### PR TITLE
Datepicker - Trigger monthrendered

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `[Tabs]` Fixed on close button not showing in Firefox. ([#6610](https://github.com/infor-design/enterprise/issues/6610))
 - `[Tabs Module]` Fixed category border when focusing the searchfield. ([#6618](https://github.com/infor-design/enterprise/issues/6618))
 - `[Montview]` Fixed missing legend data on visible previous / next month with using loadLegend API. ([#6665](https://github.com/infor-design/enterprise/issues/6665))
+- `[Datepicker]` Fixed missing monthrendered event on initial calendar open. ([NG#1345](https://github.com/infor-design/enterprise-ng/issues/1345))
 
 ## v4.65.0
 

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -851,6 +851,13 @@ DatePicker.prototype = {
       this.element.trigger('monthrendered', args);
     });
 
+    this.element.trigger('monthrendered', {
+      year: this.calendarAPI.currentYear,
+      month: this.calendarAPI.currentMonth,
+      elem: this.calendar,
+      api: this.calendarAPI
+    });
+
     if (s.showTime) {
       this.calendar.addClass('is-timepicker');
     }

--- a/test/components/datepicker/datepicker-events.func-spec.js
+++ b/test/components/datepicker/datepicker-events.func-spec.js
@@ -66,13 +66,26 @@ describe('DatePicker Aria', () => {
     }, 100);
   });
 
-  it('should trigger monthrendered event', (done) => {
+  it('should trigger monthrendered event on open.', (done) => {
     const field = document.querySelector('#date-field-normal');
     field.value = '11/06/2018';
 
     const spyEvent = spyOnEvent('#date-field-normal', 'monthrendered');
     datepickerAPI.openCalendar();
     setTimeout(() => {
+      expect(spyEvent).toHaveBeenTriggered();
+      done();
+    }, 100);
+  });
+
+  it('should trigger monthrendered event on month change.', (done) => {
+    const field = document.querySelector('#date-field-normal');
+    field.value = '11/06/2018';
+
+    const spyEvent = spyOnEvent('#date-field-normal', 'monthrendered');
+    datepickerAPI.openCalendar();
+    setTimeout(() => {
+      spyEvent.reset();
       const nextMonth = document.querySelector('#monthview-popup .calendar-toolbar button.next');
       nextMonth.click();
 


### PR DESCRIPTION
When the MonthView Calendar is opened from a Datepicker. The monthrendered event was not firing on the initial load. This is inconsistent behavior and causes hacks / work arounds.

**Related github/jira issue (required)**:
https://github.com/infor-design/enterprise-ng/issues/1345

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
