### PR TITLE
7166 - Fix button disabled color in toolbar/toolbar flex

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Header]` Changed the default color from azure to alabaster. I.E. The default header color is now alabaster but can still be set to any of the other 8 colors. So far the older look azure can be used. ([#6979](https://github.com/infor-design/enterprise/issues/6979))
 - `[Tabs Header]` Changed the default background color for tabs header to also use alabaster with the same ability to use any of the other 8 personalization colors. ([#6979](https://github.com/infor-design/enterprise/issues/6979))
 - `[Button]` The style of all buttons (primary/tertiary and secondary) have been updated and changed, in addition we added new destructive buttons. ([#6977](https://github.com/infor-design/enterprise/issues/6977))
+- `[Button]` Fixed button status colors disabled in toolbar/toolbar flex in alabaster and personalize colors. ([#7166](https://github.com/infor-design/enterprise/issues/7166))
 - `[Datagrid]` Added ability to change the color of the header in datagrid between (`dark` or `light (alabaster)`). ([#7008](https://github.com/infor-design/enterprise/issues/7008))
 - `[Searchfield]` Completed a design review of searchfield and enhanced it with updated several design improvements. ([#6707](https://github.com/infor-design/enterprise/issues/6707))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ids-enterprise",
-  "version": "4.72.0-dev.20230111",
+  "version": "4.81.0-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ids-enterprise",
-      "version": "4.72.0-dev.20230111",
+      "version": "4.81.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
         "d3": "^7.8.2",

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -380,8 +380,11 @@ html[class*="theme-new-"] .is-personalizable.tab-container.header-tabs > .tab-li
 }
 
 .header.is-personalizable .flex-toolbar [class^='btn'][disabled] .icon,
-.header.is-personalizable  .flex-toolbar [class^='btn']:focus:not(.hide-focus) .icon,
-.header.is-personalizable .btn:not(.searchfield-category-button) span {
+.header.is-personalizable .btn:not(.searchfield-category-button)[disabled] span {
+  color: rgba(255, 255, 255, 0.3) !important;
+}
+
+.header.is-personalizable  .flex-toolbar [class^='btn']:focus:not(.hide-focus) .icon {
   color: ${colors.contrast} !important;
 }
 

--- a/src/themes/theme-new-contrast.scss
+++ b/src/themes/theme-new-contrast.scss
@@ -185,6 +185,8 @@ $button-color-secondary-disabled-font-new: $ids-color-palette-slate-50;
 $button-color-tertiary-hover-background-new: $ids-color-palette-azure-20;
 $button-color-tertiary-hover-font-new: $ids-color-palette-azure-80;
 
+$button-color-primary-disabled-font-new: $ids-color-palette-white;
+
 // Tertiary Buttons
 $button-color-tertiary-initial-font: $ids-color-palette-slate-80;
 $tertiary-btn-ripple-color: $ids-color-brand-primary-alt;

--- a/src/themes/theme-new-light.scss
+++ b/src/themes/theme-new-light.scss
@@ -200,6 +200,10 @@ $timepicker-disabled-border-color: $ids-color-palette-slate-30;
 $timepicker-disabled-color: $ids-color-palette-slate-30;
 $timepicker-readonly-icon-color: $ids-color-palette-slate-40;
 
+// Buttons
+$header-button-disabled-color: $ids-color-palette-slate-30;
+$button-color-primary-disabled-font-new: $ids-color-palette-white;
+
 // Badges
 $badge-neutral-color: $ids-color-palette-slate-100;
 $badge-neutral-icon-color: $ids-color-palette-slate-100;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes color of disabled button in alabaster and in personalize colors.

**Related github/jira issue (required)**:

Closes #7166

**Steps necessary to review your pull request (required)**:

- Pull this branch, build, and run the app
- Go to 
  - http://localhost:4000/components/header/example-flex-toolbar.html
  - http://localhost:4000/components/header/example-flex-toolbar.html?colors=BB5500
  - http://localhost:4000/components/header/example-disabled-buttons.html?colors=7928E1
  - http://localhost:4000/components/header/example-disabled-buttons.html?colors=0066D4
  - Disabled button should look disabled now

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
