### PR TITLE
NG 1431 - Fixed bug in Safari where dynamically switching from RTL to LTR doesn't update all the alignments

### DIFF
--- a/app/views/components/datagrid/test-rtl-swap.html
+++ b/app/views/components/datagrid/test-rtl-swap.html
@@ -1,0 +1,87 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <div role="toolbar" class="toolbar">
+      <div class="title">
+        Data Grid Header Title
+        <span class="datagrid-result-count">(N Results)</span>
+      </div>
+
+      <div class="buttonset">
+        <button id="btn-eng" class="btn btn-secondary" type="button">English</button>
+        <button id="btn-ar" class="btn btn-secondary" type="button">Arabic</button>
+      </div>
+    </div>
+
+    <div class="contextual-toolbar toolbar is-hidden">
+      <div class="title selection-count">1 Selected</div>
+      <div class="buttonset">
+        <button class="btn-icon" type="button" id="remove-btn">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-delete"></use>
+          </svg>
+          <span class="audible">Remove</span>
+        </button>
+      </div>
+    </div>
+
+    <div id="datagrid"></div>
+  </div>
+</div>
+
+<script>
+  var gridApi = null;
+
+  $('body').one('initialized', function () {
+    var grid,
+      columns = [],
+      data = [];
+
+    var isDisabled = function(row, cell, value, item) {
+      return (row % 2 === 0);
+    }
+
+    data.push({ id: 1, productName: 'Compressor', quantity: 1, portable: false, action: 1 });
+    data.push({ id: 2, productName: 'console.log', quantity: 2, portable: false, action: 1 });
+    data.push({ id: 3, productName: 'Portable Compressor', portable: true, quantity: null, action: 2});
+    data.push({ id: 4, productName: 'Another Compressor', portable: true, quantity: 3, action: 3 });
+    data.push({ id: 5, productName: 'De Wallt Compressor', portable: false, quantity: 4, action: 1});
+    data.push({ id: 6, productName: 'Air Compressors', portable: false, quantity: 41, action: 2});
+    data.push({ id: 7, productName: 'Some Compressor', portable: true, quantity: 41, action: 2});
+
+    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Soho.Formatters.SelectionCheckbox, align: 'center'});
+    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Soho.Formatters.Hyperlink, editor: Soho.Editors.Input});
+    columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', align: 'right', editor: Soho.Editors.Input, mask: '###', isEditable: isDisabled});
+    columns.push({ id: 'portable', name: 'Portable', field: 'portable', align: 'center', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox});
+    columns.push({ id: 'action', name: 'Action', field: 'action', formatter: Soho.Formatters.Dropdown, editor: Soho.Editors.Dropdown, validate: 'required', isEditable: isDisabled,
+    options: [{id: '', label: '', value: -1}, {id: 'oh1', label: 'On Hold', value: 1}, {id: 'sh1', label: 'Shipped', value: 2} , {id: 'ac1', label: 'Action', value: 3}, {id: 'pen', label: 'Pending', value: 4}, {id: 'bk1', label: 'Backorder', value: 5}, {id: 'can', label: 'Cancelled', value: 6}, {id: 'pro', label: 'Processing', value: 7}]
+    });
+
+    //Init and get the api for the grid
+    grid = $('#datagrid').datagrid({
+      columns: columns,
+      dataset: data,
+      editable: true,
+      showNewRowIndicator: false,
+      clickToSelect: false,
+      selectable: 'multiple',
+      toolbar: {title: 'Data Grid Header Title', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: true,  collapsibleFilter: true},
+      paging: true,
+      pagesize: 5,
+      pagesizes: [2, 5, 6],
+      trimSpaces: true,
+      columnReorder: true,
+      showDirty: true
+    });
+    gridApi = $('#datagrid').data('datagrid');
+    window.data = data;
+  });
+
+  $('#btn-ar').on('click', () => {
+    Soho.Locale.set('ar-SA');
+  });
+
+  $('#btn-eng').on('click', () => {
+    Soho.Locale.set('en-US');
+  });
+</script>

--- a/app/views/components/datagrid/test-rtl-swap.html
+++ b/app/views/components/datagrid/test-rtl-swap.html
@@ -1,4 +1,69 @@
+<div class="row">
+  <div class="twelve columns">
+    <div class="flex-toolbar" data-options="{ 'attributes': [ { 'name': 'data-automation-id', 'value': 'my-toolbar' } ] }">
+      <div class="toolbar-section title">
+        <h2>Toolbar</h2>
+      </div>
 
