### PR TITLE
7116 - Timepicker fix field value when day period goes first in the time format

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Dropdown]` Fixed swatch default color in themes. ([#7108](https://github.com/infor-design/enterprise/issues/7108))
 - `[Dropdown/Multiselect]` Fixed disabled options are not displayed as disabled when using ajax. ([#7150](https://github.com/infor-design/enterprise/issues/7150))
 - `[Hyperlink]` Changed hover color in dark theme. ([#7095](https://github.com/infor-design/enterprise/issues/7095))
+- `[Timepicker]` Fixed field value when day period goes first in the time format. ([#7116](https://github.com/infor-design/enterprise/issues/7116))
 
 ## v4.80.0
 

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -592,12 +592,13 @@ const Locale = {  // eslint-disable-line
     let ret = '';
     const cal = (localeData.calendars ? localeData.calendars[0] : null);
 
-    if (options.pattern) {
-      pattern = options.pattern;
-    }
-
     if (options.date && cal) {
       pattern = cal.dateFormat[options.date];
+    }
+
+    // If pattern is defined in options it will override date format from locale
+    if (options.pattern) {
+      pattern = options.pattern;
     }
 
     if (typeof options === 'string' && options !== '') {

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -596,7 +596,7 @@ const Locale = {  // eslint-disable-line
       pattern = options.pattern;
     }
 
-    if (options.date) {
+    if (options.date && cal) {
       pattern = cal.dateFormat[options.date];
     }
 

--- a/src/components/timepicker/timepicker.js
+++ b/src/components/timepicker/timepicker.js
@@ -828,7 +828,7 @@ TimePicker.prototype = {
     val = val.replace('午', `午${sep}`);
     parts = val.split(sep);
 
-    const isStandardTimeFormatOnly = timeFormat.slice(0, 2) === 'ah' && !$('.datepicker').length > 0;
+    const isStandardTimeFormatOnly = timeFormat.replace(' ', '').slice(0, 2) !== 'ah' && !$('.datepicker').length > 0;
     const aLoc = this.currentCalendar.timeFormat.toLowerCase().indexOf('a');
     const isAmFirst = aLoc !== -1 && (aLoc <
       this.currentCalendar.timeFormat.toLowerCase().indexOf('h'));

--- a/src/components/timepicker/timepicker.js
+++ b/src/components/timepicker/timepicker.js
@@ -2,6 +2,7 @@ import * as debug from '../../utils/debug';
 import { utils } from '../../utils/utils';
 import { Locale } from '../locale/locale';
 import { stringUtils as str } from '../../utils/string';
+import { dateUtils } from '../../utils/date';
 
 // jQuery components
 import '../dropdown/dropdown.jquery';
@@ -997,25 +998,15 @@ TimePicker.prototype = {
    * @returns {void}
    */
   setTimeOnField() {
+    const timeFormat = this.settings.timeFormat;
     const hours = this.hourSelect ? this.hourSelect[0]?.value : '';
     const minutes = this.minuteSelect ? this.minuteSelect[0]?.value : '';
     const seconds = this.secondSelect ? this.secondSelect[0]?.value : '';
-    let period = (this.periodSelect ? this.periodSelect[0]?.value : '');
-    const sep = this.getTimeSeparator();
-    let timeString = `${hours}${sep}${minutes}${this.hasSeconds() ? sep + seconds : ''}`;
-
-    period = (!this.is24HourFormat() && period === '') ? document.querySelector(`#${this.periodId}-shdo`).value : period;
-
-    // Day period goes first in time format
-    if (this.settings.timeFormat?.indexOf('a') === 0) {
-      timeString = period ? `${this.translateDayPeriod(period)} ${timeString}` : timeString;
-    } else {
-      timeString += period ? ` ${this.translateDayPeriod(period)}` : '';
-    }
-
-    if (timeString.indexOf(sep) > -1 && this.settings.timeFormat === 'HHmm') {
-      timeString = timeString.replace(sep, '');
-    }
+    const dayPeriod = (this.periodSelect ? this.periodSelect[0]?.value : '');
+    const dayPeriodIndex = Locale?.calendar().dayPeriods?.indexOf(dayPeriod);
+    const date = new Date();
+    date.setHours(dateUtils.hoursTo24(parseInt(hours, 10), dayPeriodIndex), minutes, seconds);
+    const timeFormatted = Locale.formatDate(date, { date: 'hour', pattern: timeFormat });
 
     /**
     * Fires when the value is changed by typing or the picker.
@@ -1023,7 +1014,7 @@ TimePicker.prototype = {
     * @memberof TimePicker
     * @property {object} event - The jquery event object
     */
-    this.element.val(timeString)
+    this.element.val(timeFormatted)
       .trigger('change');
 
     this.element

