### PR TITLE
7097 - Dark Mode Classic View Tabs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,7 @@
 - `[Searchfield]` Fix on non-collapsible positioning and borders. ([#7111](https://github.com/infor-design/enterprise/issues/7111))
 - `[Searchfield]` Adjust icon position and colors. ([#7106](https://github.com/infor-design/enterprise/issues/7106))
 - `[Splitter]` Store location only when save setting is set to true. ([#7045](https://github.com/infor-design/enterprise/issues/7045))
+- `[Tabs]` Fixed a bug where tab list is not viewable dark mode classic view. ([#7097](https://github.com/infor-design/enterprise/issues/7097))
 - `[Tabs Module]` Fixed a bug in go button where it was affected by the latest changes for button. ([#7037](https://github.com/infor-design/enterprise/issues/7037))
 - `[Tabs]` Fixed a bug in tabs header and swatch personalize colors. ([#7046](https://github.com/infor-design/enterprise/issues/7046))
 - `[Tabs Header]` Updated example page, recalibrated positionining and fixed theme discrepancies. ([#7085](https://github.com/infor-design/enterprise/issues/7085))

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -3897,11 +3897,6 @@ Tabs.prototype = {
         targetRectObj.height -= 4;
       }
 
-      if (!self.element.hasClass('header-tabs')) {
-        targetRectObj.top += 9;
-        targetRectObj.height += 4;
-      }
-
       return targetRectObj;
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR will fix bug where tab list is not viewable dark mode classic view.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/7097

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/tabs/example-index?theme=classic&mode=dark&colors=2578a9l
- Try to select a tab. Tabs should be viewable when selected.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