+      <div class="toolbar-section buttonset">
+        <button class="btn">
+          <span>Text Button</span>
+        </button>
+
+        <button class="btn-menu" data-options="{ 'attributes': [ { 'name': 'data-automation-id', 'value': 'my-menubutton' } ] }">
+          <span>Menu Button</span>
+        </button>
+        <ul class="popupmenu">
+          <li><a href="#">Item One</a></li>
+          <li><a href="#">Item Two</a></li>
+          <li class="submenu">
+            <a href="#">Item Three</a>
+            <ul class="popupmenu">
+              <li><a href="#">Sub-Item One</a></li>
+              <li><a href="#">Sub-Item Two</a></li>
+            </ul>
+          </li>
+          <li><a href="#">Item Four</a></li>
+        </ul>
+
+        <button class="btn-icon" disabled="true">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-settings"></use>
+          </svg>
+          <span class="audible">Settings</span>
+        </button>
+
+        <button class="btn-icon">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-delete"></use>
+          </svg>
+          <span class="audible">Trash</span>
+        </button>
+      </div>
+
+      <div class="toolbar-section search">
+        <div class="searchfield-wrapper">
+          <label for="toolbar-searchfield-01" class="audible">Toolbar Search</label>
+          <input id="toolbar-searchfield-01" class="searchfield" placeholder="Search..." data-options="{ collapsible: true }"/>
+        </div>
+      </div>
+
+      <div class="toolbar-section more">
+        <button class="btn-actions">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-more"></use>
+          </svg>
+          <span class="audible">More Actions</span>
+        </button>
+        <ul class="popupmenu">
+          <li><a href="#">Pre-defined Item #1</a></li>
+          <li><a href="#">Pre-defined Item #2</a></li>
+          <li><a href="#">Pre-defined Item #3</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
 <div class="row">
   <div class="twelve columns">
     <div role="toolbar" class="toolbar">

--- a/app/views/components/datagrid/test-rtl-swap.html
+++ b/app/views/components/datagrid/test-rtl-swap.html
@@ -57,7 +57,6 @@
     options: [{id: '', label: '', value: -1}, {id: 'oh1', label: 'On Hold', value: 1}, {id: 'sh1', label: 'Shipped', value: 2} , {id: 'ac1', label: 'Action', value: 3}, {id: 'pen', label: 'Pending', value: 4}, {id: 'bk1', label: 'Backorder', value: 5}, {id: 'can', label: 'Cancelled', value: 6}, {id: 'pro', label: 'Processing', value: 7}]
     });
 
-    //Init and get the api for the grid
     grid = $('#datagrid').datagrid({
       columns: columns,
       dataset: data,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[Accordion]` Additional fix in accordion collapsing cards on expand bug. ([#6820](https://github.com/infor-design/enterprise/issues/6820))
 - `[Datagrid]` Fixed background color of lookups in filter row when in light mode. ([#7176](https://github.com/infor-design/enterprise/issues/7176))
 - `[Datagrid]` Fixed a bug in datagrid where custom toolbar is being replaced with data grid generated toolbar. ([NG#1434](https://github.com/infor-design/enterprise-ng/issues/1434))
+- `[Datagrid]` Fixed bug in Safari where dynamically switching from RTL to LTR doesn't update all the alignments. ([NG#1431](https://github.com/infor-design/enterprise-ng/issues/1431))
 - `[Dropdown]` Fixed swatch default color in themes. ([#7108](https://github.com/infor-design/enterprise/issues/7108))
 - `[Dropdown/Multiselect]` Fixed disabled options are not displayed as disabled when using ajax. ([#7150](https://github.com/infor-design/enterprise/issues/7150))
 - `[Header]` Fixed a bug in subheader where the color its not appropriate on default theme. ([#7173](https://github.com/infor-design/enterprise/issues/7173))

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -107,7 +107,7 @@ const Locale = {  // eslint-disable-line
     if (this.isRTL()) {
       html.attr('dir', 'rtl');
     } else {
-      html.removeAttr('dir');
+      html.attr('dir', 'ltr');
     }
 
     // ICONS: Right to Left Direction


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Updated dir to ltr instead of removing dir attribute when changing locales to make Safari update alignments.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise-ng/issues/1431

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Open Safari
- Go to: http://localhost:4000/components/datagrid/test-rtl-swap
- Click on Arabic button
- Check alignments. Click on editable fields and check alignments
- Click on English button
- Check alignments. Click on editable fields and check alignments

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
