### PR TITLE
NG 1417 - Context Menu Fix wrong menu is displayed in nested menus on mobile device

### DIFF
--- a/app/views/components/contextmenu/example-nested-menus.html
+++ b/app/views/components/contextmenu/example-nested-menus.html
@@ -1,0 +1,37 @@
+<div class="row top-padding">
+  <div class="twelve columns">
+    <ul id="parent" style="height: 500px; border: 1px solid red; padding: 10px;">
+      <p style="color: red;">Parent</p>
+      <li id="child" style="height: 100px; border: 1px solid orange;">
+        <p style="color: orange;">Child</p>
+      </li>
+      <ul id="child-menu">
+        <li><a>Child 1</a></li>
+        <li><a>Child 2</a></li>
+        <li><a>Child 3</a></li>
+      </ul>
+    </ul>
+    <ul id="parent-menu">
+      <li><a>Parent 1</a></li>
+      <li><a>Parent 2</a></li>
+      <li><a>Parent 3</a></li>
+    </ul>
+  </div>
+</div>
+
+<script id="test-script">
+  $('#child').popupmenu({
+    menu: 'child-menu',
+    trigger: 'rightClick',
+    attributes: [
+      { name: 'data-automation-id', value: 'contextmenu-child' }
+    ]
+  });
+  $('#parent').popupmenu({
+    menu: 'parent-menu',
+    trigger: 'rightClick',
+    attributes: [
+      { name: 'data-automation-id', value: 'contextmenu-parent' }
+    ]
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Bar]` Fixed bug introduced by d3 changes with bar selection. ([#7182](https://github.com/infor-design/enterprise/issues/7182))
 - `[Button]` Fixed icon button size and icon centering. ([#7201](https://github.com/infor-design/enterprise/issues/7201))
 - `[Accordion]` Additional fix in accordion collapsing cards on expand bug. ([#6820](https://github.com/infor-design/enterprise/issues/6820))
+- `[ContextMenu]` Fixed a bug where wrong menu is displayed in nested menus on mobile device. ([NG#1417](https://github.com/infor-design/enterprise-ng/issues/1417))
 - `[Datagrid]` Fixed background color of lookups in filter row when in light mode. ([#7176](https://github.com/infor-design/enterprise/issues/7176))
 - `[Datagrid]` Fixed a bug in datagrid where custom toolbar is being replaced with data grid generated toolbar. ([NG#1434](https://github.com/infor-design/enterprise-ng/issues/1434))
 - `[Datagrid]` Fixed bug in Safari where dynamically switching from RTL to LTR doesn't update all the alignments. ([NG#1431](https://github.com/infor-design/enterprise-ng/issues/1431))

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -983,6 +983,8 @@ PopupMenu.prototype = {
                 .removeClass('longpress-target');
             })
             .on('longpress.popupmenu', (e, originalE) => {
+              e.stopPropagation();
+
               self.openedWithTouch = true;
               contextMenuHandler(originalE);
             });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a bug where wrong menu is displayed in nested menus on mobile device by stopping propagation of the `longpress` event to a parent container.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1417

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4000/components/contextmenu/example-nested-menus.html
- open the page on a mobile device or toggle browser’s device toolbar -> choose iOS or Android device
- long press on the parent container -> parent menu appears
- long press on the child container -> child menu appears

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.
