### PR TITLE
7005 - Fix on inverse colors not showing in popupmenu in masthead

### DIFF
--- a/app/views/components/popupmenu/test-masthead.html
+++ b/app/views/components/popupmenu/test-masthead.html
@@ -1,0 +1,26 @@
+<nav class="masthead">
+  <div class="buttonset" style="display: flex">
+    <div>
+      <button id="no-class" class="btn-menu">
+        <span>No Class</span>
+      </button>
+      <div class="popupmenu-wrapper">
+        <ul class="popupmenu">
+          <li><a href="#">Item One</a></li>
+          <li><a href="#">Item Two</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="field">
+      <button id="has-class" class="btn-menu">
+        <span>Has Class</span>
+      </button>
+      <div class="popupmenu-wrapper">
+        <ul class="popupmenu">
+          <li><a href="#">Item One</a></li>
+          <li><a href="#">Item Two</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</nav>

--- a/app/views/components/popupmenu/test-masthead.html
+++ b/app/views/components/popupmenu/test-masthead.html
@@ -1,5 +1,5 @@
 <nav class="masthead">
-  <div class="buttonset" style="display: flex">
+  <div class="buttonset" style="display: flex; padding-top: 2px">
     <div>
       <button id="no-class" class="btn-menu">
         <span>No Class</span>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@
 - `[General]` Project now uses node 18 (18.13.0) for development. All dependencies are updated. ([#6634](https://github.com/infor-design/enterprise/issues/6634))
 - `[General]` Updated to d3.v7 which impacts all charts. ([#6634](https://github.com/infor-design/enterprise/issues/6634))
 
+## v4.82.0 Fixes
+
+- `[Popupmenu]` Fix on inverse colors not showing in popupmenu in masthead. ([#7005](https://github.com/infor-design/enterprise/issues/7005))
+
 ## v4.81.0
 
 ## v4.80.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Popupmenu]` Fix on inverse colors not showing in popupmenu in masthead. ([#7005](https://github.com/infor-design/enterprise/issues/7005))
 
 ## v4.81.0
+
 ## v4.81.0 Fixes
 
 - `[Hyperlink]` Changed hover color in dark theme. ([#7095](https://github.com/infor-design/enterprise/issues/7095))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,11 +15,8 @@
 
 ## v4.81.0 Fixes
 
-- `[Hyperlink]` Changed hover color in dark theme. ([#7095](https://github.com/infor-design/enterprise/issues/7095))
-
-## v4.81.0 Fixes
-
 - `[Dropdown]` Fixed swatch default color in themes. ([#7108](https://github.com/infor-design/enterprise/issues/7108))
+- `[Hyperlink]` Changed hover color in dark theme. ([#7095](https://github.com/infor-design/enterprise/issues/7095))
 
 ## v4.80.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,18 +7,12 @@
 - `[General]` Project now uses node 18 (18.13.0) for development. All dependencies are updated. ([#6634](https://github.com/infor-design/enterprise/issues/6634))
 - `[General]` Updated to d3.v7 which impacts all charts. ([#6634](https://github.com/infor-design/enterprise/issues/6634))
 
-## v4.82.0 Fixes
-
-- `[Hyperlink]` Changed hover color in dark theme. ([#7095](https://github.com/infor-design/enterprise/issues/7095))
-- `[Popupmenu]` Fix on inverse colors not showing in popupmenu in masthead. ([#7005](https://github.com/infor-design/enterprise/issues/7005))
-
-## v4.81.0
-
 ## v4.81.0 Fixes
 
 - `[Dropdown]` Fixed swatch default color in themes. ([#7108](https://github.com/infor-design/enterprise/issues/7108))
 - `[Dropdown/Multiselect]` Fixed disabled options are not displayed as disabled when using ajax. ([#7150](https://github.com/infor-design/enterprise/issues/7150))
 - `[Hyperlink]` Changed hover color in dark theme. ([#7095](https://github.com/infor-design/enterprise/issues/7095))
+- `[Popupmenu]` Fix on inverse colors not showing in popupmenu in masthead. ([#7005](https://github.com/infor-design/enterprise/issues/7005))
 
 ## v4.80.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## v4.82.0 Fixes
 
+- `[Hyperlink]` Changed hover color in dark theme. ([#7095](https://github.com/infor-design/enterprise/issues/7095))
 - `[Popupmenu]` Fix on inverse colors not showing in popupmenu in masthead. ([#7005](https://github.com/infor-design/enterprise/issues/7005))
 
 ## v4.81.0
@@ -16,7 +17,6 @@
 ## v4.81.0 Fixes
 
 - `[Dropdown]` Fixed swatch default color in themes. ([#7108](https://github.com/infor-design/enterprise/issues/7108))
-- `[Hyperlink]` Changed hover color in dark theme. ([#7095](https://github.com/infor-design/enterprise/issues/7095))
 
 ## v4.80.0
 

--- a/src/components/masthead/_masthead-new.scss
+++ b/src/components/masthead/_masthead-new.scss
@@ -39,7 +39,7 @@
   }
 }
 
-.masthead .toolbar-searchfield-wrapper:not(.active) .icon:not(.close):not(.icon-dropdown)  {
+.masthead .toolbar-searchfield-wrapper:not(.active) .icon:not(.close):not(.icon-dropdown) {
   top: -3px;
 }
 

--- a/src/components/masthead/_masthead-new.scss
+++ b/src/components/masthead/_masthead-new.scss
@@ -39,6 +39,10 @@
   }
 }
 
+.masthead .toolbar-searchfield-wrapper:not(.active) .icon:not(.close):not(.icon-dropdown)  {
+  top: -3px;
+}
+
 .masthead .toolbar.has-title,
 .masthead .formatter-toolbar.has-title {
   padding: 0 8px;

--- a/src/components/masthead/_masthead-new.scss
+++ b/src/components/masthead/_masthead-new.scss
@@ -32,6 +32,7 @@
 
   &.btn-menu {
     margin-right: -6px !important;
+    margin-top: 6px;
   }
 
   .icon {

--- a/src/components/masthead/_masthead-new.scss
+++ b/src/components/masthead/_masthead-new.scss
@@ -32,7 +32,7 @@
 
   &.btn-menu {
     margin-right: -6px !important;
-    margin-top: 6px;
+    margin-top: 3px;
   }
 
   .icon {
@@ -53,4 +53,12 @@
 .masthead .image-initials,
 .masthead .image-round {
   line-height: 28px;
+}
+
+.masthead .toolbar-searchfield-wrapper.active .searchfield {
+  height: 32px !important;
+}
+
+.masthead .toolbar-searchfield-wrapper.is-open .icon:not(.close) {
+  top: -2px !important;
 }

--- a/src/components/masthead/_masthead-new.scss
+++ b/src/components/masthead/_masthead-new.scss
@@ -41,7 +41,7 @@
 }
 
 .masthead .toolbar-searchfield-wrapper:not(.active) .icon:not(.close):not(.icon-dropdown) {
-  top: -3px;
+  top: -2px;
 }
 
 .masthead .toolbar.has-title,

--- a/src/components/masthead/_masthead.scss
+++ b/src/components/masthead/_masthead.scss
@@ -28,6 +28,7 @@
   [class^='btn'] {
     height: 32px;
     min-width: 32px;
+    color: $masthead-text-color;
 
     &:hover:not(:disabled),
     &.is-open {
@@ -40,7 +41,7 @@
     }
 
     &:focus:not(.hide-focus) {
-      box-shadow: 0 0 0 2px transparent, 0 0 0 1px $ids-color-palette-white, $focus-box-shadow;
+      box-shadow: 0 0 0 2px transparent, 0 0 0 1px $masthead-button-focus-color, $header-focus-box-shadow;
     }
 
     &.collapse-button {

--- a/src/components/masthead/_masthead.scss
+++ b/src/components/masthead/_masthead.scss
@@ -159,6 +159,10 @@
       border-color: transparent;
       color: $masthead-text-color;
 
+      &.btn-menu {
+        margin-top: 1px;
+      }
+
       .ripple-effect {
         background-color: $ids-color-palette-white;
       }

--- a/src/components/masthead/_masthead.scss
+++ b/src/components/masthead/_masthead.scss
@@ -26,8 +26,10 @@
   }
 
   [class^='btn'] {
-    height: 32px;
+    height: 30px !important;
     min-width: 32px;
+    padding-right: 8px;
+    min-height: 32px;
     color: $masthead-text-color;
 
     svg.icon {
@@ -112,7 +114,7 @@
       }
 
       .toolbar-searchfield-wrapper {
-        margin: 2px 5px 1px 0;
+        margin: 1px 0 0;
       }
     }
 

--- a/src/components/masthead/_masthead.scss
+++ b/src/components/masthead/_masthead.scss
@@ -29,6 +29,20 @@
     height: 32px;
     min-width: 32px;
 
+    &:hover:not(:disabled),
+    &.is-open {
+      color: $ids-color-palette-white;
+      background-color: transparent;
+
+      svg.icon {
+        color: $ids-color-palette-white;
+      }
+    }
+
+    &:focus:not(.hide-focus) {
+      box-shadow: 0 0 0 2px transparent, 0 0 0 1px $ids-color-palette-white, $focus-box-shadow;
+    }
+
     &.collapse-button {
       height: inherit;
     }
@@ -137,9 +151,7 @@
 
     [class^='btn'] {
       background-color: transparent;
-      border-left-color: transparent;
-      border-right-color: transparent;
-      border-top-color: transparent;
+      border-color: transparent;
       color: $masthead-text-color;
 
       .ripple-effect {

--- a/src/components/masthead/_masthead.scss
+++ b/src/components/masthead/_masthead.scss
@@ -30,6 +30,10 @@
     min-width: 32px;
     color: $masthead-text-color;
 
+    svg.icon {
+      color: $masthead-button-color;
+    }
+
     &:hover:not(:disabled),
     &.is-open {
       color: $ids-color-palette-white;

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -371,8 +371,7 @@ PopupMenu.prototype = {
 
     // If button is part of a header/masthead or a container using the "alternate"
     // UI color, add the "alternate" class.
-    if (containerClass !== undefined &&
-      (this.element.closest('.masthead').not('.search-results .masthead').length > 0)) {
+    if (this.element.closest('.masthead').not('.search-results .masthead').length > 0) {
       this.menu.parent('.popupmenu-wrapper').addClass('inverse');
     }
 

--- a/src/components/searchfield/_searchfield-new.scss
+++ b/src/components/searchfield/_searchfield-new.scss
@@ -66,7 +66,6 @@
   &:not(.is-open),
   &.non-collapsible {
     .searchfield {
-      padding-bottom: 6px;
       padding-top: 6px;
 
       @media only screen and (max-width: $breakpoint-phone-to-tablet) {

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -780,6 +780,7 @@ $toolbarsearchfield-category-empty-width: 51px;
     &.is-open {
       .icon {
         color: $searchfield-header-icon-color;
+        top: 1px;
       }
     }
   }

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -75,12 +75,6 @@ $toolbarsearchfield-category-empty-width: 51px;
     }
   }
 
-  &.is-open {
-    .icon:not(.close) {
-      top: 2px;
-    }
-  }
-
   &.non-collapsible {
     .searchfield {
       padding-bottom: 6px !important;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Removed containerClass undefined check

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #7005 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/popupmenu/test-masthead
- Click on "No Class"
- Click on "Has Class"
- Both popups should use inverse colors

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
