### PR TITLE
7116 - Timepicker add fixes to parseDate function for ah time formats

### DIFF
--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -1016,7 +1016,7 @@ const Locale = {  // eslint-disable-line
     dateString = dateString.replace(' de ', ' ');
 
     // Fix ah
-    dateFormat = dateFormat.replace('/ah/', '/a/h/');
+    dateFormat = dateFormat.replace('ah', 'a/h');
     dateString = dateString.replace('午', '午/');
 
     // Remove commas

--- a/src/components/timepicker/timepicker.js
+++ b/src/components/timepicker/timepicker.js
@@ -1075,7 +1075,7 @@ TimePicker.prototype = {
         const maxHourCount = is24HourFormat ? 24 : 13;
         const hourSelect = $('select.hours.dropdown');
         let hourValue = hourSelect.siblings('.dropdown-wrapper').find('.dropdown').children('span').text();
-        if (hourValue.indexOf('Hours') > -1) {
+        if (hourValue.indexOf(Locale.translate('Hours')) > -1) {
           hourValue = hourValue.split(' ')[1];
         }
 

--- a/test/components/locale/locale-func-test.js
+++ b/test/components/locale/locale-func-test.js
@@ -349,6 +349,18 @@ describe('Locale API', () => {
 
     expect(Locale.parseDate('2020/3/4 下午9:00', { pattern: 'yyyy/M/d ah:mm' }).getTime())
       .toEqual(new Date(2020, 2, 4, 21, 0, 0).getTime());
+
+    expect(Locale.parseDate('上午1:00', { dateFormat: 'ah:mm' }).getHours()).toEqual(1);
+    expect(Locale.parseDate('上午12:00', { dateFormat: 'ah:mm' }).getHours()).toEqual(0);
+    expect(Locale.parseDate('下午2:00', { dateFormat: 'ah:mm' }).getHours()).toEqual(14);
+    expect(Locale.parseDate('下午12:00', { dateFormat: 'ah:mm' }).getHours()).toEqual(12);
+  });
+
+  it('should not parse incorrect time string with strictTime option', () => {
+    Locale.set('en-US');
+
+    expect(Locale.parseDate('1', { dateFormat: 'h:mm a', strictTime: true })).toBeUndefined();
+    expect(Locale.parseDate('1', { dateFormat: 'HH:mm', strictTime: true })).toBeUndefined();
   });
 
   it('should format en-US dates', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds fix to parseDate function for `ah...` time formats and fixes extra value in hours dropdown for timepicker component

**Related github/jira issue (required)**:
Fixes #7116 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4000/components/timepicker/example-index.html?locale=zh-CH
- set a time
- see there is no validation error
- select an hour (11 or 12), select AM->PM or PM->AM, see the hours dropdown doesn't have any extra value in it, just a number
- set time and see there is no validation error

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
~- [ ] A note to the change log.~
