### PR TITLE
7032 Fixed Calendar Toolbar Destroy

### DIFF
--- a/src/components/calendar/calendar-toolbar.js
+++ b/src/components/calendar/calendar-toolbar.js
@@ -63,6 +63,7 @@ function CalendarToolbar(element, settings) {
 // CalendarToolbar Methods
 CalendarToolbar.prototype = {
 
+
   init() {
     this
       .setLocale()
@@ -405,45 +406,46 @@ CalendarToolbar.prototype = {
     return this;
   },
 
+  resize() {
+    if (this.viewChanger) {
+      if (breakpoints.isBelow('phablet')) {
+        this.viewChanger.next().addClass('dropdown-wrapper-small');
+        this.viewChanger.next().find('.dropdown').css({
+          width: `${breakpoints.isBelow('phone') ? '60' : '90'}px`
+        });
+        $('.today').css(breakpoints.isBelow('slim') ? { display: 'none' } : {});
+      } else {
+        this.viewChanger.next().removeClass('dropdown-wrapper-small');
+        this.viewChanger.next().find('.dropdown').removeAttr('style');
+        $('.today').removeAttr('style');
+      }
+    }
+
+    if (this.monthPicker) {
+      const monthPickerText = breakpoints.isBelow('slim') && this.currentCalendar.months ? `${this.currentCalendar.months.abbreviated[this.currentMonth]} ${this.currentYear}` : Locale.formatDate(
+        new Date(this.currentYear, this.currentMonth, this.currentDay),
+        { date: 'year', locale: this.locale.name, language: this.settings.language }
+      );
+
+      this.monthPicker.text(monthPickerText);
+    }
+  },
+
+
   /**
    * Handle resize of calendar.
    * @private
    * @returns {void}
    */
   handleResize() {
-    const resize = () => {
-      if (this.viewChanger) {
-        if (breakpoints.isBelow('phablet')) {
-          this.viewChanger.next().addClass('dropdown-wrapper-small');
-          this.viewChanger.next().find('.dropdown').css({
-            width: `${breakpoints.isBelow('phone') ? '60' : '90'}px`
-          });
-          $('.today').css(breakpoints.isBelow('slim') ? { display: 'none' } : {});
-        } else {
-          this.viewChanger.next().removeClass('dropdown-wrapper-small');
-          this.viewChanger.next().find('.dropdown').removeAttr('style');
-          $('.today').removeAttr('style');
-        }
-      }
 
-      if (this.monthPicker) {
-        const monthPickerText = breakpoints.isBelow('slim') && this.currentCalendar.months ? `${this.currentCalendar.months.abbreviated[this.currentMonth]} ${this.currentYear}` : Locale.formatDate(
-          new Date(this.currentYear, this.currentMonth, this.currentDay),
-          { date: 'year', locale: this.locale.name, language: this.settings.language }
-        );
+    this.resize();
 
-        this.monthPicker.text(monthPickerText);
-      }
-    };
-
-    resize();
-
-    $(window).on('resize', () => {
-      resize();
-    });
+    $(window).on('resize', this.resize);
 
     return this;
   },
+
 
   /**
    * Resync the UI and Settings.
@@ -464,6 +466,7 @@ CalendarToolbar.prototype = {
    * @returns {void}
    */
   teardown() {
+    $(window).off('resize',this.resize);
     this.element.off();
     this.monthPicker.off();
     this.todayLink.off();
@@ -476,7 +479,7 @@ CalendarToolbar.prototype = {
    * @returns {void}
    */
   destroy() {
-    this.unbind();
+    this.teardown();
     $.removeData(this.element[0], COMPONENT_NAME);
   }
 

--- a/src/components/calendar/calendar-toolbar.js
+++ b/src/components/calendar/calendar-toolbar.js
@@ -431,7 +431,6 @@ CalendarToolbar.prototype = {
     }
   },
 
-
   /**
    * Handle resize of calendar.
    * @private
@@ -445,7 +444,6 @@ CalendarToolbar.prototype = {
 
     return this;
   },
-
 
   /**
    * Resync the UI and Settings.

--- a/src/components/calendar/calendar-toolbar.js
+++ b/src/components/calendar/calendar-toolbar.js
@@ -63,7 +63,6 @@ function CalendarToolbar(element, settings) {
 // CalendarToolbar Methods
 CalendarToolbar.prototype = {
 
-
   init() {
     this
       .setLocale()
@@ -437,11 +436,8 @@ CalendarToolbar.prototype = {
    * @returns {void}
    */
   handleResize() {
-
     this.resize();
-
     $(window).on('resize', this.resize);
-
     return this;
   },
 
@@ -464,7 +460,7 @@ CalendarToolbar.prototype = {
    * @returns {void}
    */
   teardown() {
-    $(window).off('resize',this.resize);
+    $(window).off('resize', this.resize);
     this.element.off();
     this.monthPicker.off();
     this.todayLink.off();

--- a/src/components/monthview/monthview.js
+++ b/src/components/monthview/monthview.js
@@ -2798,6 +2798,7 @@ MonthView.prototype = {
    * @returns {object} The prototype.
    */
   destroy() {
+    this.calendarToolbarAPI?.destroy();
     this.teardown();
     if (this.element) {
       this.element.empty();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Now monthview.js will call the destroy function from calendar-toolbar.js, the resize event handlers is destroyed in teardown() properly.

**Related github/jira issue (required)**:
#7032 

**Steps necessary to review your pull request (required)**:
Added a toggle button to simulate destroy and create the calendar:
![image](https://user-images.githubusercontent.com/90947192/209362947-7b193b62-6c45-405d-a2fb-27510cfbddea.png)
initially 3 resize handler events
![image](https://user-images.githubusercontent.com/90947192/209363075-870d643a-40f4-4937-bced-e7aaf7d623d4.png)
on destroy, the 2 resize handler events created by calendar-toobar.js is properly destroyed
![image](https://user-images.githubusercontent.com/90947192/209363230-2c968c34-29c2-44d5-a3f4-a905d68fb3df.png)
creating calendar again, resize.length becomes 3 again

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
