### PR TITLE
7188 - Timepicker fix 24h validation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `[Header]` Fixed a bug in subheader where the color its not appropriate on default theme. ([#7173](https://github.com/infor-design/enterprise/issues/7173))
 - `[MenuButton]` Fixed some color on menu buttons. ([#7184](https://github.com/infor-design/enterprise/issues/7184))
 - `[Hyperlink]` Changed hover color in dark theme. ([#7095](https://github.com/infor-design/enterprise/issues/7095))
+- `[Timepicker]` Fixed 24h time validation. ([#7188](https://github.com/infor-design/enterprise/issues/7188))
 - `[Slider]` Fixed sliding and dropping the handle outside of the component doesn't trigger the change event. ([#7028](https://github.com/infor-design/enterprise/issues/7028))
 - `[Popupmenu]` Fix on inverse colors not showing in popupmenu in masthead. ([#7005](https://github.com/infor-design/enterprise/issues/7005))
 - `[Typography]` Updated documentation to align usage guidance. ([#7187](https://github.com/infor-design/enterprise/issues/7187))

--- a/src/components/validation/validation.js
+++ b/src/components/validation/validation.js
@@ -445,7 +445,8 @@ function ValidationRules() {
 
     time: {
       check(value, field) {
-        value = value.replace(/ /g, '');
+        if (!value) return true;
+
         this.message = Locale.translate('InvalidTime');
         const timepicker = field && field.data('timepicker');
         const timepickerSettings = timepicker ? field.data('timepicker').settings : {};
@@ -460,62 +461,9 @@ function ValidationRules() {
           }
         }
 
-        const is24Hour = (pattern.match('HH') || pattern.match('H') || []).length > 0;
-        const maxHours = is24Hour ? 24 : 12;
-        const sep = value.indexOf(Locale.calendar().dateFormat.timeSeparator);
-        let valueHours = 0;
-        let valueMins = 0;
-        let valueSecs = 0;
-        let valueM;
-        let timeparts;
+        const parsedTime = Locale.parseDate(value, { dateFormat: pattern, strictTime: true });
 
-        if (value === '') {
-          return true;
-        }
-
-        valueHours = parseInt(value.substring(0, sep), 10);
-        valueMins = parseInt(value.substring(sep + 1, sep + 3), 10);
-
-        // getTimeFromField
-        if (timepicker) {
-          timeparts = timepicker.getTimeFromField();
-
-          valueHours = timeparts.hours;
-          valueMins = timeparts.minutes;
-
-          if (timepicker.hasSeconds()) {
-            valueSecs = timeparts.seconds;
-          }
-        }
-
-        if (valueHours.toString().length < 1 || isNaN(valueHours) ||
-          parseInt(valueHours, 10) < 0 || parseInt(valueHours, 10) > maxHours) {
-          return false;
-        }
-        if (valueMins.toString().length < 1 || isNaN(valueMins) ||
-          parseInt(valueMins, 10) < 0 || parseInt(valueMins, 10) > 59) {
-          return false;
-        }
-        if (valueSecs.toString().length < 1 || isNaN(valueSecs) ||
-          parseInt(valueSecs, 10) < 0 || parseInt(valueSecs, 10) > 59) {
-          return false;
-        }
-
-        // AM/PM
-        if (!is24Hour) {
-          if (parseInt(valueHours, 10) < 1) {
-            return false;
-          }
-          const period0 = new RegExp(Locale.calendar().dayPeriods[0], 'i');
-          const period1 = new RegExp(Locale.calendar().dayPeriods[1], 'i');
-
-          valueM = value.match(period0) || value.match(period1) || [];
-          if (valueM.length === 0) {
-            return false;
-          }
-        }
-
-        return true;
+        return parsedTime instanceof Date && !Number.isNaN(parsedTime) && parsedTime.toString() !== 'Invalid Date';
       },
       message: 'Invalid Time',
       type: 'error',

--- a/test/components/timepicker/timepicker-puppeteer-test.js
+++ b/test/components/timepicker/timepicker-puppeteer-test.js
@@ -34,42 +34,6 @@ describe('Timepicker Puppeteer Tests', () => {
 
       expect(await page.evaluate(el => el.value, timepickerEl)).toEqual('1:00 AM');
     });
-
-    it('should validate input', async () => {
-      const timepickerEl = await page.$('#timepicker-id-1');
-
-      const changeTimeFormat = async (format) => {
-        await page.evaluate((timeFormat) => {
-          $('#timepicker-id-1').data('timepicker').settings.timeFormat = timeFormat;
-        }, format);
-      };
-
-      const setValueAndValidate = async (value) => {
-        await page.evaluate((el, val) => {
-          el.value = val;
-          el.dispatchEvent(new FocusEvent('blur'));
-        }, timepickerEl, value);
-      };
-
-      const checkError = async () => {
-        const hasError = await page.evaluate(() => document.querySelector('#timepicker-id-1').classList.contains('error'));
-
-        return hasError;
-      };
-
-      await setValueAndValidate('1');
-      await page.waitForTimeout(300);
-      expect(await checkError()).toBeTruthy();
-
-      await setValueAndValidate('');
-      await page.waitForTimeout(300);
-      expect(await checkError()).toBeFalsy();
-
-      await changeTimeFormat('HH:mm');
-      await setValueAndValidate('1');
-      await page.waitForTimeout(300);
-      expect(await checkError()).toBeTruthy();
-    });
   });
 
   describe('Timepicker Example Hour Range Tests', () => {

--- a/test/components/timepicker/timepicker-puppeteer-test.js
+++ b/test/components/timepicker/timepicker-puppeteer-test.js
@@ -34,6 +34,42 @@ describe('Timepicker Puppeteer Tests', () => {
 
       expect(await page.evaluate(el => el.value, timepickerEl)).toEqual('1:00 AM');
     });
+
+    it('should validate input', async () => {
+      const timepickerEl = await page.$('#timepicker-id-1');
+
+      const changeTimeFormat = async (format) => {
+        await page.evaluate((timeFormat) => {
+          $('#timepicker-id-1').data('timepicker').settings.timeFormat = timeFormat;
+        }, format);
+      };
+
+      const setValueAndValidate = async (value) => {
+        await page.evaluate((el, val) => {
+          el.value = val;
+          el.dispatchEvent(new FocusEvent('blur'));
+        }, timepickerEl, value);
+      };
+
+      const checkError = async () => {
+        const hasError = await page.evaluate(() => document.querySelector('#timepicker-id-1').classList.contains('error'));
+
+        return hasError;
+      };
+
+      await setValueAndValidate('1');
+      await page.waitForTimeout(300);
+      expect(await checkError()).toBeTruthy();
+
+      await setValueAndValidate('');
+      await page.waitForTimeout(300);
+      expect(await checkError()).toBeFalsy();
+
+      await changeTimeFormat('HH:mm');
+      await setValueAndValidate('1');
+      await page.waitForTimeout(300);
+      expect(await checkError()).toBeTruthy();
+    });
   });
 
   describe('Timepicker Example Hour Range Tests', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes 24h validation in time validation by using `Locale.parseDate` with `strictTime` option

**Related github/jira issue (required)**:
Closes #7188 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4000/components/timepicker/example-index.html?locale=nl-NL
- in the input field enter the '1' character and press tab
- see a validation error appears

**Included in this Pull Request**:
~- [] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.