### PR TITLE
7183/ 7181 - Fix bar chart regressions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - `[General]` Project now uses node 18 (18.13.0) for development. All dependencies are updated. ([#6634](https://github.com/infor-design/enterprise/issues/6634))
 - `[General]` Updated to d3.v7 which impacts all charts. ([#6634](https://github.com/infor-design/enterprise/issues/6634))
+- `[Bar]` Fixed missing left axis label. ([#7181](https://github.com/infor-design/enterprise/issues/7181))
+- `[Bar]` Fixed regressed long text example. ([#7183](https://github.com/infor-design/enterprise/issues/7183))
 
 ## v4.81.0 Fixes
 
@@ -23,7 +25,7 @@
 - `[Hyperlink]` Changed hover color in dark theme. ([#7095](https://github.com/infor-design/enterprise/issues/7095))
 - `[Datagrid]` Fixed background color of lookups in filter row when in light mode. ([#7176](https://github.com/infor-design/enterprise/issues/7176))
 - `[Dropdown/Multiselect]` Fixed disabled options are not displayed as disabled when using ajax. ([#7150](https://github.com/infor-design/enterprise/issues/7150))
-- `[Header]` Fixed a bug in subheader where the color its not appropriate on default theme. ([#7173](https://github.com/infor-design/enterprise/issues/7173))
+- `[Header]` Fixed a bug in `subheader` where the color its not appropriate on default theme. ([#7173](https://github.com/infor-design/enterprise/issues/7173))
 - `[MenuButton]` Fixed some color on menu buttons. ([#7184](https://github.com/infor-design/enterprise/issues/7184))
 
 ## v4.80.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "jasmine-jquery": "^2.1.1",
         "jasmine-spec-reporter": "^7.0.0",
         "jest": "^29.4.1",
+        "jest-canvas-mock": "^2.4.0",
         "jest-environment-jsdom": "^29.4.1",
         "jest-image-snapshot": "^6.1.0",
         "jest-puppeteer": "^6.2.0",
@@ -6004,6 +6005,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==",
+      "dev": true
+    },
     "node_modules/cssmin": {
       "version": "0.4.3",
       "dev": true,
@@ -10793,6 +10800,16 @@
         }
       }
     },
+    "node_modules/jest-canvas-mock": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.4.0.tgz",
+      "integrity": "sha512-mmMpZzpmLzn5vepIaHk5HoH3Ka4WykbSoLuG/EKoJd0x0ID/t+INo1l8ByfcUJuDM+RIsL4QDg/gDnBbrj2/IQ==",
+      "dev": true,
+      "dependencies": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
+      }
+    },
     "node_modules/jest-changed-files": {
       "version": "29.4.0",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.4.0.tgz",
@@ -14731,6 +14748,21 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/moo-color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
+      "integrity": "sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "^1.1.4"
+      }
+    },
+    "node_modules/moo-color/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -25872,6 +25904,12 @@
       "version": "3.0.0",
       "dev": true
     },
+    "cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==",
+      "dev": true
+    },
     "cssmin": {
       "version": "0.4.3",
       "dev": true
@@ -28984,6 +29022,16 @@
         "jest-cli": "^29.4.1"
       }
     },
+    "jest-canvas-mock": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.4.0.tgz",
+      "integrity": "sha512-mmMpZzpmLzn5vepIaHk5HoH3Ka4WykbSoLuG/EKoJd0x0ID/t+INo1l8ByfcUJuDM+RIsL4QDg/gDnBbrj2/IQ==",
+      "dev": true,
+      "requires": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
+      }
+    },
     "jest-changed-files": {
       "version": "29.4.0",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.4.0.tgz",
@@ -31641,6 +31689,23 @@
     "moment": {
       "version": "2.29.4",
       "dev": true
+    },
+    "moo-color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
+      "integrity": "sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.1.4"
+      },
+      "dependencies": {
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
     },
     "mri": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "jasmine-jquery": "^2.1.1",
     "jasmine-spec-reporter": "^7.0.0",
     "jest": "^29.4.1",
+    "jest-canvas-mock": "^2.4.0",
     "jest-environment-jsdom": "^29.4.1",
     "jest-image-snapshot": "^6.1.0",
     "jest-puppeteer": "^6.2.0",

--- a/src/components/charts/charts.js
+++ b/src/components/charts/charts.js
@@ -1102,7 +1102,6 @@ charts.triggerContextMenu = function (container, elem, d, event) {
  * @returns {number} The calculated text width in pixels.
  */
 charts.calculateTextRenderWidth = function (textStr, fonts) {
-  if (!this.canvas) return 0;
   const defaultFonts = {
     soho: '700 12px arial',
     uplift: '600 14px arial',
@@ -1113,7 +1112,9 @@ charts.calculateTextRenderWidth = function (textStr, fonts) {
   let themeId = (theme?.currentTheme?.id || '').match(/soho|uplift|new|classic/);
   themeId = themeId ? themeId[0] : 'new';
   this.canvas = this.canvas || (this.canvas = document.createElement('canvas'));
+  if (!this.canvas) return 0;
   const context = this.canvas?.getContext('2d');
+  if (!context?.font) return 0;
   context.font = fonts[themeId];
   return context.measureText(textStr).width;
 };

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5319,9 +5319,10 @@ Datagrid.prototype = {
    * @returns {number} the calculated text width in pixels.
    */
   calculateTextRenderWidth(maxText, isHeader) {
-    if (!this.canvas) return 0;
     // if given, use cached canvas for better performance, else, create new canvas
     this.canvas = this.canvas || (this.canvas = document.createElement('canvas'));
+
+    if (!this.canvas || !this.canvas?.getContext) return 0;
     const context = this.canvas?.getContext('2d');
     const isNewTheme = (theme.currentTheme.id.indexOf('uplift') > -1 || theme.currentTheme.id.indexOf('new') > -1);
 
@@ -5339,6 +5340,7 @@ Datagrid.prototype = {
       }
     }
 
+    if (!context?.font) return 0;
     context.font = this.fontCached;
     if (isHeader) {
       context.font = this.fontHeaderCached;

--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -193,7 +193,7 @@ Personalize.prototype = {
     });
     isDark = foundColor ? 'white' : null;
 
-    // START OF NEW THEME COLOR STYLES 
+    // START OF NEW THEME COLOR STYLES
     const buttonNewColors = {
       amber: ['#bb5500', '#fbaf50', '#fcc888', '#fef2e5'],
       amethyst: ['#7928e1', '#c2a1f1', '#ddcbf7', '#f1ebfc'],
@@ -202,22 +202,22 @@ Personalize.prototype = {
       graphite: ['#535353', '#97979b', '#b7b7ba', '#efeff0'],
       ruby: ['#8d0b0e', '#ee9496', '#f5c3c4', '#fbe7e8'],
       slate: ['#606066', '#97979b', '#b7b7ba', '#efeff0'],
-      turquoise: ['#297b7b', '#82d4d4', '#a8e1e1', '#ecf8f8'] 
+      turquoise: ['#297b7b', '#82d4d4', '#a8e1e1', '#ecf8f8']
     };
-    
+
     const currentColor = `${colors.header || defaultColors.header}`.toLowerCase();
     Object.keys(buttonNewColors).forEach((color) => {
       if (buttonNewColors[color].indexOf(currentColor) > -1) {
         colors.darkNewButton = buttonNewColors[color][1];
         colors.darkNewButtonHover = buttonNewColors[color][2];
-        colors.secondaryButtonHover = buttonNewColors[color][3]; 
+        colors.secondaryButtonHover = buttonNewColors[color][3];
       }
     });
 
     colors.darkNewButtonLighterHover = '#3e3e42';
     colors.darkNewButtonDisabled = '#47474c';
     colors.darkNewButtonTextDisabled = '#77777c';
-    // END OF NEW THEME COLOR STYLES 
+    // END OF NEW THEME COLOR STYLES
 
     // Evaluate text contrast colors.
     // If the primary color is too "bright", this will flip the text color to black.
@@ -321,7 +321,6 @@ Personalize.prototype = {
     defaultColors.tooltipText = tooltipContrast === 'white' ? 'ffffff' : '000000';
     colors.tooltipText = colorUtils.validateHex(colors.tooltipText || defaultColors.tooltipText);
 
-    console.log(colors);
     return personalizeStyles(colors);
   },
 

--- a/test/jest.config.cjs
+++ b/test/jest.config.cjs
@@ -17,7 +17,7 @@ module.exports = {
 
   // The paths to modules that run some code to configure or set
   // up the testing environment before each test
-  // setupFiles: [],
+  setupFiles: ['jest-canvas-mock'],
 
   // A list of paths to modules that run some code to configure
   // or set up the testing framework before each test


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This fixes bar chart issues due to canvas being nulled out for jest tests to pass. This is fallout from some d3 changes.
This was only an issue on main and does not require patches.

**Related github/jira issue (required)**:
Fixes #7183 
Fixes #7181 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/bar/example-long-text.html -> long test should all appear again
- go to http://localhost:4000/components/bar/example-axis-labels.html -> left axis label should appear again

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
