### PR TITLE
6748 - Bar Charts Identical Arias

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## v4.68.0 Fixes
 
+- `[Bar Chart]` Fixed a bug in bar charts grouped, where arias are identical to each series. ([#6748](https://github.com/infor-design/enterprise/issues/6748))
 - `[Datagrid]` Fixed alignment issues in trigger fields. ([#6678](https://github.com/infor-design/enterprise/issues/6678))
 - `[Datagrid]` Allow beforeCommitCellEdit event to be sent for Editors.Fileupload. ([#6821](https://github.com/infor-design/enterprise/issues/6821))
 

--- a/src/components/bar/bar.js
+++ b/src/components/bar/bar.js
@@ -437,10 +437,10 @@ Bar.prototype = {
       .attr('tabindex', 0)
       .attr('data-group-id', (d, i) => i);
 
-    $(groups._parents).children('.series-group').each((idx, obj) => {
+    $(groups._parents).children('.series-group').each((position, obj) => {
       const item = $(obj);
-      item.attr('aria-label', `${s.dataset[idx].name ? s.dataset[idx].name : 'Name Label'}`);
-    })
+      item.attr('aria-label', `${s.dataset[position].name ? s.dataset[position].name : 'Name Label'}`);
+    });
 
     s.isGrouped = (self.svg.selectAll('.series-group').nodes().length > 1 && !s.isStacked) || (s.isGrouped && dataset.length === 1);
     s.isSingle = (self.svg.selectAll('.series-group').nodes().length === 1 && s.isStacked);

--- a/src/components/bar/bar.js
+++ b/src/components/bar/bar.js
@@ -437,11 +437,6 @@ Bar.prototype = {
       .attr('tabindex', 0)
       .attr('data-group-id', (d, i) => i);
 
-    $(groups._parents).children('.series-group').each((position, obj) => {
-      const item = $(obj);
-      item.attr('aria-describedby', `${s.dataset[position].name ? s.dataset[position].name : 'Name Label'}`);
-    });
-
     s.isGrouped = (self.svg.selectAll('.series-group').nodes().length > 1 && !s.isStacked) || (s.isGrouped && dataset.length === 1);
     s.isSingle = (self.svg.selectAll('.series-group').nodes().length === 1 && s.isStacked);
 
@@ -476,7 +471,6 @@ Bar.prototype = {
           });
         });
       })
-      .attr('aria-label', 'item value')
       .attr('class', (d, i) => `bar series-${i}`)
       .attr('aria-hidden', true)
       .style('fill', (d, i) => (s.isStacked ? // eslint-disable-line
@@ -731,6 +725,16 @@ Bar.prototype = {
         // Run double click action
         self.doDoubleClickAction(d, i, selector);
       });
+
+    $(sGroup._parents).each((parentPos, parentEl) => {
+      const parentItem = $(parentEl);
+      const $parentPos = parentPos;
+      parentItem.attr('aria-label', `${s.dataset[parentPos].name ? s.dataset[parentPos].name : 'Name Label'}`);
+      parentItem.children('.bar').each((childPos, childEl) => {
+        const mainLabel = s.dataset[$parentPos].name;
+        $(childEl).attr('aria-label', `${s.dataset[$parentPos].data[childPos].value ? `${mainLabel} ${s.dataset[$parentPos].data[childPos].value}` : 'Name Label'}`);
+      });
+    });
 
     if (self.settings.isSingle) {
       // Add text svg for VPAT accessibility

--- a/src/components/bar/bar.js
+++ b/src/components/bar/bar.js
@@ -439,7 +439,7 @@ Bar.prototype = {
 
     $(groups._parents).children('.series-group').each((position, obj) => {
       const item = $(obj);
-      item.attr('aria-label', `${s.dataset[position].name ? s.dataset[position].name : 'Name Label'}`);
+      item.attr('aria-describedby', `${s.dataset[position].name ? s.dataset[position].name : 'Name Label'}`);
     });
 
     s.isGrouped = (self.svg.selectAll('.series-group').nodes().length > 1 && !s.isStacked) || (s.isGrouped && dataset.length === 1);

--- a/src/components/bar/bar.js
+++ b/src/components/bar/bar.js
@@ -435,8 +435,12 @@ Bar.prototype = {
       .attr('role', 'list')
       .attr('title', `${s.type}`)
       .attr('tabindex', 0)
-      .attr('aria-label', `${s.dataset[0].name ? s.dataset[0].name : 'Name Label'}`)
       .attr('data-group-id', (d, i) => i);
+
+    $(groups._parents).children('.series-group').each((idx, obj) => {
+      const item = $(obj);
+      item.attr('aria-label', `${s.dataset[idx].name ? s.dataset[idx].name : 'Name Label'}`);
+    })
 
     s.isGrouped = (self.svg.selectAll('.series-group').nodes().length > 1 && !s.isStacked) || (s.isGrouped && dataset.length === 1);
     s.isSingle = (self.svg.selectAll('.series-group').nodes().length === 1 && s.isStacked);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug in bar charts grouped, where arias are identical to each series.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6748

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/bar-grouped/example-formatter.html
- Inspect element for each of the bars.
- See that they have identical aria labels.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

