### PR TITLE
7150 - Dropdown/Multiselect disabled options

### DIFF
--- a/app/views/components/dropdown/example-ajax.html
+++ b/app/views/components/dropdown/example-ajax.html
@@ -26,7 +26,7 @@
     $('#ajax-test').dropdown({
       source: function (response, term) {
         $.getJSON('{{basepath}}api/states', function(data, term) {
-          // Making some data items disabled for testing purposes
+          // Make some data items disabled for testing purposes
           response(data.map(item => ['AK', 'AR', 'WY'].includes(item.value) ? {
             ...item,
             disabled: true

--- a/app/views/components/dropdown/example-ajax.html
+++ b/app/views/components/dropdown/example-ajax.html
@@ -26,7 +26,11 @@
     $('#ajax-test').dropdown({
       source: function (response, term) {
         $.getJSON('{{basepath}}api/states', function(data, term) {
-          response(data);
+          // Making some data items disabled for testing purposes
+          response(data.map(item => ['AK', 'AR', 'WY'].includes(item.value) ? {
+            ...item,
+            disabled: true
+          } : item));
         });
       }
     });

--- a/app/views/components/multiselect/example-ajax.html
+++ b/app/views/components/multiselect/example-ajax.html
@@ -78,7 +78,11 @@
     console.log('Searching for term: "' + term + '".');
     $.getJSON(apiRoute, function(data) {
       cachedData = data;
-      response(data);
+      // Making some data items disabled for testing purposes
+      response(data.map(item => ['AK', 'AR', 'WY'].includes(item.value) ? {
+        ...item,
+        disabled: true
+      } : item));
     });
   }
 

--- a/app/views/components/multiselect/example-ajax.html
+++ b/app/views/components/multiselect/example-ajax.html
@@ -78,7 +78,7 @@
     console.log('Searching for term: "' + term + '".');
     $.getJSON(apiRoute, function(data) {
       cachedData = data;
-      // Making some data items disabled for testing purposes
+      // Make some data items disabled for testing purposes
       response(data.map(item => ['AK', 'AR', 'WY'].includes(item.value) ? {
         ...item,
         disabled: true

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,12 +9,9 @@
 
 ## v4.81.0 Fixes
 
-- `[Hyperlink]` Changed hover color in dark theme. ([#7095](https://github.com/infor-design/enterprise/issues/7095))
-
-## v4.81.0 Fixes
-
 - `[Dropdown]` Fixed swatch default color in themes. ([#7108](https://github.com/infor-design/enterprise/issues/7108))
 - `[Dropdown/Multiselect]` Fixed disabled options are not displayed as disabled when using ajax. ([#7150](https://github.com/infor-design/enterprise/issues/7150))
+- `[Hyperlink]` Changed hover color in dark theme. ([#7095](https://github.com/infor-design/enterprise/issues/7095))
 
 ## v4.80.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## v4.81.0 Fixes
 
 - `[Dropdown]` Fixed swatch default color in themes. ([#7108](https://github.com/infor-design/enterprise/issues/7108))
+- `[Dropdown/Multiselect]` Fixed disabled options are not displayed as disabled when using ajax. ([#7150](https://github.com/infor-design/enterprise/issues/7150))
 
 ## v4.80.0
 

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -3387,6 +3387,7 @@ Dropdown.prototype = {
         let id = '';
         let selected = '';
         let textContent = '';
+        let disabled = '';
 
         if (isString) {
           option = {
@@ -3426,6 +3427,9 @@ Dropdown.prototype = {
         if (option.selected) {
           selected = ' selected';
         }
+        if (option.disabled) {
+          disabled = ' disabled';
+        }
 
         // Make sure that text content is populated.
         // If all else fails, just use the value.
@@ -3434,7 +3438,7 @@ Dropdown.prototype = {
         }
 
         // Render the option element
-        list += `<option${id} value="${option.value}"${selected}>
+        list += `<option${id} value="${option.value}"${selected}${disabled}>
           ${textContent}
         </option>`;
       }

--- a/test/components/dropdown/dropdown-api-func-test.js
+++ b/test/components/dropdown/dropdown-api-func-test.js
@@ -4,6 +4,8 @@
 import { Dropdown } from '../../../src/components/dropdown/dropdown';
 import { cleanup } from '../../helpers/func-utils';
 
+const statesDropdownData = require('../../../app/data/states-all.json');
+
 const dropdownHTML = `<div class="row">
   <div class="twelve columns">
     <div class="field">
@@ -161,3 +163,50 @@ describe('Dropdown API', () => {
     expect(dropdownObj.element.val()).toBe('NH');
   });
 });
+
+describe('Dropdown API (ajax)', () => {
+  const dropdownAjaxHtml = `
+    <div class="field">
+      <label for="custom-dropdown-ajax" class="label">State</label>
+      <select id="custom-dropdown-ajax" class="dropdown"></select>
+    </div>
+  `;
+
+  beforeEach(() => {
+    dropdownEl = null;
+    dropdownObj = null;
+    document.body.insertAdjacentHTML('afterbegin', dropdownAjaxHtml);
+    dropdownEl = document.body.querySelector('.dropdown');
+  });
+
+  afterEach(() => {
+    dropdownObj.destroy();
+    cleanup();
+  });
+
+  it('should disable options', () => {
+    const statesToDisable = ['AK', 'AR', 'WY'];
+    const statesDisabledData = statesDropdownData.map((item) => {
+      if (statesToDisable.includes(item.value)) {
+        return {
+          ...item,
+          disabled: true
+        };
+      }
+
+      return item;
+    });
+    dropdownObj = new Dropdown(dropdownEl, {
+      source: (response) => {
+        response(statesDisabledData);
+      }
+    });
+
+    dropdownObj.open();
+
+    const listDisabled = document.querySelectorAll('.dropdown-list[data-element-id="custom-dropdown-ajax"] .is-disabled');
+
+    expect([...listDisabled].map(item => item.dataset.val)).toEqual(statesToDisable);
+  });
+});
+

--- a/test/components/multiselect/multiselect-api-func-test.js
+++ b/test/components/multiselect/multiselect-api-func-test.js
@@ -107,8 +107,8 @@ describe('MultiSelect API', () => {
 describe('Multiselect API (ajax)', () => {
   const multiSelectSingleItemHTML = `
     <div class="field">
-      <label for="multi-standard" class="label">Multiselect</label>
-      <select multiple id="multi-standard" name="multi-standard" data-maxselected="10" class="multiselect">
+      <label for="multi-standard-ajax" class="label">Multiselect</label>
+      <select multiple id="multi-standard-ajax" name="multi-standard" data-maxselected="10" class="multiselect">
         <option selected value="FL">Florida</option>
       </div>
     </div>
@@ -151,5 +151,30 @@ describe('Multiselect API (ajax)', () => {
       expect(multiSelectObj.dropdown.selectedValues.includes(predefinedOpt.value)).toBeTruthy();
       done();
     }, 650);
+  });
+
+  it('should disable options', () => {
+    const statesToDisable = ['AK', 'AR', 'WY'];
+    const statesDisabledData = statesMultiselectData.map((item) => {
+      if (statesToDisable.includes(item.value)) {
+        return {
+          ...item,
+          disabled: true
+        };
+      }
+
+      return item;
+    });
+    multiSelectObj = new MultiSelect(multiSelectEl, {
+      source: (response) => {
+        response(statesDisabledData);
+      }
+    });
+
+    multiSelectObj.dropdown.open();
+
+    const listDisabled = document.querySelectorAll('.dropdown-list[data-element-id="multi-standard-ajax"] .is-disabled');
+
+    expect([...listDisabled].map(item => item.dataset.val)).toEqual(statesToDisable);
   });
 });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes disabled options not disabled when using ajax and not templateManaged by adding a check for disabled flags to `buildOption` function

**Related github/jira issue (required)**:
Closes #7150 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4000/components/dropdown/example-ajax.html and http://localhost:4000/components/multiselect/example-ajax.html
- open the dropdown
- see some options are disabled

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
