### PR TITLE
1370 - Additional checks when updating cell so that numbers aren't converted twice

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## v4.69.0 Fixes
 
 - `[Datagrid]` Fixed a bug in datagrid where icon is not rendering properly in small and extra small row height. ([#6866](https://github.com/infor-design/enterprise/issues/6866))
+- `[Datagrid]` Additional checks when updating cell so that numbers aren't converted twice. ([NG#1370](https://github.com/infor-design/enterprise-ng/issues/1370))
 
 ## v4.68.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,6 @@
 - `[Datagrid]` Fixed a bug in datagrid where row shading is not rendered properly. ([#6850](https://github.com/infor-design/enterprise/issues/6850))
 - `[Datagrid]` Fixed a bug in datagrid where icon is not rendering properly in small and extra small row height. ([#6866](https://github.com/infor-design/enterprise/issues/6866))
 - `[Datagrid]` Additional checks when updating cell so that numbers aren't converted twice. ([NG#1370](https://github.com/infor-design/enterprise-ng/issues/1370))
-- `[Splitter]` Fix on splitter not working when parent height changes dynamically. ([#6819](https://github.com/infor-design/enterprise/issues/6819))
 - `[Modal]` Fixed a bug where suppress key setting is not working. ([#6793](https://github.com/infor-design/enterprise/issues/6793))
 - `[Splitter]` Fixed on splitter not working when parent height changes dynamically. ([#6819](https://github.com/infor-design/enterprise/issues/6819))
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -11065,7 +11065,7 @@ Datagrid.prototype = {
       } else {
         newVal = Locale.formatDate(value, { pattern: col.sourceFormat });
       }
-    } else if (typeof oldVal === 'number' && value && !nonNumberCharacters.test(value)) {
+    } else if (typeof oldVal === 'number' && value && (typeof value !== 'number' && !nonNumberCharacters.test(value))) {
       newVal = Locale.parseNumber(value); // remove thousands sep , keep a number a number
     }
 
@@ -11142,7 +11142,7 @@ Datagrid.prototype = {
     let oldVal = this.fieldValue(rowData, col.field);
 
     // Coerce/Serialize value if from cell edit
-    if (!fromApiCall) {
+    if (!fromApiCall && oldVal !== value) {
       coercedVal = this.coerceValue(value, oldVal, col, row, cell);
 
       // coerced value may be coerced to empty string, null, or 0

--- a/test/components/datagrid/datagrid.puppeteer-spec.js
+++ b/test/components/datagrid/datagrid.puppeteer-spec.js
@@ -402,4 +402,23 @@ describe('Datagrid', () => {
         });
     });
   });
+
+  describe('Edit cells', () => {
+    const url = `${baseUrl}/example-editable`;
+
+    it('should update number to correct value in different locale', async () => {
+      const localeUrl = `${url}?locale=de-DE`;
+      await page.goto(localeUrl, { waitUntil: ['domcontentloaded', 'networkidle0'] });
+
+      const priceCell = await page.$('#datagrid table > tbody > tr:nth-child(1) > td:nth-child(7)');
+      await priceCell.click();
+      await priceCell.type('1,5');
+      await page.keyboard.press('Enter');
+      await priceCell.evaluate(el => el.textContent).then(text => expect(text).toEqual('1,500'));
+
+      await priceCell.click();
+      await page.keyboard.press('Enter');
+      await priceCell.evaluate(el => el.textContent).then(text => expect(text).toEqual('1,500'));
+    });
+  });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
There are times that parseNumber is called multiple times, causing it to convert the value again. Added checks to avoid parseNumber being called again.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise-ng/issues/1370

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datagrid/example-editable.html?locale=de-DE
- On any Price cell, change to "1,5"
- Cell should be 1,500
- Click to edit, change nothing, and press Enter
- Cell should be 1,500

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
