### PR TITLE
7167 - Fix personalization default color

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[Dropdown/Multiselect]` Fixed disabled options are not displayed as disabled when using ajax. ([#7150](https://github.com/infor-design/enterprise/issues/7150))
 - `[MenuButton]` Fixed some color on menu buttons. ([#7184](https://github.com/infor-design/enterprise/issues/7184))
 - `[Hyperlink]` Changed hover color in dark theme. ([#7095](https://github.com/infor-design/enterprise/issues/7095))
+- `[Personalization]` Fixed default color. ([#7167](https://github.com/infor-design/enterprise/issues/7167))
 - `[Popupmenu]` Fix on inverse colors not showing in popupmenu in masthead. ([#7005](https://github.com/infor-design/enterprise/issues/7005))
 
 ## v4.80.1 Fixes

--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -193,7 +193,7 @@ Personalize.prototype = {
     });
     isDark = foundColor ? 'white' : null;
 
-    // START OF NEW THEME COLOR STYLES 
+    // START OF NEW THEME COLOR STYLES
     const buttonNewColors = {
       amber: ['#bb5500', '#fbaf50', '#fcc888', '#fef2e5'],
       amethyst: ['#7928e1', '#c2a1f1', '#ddcbf7', '#f1ebfc'],
@@ -202,22 +202,22 @@ Personalize.prototype = {
       graphite: ['#535353', '#97979b', '#b7b7ba', '#efeff0'],
       ruby: ['#8d0b0e', '#ee9496', '#f5c3c4', '#fbe7e8'],
       slate: ['#606066', '#97979b', '#b7b7ba', '#efeff0'],
-      turquoise: ['#297b7b', '#82d4d4', '#a8e1e1', '#ecf8f8'] 
+      turquoise: ['#297b7b', '#82d4d4', '#a8e1e1', '#ecf8f8']
     };
-    
+
     const currentColor = `${colors.header || defaultColors.header}`.toLowerCase();
     Object.keys(buttonNewColors).forEach((color) => {
       if (buttonNewColors[color].indexOf(currentColor) > -1) {
         colors.darkNewButton = buttonNewColors[color][1];
         colors.darkNewButtonHover = buttonNewColors[color][2];
-        colors.secondaryButtonHover = buttonNewColors[color][3]; 
+        colors.secondaryButtonHover = buttonNewColors[color][3];
       }
     });
 
     colors.darkNewButtonLighterHover = '#3e3e42';
     colors.darkNewButtonDisabled = '#47474c';
     colors.darkNewButtonTextDisabled = '#77777c';
-    // END OF NEW THEME COLOR STYLES 
+    // END OF NEW THEME COLOR STYLES
 
     // Evaluate text contrast colors.
     // If the primary color is too "bright", this will flip the text color to black.
@@ -321,7 +321,6 @@ Personalize.prototype = {
     defaultColors.tooltipText = tooltipContrast === 'white' ? 'ffffff' : '000000';
     colors.tooltipText = colorUtils.validateHex(colors.tooltipText || defaultColors.tooltipText);
 
-    console.log(colors);
     return personalizeStyles(colors);
   },
 

--- a/src/components/theme/theme.js
+++ b/src/components/theme/theme.js
@@ -71,7 +71,16 @@ const theme = {
     const brand = this.themeColors().brand;
     const personalize = {};
     const opts = { showBrackets: false };
-    personalize.default = { id: 'default', name: Locale.translate('Default', opts), backgroundColorClass: 'primary-bg-color', value: brand.primary.base.value };
+    const defaultColor = () => ([
+      { id: 'theme-classic-light', color: '#2578a9' },
+      { id: 'theme-classic-dark', color: '#50535A' },
+      { id: 'theme-classic-contrast', color: '#134d71' },
+      { id: 'theme-new-light', color: '#ffffff' },
+      { id: 'theme-new-dark', color: '#606066' },
+      { id: 'theme-new-contrast', color: '#ffffff' }
+    ].filter(color => color.id === this.currentTheme.id)?.[0]?.color);
+
+    personalize.default = { id: 'default', name: Locale.translate('Default', opts), backgroundColorClass: 'primary-bg-color', value: defaultColor() || brand.primary.base.value };
     personalize.amber = { id: 'amber', name: Locale.translate('Amber', opts), backgroundColorClass: 'amber09', value: palette.amber['90'].value };
     personalize.amethyst = { id: 'amethyst', name: Locale.translate('Amethyst', opts), backgroundColorClass: 'amethyst06', value: palette.amethyst['60'].value };
     personalize.azure = { id: 'azure', name: Locale.translate('Azure', opts), backgroundColorClass: 'azure07', value: palette.azure['70'].value };


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed personalization default color.

**Related github/jira issue (required)**:
Closes #7167 

**Steps necessary to review your pull request (required)**:
Pull this branch and build/run the demo app
- Navigate to: http://localhost:4000/components/personalize/example-index.html
- Open developer tool and run on console
- `Soho.theme.personalizationColors().default.value` - should give you right theme default color
- Try switch themes and run same command

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
