### PR TITLE
7017 - Datagrid Fix dragging columns after a cancelled drop moves more than one column

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[Datagrid]` Fixed a bug in datagrid where custom toolbar is being replaced with data grid generated toolbar. ([NG#1434](https://github.com/infor-design/enterprise-ng/issues/1434))
 - `[Datagrid]` Fixed bug in Safari where dynamically switching from RTL to LTR doesn't update all the alignments. ([NG#1431](https://github.com/infor-design/enterprise-ng/issues/1431))
 - `[Datagrid]` Fixed odd hover color when using row activation and is list. ([#7232](https://github.com/infor-design/enterprise/issues/7232))
+- `[Datagrid]` Fixed dragging columns after a cancelled drop moves more than one column. ([#7017](https://github.com/infor-design/enterprise/issues/7017))
 - `[Dropdown]` Fixed swatch default color in themes. ([#7108](https://github.com/infor-design/enterprise/issues/7108))
 - `[Dropdown/Multiselect]` Fixed disabled options are not displayed as disabled when using ajax. ([#7150](https://github.com/infor-design/enterprise/issues/7150))
 - `[Header]` Fixed a bug in subheader where the color its not appropriate on default theme. ([#7173](https://github.com/infor-design/enterprise/issues/7173))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3218,6 +3218,7 @@ Datagrid.prototype = {
         header.drag({
           clone: true, cloneAppendTo: headers.first().parent().parent(), clonePosIsFixed: true
         })
+          .off('dragstart.datagrid')
           .on('dragstart.datagrid', (dragStartEvent, pos, thisClone) => {
             clone = thisClone;
 
@@ -3240,6 +3241,7 @@ Datagrid.prototype = {
             self.draggableStatus.startIndex = index;
             e.stopImmediatePropagation();
           })
+          .off('drag.datagrid')
           .on('drag.datagrid', (dragEvent, pos) => {
             clone[0].style.left = `${parseInt(!Locale.isRTL() ? pos.left : ((pos.left + pos.offset.x) - pos.clone.width()), 10)}px`;
             clone[0].style.top = `${parseInt(pos.top, 10)}px`;
@@ -3280,6 +3282,7 @@ Datagrid.prototype = {
 
             e.stopImmediatePropagation();
           })
+          .off('dragend.datagrid')
           .on('dragend.datagrid', (dragendEvent, pos) => {
             if (!Locale.isRTL()) {
               clone[0].style.left = `${parseInt(pos.left, 10)}px`;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds `off` for drag events what fixes dragging columns after a cancelled drop moves more than one column

**Related github/jira issue (required)**:
Closes #7017 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4000/components/datagrid/example-reorder.html
- grab a column and move it somewhere where reordering doesn't happen (same place where it was, between columns like in the issue  #7017  etc) so `dragstart` `drag` `dragend` events trigger but the datagrid doesn't rerender
- grab the column and move it so reordering does happen this time
- see the order of the columns is correct and `settingschanged` event triggers only once (browser's console)

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.
