### PR TITLE
6773 - fix for validation breaks after enabling disabling

### DIFF
--- a/app/views/components/textarea/test-toggle.html
+++ b/app/views/components/textarea/test-toggle.html
@@ -1,0 +1,23 @@
+<div class="row">
+  <div class="twelve column">
+    <div class="field">
+      <label for="description-error" class="required">Notes</label>
+      <textarea id="description-error" class="textarea" aria-required="true" data-validate="required" name="description-error"></textarea>
+    </div>
+    <button class="btn-secondary" type="button" id="btn-toggle">Toggle</button>
+  </div>
+</div>
+
+<script>
+  $('.btn-primary').on('click', () => {
+    const textEl = document.getElementById('description-error');
+    const el = $('.textarea').data('textarea');
+
+    if (textEl.disabled) {
+      el.enable();
+    } else {
+      el.disable();
+    }
+    el.updated();
+  })
+</script>

--- a/app/views/components/textarea/test-toggle.html
+++ b/app/views/components/textarea/test-toggle.html
@@ -9,7 +9,7 @@
 </div>
 
 <script>
-  $('.btn-primary').on('click', () => {
+  $('#btn-toggle').on('click', () => {
     const textEl = document.getElementById('description-error');
     const el = $('.textarea').data('textarea');
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `[Datagrid]` Added null guard in tree list when list is not yet loaded. ([#6816](https://github.com/infor-design/enterprise/issues/6816))
 - `[Editor]` Fixed a bug in editor where blockquote is not continued in the next line. ([#6794](https://github.com/infor-design/enterprise/issues/6794))
 - `[Modal]` Fixed a bug where suppress key setting is not working. ([#6793](https://github.com/infor-design/enterprise/issues/6793))
+- `[Textarea]` Fixed a bug in textarea where validation breaks after enabling/disabling. ([#6773](https://github.com/infor-design/enterprise/issues/6773))
 - `[Typography]` Updated text link color in dark theme. ([#6807](https://github.com/infor-design/enterprise/issues/6807))
 
 ## v4.67.0

--- a/src/components/textarea/textarea.js
+++ b/src/components/textarea/textarea.js
@@ -268,6 +268,10 @@ Textarea.prototype = {
 
     this.destroy();
     this.init();
+
+    if (this.element.data('validate')) {
+      this.element.validate();
+    }
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug in textarea where validation breaks after enabling/disabling.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6773

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/textarea/test-toggle.html
- Focus the textarea and then click anywhere outside it to remove the focus. The validation error should now should up.
- Click the `Toggle` button and confirm the textarea is disabled.
- Click the `Toggle` button again to enable the textarea.
- Start typing in the textarea and notice that the validation is now okay.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

