### PR TITLE
7166 - Fix button disabled color in toolbar/toolbar flex [4.80.x]

### DIFF
--- a/app/views/components/header/example-flex-toolbar.html
+++ b/app/views/components/header/example-flex-toolbar.html
@@ -1,3 +1,9 @@
+<style>
+  .popupmenu.has-icons.is-selectable a {
+    padding-left: 48px !important;
+  }
+</style>
+
 <header id="test-header" class="header is-personalizable">
   <div class="flex-toolbar">
     <div class="toolbar-section">
@@ -47,25 +53,6 @@
       </button>
     </div>
 
-    <div id="more-button" class="toolbar-section more">
-      <button class="btn-actions" type="button">
-        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-          <use href="#icon-more"></use>
-        </svg>
-        <span class="audible" data-translate="text">More</span>
-      </button>
-      <ul class="popupmenu">
-        <li><a href="#">Item One</a></li>
-        <li><a href="#">Item Two</a></li>
-        <li class="submenu">
-          <a href="#">Item Three</a>
-          <ul class="popupmenu">
-            <li><a href="#">Sub-Item One</a></li>
-            <li><a href="#">Sub-Item Two</a></li>
-          </ul>
-        </li>
-        <li><a href="#">Item Four</a></li>
-      </ul>
-    </div>
+    {{> includes/header-actionbutton}}
   </div>
 </header>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise
 
+## v4.80.1
+
+## v4.80.1 Fixes
+
+- `[Button]` Fixed button status colors disabled in toolbar/toolbar flex in alabaster and personalize colors. ([#7166](https://github.com/infor-design/enterprise/issues/7166))
+
 ## v4.80.0
 
 ## v4.80.0 Important Changes

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -380,8 +380,11 @@ html[class*="theme-new-"] .is-personalizable.tab-container.header-tabs > .tab-li
 }
 
 .header.is-personalizable .flex-toolbar [class^='btn'][disabled] .icon,
-.header.is-personalizable  .flex-toolbar [class^='btn']:focus:not(.hide-focus) .icon,
-.header.is-personalizable .btn:not(.searchfield-category-button) span {
+.header.is-personalizable .btn:not(.searchfield-category-button)[disabled] span {
+  color: rgba(255, 255, 255, 0.3) !important;
+}
+
+.header.is-personalizable  .flex-toolbar [class^='btn']:focus:not(.hide-focus) .icon {
   color: ${colors.contrast} !important;
 }
 

--- a/src/themes/theme-new-contrast.scss
+++ b/src/themes/theme-new-contrast.scss
@@ -185,6 +185,8 @@ $button-color-secondary-disabled-font-new: $ids-color-palette-slate-50;
 $button-color-tertiary-hover-background-new: $ids-color-palette-azure-20;
 $button-color-tertiary-hover-font-new: $ids-color-palette-azure-80;
 
+$button-color-primary-disabled-font-new: $ids-color-palette-white;
+
 // Tertiary Buttons
 $button-color-tertiary-initial-font: $ids-color-palette-slate-80;
 $tertiary-btn-ripple-color: $ids-color-brand-primary-alt;

--- a/src/themes/theme-new-light.scss
+++ b/src/themes/theme-new-light.scss
@@ -200,6 +200,10 @@ $timepicker-disabled-border-color: $ids-color-palette-slate-30;
 $timepicker-disabled-color: $ids-color-palette-slate-30;
 $timepicker-readonly-icon-color: $ids-color-palette-slate-40;
 
+// Buttons
+$header-button-disabled-color: $ids-color-palette-slate-30;
+$button-color-primary-disabled-font-new: $ids-color-palette-white;
+
 // Badges
 $badge-neutral-color: $ids-color-palette-slate-100;
 $badge-neutral-icon-color: $ids-color-palette-slate-100;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes color of disabled button in alabaster and in personalize colors.

**Related github/jira issue (required)**:

Closes #7166

**Steps necessary to review your pull request (required)**:

- Pull this branch, build, and run the app
- Go to 
  - http://localhost:4000/components/header/example-flex-toolbar.html
  - http://localhost:4000/components/header/example-flex-toolbar.html?colors=BB5500
  - http://localhost:4000/components/header/example-disabled-buttons.html?colors=7928E1
  - http://localhost:4000/components/header/example-disabled-buttons.html?colors=0066D4
  - Disabled button should look disabled now

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
