### PR TITLE
NG1380. Fixed a bug in mask value in datepicker when update is called

### DIFF
--- a/app/views/components/datepicker/test-mask-disable-update.html
+++ b/app/views/components/datepicker/test-mask-disable-update.html
@@ -1,0 +1,55 @@
+
+<div class="row">
+  <div class="four columns">
+
+    <div class="field">
+      <label for="date-field-1" class="label">Date Field 1</label>
+      <input id="date-field-1" class="datepicker" name="date-field-1" style="width: 200px"/>
+    </div>
+
+    <div class="field">
+      <label for="date-field-2" class="label">Date Field 2</label>
+      <input id="date-field-2" class="datepicker" name="date-field-2" style="width: 200px"/>
+    </div>
+    <button class="btn-primary" type="button" id="toggle">Update Disable</button>
+  </div>
+</div>
+
+<script>
+  $('body').on('initialized', function() {
+    const format1 = 'MMM EEE d, yyyy';
+    const format2 = 'EEE MMM d, yyyy';
+
+    const date1 = Locale.formatDate(new Date(2022, 8, 22), { pattern: format1 });
+    const date2 = Locale.formatDate(new Date(2022, 8, 22), { pattern: format2 });
+
+    const disableOptions = [
+      {
+        dates: '',
+        minDate: '09/20/2022',
+        maxDate: '09/24/2022',
+        dayOfWeek: []
+      },
+      {
+        dates: '',
+        minDate: new Date(2022, 8, 15),
+        maxDate: new Date(2022, 8, 30),
+        dayOfWeek: [],
+      }
+    ];
+
+    let disable = 0;
+
+    $('#date-field-1').val(date1);
+    const dateApi1 = $('#date-field-1').datepicker({ disable: disableOptions[disable], dateFormat: format1 }).data('datepicker');
+
+    $('#date-field-2').val(date2);
+    const dateApi2 = $('#date-field-2').datepicker({ disable: disableOptions[disable], dateFormat: format2 }).data('datepicker');
+
+    $('#toggle').on('click', () => {
+      disable = disable === 0 ? 1 : 0;
+      dateApi1.updated({ disable: disableOptions[disable], dateFormat: format1 });
+      dateApi2.updated({ disable: disableOptions[disable], dateFormat: format2 });
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[Datagrid]` Fixed a bug where frozen column headers are not rendered on update. ([NG#1399](https://github.com/infor-design/enterprise-ng/issues/1399))
 - `[Datagrid]` Added toolbar update on datagrid update. ([NG#1357](https://github.com/infor-design/enterprise-ng/issues/1357))
 - `[Datepicker]` Added Firefox increment/decrement keys. ([#6877](https://github.com/infor-design/enterprise/issues/6877))
+- `[Datepicker]` Fixed a bug in mask value in datepicker when update is called. ([NG#1380](https://github.com/infor-design/enterprise-ng/issues/1380))
 - `[Editor]` Fixed a bug in editor where insert image is not working properly when adding attributes. ([#6864](https://github.com/infor-design/enterprise/issues/6864))
 - `[Editor]` Fixed a bug in editor where paste and plain text is not cleaning the text/html properly. ([#6892](https://github.com/infor-design/enterprise/issues/6892))
 - `[Locale]` Fixed a bug in locale where same language translation does not render properly. ([#6847](https://github.com/infor-design/enterprise/issues/6847))

--- a/src/components/mask/mask-input.js
+++ b/src/components/mask/mask-input.js
@@ -379,7 +379,7 @@ MaskInput.prototype = {
       if (this.element.value !== finalValue) {
         this.element.value = finalValue;
       }
-    } else if (this.element.value.length === 0) {
+    } else {
       this.element.value = finalValue;
     }
     utils.safeSetSelection(this.element, processed.caretPos);

--- a/src/components/mask/mask-input.js
+++ b/src/components/mask/mask-input.js
@@ -379,7 +379,7 @@ MaskInput.prototype = {
       if (this.element.value !== finalValue) {
         this.element.value = finalValue;
       }
-    } else {
+    } else if (this.element.value.length === 0) {
       this.element.value = finalValue;
     }
     utils.safeSetSelection(this.element, processed.caretPos);

--- a/src/components/mask/masks.js
+++ b/src/components/mask/masks.js
@@ -455,7 +455,7 @@ masks.dateMask = function dateMask(rawValue, options) {
   const format = options.format;
   const splitterStr = str.removeDuplicates(format.replace(/[dMyHhmsa]+/g, ''));
   const splitterRegex = getSplitterRegex(splitterStr);
-  const formatArray = format.match(/(d{1,2}|M{1,4}|y{1,4}|H{1,2}|h{1,2}|m{1,2}|s{1,2}|a{1}|z{1, 4}|E{1, 4})/g);
+  const formatArray = format.match(/(d{1,2}|M{1,4}|y{1,4}|H{1,2}|h{1,2}|m{1,2}|s{1,2}|a{1}|z{1,4}|E{1,4})/g);
   const rawValueArray = rawValue.split(splitterRegex);
   const maxValue = DATE_MAX_VALUES;
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Updated regex expression for mask

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise-ng/issues/1380

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datepicker/test-mask-disable-update.html
- Select dates in both datepickers
- Click outside
- Click Update Disable button
- Change the dates in the datepickers
- Click outside

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