--- a/src/components/timepicker/timepicker.js
+++ b/src/components/timepicker/timepicker.js
@@ -1005,7 +1005,13 @@ TimePicker.prototype = {
     let timeString = `${hours}${sep}${minutes}${this.hasSeconds() ? sep + seconds : ''}`;
 
     period = (!this.is24HourFormat() && period === '') ? document.querySelector(`#${this.periodId}-shdo`).value : period;
-    timeString += period ? ` ${this.translateDayPeriod(period)}` : '';
+
+    // Day period goes first in time format
+    if (this.settings.timeFormat?.indexOf('a') === 0) {
+      timeString = period ? `${this.translateDayPeriod(period)} ${timeString}` : timeString;
+    } else {
+      timeString += period ? ` ${this.translateDayPeriod(period)}` : '';
+    }
 
     if (timeString.indexOf(sep) > -1 && this.settings.timeFormat === 'HHmm') {
       timeString = timeString.replace(sep, '');

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -126,4 +126,24 @@ dateUtils.isDaylightSavingTime = function (date) {
   return Math.max(jan, jul) !== date.getTimezoneOffset();
 };
 
+/**
+ * Convert 12/24 hour format to 24 hour format based on a day period
+ * @param {number} hours in 12 or 24 hour format
+ * @param {number} dayPeriodIndex 0 or 1 if time format with a day period
+ * @returns {number} hours in 24 hour format
+ */
+dateUtils.hoursTo24 = function (hours, dayPeriodIndex) {
+  const hasDayPeriod = dayPeriodIndex >= 0;
+
+  if (hours === 12 && hasDayPeriod) {
+    if (dayPeriodIndex === 0) {
+      return 0;
+    }
+
+    return hours;
+  }
+
+  return hours + (!hasDayPeriod ? 0 : dayPeriodIndex) * 12;
+};
+
 export { dateUtils }; //eslint-disable-line

--- a/test/components/timepicker/timepicker-puppeteer-test.js
+++ b/test/components/timepicker/timepicker-puppeteer-test.js
@@ -88,7 +88,8 @@ describe('Timepicker Puppeteer Tests', () => {
       await page.click('#timepicker-id-1-trigger');
       await page.click('.set-time');
 
-      expect(await page.evaluate(el => el.value, timepickerEl)).toEqual('1:00 上午');
+      // ah:mm
+      expect(await page.evaluate(el => el.value, timepickerEl)).toEqual('上午1:00');
       // eslint-disable-next-line jasmine/prefer-jasmine-matcher
       expect(errorMessage === null).toBeTruthy(); // Error message should not be shown/presented.
     });

--- a/test/components/timepicker/timepicker-puppeteer-test.js
+++ b/test/components/timepicker/timepicker-puppeteer-test.js
@@ -34,6 +34,86 @@ describe('Timepicker Puppeteer Tests', () => {
 
       expect(await page.evaluate(el => el.value, timepickerEl)).toEqual('1:00 AM');
     });
+
+    it('should set time on field from popup', async () => {
+      const timepickerEl = await page.$('#timepicker-id-1');
+
+      const openPopup = async () => {
+        await page.click('#timepicker-id-1-trigger');
+      };
+
+      const setTime = async () => {
+        await page.click('.set-time');
+      };
+
+      const getValue = async () => {
+        const value = await page.evaluate(el => el.value, timepickerEl);
+
+        return value;
+      };
+
+      const clearValue = async () => {
+        await page.$('#timepicker-id-1', (el) => {
+          el.value = '';
+        });
+      };
+
+      const changeTimeFormat = async (format) => {
+        await page.evaluate((timeFormat) => {
+          $('#timepicker-id-1').data('timepicker').settings.timeFormat = timeFormat;
+        }, format);
+      };
+
+      const setDropdowns = async (value) => {
+        await page.evaluate((items) => {
+          Object.keys(items).forEach((item) => {
+            document.querySelector(`.${item}.dropdown`).value = items[item];
+          });
+        }, value);
+      };
+
+      await openPopup();
+      await setDropdowns({ period: 'PM', hours: '11', minutes: '05' });
+      await setTime();
+
+      expect(await getValue()).toEqual('11:05 PM');
+
+      await openPopup();
+      await setDropdowns({ period: 'AM', hours: '5', minutes: '20' });
+      await setTime();
+
+      expect(await getValue()).toEqual('5:20 AM');
+
+      await clearValue();
+      await changeTimeFormat('ah:mm');
+
+      await openPopup();
+      await setDropdowns({ period: 'PM', hours: '11', minutes: '05' });
+      await setTime();
+
+      expect(await getValue()).toEqual('PM11:05');
+
+      await openPopup();
+      await setDropdowns({ period: 'AM', hours: '5', minutes: '20' });
+      await setTime();
+
+      expect(await getValue()).toEqual('AM5:20');
+
+      await clearValue();
+      await changeTimeFormat('HH:mm:ss');
+
+      await openPopup();
+      await setDropdowns({ hours: '23', minutes: '05', seconds: '05' });
+      await setTime();
+
+      expect(await getValue()).toEqual('23:05:05');
+
+      await openPopup();
+      await setDropdowns({ hours: '00', minutes: '00', seconds: '00' });
+      await setTime();
+
+      expect(await getValue()).toEqual('00:00:00');
+    });
   });
 
   describe('Timepicker Example Hour Range Tests', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes field value when day period goes first in the time format by using locale format date to set value on the field

**Related github/jira issue (required)**:
Closes #7116 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4000/components/timepicker/example-index.html?locale=ko-KR
- select a time and press the `Set Time` button
- see the day period goes first in the field and there are no validation errors
- go to http://localhost:4000/components/timepicker/example-index.html?locale=zh-CN
- select a time and press the `Set Time` button
- see the day period goes first in the field and there are no validation errors

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
