### PR TITLE
7053 - Fix incorrect background color of datepicker trigger when hovering

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ## v4.71.0 Fixes
 
+- `[Datagrid]` Fixed a bug where datepicker icon background color is incorrect upon hovering. ([#7053](https://github.com/infor-design/enterprise/issues/7053))
 - `[Datagrid]` Fixed a bug in datagrid where dropdown filter does not render correctly. ([#7006](https://github.com/infor-design/enterprise/issues/7006))
 - `[Datagrid]` Fixed a bug in datagrid where flex toolbar is not properly destroyed. ([NG#1423](https://github.com/infor-design/enterprise-ng/issues/1423))
 - `[Datagrid]` Fixed a bug in datagrid in datagrid where the icon cause clipping issues. ([#7000](https://github.com/infor-design/enterprise/issues/7000))

--- a/src/components/datagrid/_datagrid-new.scss
+++ b/src/components/datagrid/_datagrid-new.scss
@@ -45,6 +45,12 @@
       }
     }
 
+    .datepicker + .trigger {
+      &:hover {
+        background-color: transparent;
+      }
+    }
+
     .lookup-wrapper {
       .trigger {
         .icon {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes a bug where datepicker icon background color is incorrect upon hovering.

**Related github/jira issue (required)**:

Closes #7053

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/example-custom-filter-conditions.html, http://localhost:4000/components/datagrid/example-custom-filter-conditions-and-defaults.html, http://localhost:4000/components/datagrid/example-compact-mode.html
- Hover on the datepicker trigger icon
- Background should be transparent

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
