### PR TITLE
5273 - datagrid filter is empty not working

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## v4.69.0 Fixes
 
+- `[Datagrid]` Fixed a bug in datagrid where is empty and is not empty is not working properly. ([#5273](https://github.com/infor-design/enterprise/issues/5273))
 - `[Datagrid]` Fixed a bug in datagrid where multiselect filter is not rendering properly. ([#6846](https://github.com/infor-design/enterprise/issues/6846))
 - `[Datagrid]` Fixed a bug in datagrid where row shading is not rendered properly. ([#6850](https://github.com/infor-design/enterprise/issues/6850))
 - `[Datagrid]` Fixed a bug in datagrid where icon is not rendering properly in small and extra small row height. ([#6866](https://github.com/infor-design/enterprise/issues/6866))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -2735,6 +2735,10 @@ Datagrid.prototype = {
             if (conditions[i].filterType === 'checkbox' || conditions[i].value.toString().trim() !== '') {
               isEmpty = false;
             }
+
+            if (conditions[i].filterType === 'text' && conditions[i].operator === 'is-empty') {
+              isEmpty = false;
+            }
           }
           return isEmpty;
         };

--- a/test/components/datagrid/datagrid.puppeteer-spec.js
+++ b/test/components/datagrid/datagrid.puppeteer-spec.js
@@ -86,6 +86,33 @@ describe('Datagrid', () => {
     });
   });
 
+  describe('Tree Filter Empty', () => {
+    const url = `${baseUrl}/test-tree-filter.html`;
+
+    beforeAll(async () => {
+      await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });
+    });
+
+    it('Should be able to use filter empty without text in input box', async () => {
+      expect(await page.$$eval('tr.datagrid-row', el => el.length)).toEqual(22);
+
+      const filterBtn = await page.$('#test-tree-filter-datagrid-1-header-3 .btn-filter');
+      await filterBtn.click();
+
+      await page.waitForSelector('.popupmenu.is-open', { visible: true })
+        .then(element => expect(element).toBeTruthy());
+
+      await page.waitForSelector('.popupmenu.is-open li.is-empty', { visible: true })
+        .then(element => expect(element).toBeTruthy());
+
+      const isEmptyBtn = await page.$('.popupmenu.is-open li.is-empty');
+      await isEmptyBtn.click();
+
+      expect(await page.$$eval('tr.datagrid-row.is-hidden', el => el.length)).toEqual(7);
+      expect(await page.$$eval('tr.datagrid-row:not(.is-hidden)', el => el.length)).toEqual(1);
+    });
+  });
+
   describe('Key row select', () => {
     const url = `${baseUrl}/example-key-row-select.html`;
     beforeAll(async () => {

--- a/test/components/datagrid/datagrid.puppeteer-spec.js
+++ b/test/components/datagrid/datagrid.puppeteer-spec.js
@@ -119,7 +119,7 @@ describe('Datagrid', () => {
       await page.goto(url, { waitUntil: ['domcontentloaded', 'networkidle0'] });
     });
 
-    it('Should be able to use filter empty without text in input box', async () => {
+    it('should be able to use filter empty without text in input box', async () => {
       expect(await page.$$eval('tr.datagrid-row', el => el.length)).toEqual(22);
 
       const filterBtn = await page.$('#test-tree-filter-datagrid-1-header-3 .btn-filter');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug in datagrid where is empty and is not empty is not working properly.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5273

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-tree-filter.html
- On the `Description` Column, click `Is Empty` filter

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

