### PR TITLE
6794 - editor block quote format

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `[Datagrid]` Fixed alignment issues in trigger fields. ([#6678](https://github.com/infor-design/enterprise/issues/6678))
 - `[Datagrid]` Allow beforeCommitCellEdit event to be sent for Editors.Fileupload. ([#6821](https://github.com/infor-design/enterprise/issues/6821))
+- `[Editor]` Fixed a bug in editor where blockquote is not continued in the next line. ([#6794](https://github.com/infor-design/enterprise/issues/6794))
 
 ## v4.67.0
 

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -335,7 +335,7 @@ Editor.prototype = {
     const currentElement = this.getCurrentElement();
     currentElement.on('keyup.editor', (e) => {
       let node = this.getSelectionStart();
-      let tagName;
+      const tagName = node.tagName.toLowerCase();
 
       if (node && node.getAttribute('data-editor') && node.children.length === 0) {
         document.execCommand('formatBlock', false, 'p');
@@ -343,7 +343,10 @@ Editor.prototype = {
 
       if (e.which === 13) {
         node = this.getSelectionStart();
-        tagName = node.tagName.toLowerCase();
+
+        if (tagName === 'blockquote') {
+          return;
+        }
 
         if (tagName !== 'li' && !this.isListItemChild(node)) {
           if (!e.shiftKey) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug in editor where blockquote is not continued in the next line.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6794

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/editor/example-index?theme=uplift&variant=light
- Enter Text
- Select the text
- Click `Block quote` format
- Unselect the text
- Press Enter

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

