### PR TITLE
6725 - Change inline width only if column width is specified

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `[Calendar]` Fixed a bug in calendar where bottom border is not properly rendering. ([#6668](https://github.com/infor-design/enterprise/issues/6668))
 - `[Color Palette]` Added status color CSS classes for color and border-color properties. ([#6711](https://github.com/infor-design/enterprise/issues/6711))
 - `[Datagrid]` Updated datagrid header CSS height. ([#6697](https://github.com/infor-design/enterprise/issues/6697))
+- `[Datagrid]` Fix on datagrid column width. ([#6725](https://github.com/infor-design/enterprise/issues/6725))
 - `[Listview]` Fix a bug where listview is not rendering properly when dataset has zero integer value. ([#6640](https://github.com/infor-design/enterprise/issues/6640))
 
 ## v4.66.0

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -6843,7 +6843,7 @@ Datagrid.prototype = {
     $('body').on('open.modal.datagrid', (modal) => {
       const modalEl = $(modal.target);
       if (modalEl.find(this.table).length > 0) {
-        if (this.table.width() > modalEl.width() || this.widthSpecified) {
+        if (this.table.width() > modalEl.width() && this.widthSpecified) {
           this.table.width(466);
         }
       }

--- a/test/components/datagrid/datagrid.puppeteer-spec.js
+++ b/test/components/datagrid/datagrid.puppeteer-spec.js
@@ -316,8 +316,8 @@ describe('Datagrid', () => {
       const value = await page.$eval('#datagrid > div > table.datagrid > tbody > tr > td:nth-child(5) > div', element => element.innerHTML);
       expect(value).toEqual('0');
 
-      await page.$eval('#datagrid > div > table.datagrid > tbody > tr > td:nth-child(5) > div', (el) => { 
-        el.innerHTML = '4'; 
+      await page.$eval('#datagrid > div > table.datagrid > tbody > tr > td:nth-child(5) > div', (el) => {
+        el.innerHTML = '4';
       });
 
       await page.waitForTimeout(200);
@@ -325,6 +325,51 @@ describe('Datagrid', () => {
       const newValue = await page.$eval('#datagrid > div.datagrid-wrapper.center.scrollable-x.scrollable-y > table > tbody > tr:nth-child(2) > td:nth-child(5) > div', element => element.innerHTML);
 
       expect(newValue).toEqual('4');
+    });
+  });
+
+  describe('Column width', () => {
+    const url = `${baseUrl}/test-column-size`;
+    let windowSize;
+
+    beforeAll(async () => {
+      await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });
+      windowSize = await page.viewport();
+    });
+
+    afterAll(async () => {
+      await page.setViewport(windowSize);
+    });
+
+    it('should not have inline width when no column width is specified', async () => {
+      await page.setViewport({ width: 600, height: 600 });
+      await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });
+
+      await page.click('#show-model');
+
+      await page.waitForSelector('#modal-content', { visible: true })
+        .then(elHandle => elHandle.$('table.datagrid'))
+        .then(async (elHandle) => {
+          await page.waitForTimeout(400);
+          return elHandle.evaluate(e => e.getAttribute('style'));
+        })
+        .then(style => expect(style).toBeFalsy());
+    });
+
+    it('should have inline width when column width is specified and screen is small', async () => {
+      await page.setViewport({ width: 600, height: 600 });
+      await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });
+
+      await page.$eval('#width', (el) => { el.value = '35'; });
+      await page.click('#show-model');
+
+      await page.waitForSelector('#modal-content', { visible: true })
+        .then(elHandle => elHandle.$('table.datagrid'))
+        .then(async (elHandle) => {
+          await page.waitForTimeout(400);
+          return elHandle.evaluate(e => e.getAttribute('style'));
+        })
+        .then(style => expect(style).toContain('width'));
     });
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Column width will only change if it's specified in column settings.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #6725 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch and build
- Use this IDS version to build in IDS NG
- Build and run IDS NG
- Go to: http://localhost:4200/ids-enterprise-ng-demo/modal-dialog
- Click on "Dialog with DataGrid"
- Datagrid should be in default width and have no inline width style on the table element

Using the same IDS build, test the issue mentioned here: https://github.com/infor-design/enterprise-ng/pull/1361

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
