### PR TITLE
7028 - Fix sliding and dropping the handle outside of the component doesn't trigger the change event 

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Dropdown]` Fixed swatch default color in themes. ([#7108](https://github.com/infor-design/enterprise/issues/7108))
 - `[Dropdown/Multiselect]` Fixed disabled options are not displayed as disabled when using ajax. ([#7150](https://github.com/infor-design/enterprise/issues/7150))
 - `[Hyperlink]` Changed hover color in dark theme. ([#7095](https://github.com/infor-design/enterprise/issues/7095))
+- `[Slider]` Fixed sliding and dropping the handle outside of the component doesn't trigger the change event. ([#7028](https://github.com/infor-design/enterprise/issues/7028))
 
 ## v4.80.0
 

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -597,6 +597,7 @@ Slider.prototype = {
         $(this).removeClass('is-dragging');
         self.range.removeClass('is-dragging');
         self.element.trigger('slidestop', handle);
+        self.element.trigger('change', { element: self.element, value: self._value });
       });
   },
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds change event trigger to `dragend` event

**Related github/jira issue (required)**:
Closes #7028 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4000/components/slider/example-stepping.html
- grab the handle and slide it
- see the toast appears at the top right corner

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.
