### PR TITLE
6679 - Fix trigger icon background color on hover when row is activated

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## v4.66.0 Fixes
 
+- `[Datagrid]` Fixed trigger icon background color on hover when row is activated. ([#6679](https://github.com/infor-design/enterprise/issues/6679))
 - `[Datagrid]` Fixed the datagrid alert icon was not visible and the trigger cell moves when hovering over when editor has trigger icon. ([#6663](https://github.com/infor-design/enterprise/issues/6663))
 - `[Datagrid]` Fixed redundant aria-describedby attributes at cells. ([#6530](https://github.com/infor-design/enterprise/issues/6530))
 - `[Datagrid]` Fixed on edit outline in textarea not filling the entire cell. ([#6588](https://github.com/infor-design/enterprise/issues/6588))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -2172,7 +2172,7 @@ $datagrid-small-row-height: 25px;
     &.is-rowactivated td:not(.is-editing) .datagrid-cell-wrapper {
       background-color: $datagrid-row-selected-color;
 
-      .icon-search-list {
+      .icon {
         @include trigger-icon-background($datagrid-row-selected-color);
       }
 

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -2172,6 +2172,10 @@ $datagrid-small-row-height: 25px;
     &.is-rowactivated td:not(.is-editing) .datagrid-cell-wrapper {
       background-color: $datagrid-row-selected-color;
 
+      .icon-search-list {
+        @include trigger-icon-background($datagrid-row-selected-color);
+      }
+
       .btn.row-btn {
         background-color: $button-color-primary-initial-background;
         border: 1px solid  $button-color-primary-initial-background;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the trigger icon background color on hover when a row is activated.

**Related github/jira issue (required)**:

Closes
- #6679 

**Steps necessary to review your pull request (required)**:
- Go to http://localhost:4000/components/datagrid/test-landmark
- Activate a row by clicking a noneditable cell (click `Dakar XLT 2 `) it should highlight the row.
- Then hover over other cells that have an icon when hovering.
- The trigger icon background should be the same as the color of the row.
- Test in classic and in different modes

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
