### PR TITLE
6711 - Added CSS classes for IDS Status Colors to target color and border-color properties

### DIFF
--- a/app/views/components/colors/example-index.html
+++ b/app/views/components/colors/example-index.html
@@ -577,9 +577,7 @@
       <svg class="icon status-01-color demo-center" focusable="false" aria-hidden="true" role="presentation">
         <use href="#icon-error-alert"></use>
       </svg>
-      <span class="light-color">
-        <span class="palette-hex"></span>
-      </span>
+      <p class="palette-hex-svg"></p>
     </div>
   </div>
   <div class="palette-column">
@@ -588,9 +586,7 @@
       <svg class="icon status-02-color demo-center" focusable="false" aria-hidden="true" role="presentation">
         <use href="#icon-error-alert"></use>
       </svg>
-      <span class="light-color">
-        <span class="palette-hex"></span>
-      </span>
+      <p class="palette-hex-svg"></p>
     </div>
   </div>
   <div class="palette-column">
@@ -599,9 +595,7 @@
       <svg class="icon status-03-color demo-center" focusable="false" aria-hidden="true" role="presentation">
         <use href="#icon-error-alert"></use>
       </svg>
-      <span class="light-color">
-        <span class="palette-hex"></span>
-      </span>
+      <p class="palette-hex-svg"></p>
     </div>
   </div>
   <div class="palette-column">
@@ -610,9 +604,7 @@
       <svg class="icon status-04-color demo-center" focusable="false" aria-hidden="true" role="presentation">
         <use href="#icon-error-alert"></use>
       </svg>
-      <span class="light-color">
-        <span class="palette-hex"></span>
-      </span>
+      <p class="palette-hex-svg"></p>
     </div>
   </div>
   <div class="palette-column">
@@ -621,12 +613,11 @@
       <svg class="icon status-05-color demo-center" focusable="false" aria-hidden="true" role="presentation">
         <use href="#icon-error-alert"></use>
       </svg>
-      <span class="light-color">
-        <span class="palette-hex"></span>
-      </span>
+      <p class="palette-hex-svg"></p>
     </div>
   </div>
 </div>
