### PR TITLE
7204 - Personalize Fix header secondary button bg color on hover

### DIFF
--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -378,7 +378,7 @@ Personalize.prototype = {
   * @returns {this} component instance
   */
   setColors(colors) {
-    if (colors === '' || colors === 'default' || colors.header === 'default') {
+    if (colors === '' || colors === 'default' || colors?.header === 'default') {
       this.setColorsToDefault();
       return this;
     }

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -111,7 +111,7 @@ html.theme-new-dark .is-personalizable:not(.header) .btn-primary:not(.destructiv
   border-color: ${colors.darkNewButtonHover} !important;
 }
 
-html[class*="new-"] .is-personalizable .btn-secondary:not(.go-button):not(.is-select):not(.is-select-month-pane):not(.is-cancel):not(.is-cancel-month-pane):hover:not(:disabled) {
+html[class*="new-"] .is-personalizable:not(.header) .btn-secondary:not(.go-button):not(.is-select):not(.is-select-month-pane):not(.is-cancel):not(.is-cancel-month-pane):hover:not(:disabled) {
   background-color: ${colors.lightestPalette} !important;
 }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes header secondary button hover state and a console error appearing when selecting a color

**Related github/jira issue (required)**:
Fixes [#7204 ](https://github.com/infor-design/enterprise/issues/7204#issuecomment-1447643018)

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4000/components/personalize/example-header-buttons.html
- select new theme and some color
- hover over the secondary button, background color should be the same as the other buttons
- browser's console should not have any errors

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
~- [ ] A note to the change log.~
