### PR TITLE
7185 - Fix disabled button color in classic

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `[Actionsheet]` Updated font and icon colors for classic actionsheet. ([#7012](https://github.com/infor-design/enterprise/issues/7012))
 - `[Bar]` Fixed bug introduced by d3 changes with bar selection. ([#7182](https://github.com/infor-design/enterprise/issues/7182))
 - `[Button]` Fixed icon button size and icon centering. ([#7201](https://github.com/infor-design/enterprise/issues/7201))
+- `[Button]` Fixed disabled button color in classic version. ([#7185](https://github.com/infor-design/enterprise/issues/7185))
 - `[Accordion]` Additional fix in accordion collapsing cards on expand bug. ([#6820](https://github.com/infor-design/enterprise/issues/6820))
 - `[Datagrid]` Fixed background color of lookups in filter row when in light mode. ([#7176](https://github.com/infor-design/enterprise/issues/7176))
 - `[Datagrid]` Fixed a bug in datagrid where custom toolbar is being replaced with data grid generated toolbar. ([NG#1434](https://github.com/infor-design/enterprise-ng/issues/1434))

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -20,6 +20,10 @@ function personalizeStyles(colors) {
   border-color: ${colors.base} !important;
 }
 
+html.theme-classic-dark .is-personalizable .btn-primary:not(.destructive):not(.is-select):not(.is-select-month-pane):not(.is-cancel):not(.is-cancel-month-pane):disabled {
+  color: #888B94 !important;
+}
+
 html.theme-new-dark .is-personalizable .btn-primary:not(.destructive):not(.is-select):not(.is-select-month-pane):not(.is-cancel):not(.is-cancel-month-pane):not(:disabled) {
   background-color: ${colors.darkNewButton} !important;
   border-color: ${colors.darkNewButton} !important;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR addresses the color of disabled button in classic DARK version only. 

The value of color can be change into dynamic value. I created a method that can map the current colors that we have in here https://github.com/infor-design/enterprise/pull/7238/files#diff-ed599124c2d873d0bfaabf66b0e010b8c8262139301ecc4100d4ba14e4049d9aR117

But for now we can use hard coded hex color. Once this [PR](https://github.com/infor-design/enterprise/pull/7238) is approved, we can change that into a dynamic. value.

**Related github/jira issue (required)**:

Closes #7185

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/button/example-index.html?theme=classic&mode=dark&colors=2578a9
- Disabled button text color should be darker
- Test in all colors dark mode

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
