### PR TITLE
Fix for git issue #6705. Searchfield icon has overflow underneath when collapsed.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # What's New with Enterprise
 
+## v4.64.4 Fixes
+- `[SearchField]` Added part of the fix from #6418 to fix an extra scrollbar on collapsed search fields. ([#6418](https://github.com/infor-design/enterprise/issues/6418))`
+
 ## v4.64.3 Fixes
 
 - `[Datepicker]` Fixed missing monthrendered event on initial calendar open. ([NG#1345](https://github.com/infor-design/enterprise-ng/issues/1345))

--- a/src/components/searchfield/_searchfield-new.scss
+++ b/src/components/searchfield/_searchfield-new.scss
@@ -35,6 +35,8 @@
   // missing text height.  The padding values should equal to `1px` taller on each side
   // than the standard input field padding.  The "closed" state also shifts the visual
   // location of the text/icon to better align it with other toolbar buttons.
+  overflow: hidden;
+
   &:not(.is-open),
   &.non-collapsible {
     .searchfield {
@@ -75,6 +77,7 @@ html.is-firefox {
 
     &.toolbar-searchfield-wrapper {
       height: 38px;
+      overflow: hidden;
     }
 
     .searchfield-category-button {

--- a/src/components/toolbar-flex/_toolbar-flex.scss
+++ b/src/components/toolbar-flex/_toolbar-flex.scss
@@ -82,6 +82,7 @@
       bottom: 1px;
       display: flex;
       position: relative;
+      overflow: hidden;
 
       &.toolbar-searchfield-wrapper.has-close-icon-button {
         .btn-icon.close {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes 6705. This has been fixed in 4.65.x. This change is also needed in 4.64.x

**Related github/jira issues (required)**:
https://github.com/infor-design/enterprise/issues/6705
https://github.com/infor-design/enterprise/commit/64161d0b4f4350a489c0814ce28d9a9090e44e8e

**Steps necessary to review your pull request (required)**:
1. Checkout branch 6705-searchfield
2. Navigate to http://localhost:4000/components/toolbar-flex/test-gauntlet.html
3. Resize browser to smaller resolution.
4. Notice no scrollbar under search icon.

<img width="539" alt="fixed" src="https://user-images.githubusercontent.com/1056684/182465898-2e3de417-c576-48a7-bad9-6eeef3f76210.png">