### PR TITLE
7084 - Added 'info' and theme color options in settings

### DIFF
--- a/app/views/components/donut/example-colors.html
+++ b/app/views/components/donut/example-colors.html
@@ -19,31 +19,31 @@ $('body').on('initialized', function () {
 
   var donutData = [{
     data: [{
-        name: 'Ruby',
+        name: 'Ruby 10',
         value: 10,
         color: 'ruby10'
     }, {
-        name: 'Amber',
+        name: 'Amber 9',
         value: 15,
         color: 'amber09'
     }, {
-        name: 'Emerald',
+        name: 'Emerald 8',
         value: 5,
         color: 'emerald08'
     }, {
-        name: 'Azure',
+        name: 'Azure 7',
         value: 10,
         color: 'azure07'
     }, {
-        name: 'Turquoise',
+        name: 'Turquoise 6',
         value: 20,
         color: 'turquoise06'
     }, {
-        name: 'Amethyst',
+        name: 'Amethyst 5',
         value: 10,
         color: 'amethyst05'
     }, {
-        name: 'Slate',
+        name: 'Slate 4',
         value: 15,
         color: 'slate04'
     }],

--- a/app/views/components/donut/example-colors.html
+++ b/app/views/components/donut/example-colors.html
@@ -17,24 +17,35 @@
 <script>
 $('body').on('initialized', function () {
 
-  // error, alert, alertYellow, good, neutral or hex can be used
   var donutData = [{
     data: [{
-        name: 'Positive',
-        value: 20,
-        color: 'good'
-    }, {
-        name: 'Negative',
-        value: 25,
-        color: 'error'
-    }, {
-        name: 'Neutral',
+        name: 'Ruby',
         value: 10,
-        color: 'neutral'
+        color: 'ruby10'
     }, {
-        name: 'Info',
+        name: 'Amber',
         value: 15,
-        color: 'info'
+        color: 'amber09'
+    }, {
+        name: 'Emerald',
+        value: 5,
+        color: 'emerald08'
+    }, {
+        name: 'Azure',
+        value: 10,
+        color: 'azure07'
+    }, {
+        name: 'Turquoise',
+        value: 20,
+        color: 'turquoise06'
+    }, {
+        name: 'Amethyst',
+        value: 10,
+        color: 'amethyst05'
+    }, {
+        name: 'Slate',
+        value: 15,
+        color: 'slate04'
     }],
     centerLabel: 'Donut Chart'
   }];

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[Radar]` Converted Radar scripts to puppeteer. ([#6989](https://github.com/infor-design/enterprise/issues/6989))
 - `[Colors]` Correct Status Colors.([#6993](https://github.com/infor-design/enterprise/issues/6993))
 - `[Colors]` Re-add yellow alerts.([#6922](https://github.com/infor-design/enterprise/issues/6922))
+- `[Chart]` Added 'info' and theme color options in settings.([#7084](https://github.com/infor-design/enterprise/issues/7084))
 - `[Icons]` Added three new icons: `icon-paint-brush, icon-psych-precaution, icon-observation-precaution`. ([#7040](https://github.com/infor-design/enterprise/issues/7040))
 
 ## v4.71.0 Fixes

--- a/src/components/charts/charts.js
+++ b/src/components/charts/charts.js
@@ -219,8 +219,19 @@ charts.chartColor = function chartColor(i, chartType, data) {
     if (specifiedColor === 'neutral') {
       return theme.themeColors().palette.graphite['30'].value;
     }
-    if (specifiedColor && specifiedColor.indexOf('#') === 0) {
-      return data.color;
+    if (specifiedColor === 'info') {
+      return theme.themeColors().palette.azure['70'].value;
+    }
+    if (specifiedColor) {
+      if (specifiedColor.indexOf('#') === 0) {
+        return data.color;
+      }
+
+      const num = specifiedColor.slice(-2);
+      if (/\d/.test(num)) {
+        const color = specifiedColor.slice(0, specifiedColor.length - 2);
+        return theme.themeColors().palette[color][parseInt(num, 10) * 10].value;
+      }
     }
   }
 
@@ -258,9 +269,10 @@ charts.chartColorName = function chartColor(i, chartType, data) {
     if (specifiedColor === 'neutral') {
       return 'graphite03';
     }
-    if (specifiedColor && specifiedColor.indexOf('#') === 0) {
-      return data.color;
+    if (specifiedColor === 'info') {
+      return 'azure07';
     }
+    return data.color;
   }
 
   // Some configuration by specific chart types


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Added info and theme color options for chart

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #7084 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/donut/example-alerts
- Info color and legend should be blue
- Go to: http://localhost:4000/components/donut/example-colors
- Check colors

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
