### PR TITLE
6816 - Add null guard in tree list when list is not yet loaded

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `[Datagrid]` Fixed alignment issues in trigger fields. ([#6678](https://github.com/infor-design/enterprise/issues/6678))
 - `[Datagrid]` Allow beforeCommitCellEdit event to be sent for Editors.Fileupload. ([#6821](https://github.com/infor-design/enterprise/issues/6821))
+- `[Datagrid]` Add null guard in tree list when list is not yet loaded. ([#6816](https://github.com/infor-design/enterprise/issues/6816))
 
 ## v4.67.0
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -8318,7 +8318,7 @@ Datagrid.prototype = {
     if (!rowNode.hasClass('is-selected') || isServerSideMultiSelect) {
       let rowData;
 
-      if (s.treeGrid) {
+      if (s.treeGrid && s.treeDepth.length > 0) {
         const level = parseInt(rowNode.attr('aria-level'), 10);
         rowData = s.treeDepth[self.pagerAPI && s.source ? rowNode.index() : idx].node;
         if (rowNode.is('.datagrid-tree-parent') && s.selectable === 'multiple') {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Added check if tree depth is not empty to avoid null exception.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #6816 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
Unsure how to test in local.

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
