### PR TITLE
NG1363 - rich text editor breaking space dirty indicator

### DIFF
--- a/app/views/components/editor/example-dirty-tracking.html
+++ b/app/views/components/editor/example-dirty-tracking.html
@@ -8,7 +8,7 @@
     <div class="field">
       <span class="label">Comments</span>
       <div class="editor" id="editor1" role="textbox" aria-multiline="true" aria-label="Comments" data-trackdirty="true">
-        <p>Embrace <a href="http://en.wikipedia.org/wiki/e-commerce" class="hyperlink">e-commerce action-items</a>, reintermediate, ecologies paradigms wireless share life-hacks create innovative harness. Evolve solutions rich-clientAPIs synergies harness relationships virtual vertical facilitate end-to-end, wireless, evolve synergistic synergies.</p>
+        <p>Embrace <a href="http://en.wikipedia.org/wiki/e-commerce" class="hyperlink">e-commerce &nbsp;action-items</a>, reintermediate, ecologies paradigms wireless share life-hacks create innovative harness. Evolve solutions rich-clientAPIs synergies harness relationships virtual vertical facilitate end-to-end, wireless, evolve synergistic synergies.</p>
         <p>Cross-platform, evolve, ROI scale cultivate eyeballs addelivery, e-services content cross-platform leverage extensible viral incentivize integrateAJAX-enabled sticky evolve magnetic cultivate leverage; cutting-edge. Innovate, end-to-end podcasting, whiteboard streamline e-business social; compelling, "cross-media exploit infomediaries innovative integrate integrateAJAX-enabled." Killer interactive reinvent, cultivate widgets leverage morph.</p>
       </div>
     </div>

--- a/app/views/components/editor/test-dirty-tracking.html
+++ b/app/views/components/editor/test-dirty-tracking.html
@@ -8,8 +8,8 @@
 
     <div class="field">
       <span id="comments-label" class="label">Comments</span>
-      <div class="editor" id="editor1" aria-label="Comments" data-options="{attributes: [{name: 'id', value: 'example1'}, {name: 'data-automation-id', value: 'automation-id-example1'}]}">
-        <p>Embrace <a href="http://en.wikipedia.org/wiki/e-commerce" class="hyperlink">e-commerce action-items</a>, reintermediate, ecologies paradigms wireless share life-hacks create innovative harness. Evolve solutions rich-clientAPIs synergies harness relationships virtual vertical facilitate end-to-end, wireless, evolve synergistic synergies.</p>
+      <div class="editor" id="editor1" role="textbox" aria-multiline="true" aria-label="Comments" data-trackdirty="true">
+        <p>Embrace <a href="http://en.wikipedia.org/wiki/e-commerce" class="hyperlink">e-commerce &nbsp;action-items</a>, reintermediate, ecologies paradigms wireless share life-hacks create innovative harness. Evolve solutions rich-clientAPIs synergies harness relationships virtual vertical facilitate end-to-end, wireless, evolve synergistic synergies.</p>
         <p>Cross-platform, evolve, ROI scale cultivate eyeballs addelivery, e-services content cross-platform leverage extensible viral incentivize integrateAJAX-enabled sticky evolve magnetic cultivate leverage; cutting-edge. Innovate, end-to-end podcasting, whiteboard streamline e-business social; compelling, "cross-media exploit infomediaries innovative integrate integrateAJAX-enabled." Killer interactive reinvent, cultivate widgets leverage morph.</p>
       </div>
     </div>

--- a/app/views/components/editor/test-dirty-tracking.html
+++ b/app/views/components/editor/test-dirty-tracking.html
@@ -1,3 +1,4 @@
+
 <div class="row">
   <div class="twelve columns">
     <div class="field">
@@ -6,8 +7,8 @@
     </div>
 
     <div class="field">
