### PR TITLE
6952 - datagrid dirty cell indicator frozen 4.68.x

### DIFF
--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1821,6 +1821,8 @@ $datagrid-small-row-height: 25px;
           .icon-rowstatus {
             left: -1px;
             top: 0;
+            background-color: transparent;
+            box-shadow: unset;
           }
         }
       }

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10856,6 +10856,7 @@ Datagrid.prototype = {
     node.removeAttribute(`data-${type}message`);
 
     const icon = node.querySelector(`.icon-${type}`);
+    node?.classList.remove('rowstatus-cell');
     if (icon) {
       icon.parentNode.removeChild(icon);
       this.hideTooltip();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug in datagrid where clear dirty cell does not work properly in frozen columns.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6952

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-addrow-with-frozen-columns.html
- Click `Add Row`
- Enter new values for each of the columns in the new row
- Notice the dirty indicator on each cell
- Click on `Save and New`

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

