### PR TITLE
6877 - Added Firefox increment/decrement keys

### DIFF
--- a/app/views/components/datagrid/example-editable.html
+++ b/app/views/components/datagrid/example-editable.html
@@ -106,7 +106,20 @@
     columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', align: 'right', editor: Editors.Input, mask: '###', isEditable: isDisabled});
     columns.push({ id: 'portable', name: 'Portable', field: 'portable', align: 'center', formatter: Formatters.Checkbox, editor: Editors.Checkbox});
     columns.push({ id: 'price', name: 'Price', field: 'price', align: 'right', formatter: Formatters.Decimal, validate: 'required', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input});
-    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date, editorOptions: {showLegend: true, legend: [{name: 'Weekend', color: '#579E95', dayOfWeek: [0,6]}], disable: { years: [], dates: [], minDate: '01-01-2014', maxDate: `${month}-${day}-${year}`, dayOfWeek: [], isEnable: false, restrictMonths: false }, showTime: false, showMonthYearPicker: true, placeholder: true}, validate: 'availableDate required date', width: 120});
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date, editorOptions: {
+      showLegend: true, legend:
+      [{name: 'Weekend', color: '#579E95', dayOfWeek: [0,6]}],
+      disable: { years: [], dates: [], minDate: '01-01-2014', maxDate: `${month}-${day}-${year}`,
+      dayOfWeek: [],
+      isEnable: false,
+      restrictMonths: false },
+      showTime: false,
+      showMonthYearPicker: true,
+      placeholder: true,
+      incrementWithKeyboard: true,
+      todayWithKeyboard: true},
+      validate: 'availableDate required date', width: 120
+    });
     columns.push({ id: 'action', name: 'Action', field: 'action', formatter: Formatters.Dropdown, editor: Editors.Dropdown, validate: 'required', isEditable: isDisabled,
     options: [{id: '', label: '', value: -1}, {id: 'oh1', label: 'On Hold', value: 1}, {id: 'sh1', label: 'Shipped', value: 2} , {id: 'ac1', label: 'Action', value: 3}, {id: 'pen', label: 'Pending', value: 4}, {id: 'bk1', label: 'Backorder', value: 5}, {id: 'can', label: 'Cancelled', value: 6}, {id: 'pro', label: 'Processing', value: 7}]
     });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `[Counts]` Fixed a bug in counts where two rows of labels cause misalignment. ([#6845](https://github.com/infor-design/enterprise/issues/6845))
 - `[Datagrid]` Adjusted date and timepicker icons in datagrid filter. ([#6917](https://github.com/infor-design/enterprise/issues/6917))
+- `[Datepicker]` Added Firefox increment/decrement keys. ([#6877](https://github.com/infor-design/enterprise/issues/6877))
 - `[Editor]` Fixed a bug in editor where insert image is not working properly when adding attributes. ([#6864](https://github.com/infor-design/enterprise/issues/6864))
 - `[Popupmenu]` Fixed a bug in popupmenu where submenu and submenu items are not indented properly. ([#6860](https://github.com/infor-design/enterprise/issues/6860))
 - `[Process Indicator]` Fix on extra line after final step. ([#6744](https://github.com/infor-design/enterprise/issues/6744))

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -5,6 +5,7 @@ import { stringUtils } from '../../utils/string';
 import { xssUtils } from '../../utils/xss';
 import { Locale } from '../locale/locale';
 import { MonthView } from '../monthview/monthview';
+import { Environment as env } from '../../utils/environment';
 
 // jQuery Components
 import '../expandablearea/expandablearea.jquery';
@@ -438,13 +439,13 @@ DatePicker.prototype = {
         const inputVal = $(e.currentTarget).val();
 
         // '-' decrements day
-        if (key === 189 || key === 109) {
+        if (key === 189 || key === 109 || (env.browser.isFirefox() && key === 173)) {
           handled = true;
           this.adjustDay(false, inputVal);
         }
 
         // '+' increments day
-        if (key === 187 || key === 107) {
+        if (key === 187 || key === 107 || (env.browser.isFirefox() && key === 61)) {
           handled = true;
           this.adjustDay(true, inputVal);
         }

--- a/src/utils/environment.js
+++ b/src/utils/environment.js
@@ -349,6 +349,13 @@ Environment.browser.isIE10 = function () {
   return Environment.browser.name === 'ie' && Environment.browser.version === '10';
 };
 
+/**
+ * @returns {boolean} whether or not the current browser is Firefox
+ */
+Environment.browser.isFirefox = function () {
+  return Environment.browser.name === 'firefox';
+};
+
 Environment.browser.isIPad = function () {
   return !!(navigator.userAgent.match(/(iPad)/) ||
     (navigator.platform === 'MacIntel' && typeof navigator.standalone !== 'undefined'));


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Included the "+" and "-" key values in Firefox for increment/decrement keydown check in datepicker.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #6877 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- In Firefox, go to:
   - http://localhost:4000/components/datagrid/example-editable.html
   - http://localhost:4000/components/datepicker/test-datepicker-today-increment-key.html
- Select a date cell to edit
- Press the "+" and "-" keys on the QWERTY keyboard to increment/decrement the date

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
