### PR TITLE
6820 - Fixed a bug where expanded card closes in NG when opening accordion

### DIFF
--- a/app/views/components/applicationmenu/test-accordion-card.html
+++ b/app/views/components/applicationmenu/test-accordion-card.html
@@ -1,0 +1,117 @@
+{{> includes/head}}
+
+<body class="no-scroll">
+  <a href="#maincontent" class="skip-link" data-translate="text">SkipToMain</a>
+  {{> includes/svg-inline-refs}}
+  {{> includes/applicationmenu-deep-menu-level}}
+
+  <div class="page-container scrollable">
+
+      <header class="header is-personalizable">
+        <div class="toolbar">
+          <div class="title">
+            {{> includes/header-appmenu-trigger}}
+            <h1><span data-translate="text">UserProfile</span></h1>
+          </div>
+          {{> includes/header-actionbutton}}
+        </div>
+      </header>
+
+    <div id="maincontent" class="page-container scrollable" role="main">
+      <div class="one-half column">
+        <div class="accordion" data-demo-set-links="true" data-options='{ "allowOnePane": false }'>
+          <div id="header-one" class="accordion-header">
+            <a href="#" id="warehouse-location" data-automation-id="accordion-a-header-one"><span>Dates of Service</span></a>
+            <button id="personal-expander" data-automation-id="accordion-btn-warehouse-location" class="btn">
+              <svg class="chevron icon">
+                <use href="#icon-caret-down"></use>
+              </svg>
+              <span class="audible">Expand</span>
+            </button>
+          </div>
+          <div class="accordion-pane">
+            <div class="accordion-content">
+              <p>
+              Remix, optimize, "B2B, iterate?" Best-of-breed efficient beta-test; social cutting-edge: rich magnetic tagclouds front-end infomediaries viral authentic incentivize sexy extensible functionalities incentivize. Generate killer authentic grow vertical blogospheres, functionalities ecologies harness, "tag solutions synergies exploit data-driven B2C open-source e-markets optimize create, enhance convergence create." Out-of-the-box strategize best-of-breed back-end, deploy design markets metrics. Content web services enhance leading-edge Cluetrain, deliverables dot-com scalable. User-centric morph, back-end, synthesize mesh, frictionless, exploit next-generation tag portals, e-commerce channels; integrate; recontextualize distributed revolutionize innovative eyeballs.
+              </p>
+            </div>
+          </div>
+
+          <div id="header-two" class="accordion-header">
+            <a href="#" id="sort-by" data-automation-id="accordion-a-sort-by"><span>Personal Information</span></a>
+            <button id="sort-by-expander" data-automation-id="accordion-btn-sort-by" class="btn">
+              <svg class="chevron icon">
+                <use href="#icon-caret-down"></use>
+              </svg>
+              <span class="audible">Expand</span>
+            </button>
+          </div>
+          <div class="accordion-pane">
+            <div class="accordion-content">
+              <p>Aute est literally, salvia fam esse dolor. Banh mi scenester velit franzen trust fund esse dolore truffaut XOXO, shabby chic nisi nostrud typewriter cliche. Cray fanny pack blue bottle dreamcatcher, pariatur iPhone cronut vaporware offal franzen. Ennui selvage man bun cronut kombucha aesthetic gastropub.</p>
+            </div>
+          </div>
+
+          <div id="header-three" class="accordion-header">
+            <a id="brand-name" data-automation-id="accordion-a-brand-name" href="#"><span>My Password</span></a>
+            <button id="brand-name-expander" data-automation-id="accordion-btn-brand-name" class="btn">
+              <svg class="chevron icon">
+                <use href="#icon-caret-down"></use>
+              </svg>
+              <span class="audible">Expand</span>
+            </button>
+          </div>
+          <div class="accordion-pane">
+            <div class="accordion-content">
+                <p>
+                Revolutionize implement infrastructures social front-end, world-class bricks-and-clicks extensible recontextualize? User-contributed e-business relationships widgets bleeding-edge transform, "viral world-class, unleash sexy embrace cross-media best-of-breed wireless, functionalities." Markets, "transition architectures, redefine infomediaries world-class back-end harness, mindshare blogospheres; schemas disintermediate rich," benchmark integrated markets blogging synergies dynamic social back-end convergence. Reinvent A-list A-list B2C rss-capable, mesh bandwidth mission-critical disintermediate strategize networks distributed integrated bleeding-edge rss-capable partnerships incubate, web-enabled e-markets. A-list channels enhance citizen-media, value solutions beta-test platforms enable interfaces, transition interfaces one-to-one expedite scalable.
+                </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="one-half column">
+        <div id="expandable-card" class="card is-expanded">
+          <div class="card-header">
+            <p class="heading">Very Important Details</p>
+            <button type="button" class="btn-actions" type="button" id="btn-1">
+              <span class="audible">Actions</span>
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use href="#icon-more"></use>
+              </svg>
+            </button>
+            <ul class="popupmenu actions">
+              <li><a href="#" id="action-1">Action One</a></li>
+              <li><a href="#" id="action-2">Action Two</a></li>
+            </ul>
+          </div>
+          <div class="card-pane">
+            <div class="card-content" style="padding: 20px">
+              <p>Man bun portland venmo, reprehenderit cillum exercitation culpa adaptogen pitchfork unicorn. Jianbing mlkshk cloud bread id. Qui forage twee meditation hammock commodo heirloom gochujang shaman tattooed. Ethical commodo woke, ea est in artisan farm-to-table asymmetrical four loko ut cleanse thundercats. Gochujang reprehenderit schlitz cred squid tote bag tempor literally consequat exercitation.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {{> includes/footer}}
+
+  <script>
+    $('#expandable-card').cards({
+    expandableHeader: true,
+    verticalButtonAction: true,
+    attributes: [{
+        name: 'id',
+        value: 'card-id-1'
+      },
+      {
+        name: 'data-automation-id',
+        value: 'card-automation-id-1'
+      }
+    ]
+  });
+  </script>
+</body>
+</html>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## v4.70.0 Fixes
 
