### PR TITLE
6726 - Remove infor logo from app menu

### DIFF
--- a/app/views/components/applicationmenu/example-index.html
+++ b/app/views/components/applicationmenu/example-index.html
@@ -50,12 +50,6 @@
       </div>
 
     </div>
-
-    <div class="branding">
-      <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
-        <use href="#icon-logo"></use>
-      </svg>
-    </div>
   </nav>
 
   <div class="page-container scrollable" role="main">

--- a/app/views/components/applicationmenu/example-performance.html
+++ b/app/views/components/applicationmenu/example-performance.html
@@ -14045,12 +14045,6 @@
       </div>
 
     </div>
-
-    <div class="branding">
-      <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
-        <use href="#icon-logo"></use>
-      </svg>
-    </div>
   </nav>
 
   <div class="page-container scrollable" role="main">

--- a/app/views/components/applicationmenu/test-app-menu.html
+++ b/app/views/components/applicationmenu/test-app-menu.html
@@ -19,12 +19,6 @@
         </div>
       </div>
 
-      <div class="branding">
-        <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
-          <use href="#icon-logo"></use>
-        </svg>
-      </div>
-
     </nav>
 
     <div class="page-container no-scroll">
@@ -80,7 +74,7 @@
 <script>
   $('body').one('initialized', function () {
       $('#test-timepicker').timepicker();
-      
+
       $('#test-datepicker').datepicker();
 
       $('#show-modal').on('click', function () {

--- a/app/views/components/applicationmenu/test-container.html
+++ b/app/views/components/applicationmenu/test-container.html
@@ -139,12 +139,6 @@
 
       </div>
 
-      <div class="branding">
-        <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
-          <use href="#icon-logo"></use>
-        </svg>
-      </div>
-
     </nav>
 
     <div class="page-container no-scroll">

--- a/app/views/components/applicationmenu/test-long-content-string.html
+++ b/app/views/components/applicationmenu/test-long-content-string.html
@@ -111,11 +111,6 @@
 
     </div>
 
-    <div class="branding">
-      <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
-        <use href="#icon-logo"></use>
-      </svg>
-    </div>
   </nav>
   <!-- END App Menu -->
 

--- a/app/views/components/applicationmenu/test-manual-init.html
+++ b/app/views/components/applicationmenu/test-manual-init.html
@@ -51,11 +51,6 @@
 
     </div>
 
-    <div class="branding">
-      <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
-        <use href="#icon-logo"></use>
-      </svg>
-    </div>
   </nav>
 
   <div class="page-container scrollable" role="main">

--- a/app/views/components/applicationmenu/test-performance.html
+++ b/app/views/components/applicationmenu/test-performance.html
@@ -1586,11 +1586,6 @@
       </div>
     </div>
 
-    <div class="branding">
-      <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
-        <use href="#icon-logo"></use>
-      </svg>
-    </div>
   </nav>
 
   <div class="page-container scrollable" role="main">

--- a/app/views/components/applicationmenu/test-six-levels-icons.html
+++ b/app/views/components/applicationmenu/test-six-levels-icons.html
@@ -335,11 +335,6 @@
       </div>
     </div>
 
-    <div class="branding">
-      <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
-        <use href="#icon-logo"></use>
-      </svg>
-    </div>
   </nav>
 
   <div class="page-container no-scroll">

--- a/app/views/components/applicationmenu/test-six-levels.html
+++ b/app/views/components/applicationmenu/test-six-levels.html
@@ -332,11 +332,6 @@
       </div>
     </div>
 
-    <div class="branding">
-      <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
-        <use href="#icon-logo"></use>
-      </svg>
-    </div>
   </nav>
 
   <div class="page-container no-scroll">

--- a/app/views/components/applicationmenu/test-tooltips.html
+++ b/app/views/components/applicationmenu/test-tooltips.html
@@ -111,11 +111,6 @@
 
     </div>
 
-    <div class="branding">
-      <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
-        <use href="#icon-logo"></use>
-      </svg>
-    </div>
   </nav>
   <!-- END App Menu -->
 

--- a/app/views/includes/applicationmenu-from-comps.html
+++ b/app/views/includes/applicationmenu-from-comps.html
@@ -103,10 +103,4 @@
     </div>
 
   </div>
-
-  <div class="branding">
-    <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
-      <use href="#icon-logo"></use>
-    </svg>
-  </div>
 </nav>

--- a/app/views/includes/applicationmenu-many-items.html
+++ b/app/views/includes/applicationmenu-many-items.html
@@ -170,9 +170,4 @@
 
   </div>
 
-  <div class="branding">
-    <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
-      <use href="#icon-logo"></use>
-    </svg>
-  </div>
 </nav>

--- a/app/views/includes/applicationmenu-menubutton.html
+++ b/app/views/includes/applicationmenu-menubutton.html
@@ -93,9 +93,4 @@
 
   </div>
 
-  <div class="branding">
-    <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
-      <use href="#icon-logo"></use>
-    </svg>
-  </div>
 </nav>

--- a/app/views/includes/applicationmenu-openlarge.html
+++ b/app/views/includes/applicationmenu-openlarge.html
@@ -103,10 +103,4 @@
     </div>
 
   </div>
-
-  <div class="branding">
-    <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
-      <use href="#icon-logo"></use>
-    </svg>
-  </div>
 </nav>

--- a/app/views/includes/applicationmenu-with-searchfield-custom.html
+++ b/app/views/includes/applicationmenu-with-searchfield-custom.html
@@ -125,12 +125,6 @@
       </div>
     </div>
   </div>
-
-  <div class="branding">
-    <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
-      <use href="#icon-logo"></use>
-    </svg>
-  </div>
 </nav>
 
 <script>

--- a/app/views/includes/applicationmenu-with-searchfield.html
+++ b/app/views/includes/applicationmenu-with-searchfield.html
@@ -126,10 +126,4 @@
     </div>
 
   </div>
-
-  <div class="branding">
-    <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
-      <use href="#icon-logo"></use>
-    </svg>
-  </div>
 </nav>

--- a/app/views/includes/applicationmenu.html
+++ b/app/views/includes/applicationmenu.html
@@ -45,10 +45,4 @@
     </div>
 
   </div>
-
-  <div class="branding">
-    <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
-      <use href="#icon-logo"></use>
-    </svg>
-  </div>
 </nav>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v4.67.0
 
+## v4.67.0 Markup Changes
+
+- `[AppMenu]` As a design change the infor logo is no longer to be shown on the appmenu and has been removed. This reduces visual clutter, and is more inline with Koch global brand to leave it out. ([#6726](https://github.com/infor-design/enterprise/issues/6726))
+
 ## v4.67.0 Features
 
 - `[Searchfield]` Added puppeteer script for custom icon. ([#6723](https://github.com/infor-design/enterprise/issues/6723))

--- a/src/components/applicationmenu/readme.md
+++ b/src/components/applicationmenu/readme.md
@@ -72,12 +72,6 @@ This example shows a nav element for the menu that flies out. This should be top
       </div>
 
     </div>
-
-    <div class="branding">
-      <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
-        <use href="#icon-logo"></use>
-      </svg>
-    </div>
   </nav>
 ```
 
@@ -104,6 +98,17 @@ In another place (usually the header toolbar) you should have a button with the 
   <div class="buttonset">
   </div
 </div>
+```
+
+It is also possible to include a logo for customer branding in the app menu this can be included at the bottom.
+
+```html
+  <div class="branding">
+    <svg class="icon" viewBox="0 0 34 34" focusable="false" aria-hidden="true" role="presentation">
+      <use href="#customer-logo"></use>
+    </svg>
+  </div>
+</nav>
 ```
 
 You can do resizing via activating the `resizable` settings. It will wrapped the application menu to a parent `resize-app-menu-container` class, and the page container/s including the tab panel container to a `resize-page-container` class to have a proper structure for flex. You can also use to save the last position of the application menu using `savePosition` settings.
@@ -188,13 +193,13 @@ You can do resizing via activating the `resizable` settings. It will wrapped the
         </div>
       </div>
     </div>
-  
+
     <div class="application-menu-content">
       <div class="searchfield-wrapper">
         <label class="audible" for="application-menu-searchfield">Search</label>
         <input id="application-menu-searchfield" class="searchfield" data-options='{ "clearable": true }' placeholder="Look up menu items"/>
       </div>
-  
+
       <div class="accordion panel inverse" data-options="{'allowOnePane': false, 'expanderDisplay': 'plusminus'}" >
         <div class="accordion-header">
           <a href="#"><span>Home</span></a>
@@ -293,7 +298,7 @@ You can do resizing via activating the `resizable` settings. It will wrapped the
         </div>
       </div>
     </div>
-  
+
     <div class="application-menu-footer">
       <div class="application-menu-toolbar">
         <div class="flex-toolbar">
@@ -326,9 +331,9 @@ You can do resizing via activating the `resizable` settings. It will wrapped the
         </div>
       </div>
     </div>
-  
+
   </nav>
-  
+
 ```
 
 ## Behavior Guidelines


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

By Request this PR removes the infor logo from app-menu. But kept the ability as a feature if a logo such as a customer logo is wanted. Visual Tests may be needed

**Related github/jira issue (required)**:
Fixes #6726
 
**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/applicationmenu/example-index.html
- check for no logos other places in http://localhost:4000/components/applicationmenu

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.