### PR TITLE
7232 - Fix hover color in is list/mixed mode

### DIFF
--- a/app/views/components/datagrid/test-card-cell-is-list.html
+++ b/app/views/components/datagrid/test-card-cell-is-list.html
@@ -1,0 +1,137 @@
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid"></div>
+  </div>
+</div>
+
+<style>
+  .custom-card {
+    padding: 18px;
+  }
+
+  .custom-card h3 {
+    color: #1a1a1a;
+    font-size: 16px;
+    line-height: 18px;
+    padding-bottom: 14px;
+  }
+
+  .custom-card dl>div {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+  }
+
+  .custom-card dt,
+  .custom-card dd {
+    display: inline-block;
+    padding-bottom: 4px;
+  }
+
+  .custom-card dt {
+    color: #5c5c5c;
+    font-size: 12px;
+    line-height: 14px;
+    min-width: 120px;
+    padding-right: 18px;
+    text-align: right;
+  }
+
+  .custom-card dt::after {
+    content: ':';
+    display: inline-block;
+  }
+
+  .custom-card dd {
+    color: #1a1a1a;
+    font-size: 14px;
+    line-height: 16px;
+  }
+
+  .custom-card .price dd {
+    margin-top: 5px;
+  }
+</style>
+
+<script>
+  $('body').one('initialized', function () {
+
+    var grid,
+      columns = [],
+      data = [];
+
+    var customFormatter = function (row, cell, value, col) {
+      return `<div class="custom-card">
+          <h3>${value.title}</h3>
+          <dl>
+            <div><dt>Location</dt><dd>${value.location}</dd></div>
+            <div><dt>Phone</dt><dd>${value.phone}</dd></div>
+            <div><dt>Quantity</dt><dd>${value.quantity}</dd></div>
+            <div class="price">
+                <dt>
+                    <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                      <use href="#icon-alert"></use>
+                    </svg>
+                    Price
+                </dt>
+                <dd>${value.price}</dd>
+            </div>
+          </dl>
+          <div class="toolbar card-toolbar has-more-button">
+            <div class="buttonset">
+              <button class="btn"><span>Order</span></button>
+              <button class="btn"><span>Save</span></button>
+              <button class="btn"><span>Delete</span></button>
+              <button class="btn"><span>Update</span></button>
+            </div>
+          </div>
+        </div>`;
+    };
+
+    // Some Sample Data
+    data.push({
+      id: 1,
+      productId: 'T100',
+      product: {
+        title: 'Compressor (mx500)',
+        location: 'Acme Inc',
+        phone: '(888) 888-8889',
+        quantity: '100',
+        price: '$500'
+      },
+      misc: 'This is a basic cell'
+    });
+
+    data.push({
+      id: 2,
+      productId: 'C100',
+      product: {
+        title: 'Compressor (m3000)',
+        location: 'Assembly Inc',
+        phone: '(888) 888-8888',
+        quantity: '15',
+        price: '$800'
+      },
+      misc: 'This is another basic cell'
+    });
+
+    //Define Columns for the Grid.
+    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Soho.Formatters.SelectionCheckbox, align: 'center' });
+    columns.push({ id: 'productId', name: 'Id', field: 'productId', width: 100, formatter: Soho.Formatters.Text });
+    columns.push({ id: 'product', name: 'Product', field: 'product', width: 340, formatter: customFormatter });
+    columns.push({ id: 'misc', name: 'Misc', field: 'misc', formatter: Soho.Formatters.Text });
+
+    //Init and get the api for the grid
+    $('#datagrid').datagrid({
+      isList: true,
+      columns: columns,
+      selectable: 'mixed',
+      dataset: data,
+      saveColumns: false,
+      toolbar: { title: 'Compressors', actions: true, rowHeight: true, personalize: true }
+    });
+
+    $('.card-toolbar').toolbar({ rightAligned: true });
+
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[Datagrid]` Fixed background color of lookups in filter row when in light mode. ([#7176](https://github.com/infor-design/enterprise/issues/7176))
 - `[Datagrid]` Fixed a bug in datagrid where custom toolbar is being replaced with data grid generated toolbar. ([NG#1434](https://github.com/infor-design/enterprise-ng/issues/1434))
 - `[Datagrid]` Fixed bug in Safari where dynamically switching from RTL to LTR doesn't update all the alignments. ([NG#1431](https://github.com/infor-design/enterprise-ng/issues/1431))
+- `[Datagrid]` Fixed odd hover color when using row activation and is list. ([#7232](https://github.com/infor-design/enterprise/issues/7232))
 - `[Dropdown]` Fixed swatch default color in themes. ([#7108](https://github.com/infor-design/enterprise/issues/7108))
 - `[Dropdown/Multiselect]` Fixed disabled options are not displayed as disabled when using ajax. ([#7150](https://github.com/infor-design/enterprise/issues/7150))
 - `[Header]` Fixed a bug in subheader where the color its not appropriate on default theme. ([#7173](https://github.com/infor-design/enterprise/issues/7173))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -2239,7 +2239,7 @@ $datagrid-small-row-height: 25px;
 
     &.is-rowactivated td:not(.is-editing),
     &.is-rowactivated td:not(.is-editing) .datagrid-cell-wrapper {
-      background-color: $datagrid-row-selected-color;
+      background-color: $datagrid-row-selected-color !important;
 
       button.datagrid-expand-btn .icon {
         background-color: transparent;
@@ -2259,6 +2259,10 @@ $datagrid-small-row-height: 25px;
           background-color: $button-color-primary-active-background;
         }
       }
+    }
+
+    &.is-hover-row {
+      background-color: $datagrid-row-hover-color;
     }
 
     &.is-rowdisabled {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When rows are very tall the hover color and selection color for mixed mode would blend incorrectly. This is a fix

**Related github/jira issue (required)**:
Fixes #7232 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-card-cell-is-list.html
- hover the rows
- then click the row (not the checkbox) to activate
- should be no bleed through of either state
- test also http://localhost:4000/components/datagrid/test-tree-mixed.html

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
