### PR TITLE
7128: Use dataRowIdx also for summary rows.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `[Datagrid]` Fixed a bug in datagrid where flex toolbar is not properly destroyed. ([NG#1423](https://github.com/infor-design/enterprise-ng/issues/1423))
 - `[Datagrid]` Fixed a bug in datagrid in datagrid where the icon cause clipping issues. ([#7000](https://github.com/infor-design/enterprise/issues/7000))
 - `[Datagrid]` Fixed a bug in datagrid where date cell is still in edit state after editing when using Safari. ([#6963](https://github.com/infor-design/enterprise/issues/6963))
+- `[Datagrid]` Fixed a bug in datagrid where summary row become selected after selecting row one. ([#7128](https://github.com/infor-design/enterprise/issues/7128))
 - `[Datagrid]` Updated dirty cell check in datagrid. ([#6893](https://github.com/infor-design/enterprise/issues/6893))
 - `[Datepicker]` Fixed a bug in datagrid where disabled dates were not showing in Safari. ([#6920](https://github.com/infor-design/enterprise/issues/6920))
 - `[Datepicker]` Fixed a bug where range display is malformed in RTL. ([#6933](https://github.com/infor-design/enterprise/issues/6933))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4727,7 +4727,7 @@ Datagrid.prototype = {
       return containerHtml;
     }
 
-    const idx = self.settings.treeGrid ? dataRowIdx : actualIndex;
+    const idx = self.settings.treeGrid || isSummaryRow ? dataRowIdx : actualIndex;
     const ariaRowindex = ((idx + 1) +
       (self.settings.source && !self.settings.indeterminate ?
         ((activePage - 1) * self.settings.pagesize) : 0));


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR solves the issue #7128 by using dataRowIdx for summary rows instead of actualIndex, which is null in that case.

**Related github/jira issue (required)**:
Fixes #7128

**Steps necessary to review your pull request (required)**:
See the steps in issue, you should not be able to reproduce the bug.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
