### PR TITLE
NG1323 - Insert Image rendering dark screen

### DIFF
--- a/app/views/components/editor/test-editor-no-ids.html
+++ b/app/views/components/editor/test-editor-no-ids.html
@@ -1,0 +1,18 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <div class="field">
+      <label class="label" for="title">Title</label>
+      <input type="text" id="title" value="The Page Title"/>
+    </div>
+
+    <div class="field">
+      <span id="comments-label" class="label">Comments</span>
+      <div class="editor" id="editor1" aria-label="Comments">
+        <p>Embrace <a href="http://en.wikipedia.org/wiki/e-commerce" class="hyperlink">e-commerce action-items</a>, reintermediate, ecologies paradigms wireless share life-hacks create innovative harness. Evolve solutions rich-clientAPIs synergies harness relationships virtual vertical facilitate end-to-end, wireless, evolve synergistic synergies.</p>
+        <p>Cross-platform, evolve, ROI scale cultivate eyeballs addelivery, e-services content cross-platform leverage extensible viral incentivize integrateAJAX-enabled sticky evolve magnetic cultivate leverage; cutting-edge. Innovate, end-to-end podcasting, whiteboard streamline e-business social; compelling, "cross-media exploit infomediaries innovative integrate integrateAJAX-enabled." Killer interactive reinvent, cultivate widgets leverage morph.</p>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Datagrid]` Fixed unselectRow on treegrid sending rowData incorrectly. ([#6548](https://github.com/infor-design/enterprise/issues/6548))
 - `[Datagrid]` Fixed incorrect rowData for grouping tooltip callback. ([NG#1298](https://github.com/infor-design/enterprise-ng/issues/1298))
 - `[Editor]` Fixed a bug where paste function is not working on editor when copied from Windows Adobe Reader. ([#6521](https://github.com/infor-design/enterprise/issues/6521))
+- `[Editor]` Fixed a bug where editor has dark screen after inserting an image. ([NG#1323](https://github.com/infor-design/enterprise-ng/issues/1323))
 - `[Fileupload Advanced]` Fixed on max fileupload limit. ([#6625](https://github.com/infor-design/enterprise/issues/6625))
 - `[Notification]` Updated css of notification to fix alignment in rtl mode. ([#6555](https://github.com/infor-design/enterprise/issues/6555))
 - `[Tabs]` Fixed on close button not showing in Firefox. ([#6610](https://github.com/infor-design/enterprise/issues/6610))

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -1284,10 +1284,14 @@ Editor.prototype = {
             self.createLink($(`[name="em-url-${self.id}"]`, this));
           }
         } else {
-          if (self.settings.attributes.length > 1) { // eslint-disable-line
-            self.insertImage($(`[data-automation-id="${self.settings.attributes[self.settings.attributes.length - 1].value}-editor-modal-input0"`).val());
+          if (self.settings.attributes) {
+            if (self.settings.attributes.length > 1) { // eslint-disable-line
+              self.insertImage($(`[data-automation-id="${self.settings.attributes[self.settings.attributes.length - 1].value}-editor-modal-input0"`).val());
+            } else {
+              self.insertImage($(`#${self.settings.attributes[0].value}-editor-modal-input0`).val());
+            }
           } else {
-            self.insertImage($(`#${self.settings.attributes[0].value}-editor-modal-input0`).val());
+            self.insertImage($('input[id*="image-editor"]').val());
           }
         }
       });

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -1283,16 +1283,14 @@ Editor.prototype = {
           } else {
             self.createLink($(`[name="em-url-${self.id}"]`, this));
           }
-        } else {
-          if (self.settings.attributes) {
-            if (self.settings.attributes.length > 1) { // eslint-disable-line
-              self.insertImage($(`[data-automation-id="${self.settings.attributes[self.settings.attributes.length - 1].value}-editor-modal-input0"`).val());
-            } else {
-              self.insertImage($(`#${self.settings.attributes[0].value}-editor-modal-input0`).val());
-            }
+        } else if (self.settings.attributes) {
+          if (self.settings.attributes.length > 1) { // eslint-disable-line
+            self.insertImage($(`[data-automation-id="${self.settings.attributes[self.settings.attributes.length - 1].value}-editor-modal-input0"`).val());
           } else {
-            self.insertImage($('input[id*="image-editor"]').val());
+            self.insertImage($(`#${self.settings.attributes[0].value}-editor-modal-input0`).val());
           }
+        } else {
+          self.insertImage($('input[id*="image-editor"]').val());
         }
       });
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fixed a bug where dark screen is rendered after inserting an image in editor.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1323

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/editor/test-editor-no-ids.html
- Click on the insert an image button from the toolbar of the soho editor
- Paste the following link https://helpx.adobe.com/content/dam/help/en/photoshop/using/convert-color-image-black-white/jcr_content/main-pars/before_and_after/image-before/Landscape-Color.jpg and click insert

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