+- `[Accordion]` Fixed a bug where expanded card closes in NG when opening accordion. ([#6820](https://github.com/infor-design/enterprise/issues/6820))
 - `[Counts]` Fixed a bug in counts where two rows of labels cause misalignment. ([#6845](https://github.com/infor-design/enterprise/issues/6845))
 - `[Datagrid]` Fixed a bug in datagrid where expandable row input cannot edit the value. ([#6781](https://github.com/infor-design/enterprise/issues/6781))
 - `[Datagrid]` Fixed a bug in datagrid where clear dirty cell does not work properly in frozen columns. ([#6952](https://github.com/infor-design/enterprise/issues/6952))

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -1588,7 +1588,7 @@ Accordion.prototype = {
       const type = getElementType(element);
 
       // Trigger a document click since we stop propgation, to close any open menus/popups.
-      $('body').children().not('.application-menu, .modal-page-container, .page-container').closeChildren();
+      $('body').children().not('.application-menu, .modal-page-container, .page-container, .resize-app-menu-container').closeChildren();
 
       return self[`handle${type}Click`](e, element);
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Haven't been able to replicate it in IDS but have done it in Angular (stackblitz doesn't provide the correct example but based on what's in it, I'm assuming the bug was found in Angular). The card is in a resize container which does not get excluded in the click interceptor. Added resize container in the excluded list.

Note: Requires this for NG https://github.com/infor-design/enterprise-ng/pull/1406

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #6820 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch and build
- Go to: http://localhost:4000/components/applicationmenu/test-accordion-card.html
- Click on accordion to expand
- Card should not close
- Use this IDS to build NG
- Build and run IDS NG
- Go to: http://localhost:4200/ids-enterprise-ng-demo/accordion/card
- Click on accordion to expand
- Card should not close

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
