### PR TITLE
6867 - Fix on dirty indicators not updating correctly

### DIFF
--- a/app/views/components/datagrid/example-editable.html
+++ b/app/views/components/datagrid/example-editable.html
@@ -30,6 +30,9 @@
           </svg>
           <span class="audible">Add</span>
         </button>
+        <button class="btn" type="button" id="clearDirtyRows-btn">
+          <span class="audible">Clear Dirty Row</span>
+        </button>
       </div>
 
       <div class="more">
@@ -173,6 +176,10 @@
   $('#remove-btn').on('click', function () {
     gridApi.removeSelected();
   });
+
+  $('#clearDirtyRows-btn').on('click', function() {
+    gridApi.clearDirty();
+  })
 
   //A few other ways
   $('#validate').on('selected', function (e, args) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[Datagrid]` Fixed a bug in datagrid where icon is not rendering properly in small and extra small row height. ([#6866](https://github.com/infor-design/enterprise/issues/6866))
 - `[Datagrid]` Fixed a bug in datagrid where sorting is not rendering properly when there is a previously focused cell. ([#6851](https://github.com/infor-design/enterprise/issues/6851))
 - `[Datagrid]` Additional checks when updating cell so that numbers aren't converted twice. ([NG#1370](https://github.com/infor-design/enterprise-ng/issues/1370))
+- `[Datagrid]` Additional fixes on dirty indicator not updating on drag columns. ([#6867](https://github.com/infor-design/enterprise/issues/6867))
 - `[Modal]` Fixed a bug where suppress key setting is not working. ([#6793](https://github.com/infor-design/enterprise/issues/6793))
 - `[Splitter]` Fixed on splitter not working when parent height changes dynamically. ([#6819](https://github.com/infor-design/enterprise/issues/6819))
 - `[Toolbar Flex]` Added additional checks for destroying toolbar. ([#6844](https://github.com/infor-design/enterprise/issues/6844))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3254,52 +3254,55 @@ Datagrid.prototype = {
                 indexTo = tempArray[self.draggableStatus.endIndex] || 0;
 
                 if (self.settings.showDirty && self.dirtyArray) {
-                  const updateCells = (row, dirtyCells, clearCells) => {
-                    dirtyCells.forEach((d) => {
-                      const dirtyCell = { ...self.dirtyArray[row][d[0]] };
-                      dirtyCell.cell = d[1];
-                      dirtyCell.column = self.settings.columns[d[1]];
-                      self.setDirtyCell(row, d[1], dirtyCell);
-                    });
+                  const updateCells = (row, dirtyFlags, start, end) => {
+                    const clearCells = [];
+                    for (let c = start; c <= end; c++) {
+                      if (dirtyFlags[c] && typeof dirtyFlags[c] === 'object') {
+                        self.setDirtyCell(row, c, dirtyFlags[c]);
+                      } else if (dirtyFlags[c] === false) {
+                        clearCells.push(c);
+                      }
+                    }
+                    clearCells.forEach(c => self.clearDirtyCell(row, c));
+                  };
 
-                    clearCells.forEach((d) => {
-                      self.clearDirtyCell(row, d);
-                    });
+                  const setDirty = (row, dirtyRow, dirtyFlags, from, to) => {
+                    if (self.dirtyArray[row][to] && self.dirtyArray[row][to].isDirty) {
+                      dirtyFlags[to] = true;
+                    } else {
+                      dirtyFlags[to] = { ...dirtyRow[from] };
+                      dirtyFlags[to].cell = to;
+                      dirtyFlags[to].column = self.settings.columns[to];
+                    }
                   };
 
                   if (indexFrom > indexTo) {
                     self.dirtyArray.forEach((dirtyRow, row) => {
-                      const clearCells = [];
-                      const dirtyCells = [];
+                      const dirtyFlags = Array(indexFrom + 1).fill(false);
                       for (let c = indexTo; c <= indexFrom; c++) {
                         if (dirtyRow[c] && dirtyRow[c].isDirty) {
                           if (c === indexFrom) {
-                            dirtyCells.push([indexFrom, indexTo]);
+                            setDirty(row, dirtyRow, dirtyFlags, indexFrom, indexTo);
                           } else {
-                            dirtyCells.push([c, c + 1]);
+                            setDirty(row, dirtyRow, dirtyFlags, c, c + 1);
                           }
-                        } else {
-                          clearCells.push(c + 1);
                         }
                       }
-                      updateCells(row, dirtyCells, clearCells);
+                      updateCells(row, dirtyFlags, indexTo, indexFrom);
                     });
                   } else if (indexFrom < indexTo) {
                     self.dirtyArray.forEach((dirtyRow, row) => {
-                      const clearCells = [];
-                      const dirtyCells = [];
+                      const dirtyFlags = Array(indexTo + 2).fill(false);
                       for (let c = indexTo; c >= indexFrom; c--) {
                         if (dirtyRow[c] && dirtyRow[c].isDirty) {
                           if (c === indexFrom) {
-                            dirtyCells.push([indexFrom, indexTo]);
+                            setDirty(row, dirtyRow, dirtyFlags, indexFrom, indexTo);
                           } else {
-                            dirtyCells.push([c, c - 1]);
+                            setDirty(row, dirtyRow, dirtyFlags, c, c - 1);
                           }
-                        } else {
-                          clearCells.push(c - 1);
                         }
                       }
-                      updateCells(row, dirtyCells, clearCells);
+                      updateCells(row, dirtyFlags, indexFrom, indexTo);
                     });
                   }
                 }

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3280,7 +3280,7 @@ Datagrid.prototype = {
                     self.dirtyArray.forEach((dirtyRow, row) => {
                       const dirtyFlags = Array(indexFrom + 1).fill(false);
                       for (let c = indexTo; c <= indexFrom; c++) {
-                        if (dirtyRow[c] && dirtyRow[c].isDirty) {
+                        if (dirtyRow && dirtyRow[c] && dirtyRow[c].isDirty) {
                           if (c === indexFrom) {
                             setDirty(row, dirtyRow, dirtyFlags, indexFrom, indexTo);
                           } else {
@@ -3294,7 +3294,7 @@ Datagrid.prototype = {
                     self.dirtyArray.forEach((dirtyRow, row) => {
                       const dirtyFlags = Array(indexTo + 2).fill(false);
                       for (let c = indexTo; c >= indexFrom; c--) {
-                        if (dirtyRow[c] && dirtyRow[c].isDirty) {
+                        if (dirtyRow && dirtyRow[c] && dirtyRow[c].isDirty) {
                           if (c === indexFrom) {
                             setDirty(row, dirtyRow, dirtyFlags, indexFrom, indexTo);
                           } else {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Additional fixes on dirty indicator not updating correctly on drag columns.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Addresses comments in #6867 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datagrid/example-editable.html
- Edit a cell so that dirty indicator will pop up
- Select another column and drag it next to the dirty cell (do both left and right sides)
- Dirty indicator should still stay on the cell
Check this gif for a better reference: https://user-images.githubusercontent.com/76002134/193113958-67d4f1fd-824c-46d1-9168-02105c8b1ef0.gif

- Edit a cell do that dirty indicator will pop up
- On the more menu, click "Clear Dirty Row"
- Drag the column that was previously dirty

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