+
 
 <script>
   var setColorText = function(paletteType, property) {
@@ -667,7 +658,7 @@
       }
     })
     Array.prototype.forEach.call(paletteSVGColor, function(color) {
-      const paletteHex = color.querySelector('.palette-hex');
+      const paletteHex = color.querySelector('.palette-hex-svg');
       const cColor = window.getComputedStyle(color.querySelector('.icon'), null).getPropertyValue('color');
       const rgbValues = cColor.match(/\d+/g);
       if (paletteHex !== null) {

--- a/app/views/components/colors/example-index.html
+++ b/app/views/components/colors/example-index.html
@@ -515,9 +515,134 @@
   </div>
 </div>
 
+<div class="row full-width">
+  <div class="twelve columns">
+    <h1>Status Color Borders</h1>
+  </div>
+</div>
+
+<div class="palette-grid">
+  <div class="palette-column">
+    <span class="palette-label">Status 01</span>
+    <div class="palette-border status-01-border">
+      <span class="light-color">
+        <span class="palette-hex"></span>
+      </span>
+    </div>
+  </div>
+  <div class="palette-column">
+    <span class="palette-label">Status 02</span>
+    <div class="palette-border status-02-border">
+      <span class="light-color">
+        <span class="palette-hex"></span>
+      </span>
+    </div>
+  </div>
+  <div class="palette-column">
+    <span class="palette-label">Status 03</span>
+    <div class="palette-border status-03-border">
+      <span class="light-color">
+        <span class="palette-hex"></span>
+      </span>
+    </div>
+  </div>
+  <div class="palette-column">
+    <span class="palette-label">Status 04</span>
+    <div class="palette-border status-04-border">
+      <span class="light-color">
+        <span class="palette-hex"></span>
+      </span>
+    </div>
+  </div>
+  <div class="palette-column">
+    <span class="palette-label">Status 05</span>
+    <div class="palette-border status-05-border">
+      <span class="light-color">
+        <span class="palette-hex"></span>
+      </span>
+    </div>
+  </div>
+</div>
+
+<div class="row full-width">
+  <div class="twelve columns">
+    <h1>Status Colors ('color' Property)</h1>
+  </div>
+</div>
+
+<div class="palette-grid">
+  <div class="palette-column">
+    <span class="palette-label">Status 01</span>
+    <div class="palette-svg demo-svg" title="error-alert">
+      <svg class="icon status-01-color demo-center" focusable="false" aria-hidden="true" role="presentation">
+        <use href="#icon-error-alert"></use>
+      </svg>
+      <span class="light-color">
+        <span class="palette-hex"></span>
+      </span>
+    </div>
+  </div>
+  <div class="palette-column">
+    <span class="palette-label">Status 02</span>
+    <div class="palette-svg demo-svg" title="error-alert">
+      <svg class="icon status-02-color demo-center" focusable="false" aria-hidden="true" role="presentation">
+        <use href="#icon-error-alert"></use>
+      </svg>
+      <span class="light-color">
+        <span class="palette-hex"></span>
+      </span>
+    </div>
+  </div>
+  <div class="palette-column">
+    <span class="palette-label">Status 03</span>
+    <div class="palette-svg demo-svg" title="error-alert">
+      <svg class="icon status-03-color demo-center" focusable="false" aria-hidden="true" role="presentation">
+        <use href="#icon-error-alert"></use>
+      </svg>
+      <span class="light-color">
+        <span class="palette-hex"></span>
+      </span>
+    </div>
+  </div>
+  <div class="palette-column">
+    <span class="palette-label">Status 04</span>
+    <div class="palette-svg demo-svg" title="error-alert">
+      <svg class="icon status-04-color demo-center" focusable="false" aria-hidden="true" role="presentation">
+        <use href="#icon-error-alert"></use>
+      </svg>
+      <span class="light-color">
+        <span class="palette-hex"></span>
+      </span>
+    </div>
+  </div>
+  <div class="palette-column">
+    <span class="palette-label">Status 05</span>
+    <div class="palette-svg demo-svg" title="error-alert">
+      <svg class="icon status-05-color demo-center" focusable="false" aria-hidden="true" role="presentation">
+        <use href="#icon-error-alert"></use>
+      </svg>
+      <span class="light-color">
+        <span class="palette-hex"></span>
+      </span>
+    </div>
+  </div>
+</div>
+
 <script>
+  var setColorText = function(paletteType, property) {
+    Array.prototype.forEach.call(paletteType, function(color) {
+      const paletteHex = color.querySelector('.palette-hex');
+      const bgColor = window.getComputedStyle(color, null).getPropertyValue(property);
+      const rgbValues = bgColor.match(/\d+/g);
+      if (paletteHex !== null) {
+        paletteHex.innerHTML = rgbToHex(rgbValues[0], rgbValues[1], rgbValues[2]);
+      }
+    })
+  };
   var setColors = function () {
     const paletteColor = document.querySelectorAll('.palette-color');
+    const paletteBorder = document.querySelectorAll('.palette-border');
+    const paletteSVGColor = document.querySelectorAll('.palette-svg');
     function valueToHex(v) {
       const hex = v.toString(16);
       return hex.length === 1 ?  0 + hex : hex;
@@ -529,6 +654,22 @@
       const paletteHex = color.querySelector('.palette-hex');
       const bgColor = window.getComputedStyle(color, null).getPropertyValue('background-color');
       const rgbValues = bgColor.match(/\d+/g);
+      if (paletteHex !== null) {
+        paletteHex.innerHTML = rgbToHex(rgbValues[0], rgbValues[1], rgbValues[2]);
+      }
+    })
+    Array.prototype.forEach.call(paletteBorder, function(color) {
+      const paletteHex = color.querySelector('.palette-hex');
+      const borderColor = window.getComputedStyle(color, null).getPropertyValue('border-color');
+      const rgbValues = borderColor.match(/\d+/g);
+      if (paletteHex !== null) {
+        paletteHex.innerHTML = rgbToHex(rgbValues[0], rgbValues[1], rgbValues[2]);
+      }
+    })
+    Array.prototype.forEach.call(paletteSVGColor, function(color) {
+      const paletteHex = color.querySelector('.palette-hex');
+      const cColor = window.getComputedStyle(color.querySelector('.icon'), null).getPropertyValue('color');
+      const rgbValues = cColor.match(/\d+/g);
       if (paletteHex !== null) {
         paletteHex.innerHTML = rgbToHex(rgbValues[0], rgbValues[1], rgbValues[2]);
       }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,7 +20,7 @@
 - `[Searchfield]` Added option to add custom icon button. ([#6453](https://github.com/infor-design/enterprise/issues/6453))
 - `[Targeted-Achievement]` Added puppeteer test for show tooltip on targeted achievement. ([#6550](https://github.com/infor-design/enterprise/issues/6550))
 - `[Textarea]` Converted protractor tests to puppeteer. ([#6629](https://github.com/infor-design/enterprise/issues/6629))
-
+- `[Color Palette]` Added status color CSS classes for color and border-color properties. ([#6711](https://github.com/infor-design/enterprise/issues/6711))
 ## v4.66.0 Fixes
 
 - `[Datagrid]` Fixed trigger icon background color on hover when row is activated. ([#6679](https://github.com/infor-design/enterprise/issues/6679))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## v4.67.0 Fixes
 
 - `[Button]` Added dark theme button colors. ([#6512](https://github.com/infor-design/enterprise/issues/6512))
+- `[Color Palette]` Added status color CSS classes for color and border-color properties. ([#6711](https://github.com/infor-design/enterprise/issues/6711))
 
 ## v4.66.0
 
@@ -20,7 +21,7 @@
 - `[Searchfield]` Added option to add custom icon button. ([#6453](https://github.com/infor-design/enterprise/issues/6453))
 - `[Targeted-Achievement]` Added puppeteer test for show tooltip on targeted achievement. ([#6550](https://github.com/infor-design/enterprise/issues/6550))
 - `[Textarea]` Converted protractor tests to puppeteer. ([#6629](https://github.com/infor-design/enterprise/issues/6629))
-- `[Color Palette]` Added status color CSS classes for color and border-color properties. ([#6711](https://github.com/infor-design/enterprise/issues/6711))
+
 ## v4.66.0 Fixes
 
 - `[Datagrid]` Fixed trigger icon background color on hover when row is activated. ([#6679](https://github.com/infor-design/enterprise/issues/6679))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # What's New with Enterprise
 
+## v4.67.0
+
+## v4.67.0 Features
+
+## v4.67.0 Fixes
+
+- `[Button]` Added dark theme button colors. ([#6512](https://github.com/infor-design/enterprise/issues/6512))
+
 ## v4.66.0
 
 ## v4.66.0 Features

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,7 +38,7 @@
 - `[Editor]` Fixed a bug where editor has dark screen after inserting an image. ([NG#1323](https://github.com/infor-design/enterprise-ng/issues/1323))
 - `[Editor]` Fixed a bug where reset dirty is not working on special characters in Edge browser. ([#6584](https://github.com/infor-design/enterprise/issues/6584))
 - `[Fileupload Advanced]` Fixed on max fileupload limit. ([#6625](https://github.com/infor-design/enterprise/issues/6625))
-- `[Montview]` Fixed missing legend data on visible previous / next month with using loadLegend API. ([#6665](https://github.com/infor-design/enterprise/issues/6665))
+- `[Monthview]` Fixed missing legend data on visible previous / next month with using loadLegend API. ([#6665](https://github.com/infor-design/enterprise/issues/6665))
 - `[Notification]` Updated css of notification to fix alignment in rtl mode. ([#6555](https://github.com/infor-design/enterprise/issues/6555))
 - `[Searchfield]` Fixed a bug on Mac OS Safari where x button can't clear the contents of the searchfield. ([#6631](https://github.com/infor-design/enterprise/issues/6631))
 - `[Popdown]` Fixed popdown not closing when clicking outside in NG. ([NG#1304](https://github.com/infor-design/enterprise-ng/issues/1304))

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -459,7 +459,7 @@ a.btn-close {
   }
 
   .ripple-effect {
-    background: $ids-color-palette-slate-20;
+    background: $secondary-btn-ripple-color;
   }
 
   // Menu Button Form
@@ -911,17 +911,17 @@ html[lang^='fr-'] {
 }
 
 .btn-link {
-  color: $hyperlink-color;
+  color: $btn-hyperlink-color;
 
   .icon {
-    color: $hyperlink-color;
+    color: $btn-hyperlink-color;
   }
 
   &:hover {
-    color: $hyperlink-hover-color;
+    color: $btn-hyperlink-hover-color;
 
     .icon {
-      color: $hyperlink-hover-color;
+      color: $btn-hyperlink-hover-color;
     }
   }
 }

--- a/src/components/colors/_colors.scss
+++ b/src/components/colors/_colors.scss
@@ -106,24 +106,67 @@
 }
 
 // Status Colors
+//   Status Background Colors
 .status-01 {
-  background-color: $status-01-bg-color;
+  background-color: $status-01-color;
 }
 
 .status-02 {
-  background-color: $status-02-bg-color;
+  background-color: $status-02-color;
 }
 
 .status-03 {
-  background-color: $status-03-bg-color;
+  background-color: $status-03-color;
 }
 
 .status-04 {
-  background-color: $status-04-bg-color;
+  background-color: $status-04-color;
 }
 
 .status-05 {
-  background-color: $status-05-bg-color;
+  background-color: $status-05-color;
+}
+
+//   Status Border Colors
+.status-01-border {
+  border-color: $status-01-color;
+}
+
+.status-02-border {
+  border-color: $status-02-color;
+}
+
+.status-03-border {
+  border-color: $status-03-color;
+}
+
+.status-04-border {
+  border-color: $status-04-color;
+}
+
+.status-05-border {
+  border-color: $status-05-color;
+}
+
+//   Status Colors
+.status-01-color {
+  color: $status-01-color;
+}
+
+.status-02-color {
+  color: $status-02-color;
+}
+
+.status-03-color {
+  color: $status-03-color;
+}
+
+.status-04-color {
+  color: $status-04-color;
+}
+
+.status-05-color {
+  color: $status-05-color;
 }
 
 // RTL Styles

--- a/src/components/colors/_colors.scss
+++ b/src/components/colors/_colors.scss
@@ -105,6 +105,11 @@
 
 .palette-svg {
   font-size: 1.6rem;
+
+  .palette-hex-svg {
+    text-align: center;
+    margin-top: 10px;
+  }
 }
 
 .demo-center {

--- a/src/components/colors/_colors.scss
+++ b/src/components/colors/_colors.scss
@@ -92,6 +92,26 @@
   }
 }
 
+.palette-border {
+  border: none;
+  border-width: 5px;
+  border-style: dashed;
+  height: 55px;
+  width: auto;
+  margin: 10px;
+  margin-bottom: 40px;
+  font-size: 1.6rem;
+}
+
+.palette-svg {
+  font-size: 1.6rem;
+}
+
+.demo-center {
+  display: block;
+  margin: auto;
+}
+
 .theme-new-light,
 .theme-new-dark,
 .theme-new-contrast {

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -76,6 +76,8 @@ $hyperlink-focus-border-color: $link-color-initial-font;
 $hyperlink-visited-color: $link-color-visited-font;
 $hyperlink-disabled-color: $link-color-disabled-font;
 $hyperlink-hover-color: $link-color-hover-font;
+$btn-hyperlink-color: $hyperlink-color;
+$btn-hyperlink-hover-color: $hyperlink-hover-color;
 
 // Rules
 $hr-top-color: $ids-color-brand-secondary-base;
@@ -221,6 +223,7 @@ $secondary-border-btn-border-color: $ids-color-brand-secondary-alt;
 $secondary-border-btn-hover-color: $ids-color-font-base;
 $secondary-border-btn-hover-border-color: $ids-color-palette-graphite-100;
 $secondary-border-btn-ripple-color: $ids-color-palette-azure-30;
+$secondary-btn-ripple-color: $ids-color-palette-slate-20;
 
 // Menu Button
 $menubutton-height: $button-size-height;

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -167,11 +167,11 @@ $badge-disabled-text-color: $ids-color-palette-slate-50;
 $badge-disabled-bg-color: $ids-color-palette-graphite-20;
 
 // Status Colors
-$status-01-bg-color: $ids-color-palette-ruby-60;
-$status-02-bg-color: $ids-color-palette-amber-80;
-$status-03-bg-color: $ids-color-palette-amber-80;
-$status-04-bg-color: $ids-color-palette-emerald-80;
-$status-05-bg-color: $ids-color-palette-azure-70;
+$status-01-color: $ids-color-palette-ruby-60;
+$status-02-color: $ids-color-palette-amber-80;
+$status-03-color: $ids-color-palette-amber-80;
+$status-04-color: $ids-color-palette-emerald-80;
+$status-05-color: $ids-color-palette-azure-70;
 
 // Cards
 $card-content-button-color: $ids-color-palette-azure-60;

--- a/src/themes/theme-classic-dark.scss
+++ b/src/themes/theme-classic-dark.scss
@@ -79,6 +79,19 @@ $hyperlink-hover-color: $ids-color-brand-primary-base;
 $hr-top-color: $ids-color-palette-slate-90;
 $hr-bottom-color: transparent;
 
+// Buttons
+$button-color-primary-initial-background: $ids-color-palette-slate-60;
+$button-color-primary-disabled-background: $ids-color-palette-slate-70;
+$button-color-primary-disabled-border: $ids-color-palette-slate-70;
+$button-color-primary-hover-background: $ids-color-palette-slate-70;
+$button-color-primary-active-background: $ids-color-palette-slate-60;
+$btn-hyperlink-color: $ids-color-palette-slate-50;
+$btn-hyperlink-hover-color: $ids-color-palette-slate-40;
+
+// Button Ripple
+$secondary-btn-ripple-color: $ids-color-palette-slate-60;
+$tertiary-btn-ripple-color: $ids-color-palette-slate-40;
+
 // Circle Pager
 $circlepager-border-color: $ids-color-palette-slate-40;
 $circlepager-hover-border-color: $ids-color-palette-slate-20;

--- a/src/themes/theme-new-dark.scss
+++ b/src/themes/theme-new-dark.scss
@@ -72,6 +72,19 @@ $hyperlink-hover-color: $ids-color-brand-primary-base;
 $hr-top-color: $ids-color-palette-slate-90;
 $hr-bottom-color: transparent;
 
+// Buttons
+$button-color-primary-initial-background: $ids-color-palette-slate-60;
+$button-color-primary-disabled-background: $ids-color-palette-slate-80;
+$button-color-primary-disabled-border: $ids-color-palette-slate-80;
+$button-color-primary-hover-background: $ids-color-palette-slate-80;
+$button-color-primary-active-background: $ids-color-palette-slate-60;
+$btn-hyperlink-color: $ids-color-palette-slate-50;
+$btn-hyperlink-hover-color: $ids-color-palette-slate-40;
+
+// Button Ripple
+$secondary-btn-ripple-color: $ids-color-palette-slate-60;
+$tertiary-btn-ripple-color: $ids-color-palette-slate-40;
+
 // Circle Pager
 $circlepager-border-color: $ids-color-palette-slate-40;
 $circlepager-hover-border-color: $ids-color-palette-slate-20;


### PR DESCRIPTION
Resolves #6711 - Added CSS classes for IDS Status Colors affecting color and border-color properties

Added '.status-XX-border' and '.status-XX-color' classes in the colors.scss that apply status colors to border-color and color properties respectively
Renamed 'status-XX-bg-color' variables in config.scss to a more general 'status-XX-color' name
Included proposed changes in CHANGELOG

**Explain the _details_ for making this change. What existing problem does the pull request solve?**
These new classes allow developers to apply the IDS status colors to border color and color CSS properties (not just background colors)

**Related github/jira issue (required)**:
Resolves #6711
Resolves / Enhances WFM-44554
Resolves / Enhances WFM-46441

**Steps necessary to review your pull request (required)**:
Test if we can actually apply these classes (for borders -> divs, for colors -> IDS icons or text)


**Included in this Pull Request**:
- A note to the change log.

