### PR TITLE
6763 - Fix info color after header changes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ## v4.67.0 Fixes
 
+- `[Badge/Tag/Icon]` Fixed info color in dark mode. ([#6763](https://github.com/infor-design/enterprise/issues/6763))
 - `[Button]` Added notification badges for buttons with labels. ([NG#1347](https://github.com/infor-design/enterprise-ng/issues/1347))
 - `[Button]` Added dark theme button colors. ([#6512](https://github.com/infor-design/enterprise/issues/6512))
 - `[Calendar]` Fixed a bug in calendar where bottom border is not properly rendering. ([#6668](https://github.com/infor-design/enterprise/issues/6668))

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -52,6 +52,13 @@ $focus-box-shadow-input: 0 0 8px $focus-box-shadow-color;
 // Base Colors
 $inverse-color: $ids-color-palette-white;
 
+// Status Colors
+$status-01-color: $ids-color-palette-ruby-60;
+$status-02-color: $ids-color-palette-amber-80;
+$status-03-color: $ids-color-palette-amber-80;
+$status-04-color: $ids-color-palette-emerald-80;
+$status-05-color: $ids-color-palette-azure-70;
+
 // Text Color
 // These are Deprecated. Use "Default, Descriptive, Link, Muted, Alert" ect going forward
 $font-color-extrahighcontrast: $ids-color-font-base;
@@ -166,13 +173,6 @@ $badge-info-hover-icon-color: $ids-color-palette-azure-20;
 $badge-disabled-text-color: $ids-color-palette-slate-50;
 $badge-disabled-bg-color: $ids-color-palette-graphite-20;
 
-// Status Colors
-$status-01-color: $ids-color-palette-ruby-60;
-$status-02-color: $ids-color-palette-amber-80;
-$status-03-color: $ids-color-palette-amber-80;
-$status-04-color: $ids-color-palette-emerald-80;
-$status-05-color: $ids-color-palette-azure-70;
-
 // Cards
 $card-content-button-color: $ids-color-palette-azure-60;
 $card-content-status-success-color: $ids-color-palette-emerald-60;
@@ -242,7 +242,7 @@ $error-color-transparent: rgba($ids-color-status-danger, 0.3);
 $error-focus-box-shadow: 0 0 4px 2px $error-color-transparent;
 $alert-color: $ids-color-status-warning;
 $success-color: $ids-color-status-success;
-$info-color: $ids-color-brand-primary-base;
+$info-color: $status-05-color;
 $error-bg-color: rgba($ids-color-status-danger, 0.1);
 $error-icon-fill: $ids-color-status-danger;
 $dirty-icon-fill: $ids-color-status-caution;

--- a/src/themes/theme-classic-contrast.scss
+++ b/src/themes/theme-classic-contrast.scss
@@ -185,7 +185,7 @@ $error-icon-fill: #b94e4a;
 $error-border-color: #b94e4a;
 $alert-color: $ids-color-palette-amber-100;
 $success-color: $ids-color-status-success;
-$info-color: $ids-color-brand-primary-base;
+$info-color: $status-05-color;
 $error-focus-box-shadow: 0 0 4px 2px rgba(222, 129, 129, 0.3);
 $dirty-icon-fill: $ids-color-palette-amber-50;
 $success-icon-fill: $ids-color-status-success;

--- a/src/themes/theme-classic-dark.scss
+++ b/src/themes/theme-classic-dark.scss
@@ -149,7 +149,7 @@ $badge-good-hover-icon-color: $ids-color-palette-graphite-100;
 $badge-info-color: $ids-color-palette-white;
 $badge-info-icon-color: $ids-color-palette-slate-20;
 $badge-info-hover-icon-color: $ids-color-palette-white;
-$badge-info-bg-color: $ids-color-brand-primary-base;
+$badge-info-bg-color: $ids-color-palette-azure-60;
 $badge-neutral-icon-color: $ids-color-palette-slate-30;
 $badge-neutral-hover-icon-color: $ids-color-palette-white;
 $badge-disabled-text-color: $ids-color-palette-slate-30;

--- a/src/themes/theme-new-contrast.scss
+++ b/src/themes/theme-new-contrast.scss
@@ -193,7 +193,7 @@ $error-icon-fill: #a30d11;
 $error-border-color: #a30d11;
 $alert-color: $ids-color-palette-amber-100;
 $success-color: $ids-color-status-success;
-$info-color: $ids-color-brand-primary-base;
+$info-color: $status-05-color;
 $error-focus-box-shadow: 0 0 4px 2px rgba(222, 129, 129, 0.3);
 $dirty-icon-fill: $ids-color-palette-amber-50;
 $success-icon-fill: $ids-color-status-success;

--- a/src/themes/theme-new-dark.scss
+++ b/src/themes/theme-new-dark.scss
@@ -143,7 +143,7 @@ $badge-good-hover-icon-color: $ids-color-palette-slate-60;
 $badge-info-color: $ids-color-palette-white;
 $badge-info-icon-color: $ids-color-palette-slate-30;
 $badge-info-hover-icon-color: $ids-color-palette-white;
-$badge-info-bg-color: $ids-color-brand-primary-base;
+$badge-info-bg-color: $ids-color-palette-azure-60;
 $badge-neutral-icon-color: $ids-color-palette-slate-30;
 $badge-neutral-hover-icon-color: $ids-color-palette-white;
 $badge-error-bg-color: $ids-color-palette-ruby-60;

--- a/test/components/validation/validation.e2e-spec.js
+++ b/test/components/validation/validation.e2e-spec.js
@@ -661,7 +661,7 @@ describe('Validation message types', () => {
     error: { field: '#da1217', icon: '#606066' },
     alert: { field: '#f98300', icon: '#606066' },
     success: { field: '#2ac371', icon: '#606066' },
-    info: { field: '#0072ed', icon: '#606066' },
+    info: { field: '#0066d4', icon: '#606066' },
     customIcon: { field: '#000000', icon: '#606066' },
     isHelpMessage: { field: '#000000', icon: '#606066' }
   };


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
https://github.com/infor-design/enterprise/issues/6446 Caused an issue where some info colors in dark mode reverted to the header color which was changed to slate.

**Related github/jira issue (required)**:
Fixes #6763 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/tag/example-index.html?theme=new&mode=dark&colors=0066D4 -> info tag should be azure again
- go to http://localhost:4000/components/badges/example-index.html?theme=new&mode=dark&colors=0066D4-> info tag should be azure again
- go to http://localhost:4000/components/icons/example-index.html?theme=new&mode=dark&colors=0066D4)
- select one svg element and add class `info` it should be azure again

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
