### PR TITLE
NG1304. Fix "clickoutside" not triggering in NG popdown

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@
 - `[Fileupload Advanced]` Fixed on max fileupload limit. ([#6625](https://github.com/infor-design/enterprise/issues/6625))
 - `[Montview]` Fixed missing legend data on visible previous / next month with using loadLegend API. ([#6665](https://github.com/infor-design/enterprise/issues/6665))
 - `[Notification]` Updated css of notification to fix alignment in rtl mode. ([#6555](https://github.com/infor-design/enterprise/issues/6555))
+- `[Popdown]` Fixed popdown not closing when clicking outside in NG. ([NG#1304](https://github.com/infor-design/enterprise-ng/issues/1304))
 - `[Tabs]` Fixed on close button not showing in Firefox. ([#6610](https://github.com/infor-design/enterprise/issues/6610))
 - `[Tabs]` Remove target panel element on remove event. ([#6621](https://github.com/infor-design/enterprise/issues/6621))
 - `[Tabs Module]` Fixed category border when focusing the searchfield. ([#6618](https://github.com/infor-design/enterprise/issues/6618))

--- a/src/components/popdown/popdown.js
+++ b/src/components/popdown/popdown.js
@@ -141,12 +141,13 @@ Popdown.prototype = {
       })
       .on('updated.popdown', () => {
         self.updated();
-      })
-      .on('clickoutside.popdown', (e) => {
-        if (!self.settings.keepOpen) {
-          self.handleFocusOut(e);
-        }
       });
+
+    $(document).on('click', (e) => {
+      if (!self.element.is($(e.target)) && !self.settings.keepOpen) {
+        self.handleFocusOut(e);
+      }
+    });
 
     // First and last tab
     this.setFirstLastTab();
@@ -408,7 +409,9 @@ Popdown.prototype = {
    */
   handleFocusOut(e) {
     const self = this;
+    console.log('focus')
     if (self.focusableElems.includes(e.target) || self.hasFocus(e.target)) {
+      console.log(3)
       self.keyTarget = e.target;
       return;
     }
@@ -416,6 +419,7 @@ Popdown.prototype = {
     // near the front or back are focused. `keyTarget` detects what was previously clicked
     // and is used as an additional element check in these cases.
     if (e.target.tagName === 'BODY' && self.keyTarget) {
+      console.log(4)
       delete self.keyTarget;
       return;
     }

--- a/src/components/popdown/popdown.js
+++ b/src/components/popdown/popdown.js
@@ -141,13 +141,11 @@ Popdown.prototype = {
       })
       .on('updated.popdown', () => {
         self.updated();
+      }).on('clickoutside.popdown', (e) => {
+        if (!self.settings.keepOpen) {
+          self.handleFocusOut(e);
+        }
       });
-
-    $(document).on('click', (e) => {
-      if (!self.element.is($(e.target)) && !self.settings.keepOpen) {
-        self.handleFocusOut(e);
-      }
-    });
 
     // First and last tab
     this.setFirstLastTab();
@@ -409,9 +407,7 @@ Popdown.prototype = {
    */
   handleFocusOut(e) {
     const self = this;
-    console.log('focus')
     if (self.focusableElems.includes(e.target) || self.hasFocus(e.target)) {
-      console.log(3)
       self.keyTarget = e.target;
       return;
     }
@@ -419,7 +415,6 @@ Popdown.prototype = {
     // near the front or back are focused. `keyTarget` detects what was previously clicked
     // and is used as an additional element check in these cases.
     if (e.target.tagName === 'BODY' && self.keyTarget) {
-      console.log(4)
       delete self.keyTarget;
       return;
     }
@@ -464,7 +459,7 @@ Popdown.prototype = {
         // Only allow $(document).click() to close the Popdown if `keepOpen` isn't set.
         // Also run this on `focusout` events that occur outside the Popdown, for keyboard access.
         $(document).on('click.popdown', () => {
-          $('#popdown-example-trigger').trigger('clickoutside.popdown');
+          self.element.trigger('clickoutside.popdown');
         });
 
         // Setup a global keydown event that can handle the closing of modals in the proper order.


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
The event "clickoutside" was not being triggered due to "#popdown-example-trigger" not existing in Angular, changed element to popdown element instead.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Addresses issue in https://github.com/infor-design/enterprise-ng/issues/1304

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build the app
- Use this version for NG
- Pull NG branch: https://github.com/infor-design/enterprise-ng/pull/1351
- Build and run NG
- Go to: http://localhost:4200/ids-enterprise-ng-demo/popdown
- Click on My Cart
- Popdown should appear
- Click outside My Cart
- Popdown should close

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
