### PR TITLE
6821 - Allow beforeCommitCellEdit event to be sent for Editors.Fil…

### DIFF
--- a/app/views/components/datagrid/test-editable-fileupload-before-commitcelledit.html
+++ b/app/views/components/datagrid/test-editable-fileupload-before-commitcelledit.html
@@ -1,0 +1,58 @@
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid">
+
+    </div>
+  </div>
+</div>
+
+<script>
+  var gridApi = null;
+
+  $('body').one('initialized', function () {
+
+    Locale.set('en-US').done(function () {
+        var grid,
+          data = [],
+          columns = [];
+
+        // Some Sample Data
+        data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Variety of projects', quantity: 1, price: 210.99, status: 'OK', orderDate:  new Date(2016, 2, 15, 12, 30, 36), portable: false, action: 'ac', description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning', attachment: ''});
+        data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, status: '', orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false, action: 'oh', description: 'The kit has an air blow gun that can be used for cleaning', attachment: ''});
+        data.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity:  'Inspect and Repair', portable: true, quantity: 1, price: 120.992, status: null, orderDate: new Date(2014, 6, 3), action: 'ac', attachment: ''});
+
+        // Define a custom Validator that just fails
+        $.fn.validation.rules.customRule = {
+        	check: function (value, field, grid) {
+            return false;
+        	},
+        	message: 'Incorrect Input'
+        };
+
+        var beforeCommitCellEditLogic = function (args) {
+          console.log('beforeCommitCellEditLogic');
+          var files = args.editor.input[0].files;
+          if (files?.length > 0) {
+            console.log(files);
+          }
+        };
+
+        // Define Columns for the Grid.
+        columns.push({ id: 'attachmentId', name: 'Attachment', field: 'attachment', beforeCommitCellEdit: beforeCommitCellEditLogic, formatter: Formatters.Fileupload, editoEdrOptions: {allowedTypes: 'jpg|png'}, editor: Editors.Fileupload, width: 290});
+        columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', beforeCommitCellEdit: beforeCommitCellEditLogic, formatter: Formatters.Date, editor: Editors.Date, width: 130});
+        columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Formatters.Hyperlink});
+        columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Formatters.Input, editor: Editors.Input});
+        columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, align: 'right', editor: Editors.Input, formatter: Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input, mask: '###.000'});
+        columns.push({ id: 'activity', name: 'Activity', field: 'activity'});
+
+        // Init and get the api for the grid
+        $('#datagrid').datagrid({
+          columns: columns,
+          dataset: data,
+          editable: true,
+          toolbar: {title: 'Validation Example', keywordFilter: false, results: true, actions: true, rowHeight: true}
+        });
+    });
+  });
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## v4.68.0 Fixes
 
 - `[Datagrid]` Fixed alignment issues in trigger fields. ([#6678](https://github.com/infor-design/enterprise/issues/6678))
+- `[Datagrid]` Allow beforeCommitCellEdit event to be sent for Editors.Fileupload. ([#6821](https://github.com/infor-design/enterprise/issues/6821))
 
 ## v4.67.0
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10299,7 +10299,7 @@ Datagrid.prototype = {
     const rowData = this.settings.treeGrid ? this.settings.treeDepth[dataRowIndex].node :
       this.getActiveDataset()[dataRowIndex];
     let oldValue = this.fieldValue(rowData, col.field);
-    if (col.beforeCommitCellEdit && !isCallback) {
+    if (col.beforeCommitCellEdit && (isFileupload || !isCallback)) {
       const vetoCommit = col.beforeCommitCellEdit({
         cell,
         row: dataRowIndex,


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When using the Editors.Fileupload for a datagrid column, want to be able to get the beforeCommitCellEdit event so that the File object from the File API can be accessed.  The File object provides the file name, size, and type.

**Related github/jira issue (required)**:
Fixes https://github.com/infor-design/enterprise/issues/6821

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-editable-fileupload-before-commitcelledit.html
- click on the Attachment cell for a row
- click on the folder icon
- attach either a jpg or png file
- tab out of the Attachment cell
- check the console -> should see the files object 

**Included in this Pull Request**:
- [x] A note to the change log.
