### PR TITLE
6920 - Fixed a bug in datagrid where disabled dates were not showing in Safari

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## v4.71.0 Fixes
 
 - `[Datagrid]` Fixed a bug in datagrid where dropdown filter does not render correctly. ([#7006](https://github.com/infor-design/enterprise/issues/7006))
+- `[Datepicker]` Fixed a bug in datagrid where disabled dates were not showing in Safari. ([#6920](https://github.com/infor-design/enterprise/issues/6920))
 
 ## v4.70.0
 

--- a/src/components/calendar/_calendar-toolbar-new.scss
+++ b/src/components/calendar/_calendar-toolbar-new.scss
@@ -16,4 +16,11 @@
   .dropdown-wrapper {
     top: 12px;
   }
+
+  .today {
+    &.is-disabled {
+      color: $datepicker-disabled-color;
+      cursor: default;
+    }
+  }
 }

--- a/src/components/calendar/_calendar-toolbar-new.scss
+++ b/src/components/calendar/_calendar-toolbar-new.scss
@@ -19,7 +19,7 @@
 
   .today {
     &.is-disabled {
-      color: $datepicker-disabled-color;
+      color: $datepicker-disabled-bg-color;
       cursor: default;
     }
   }

--- a/src/components/calendar/_calendar-toolbar-new.scss
+++ b/src/components/calendar/_calendar-toolbar-new.scss
@@ -19,7 +19,7 @@
 
   .today {
     &.is-disabled {
-      color: $datepicker-disabled-bg-color;
+      color: rgba($datepicker-disabled-color, 0.5);
       cursor: default;
     }
   }

--- a/src/components/calendar/calendar-toolbar.js
+++ b/src/components/calendar/calendar-toolbar.js
@@ -97,8 +97,8 @@ CalendarToolbar.prototype = {
       }
     }
 
-    todayLink.class += ` hyperlink${isRippleClass}`;
-    const todayStr = s.showToday || s.inPage ? `<a class="${todayLink.class}}" href="#">${todayLink.text}</a>` : '';
+    todayLink.class += ` hyperlink${isRippleClass}${s.disableToday ? ' is-disabled' : ''}`;
+    const todayStr = s.showToday || s.inPage ? `<a class="${todayLink.class}" href="#">${todayLink.text}</a>` : '';
 
     const hitboxAttr = s.hitbox ? 'data-options="{hitbox: true}"' : '';
 

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -1088,7 +1088,7 @@ DatePicker.prototype = {
       }
     });
 
-    this.popup.off('click.datepicker-today').on('click.datepicker-today', '.hyperlink.today', (e) => {
+    this.popup.off('click.datepicker-today').on('click.datepicker-today', '.hyperlink.today:not(.is-disabled)', (e) => {
       e.preventDefault();
       if (s.range.useRange) {
         self.setToday(true);

--- a/src/components/monthview/monthview.js
+++ b/src/components/monthview/monthview.js
@@ -322,6 +322,7 @@ MonthView.prototype = {
 
     // Add Legend
     this.addLegend();
+    const today = new Date();
 
     // Invoke the toolbar
     this.calendarToolbarEl = this.header.find('.calendar-toolbar');
@@ -332,6 +333,7 @@ MonthView.prototype = {
       year: this.currentYear,
       month: this.currentMonth,
       showToday: this.settings.showToday,
+      disableToday: this.isDateDisabled(today.getFullYear(), today.getMonth(), today.getDate()),
       showNextPrevious: this.settings.showNextPrevious,
       isMonthPicker: this.settings.headerStyle === 'full',
       isAlternate: this.settings.headerStyle !== 'full',
@@ -1314,8 +1316,8 @@ MonthView.prototype = {
       });
       return deferred.promise();
     }
-    const min = (new Date(s.disable.minDate)).setHours(0, 0, 0, 0);
-    const max = (new Date(s.disable.maxDate)).setHours(0, 0, 0, 0);
+    const min = (new Date(s.disable.minDate.replace(/-/g, '/'))).setHours(0, 0, 0, 0);
+    const max = (new Date(s.disable.maxDate.replace(/-/g, '/'))).setHours(0, 0, 0, 0);
     let d2 = this.isIslamic ?
       Locale.umalquraToGregorian(year, month, date) : new Date(year, month, date);
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fixed a bug where disabled dates in Safari were not showing. Added disable state for Today if current date is disabled.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #6920 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
Test in Chrome, Edge, and Safari
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datagrid/example-editable.html
- Click on a datepicker cell
- Monthview should show disabled dates
- Click on Today
- Today should be disabled

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
