### PR TITLE
7057 - Fix script error after closing the lookup modal

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `[Datepicker]` Fixed a bug in datagrid where disabled dates were not showing in Safari. ([#6920](https://github.com/infor-design/enterprise/issues/6920))
 - `[Datepicker]` Fixed a bug where range display is malformed in RTL. ([#6933](https://github.com/infor-design/enterprise/issues/6933))
 - `[Lookup]` Adjusted width in lookup. ([#6924](https://github.com/infor-design/enterprise/issues/6924))
+- `[Lookup]` Fixed a bug where custom modal script gets error after closing the modal in the second time. ([#7057](https://github.com/infor-design/enterprise/issues/7057))
 - `[Textarea]` Added paste event listener for textarea. ([NG#6924](https://github.com/infor-design/enterprise-ng/issues/1401))
 - `[User Status Icons]` Now have a more visible fill and a stroke behind them. ([#7040](https://github.com/infor-design/enterprise/issues/7040))
 

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1213,11 +1213,15 @@ Modal.prototype = {
         (container.next().is('.pager-toolbar') ? 35 : 0) +
         (hasPager.length ? -15 : 0);
 
-      if (currentlyNeedsFullsize) {
-        table[0].style.maxHeight = '';
-        table[0].style.maxWidth = '';
-      } else {
-        if (table[0] !== undefined) {
+      // It will ensure that the style properties are only set
+      // if calcHeight and calcWidth are defined and have a value.
+      // This can prevent errors that might occur
+      // if one or both of these variables are undefined or have an unexpected value.
+      if (table[0] !== undefined) {
+        if (currentlyNeedsFullsize) {
+          table[0].style.maxHeight = '';
+          table[0].style.maxWidth = '';
+        } else if (typeof calcHeight !== 'undefined' && typeof calcWidth !== 'undefined') {
           table[0].style.maxHeight = `${calcHeight}px`;
           table[0].style.maxWidth = `${calcWidth}px`;
         }

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1217,8 +1217,10 @@ Modal.prototype = {
         table[0].style.maxHeight = '';
         table[0].style.maxWidth = '';
       } else {
-        table[0].style.maxHeight = `${calcHeight}px`;
-        table[0].style.maxWidth = `${calcWidth}px`;
+        if (table[0] !== undefined) {
+          table[0].style.maxHeight = `${calcHeight}px`;
+          table[0].style.maxWidth = `${calcWidth}px`;
+        }
       }
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes a bug where custom modal script gets error after closing the modal in the second time.

**Related github/jira issue (required)**:

Closes #7057

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/lookup/test-custom-modal.html
- Click on Lookup icon
- Close modal by clicking Cancel or Apply
- Repeat steps 2 and 3
- Check the console tab in developer tools, it should have no error

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
