### PR TITLE
7201 - Fix icon centering

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## v4.81.0 Fixes
 
 - `[Bar]` Fixed bug introduced by d3 changes with bar selection. ([#7182](https://github.com/infor-design/enterprise/issues/7182))
+- `[Button]` Fixed icon button size and icon centering. ([#7201](https://github.com/infor-design/enterprise/issues/7201))
 - `[Accordion]` Additional fix in accordion collapsing cards on expand bug. ([#6820](https://github.com/infor-design/enterprise/issues/6820))
 - `[Datagrid]` Fixed background color of lookups in filter row when in light mode. ([#7176](https://github.com/infor-design/enterprise/issues/7176))
 - `[Datagrid]` Fixed a bug in datagrid where custom toolbar is being replaced with data grid generated toolbar. ([NG#1434](https://github.com/infor-design/enterprise-ng/issues/1434))

--- a/src/components/button/_button-new.scss
+++ b/src/components/button/_button-new.scss
@@ -212,6 +212,7 @@
   > .icon {
     position: relative;
     top: -1px;
+    left: 0;
   }
 }
 
@@ -219,6 +220,7 @@
 .btn-actions {
   > .icon {
     height: 19px;
+    top: -1px;
   }
 }
 

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -721,12 +721,12 @@ a.btn-close {
 .btn-actions,
 .btn-close {
   border-radius: 18px;
-  height: 36px;
+  height: 34px;
   margin-top: 0;
-  min-height: 36px;
-  min-width: 36px;
+  min-height: 34px;
+  min-width: 34px;
   padding: 0;
-  width: 36px;
+  width: 34px;
 
   // Icon Buttons only have one icon (never two) and no text visible, so disable padding
   > .icon {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Design QA report a minor alignment issue in icon buttons.

**Related github/jira issue (required)**:
Fixes #7201 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/button/example-index.html
- inspect the two icons buttons
- make sure they are 34x34 and the icon looks centered

**Included in this Pull Request**:
- [x] A note to the change log.
