### PR TITLE
7166 - Follow-up fix for button color after click

### DIFF
--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -384,6 +384,10 @@ html[class*="theme-new-"] .is-personalizable.tab-container.header-tabs > .tab-li
   color: rgba(255, 255, 255, 0.3) !important;
 }
 
+.header.is-personalizable button:not(:disabled) {
+  color: #fff !important;
+}
+
 .header.is-personalizable  .flex-toolbar [class^='btn']:focus:not(.hide-focus) .icon {
   color: ${colors.contrast} !important;
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This is a follow-up fix for the incorrect button color in the personalization after it has been clicked.

**Related github/jira issue (required)**:

Closes #7166

**Steps necessary to review your pull request (required)**:

- Pull this branch, build and run the app
- Go to http://localhost:4000/components/header/example-flex-toolbar.html?colors=BB5500&theme=new&mode=light
- Click the non disabled button
- After clicking, hover out
- Font color should be white
- Test also in different colors

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
