### PR TITLE
6613 - Fix tooltip event handlers not cleaning up properly on hide

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `[Tabs]` Fixed on close button not showing in Firefox. ([#6610](https://github.com/infor-design/enterprise/issues/6610))
 - `[Tabs]` Remove target panel element on remove event. ([#6621](https://github.com/infor-design/enterprise/issues/6621))
 - `[Tabs Module]` Fixed category border when focusing the searchfield. ([#6618](https://github.com/infor-design/enterprise/issues/6618))
+- `[Tooltip]` Fixed tooltip event handlers created on show not cleaning up properly on hide. ([#6613](https://github.com/infor-design/enterprise/issues/6613))
 - `[Montview]` Fixed missing legend data on visible previous / next month with using loadLegend API. ([#6665](https://github.com/infor-design/enterprise/issues/6665))
 - `[Datepicker]` Fixed missing monthrendered event on initial calendar open. ([NG#1345](https://github.com/infor-design/enterprise-ng/issues/1345))
 

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -1089,6 +1089,7 @@ Tooltip.prototype = {
    * @returns {void}
    */
   detachOpenEvents() {
+    const self = this;
     this.tooltip.off(`click.${COMPONENT_NAME}`);
 
     $(document).off([


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the tooltip event handlers not cleaning up properly on the `hide` method.

**Related github/jira issue (required)**:

Closes
- #6613 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/popover/test-popover-tooltip
- In `tooltip.js` add a `debugger` in line `1094` under `detachOpenEvents` method
- On the test page, click the button `Click to Show Popover`
- Then click the close icon on popover to go through the line of code
- Print the `self.uniqueId` in the console tab
- It should return a value `popover-1`
- Before this fix, the `self` object is the window object, not the tooltip so it returns undefined

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
