### PR TITLE
6145 lookup disablefix

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `[Searchfield]` Visual fixes on go button in searchfield toolbar. ([#6686](https://github.com/infor-design/enterprise/issues/6686))
 - `[Textarea]` Fixed a bug in textarea where validation breaks after enabling/disabling. ([#6773](https://github.com/infor-design/enterprise/issues/6773))
 - `[Typography]` Updated text link color in dark theme. ([#6807](https://github.com/infor-design/enterprise/issues/6807))
+- `[Lookup]` Fixed where field stays disabled when enable API is called ([#6145](https://github.com/infor-design/enterprise/issues/6145))
 
 ## v4.67.0
 

--- a/src/components/lookup/lookup.js
+++ b/src/components/lookup/lookup.js
@@ -1086,7 +1086,7 @@ Lookup.prototype = {
    */
   enable() {
     this.element.prop('disabled', false).prop('readonly', false).removeClass('is-not-editable');
-    this.element.parent().removeClass('is-disabled');
+    this.element.closest('.field').removeClass('is-disabled');
     this.icon.prop('disabled', false);
   },
 


### PR DESCRIPTION
Fixed the bug where a field stays disabled when the field is not a direct parent of the lookup. Took the same logic to find the parent field from the disable function to the enable function.

Fixes #6145

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
Wasn't sure how to create a functional test for the issue since each functional test uses the same lookup configuration but there are multiple scenarios.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