-      <span class="label">Comments</span>
-      <div class="editor" id="editor1" role="textbox" aria-multiline="true" aria-label="Comments" data-trackdirty="true">
+      <span id="comments-label" class="label">Comments</span>
+      <div class="editor" id="editor1" aria-label="Comments" data-options="{attributes: [{name: 'id', value: 'example1'}, {name: 'data-automation-id', value: 'automation-id-example1'}]}">
         <p>Embrace <a href="http://en.wikipedia.org/wiki/e-commerce" class="hyperlink">e-commerce action-items</a>, reintermediate, ecologies paradigms wireless share life-hacks create innovative harness. Evolve solutions rich-clientAPIs synergies harness relationships virtual vertical facilitate end-to-end, wireless, evolve synergistic synergies.</p>
         <p>Cross-platform, evolve, ROI scale cultivate eyeballs addelivery, e-services content cross-platform leverage extensible viral incentivize integrateAJAX-enabled sticky evolve magnetic cultivate leverage; cutting-edge. Innovate, end-to-end podcasting, whiteboard streamline e-business social; compelling, "cross-media exploit infomediaries innovative integrate integrateAJAX-enabled." Killer interactive reinvent, cultivate widgets leverage morph.</p>
       </div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[Datagrid]` Classic theme trigger field adjustments in datagrid. ([#6678](https://github.com/infor-design/enterprise/issues/6678))
 - `[Datagrid]` Added null guard in tree list when list is not yet loaded. ([#6816](https://github.com/infor-design/enterprise/issues/6816))
 - `[Editor]` Fixed a bug in editor where blockquote is not continued in the next line. ([#6794](https://github.com/infor-design/enterprise/issues/6794))
+- `[Editor]` Fixed a bug in editor where breaking space doesn't render dirty indicator properly. ([NG#1363](https://github.com/infor-design/enterprise-ng/issues/1363))
 - `[Modal]` Fixed a bug where suppress key setting is not working. ([#6793](https://github.com/infor-design/enterprise/issues/6793))
 - `[Typography]` Updated text link color in dark theme. ([#6807](https://github.com/infor-design/enterprise/issues/6807))
 

--- a/src/components/trackdirty/trackdirty.js
+++ b/src/components/trackdirty/trackdirty.js
@@ -253,6 +253,12 @@ Trackdirty.prototype = {
           current = current.replaceAll('&nbsp;', ' ');
         }
 
+        if (typeof original === 'string' && original?.indexOf('&nbsp;') > -1) {
+          original = original.replaceAll('&nbsp;', ' ');
+        }
+
+        original = this.trimEditorText(original);
+
         if (current === original || (input.attr('multiple') && utils.equals(current, original))) {
           input.removeClass('dirty');
           $('.icon-dirty, .msg-dirty', field).add(d.icon).add(d.msg).remove();

--- a/src/components/trackdirty/trackdirty.js
+++ b/src/components/trackdirty/trackdirty.js
@@ -79,7 +79,8 @@ Trackdirty.prototype = {
       .replace(' has-tooltip', '')
       .replace(/<br(\s+)?\/?>/g, '<br>\n')
       .replace(/<\/p>(\s+)/g, '</p>\n\n')
-      .replace(/<\/blockquote>(\s+)?/g, '</blockquote>\n\n');
+      .replace(/<\/blockquote>(\s+)?/g, '</blockquote>\n\n')
+      .replaceAll('&nbsp;', ' ');
   },
 
   /**
@@ -243,21 +244,10 @@ Trackdirty.prototype = {
           // editors values are further down it's tree in a textarea,
           // so get the elements with the value
           const textArea = field.find('textarea');
-          original = textArea.data('original');
+          original = this.trimEditorText(textArea.data('original'));
           current = field.find('.editor-source').is(':visible') ? textArea.val() : textArea.text();
           current = this.trimEditorText(current);
         }
-
-        // Edge Issue in #6032
-        if (typeof current === 'string' && current?.indexOf('&nbsp;') > -1) {
-          current = current.replaceAll('&nbsp;', ' ');
-        }
-
-        if (typeof original === 'string' && original?.indexOf('&nbsp;') > -1) {
-          original = original.replaceAll('&nbsp;', ' ');
-        }
-
-        original = this.trimEditorText(original);
 
         if (current === original || (input.attr('multiple') && utils.equals(current, original))) {
           input.removeClass('dirty');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug in editor where breaking space doesn't render dirty indicator properly.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1363

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/editor/test-dirty-tracking.html
- Try to type a letter to the editor to make it dirty
- Delete the typed letter

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

