### PR TITLE
7182 - Add fix for selection

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## v4.81.0 Fixes
 
+- `[Bar]` Fixed bug introduced by d3 changes with bar selection. ([#7182](https://github.com/infor-design/enterprise/issues/7182))
 - `[Datagrid]` Fixed background color of lookups in filter row when in light mode. ([#7176](https://github.com/infor-design/enterprise/issues/7176))
 - `[Dropdown]` Fixed swatch default color in themes. ([#7108](https://github.com/infor-design/enterprise/issues/7108))
 - `[Dropdown/Multiselect]` Fixed disabled options are not displayed as disabled when using ajax. ([#7150](https://github.com/infor-design/enterprise/issues/7150))

--- a/src/components/bar/bar.js
+++ b/src/components/bar/bar.js
@@ -716,7 +716,7 @@ Bar.prototype = {
             // Run click action
             if (self.settings.selectable) {
               const ii = Array.from(selector.parentElement.children).indexOf(selector);
-              self.doClickAction(d, s.isStacked ? ii : i, selector);
+              self.doClickAction(d, s.isStacked && !s.isSingle ? ii : i, selector);
             }
           }
           prevent = false;
@@ -729,7 +729,7 @@ Bar.prototype = {
         // Run double click action
         const i = sGroup.select('rect').nodes().indexOf(this);
         const ii = Array.from(this.parentElement.children).indexOf(this);
-        self.doDoubleClickAction(d, s.isStacked ? ii : i, selector);
+        self.doDoubleClickAction(d, s.isStacked && !s.isSingle ? ii : i, selector);
       });
 
     $(sGroup._parents).each((parentPos, parentEl) => {

--- a/test/components/bar/bar-puppeteer-test.js
+++ b/test/components/bar/bar-puppeteer-test.js
@@ -88,7 +88,7 @@ describe('Bar Chart', () => {
 
       await page.waitForTimeout(200);
 
-      expect(await page.$eval('.bar.series-0', e => getComputedStyle(e).opacity)).toBe('0.6');
+      expect(await page.$eval('.bar.series-0', e => getComputedStyle(e).opacity)).toBe('1');
     });
 
     it('should be able to set id/automation id', async () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When updating d3 from 5 to 7 i introduced a bug with single bar chart selection, noticed by QA. This is the fix

**Related github/jira issue (required)**:
Fixes #7182

**Steps necessary to review your pull request (required)**:
- pull and build and go to http://localhost:4000/components/bar/example-index.html
- click each bar starting with the first
- the bar you click should be selected not the middle one as before.

**Included in this Pull Request**:
- [x] A note to the change log.