### PR TITLE
6845 - count widget misalignment

### DIFF
--- a/src/components/counts/_counts.scss
+++ b/src/components/counts/_counts.scss
@@ -106,6 +106,16 @@
   }
 }
 
+html.is-firefox {
+  .instance-count {
+    .title {
+      -moz-orient: vertical;
+      width: 120px;
+      height: 40px;
+    }
+  }
+}
+
 // RTL Styles
 html[dir='rtl'] {
   .instance-count {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix a bug in counts where two rows of labels cause misalignment (in firefox).

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/6845

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/counts/test-widget-long-title.html in Firefox
- See the two row label

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

