### PR TITLE
6826 - Follow-up fix dirty tracker position in Firefox

### DIFF
--- a/src/components/form/_form-new.scss
+++ b/src/components/form/_form-new.scss
@@ -31,3 +31,16 @@
     top: 0;
   }
 }
+
+// Firefox fixes
+.is-firefox {
+  .form-responsive {
+    .icon-dirty.dirty-checkbox.is-checked {
+      top: 0 !important;
+
+      @media (max-width: $breakpoint-phone-to-tablet) {
+        top: -1px !important;
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes dirty tracker position in Firefox.

**Related github/jira issue (required)**:

Closes #6826
Related PR https://github.com/infor-design/enterprise/pull/7078

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Open http://localhost:4000/components/checkboxes/test-checkboxes-with-form-responsive.html in Firefox
- Click the Dirty Tracking checkbox
- Dirty tracker should positioned correctly

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
