### PR TITLE
6530 - add setting ariaDescribedBy in the column to override the aria-describedby value

### DIFF
--- a/app/views/components/datagrid/test-landmark.html
+++ b/app/views/components/datagrid/test-landmark.html
@@ -5,6 +5,9 @@
 
 <script>
   $('body').one('initialized', function () {
+    var ariaDescribedBy = function (row, cell) {
+      return `id-row-${row}-cell-${cell}`;
+    }
     var settings = {
       "actionableMode": true,
       "cellNavigation": true,
@@ -35,7 +38,8 @@
             "align": "left",
             "hideable": true,
             "textOverflow": "ellipsis",
-            "formatter": Formatters.Readonly
+            "formatter": Formatters.Readonly,
+            "ariaDescribedBy": ariaDescribedBy
           },
         {
           "id": "Manufacturer0",
@@ -45,7 +49,8 @@
           "name": "Manufacturer (Ed, Ell)",
           "filterType": "lookup",
           "textOverflow": "ellipsis",
-          "editor": Editors.Lookup
+          "editor": Editors.Lookup,
+          "ariaDescribedBy": ariaDescribedBy
         },
         {
           "id": "Manufacturer1",

--- a/app/views/components/datagrid/test-landmark.html
+++ b/app/views/components/datagrid/test-landmark.html
@@ -6,7 +6,7 @@
 <script>
   $('body').one('initialized', function () {
     var ariaDescribedBy = function (row, cell) {
-      return `id-row-${row}-cell-${cell}`;
+      return `test-landmark-datagrid-${row}-header-${cell}`;
     }
     var settings = {
       "actionableMode": true,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,8 +11,7 @@
 
 - `[Datagrid]` Fixed a bug in datagrid where dropdown filter does not render correctly. ([#6834](https://github.com/infor-design/enterprise/issues/6834))
 - `[Datagrid]` Fixed alignment issues in trigger fields. ([#6678](https://github.com/infor-design/enterprise/issues/6678))
-- `[Datagrid]` Allow beforeCommitCellEdit event to be sent for Editors.Fileupload. ([#6821](https://github.com/infor-design/enterprise/issues/6821))
-- `[Datagrid]` Add null guard in tree list when list is not yet loaded. ([#6816](https://github.com/infor-design/enterprise/issues/6816))
+- `[Datagrid]` Added a null guard in tree list when list is not yet loaded. ([#6816](https://github.com/infor-design/enterprise/issues/6816))
 - `[Datagrid]` Added a setting `ariaDescribedBy` in the column to override `aria-describedby` value of the cells. ([#6530](https://github.com/infor-design/enterprise/issues/6530))
 - `[Datagrid]` Allowed beforeCommitCellEdit event to be sent for Editors.Fileupload. ([#6821](https://github.com/infor-design/enterprise/issues/6821))]
 - `[Datagrid]` Added null guard in tree list when list is not yet loaded. ([#6816](https://github.com/infor-design/enterprise/issues/6816))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Datagrid]` Fixed alignment issues in trigger fields. ([#6678](https://github.com/infor-design/enterprise/issues/6678))
 - `[Datagrid]` Allow beforeCommitCellEdit event to be sent for Editors.Fileupload. ([#6821](https://github.com/infor-design/enterprise/issues/6821))
 - `[Datagrid]` Add null guard in tree list when list is not yet loaded. ([#6816](https://github.com/infor-design/enterprise/issues/6816))
+- `[Datagrid]` Added a setting `ariaDescribedBy` in the column to override `aria-describedby` value of the cells. ([#6530](https://github.com/infor-design/enterprise/issues/6530))
 
 ## v4.67.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ids-enterprise",
-  "version": "4.67.0-dev",
+  "version": "4.68.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ids-enterprise",
-  "version": "4.68.0-dev",
+  "version": "4.67.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4853,7 +4853,14 @@ Datagrid.prototype = {
         cssClass = cssClass.replace(/^\s+|\s+$/g, '').replace(/\s+/g, ' ');
       }
 
+      const idProp = this.settings.attributes?.filter(a => a.name === 'id');
+      let ariaDescribedby = `aria-describedby="${idProp?.length === 1 ? `${idProp[0].value}-col-${col.id?.toLowerCase()}` : self.uniqueId(`-header-${j}`)}"`;
       let ariaChecked = '';
+
+      // Overriding the aria-describedby value if there's a setting in the column.
+      if (col?.ariaDescribedBy) {
+        ariaDescribedby = `aria-describedBy=${col.ariaDescribedBy(rowData.id, j)}`;
+      }
 
       // Set aria-checkbox attribute
       if (col.formatter?.toString().indexOf('function Checkbox') === 0) {
@@ -4872,13 +4879,14 @@ Datagrid.prototype = {
       }
 
       containerHtml[container] += `<td role="gridcell" ${ariaReadonly} aria-colindex="${j + 1}"` +
-          ` ${ariaChecked
-          }${isSelected ? ' aria-selected="true"' : ''
-          }${cssClass ? ` class="${cssClass}"` : ''
-          }${colspan ? ` colspan="${colspan}"` : ''
-          }${col.tooltip && typeof col.tooltip === 'string' ? ` title="${col.tooltip.replace('{{value}}', cellValue)}"` : ''
-          }${self.settings.columnGroups ? `headers = "${self.uniqueId(`-header-${j}`)} ${self.getColumnGroup(j)}"` : ''
-          }${rowspan || ''}>${rowStatus.svg}<div class="datagrid-cell-wrapper">`;
+        ` ${ariaDescribedby
+        }${ariaChecked
+        }${isSelected ? ' aria-selected="true"' : ''
+        }${cssClass ? ` class="${cssClass}"` : ''
+        }${colspan ? ` colspan="${colspan}"` : ''
+        }${col.tooltip && typeof col.tooltip === 'string' ? ` title="${col.tooltip.replace('{{value}}', cellValue)}"` : ''
+        }${self.settings.columnGroups ? `headers = "${self.uniqueId(`-header-${j}`)} ${self.getColumnGroup(j)}"` : ''
+        }${rowspan || ''}>${rowStatus.svg}<div class="datagrid-cell-wrapper">`;
 
       if (col.contentVisible) {
         const canShow = col.contentVisible(dataRowIdx + 1, j, cellValue, col, rowData);

--- a/test/components/datagrid/datagrid-aria.func-spec.js
+++ b/test/components/datagrid/datagrid-aria.func-spec.js
@@ -56,6 +56,7 @@ describe('Datagrid ARIA', () => { //eslint-disable-line
     expect(document.querySelectorAll('.datagrid-wrapper tbody tr')[0].querySelector('td').getAttribute('aria-readonly')).toEqual('true');
     expect(document.querySelectorAll('.datagrid-wrapper tbody tr')[0].querySelector('td').getAttribute('aria-colindex')).toEqual('1');
     expect(document.querySelectorAll('.datagrid-wrapper tbody tr')[0].querySelectorAll('td')[1].getAttribute('aria-colindex')).toEqual('2');
+    expect(document.querySelectorAll('.datagrid-wrapper tbody tr')[0].querySelector('td').getAttribute('aria-describedby')).toBeTruthy();
   });
 
   it('Should set ARIA attributes for selection', () => {

--- a/test/components/datagrid/datagrid.puppeteer-spec.js
+++ b/test/components/datagrid/datagrid.puppeteer-spec.js
@@ -232,7 +232,7 @@ describe('Datagrid', () => {
         e => e.map(el => el.getAttribute('aria-describedby')));
 
       for (let i = 0; i < ariaDesc.length; i++) {
-        expect(ariaDesc).toContain(`id-row-${i + 1}-cell-1`);
+        expect(ariaDesc).toContain(`test-landmark-datagrid-${i + 1}-header-1`);
       }
     });
   });

--- a/test/components/datagrid/datagrid.puppeteer-spec.js
+++ b/test/components/datagrid/datagrid.puppeteer-spec.js
@@ -228,14 +228,12 @@ describe('Datagrid', () => {
     });
 
     it('should override the aria-describedby value', async () => {
-      await page.evaluate(async () => {
-        const cells = document.querySelectorAll('tbody[role="rowgroup"] td[role="gridcell"]:nth-child(2)');
-        let ariaDesc;
+      const ariaDesc = await page.$$eval('tbody[role="rowgroup"] td[role="gridcell"]:nth-child(2)',
+        e => e.map(el => el.getAttribute('aria-describedby')));
 
-        cells.forEach((cell, idx) => ariaDesc = cell.getAttribute('aria-describedby'));
-        return ariaDesc;
-        expect(ariaDesc).toEqual(`id-row-${idx + 1}-cell-1`);
-      });
+      for (let i = 0; i < ariaDesc.length; i++) {
+        expect(ariaDesc).toContain(`id-row-${i + 1}-cell-1`);
+      }
     });
   });
 

--- a/test/components/datagrid/datagrid.puppeteer-spec.js
+++ b/test/components/datagrid/datagrid.puppeteer-spec.js
@@ -227,10 +227,14 @@ describe('Datagrid', () => {
       await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });
     });
 
-    it('should not have aria-describedby attribute at cells', async () => {
+    it('should override the aria-describedby value', async () => {
       await page.evaluate(async () => {
-        const cells = await document.querySelectorAll('.datagrid body tr td');
-        cells.forEach(cell => expect(cell.getAttribute('aria-describedby')).toBe(null));
+        const cells = document.querySelectorAll('tbody[role="rowgroup"] td[role="gridcell"]:nth-child(2)');
+        let ariaDesc;
+
+        cells.forEach((cell, idx) => ariaDesc = cell.getAttribute('aria-describedby'));
+        return ariaDesc;
+        expect(ariaDesc).toEqual(`id-row-${idx + 1}-cell-1`);
       });
     });
   });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR allows overriding the `aria-describedby` value in the cells by adding the `ariaDescribedBy` setting in the column.

**Related github/jira issue (required)**:

Closes #6530 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-landmark
- Inspect the cells in `Product Name` column `td` element
- The `aria-describedby` values of all cells should be `id-row-1-cell-1 `and incrementing +1 e.g., `id-row-2-cell-1`
- Check also the `Manufacturer` Column (the first one)
- It should also be the same as the `Product Name` column but the incrementing part is in the cell, eg., `id-row-1-cell-1`, `id-row-1-cell-2`, etc.
- The rest of the column cells should start in `test-landmark`

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
