### PR TITLE
6851 - datagrid sorting issue with previously focused cell

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## v4.69.0 Fixes
 
 - `[Datagrid]` Fixed a bug in datagrid where icon is not rendering properly in small and extra small row height. ([#6866](https://github.com/infor-design/enterprise/issues/6866))
+- `[Datagrid]` Fixed a bug in datagrid where sorting is not rendering properly when there is a previously focused cell. ([#6851](https://github.com/infor-design/enterprise/issues/6851))
 
 ## v4.68.0
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7055,6 +7055,7 @@ Datagrid.prototype = {
 
         // Prevent parent grid from sorting when nested
         e.stopPropagation();
+        self.editor = null;
         self.setSortColumn($(this).attr('data-column-id'));
         return false;
       });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug in datagrid where sorting is not rendering properly when there is a previously focused cell.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6851

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/example-editable.html
- Click on a date cell
- Select the date column header to sort
- Click on any date cell

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

