### PR TITLE
7163 - Change header pseudo element to actual svg icon

### DIFF
--- a/app/views/components/applicationmenu/example-index.html
+++ b/app/views/components/applicationmenu/example-index.html
@@ -60,11 +60,9 @@
           <div class="title">
             <button id="header-hamburger" class="btn-icon application-menu-trigger" type="button">
               <span class="audible" data-translate="text">AppMenuTriggerTextAlt</span>
-              <span class="icon app-header">
-                <span class="one"></span>
-                <span class="two"></span>
-                <span class="three"></span>
-              </span>
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use href="#icon-menu"></use>
+              </svg>
             </button>
 
             <h1>

--- a/app/views/components/applicationmenu/example-performance.html
+++ b/app/views/components/applicationmenu/example-performance.html
@@ -14055,11 +14055,9 @@
           <div class="title">
             <button id="header-hamburger" class="btn-icon application-menu-trigger" type="button">
               <span class="audible" data-translate="text">AppMenuTriggerTextAlt</span>
-              <span class="icon app-header">
-                <span class="one"></span>
-                <span class="two"></span>
-                <span class="three"></span>
-              </span>
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use href="#icon-menu"></use>
+              </svg>
             </button>
 
             <h1>

--- a/app/views/components/builder/example-builder-nosidebar.html
+++ b/app/views/components/builder/example-builder-nosidebar.html
@@ -19,11 +19,9 @@
 
           <button id="header-hamburger" class="btn-icon list-detail-back-button go-back visible-sm hidden-md hidden-lg hidden-xl" type="button">
             <span class="audible">Show navigation</span>
-            <span class="icon app-header">
-              <span class="one"></span>
-              <span class="two"></span>
-              <span class="three"></span>
-            </span>
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-arrow-left"></use>
+            </svg>
           </button>
 
           <h1>Builder</h1>
@@ -37,7 +35,7 @@
       <div class="toolbar no-actions-button">
         <div class="title">
           <h2>
-            <span class="panel-title">Builder Panel Title</span><br>
+            <span class="panel-title">Builder Panel Title</span>
             <span class="panel-subhead">Builder Panel Subheader</span>
           </h2>
         </div>

--- a/app/views/components/builder/example-builder-subtitle-test.html
+++ b/app/views/components/builder/example-builder-subtitle-test.html
@@ -19,20 +19,16 @@
 
           <button id="header-hamburger" class="btn-icon list-detail-back-button go-back visible-sm hidden-md hidden-lg hidden-xl" type="button">
             <span class="audible">Show navigation</span>
-            <span class="icon app-header">
-              <span class="one"></span>
-              <span class="two"></span>
-              <span class="three"></span>
-            </span>
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-menu"></use>
+            </svg>
           </button>
 
           <button id="header-toggle" class="btn-icon list-detail-toggle-button go-back hidden-sm visible-md visible-lg visible-xl" type="button">
             <span class="audible">Show navigation</span>
-            <span class="icon app-header">
-              <span class="one"></span>
-              <span class="two"></span>
-              <span class="three"></span>
-            </span>
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-arrow-left"></use>
+            </svg>
           </button>
           <h1>Builder</h1>
         </div>
@@ -45,7 +41,7 @@
       <div class="toolbar no-actions-button">
         <div class="title">
           <h2>
-            <span class="panel-title">Builder Panel Title - Test a really really really really really really really really long title</span><br>
+            <span class="panel-title">Builder Panel Title - Test a really really really really really really really really long title</span>
             <div class="panel-subhead">Builder Panel Subheader - Test also a really really really really really really really really long subtitle</div>
           </h2>
         </div>

--- a/app/views/components/builder/example-builder-wizard.html
+++ b/app/views/components/builder/example-builder-wizard.html
@@ -19,11 +19,9 @@
 
           <button id="header-hamburger" class="btn-icon list-detail-back-button go-back visible-sm hidden-md hidden-lg hidden-xl" type="button">
             <span class="audible">Show navigation</span>
-            <span class="icon app-header">
-              <span class="one"></span>
-              <span class="two"></span>
-              <span class="three"></span>
-            </span>
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-menu"></use>
+            </svg>
           </button>
 
           <h1>Builder</h1>

--- a/app/views/components/builder/example-builder.html
+++ b/app/views/components/builder/example-builder.html
@@ -20,11 +20,9 @@
 
           <button id="header-hamburger" class="btn-icon list-detail-back-button go-back visible-sm hidden-md hidden-lg hidden-xl" type="button">
             <span class="audible">Show navigation</span>
-            <span class="icon app-header">
-              <span class="one"></span>
-              <span class="two"></span>
-              <span class="three"></span>
-            </span>
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-menu"></use>
+            </svg>
           </button>
 
           <h1>Builder</h1>
@@ -39,7 +37,7 @@
         <div class="toolbar no-actions-button">
           <div class="title">
             <h2>
-              <span class="panel-title">Builder Panel Title</span><br>
+              <span class="panel-title">Builder Panel Title</span>
               <span class="panel-subhead">Builder Panel Subheader</span>
             </h2>
           </div>

--- a/app/views/components/button/example-badge.html
+++ b/app/views/components/button/example-badge.html
@@ -39,38 +39,30 @@
     <span class="label">Toolbar Flex Nav</span>
     <button id="header-hamburger" class="btn-icon application-menu-trigger" type="button" data-options="{notificationBadge: 'true', notificationBadgeOptions: {position: 'upper-left', color: 'complete'}}">
       <span class="audible" data-translate="text">AppMenuTriggerTextAlt</span>
-      <span class="icon app-header">
-        <span class="one"></span>
-        <span class="two"></span>
-        <span class="three"></span>
-      </span>
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use href="#icon-menu"></use>
+      </svg>
     </button>
 
     <button id="header-hamburger" class="btn-icon application-menu-trigger" type="button" data-options="{notificationBadge: 'true', notificationBadgeOptions: {position: 'upper-right', color: 'alert'}}">
       <span class="audible" data-translate="text">AppMenuTriggerTextAlt</span>
-      <span class="icon app-header">
-        <span class="one"></span>
-        <span class="two"></span>
-        <span class="three"></span>
-      </span>
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use href="#icon-menu"></use>
+      </svg>
     </button>
 
     <button id="header-hamburger" class="btn-icon application-menu-trigger" type="button" data-options="{notificationBadge: 'true', notificationBadgeOptions: {position: 'lower-left', color: 'progress'}}">
       <span class="audible" data-translate="text">AppMenuTriggerTextAlt</span>
-      <span class="icon app-header">
-        <span class="one"></span>
-        <span class="two"></span>
-        <span class="three"></span>
-      </span>
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use href="#icon-menu"></use>
+      </svg>
     </button>
 
     <button id="header-hamburger" class="btn-icon application-menu-trigger" type="button" data-options="{notificationBadge: 'true', notificationBadgeOptions: {position: 'lower-right', color: 'warning'}}">
       <span class="audible" data-translate="text">AppMenuTriggerTextAlt</span>
-      <span class="icon app-header">
-        <span class="one"></span>
-        <span class="two"></span>
-        <span class="three"></span>
-      </span>
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use href="#icon-menu"></use>
+      </svg>
     </button>
   </div>
 </div>

--- a/app/views/components/form-compact/example-list-detail.html
+++ b/app/views/components/form-compact/example-list-detail.html
@@ -20,11 +20,9 @@
           <div class="title">
             <button id="header-hamburger" class="btn-icon list-detail-back-button go-back" type="button">
               <span class="audible">Show navigation</span>
-              <span class="icon app-header">
-                <span class="one"></span>
-                <span class="two"></span>
-                <span class="three"></span>
-              </span>
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use href="#icon-menu"></use>
+              </svg>
             </button>
 
             <span>Equipment Inc.</span>

--- a/app/views/components/header/example-emphasize-id.html
+++ b/app/views/components/header/example-emphasize-id.html
@@ -5,11 +5,9 @@
     <div class="title">
       <button id="button1" type="button" class="btn-icon application-menu-trigger hide-focus" tabindex="0">
         <span class="audible">Show navigation</span>
-        <span class="icon app-header go-back">
-          <span class="one"></span>
-          <span class="two"></span>
-          <span class="three"></span>
-        </span>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-arrow-left"></use>
+        </svg>
       </button>
 
       <h1>
@@ -18,7 +16,7 @@
       </h1>
     </div>
 
-   <div class="buttonset">
+    <div class="buttonset">
       <button class="btn" type="submit">
         <svg class="icon" focusable="false">
           <use href="#icon-logout"></use>

--- a/app/views/components/header/example-emphasize-page-title.html
+++ b/app/views/components/header/example-emphasize-page-title.html
@@ -4,11 +4,9 @@
     <div class="title">
       <button id="button1" type="button" class="btn-icon application-menu-trigger hide-focus" tabindex="0">
         <span class="audible">Show navigation</span>
-        <span class="icon app-header go-back">
-          <span class="one"></span>
-          <span class="two"></span>
-          <span class="three"></span>
-        </span>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-arrow-left"></use>
+        </svg>
       </button>
 
       <h1>
@@ -17,7 +15,7 @@
       </h1>
     </div>
 
-   <div class="buttonset">
+    <div class="buttonset">
       <button class="btn" type="submit">
         <span>View Profile</span>
       </button>

--- a/app/views/components/header/example-eyebrow.html
+++ b/app/views/components/header/example-eyebrow.html
@@ -4,11 +4,9 @@
     <div class="title">
       <button id="button1" type="button" class="btn-icon application-menu-trigger hide-focus" tabindex="0">
         <span class="audible">Show navigation</span>
-        <span class="icon app-header go-back">
-          <span class="one"></span>
-          <span class="two"></span>
-          <span class="three"></span>
-        </span>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-arrow-left"></use>
+        </svg>
       </button>
 
       <h1>
@@ -17,7 +15,7 @@
       </h1>
     </div>
 
-   <div class="buttonset">
+    <div class="buttonset">
       <button class="btn" type="submit" title="Save the current record." disabled>
         <span>View Profile</span>
       </button>

--- a/app/views/components/header/example-record-id.html
+++ b/app/views/components/header/example-record-id.html
@@ -5,17 +5,15 @@
     <div class="title">
       <button id="button1" type="button" class="btn-icon application-menu-trigger hide-focus" tabindex="0">
         <span class="audible">Show navigation</span>
-        <span class="icon app-header go-back">
-          <span class="one"></span>
-          <span class="two"></span>
-          <span class="three"></span>
-        </span>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-arrow-left"></use>
+        </svg>
       </button>
 
       <h1>Sales Order SL000905262</h1>
     </div>
 
-   <div class="buttonset">
+    <div class="buttonset">
       <button class="btn" type="submit" title="Save the current record." disabled>
         <span>View Profile</span>
       </button>

--- a/app/views/components/header/test-header-gauntlet.html
+++ b/app/views/components/header/test-header-gauntlet.html
@@ -209,14 +209,14 @@
   function createTitleButton() {
     teardown();
 
-    var btn = $('<button id="app-menu-trigger" class="btn-icon application-menu-trigger" type="button">' +
-      '<span class="audible" data-text="translate">AppMenuTriggerTextAlt</span>' +
-      '<span class="icon app-header">' +
-        '<span class="one"></span>' +
-        '<span class="two"></span>' +
-        '<span class="three"></span>' +
-      '</span>' +
-    '</button>');
+    var btn = $(`
+      <button id="app-menu-trigger" class="btn-icon application-menu-trigger" type="button">
+        <span class="audible" data-text="translate">AppMenuTriggerTextAlt</span>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-arrow-left"></use>
+        </svg>
+      </button>
+    `);
 
     // Flex Toolbar has a section before the `.title`
     if (toolbarElem.is('.flex-toolbar')) {

--- a/app/views/components/page-patterns/example-list-detail-search-paging.html
+++ b/app/views/components/page-patterns/example-list-detail-search-paging.html
@@ -25,11 +25,9 @@
           <div class="title">
             <button id="header-hamburger" class="btn-icon list-detail-back-button" type="button">
               <span class="audible">Show navigation</span>
-              <span class="icon app-header">
-                <span class="one"></span>
-                <span class="two"></span>
-                <span class="three"></span>
-              </span>
+              <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+                <use href="#icon-menu"></use>
+              </svg>
             </button>
 
             <span>Auto Suite - PRD</span>

--- a/app/views/components/page-patterns/example-list-detail.html
+++ b/app/views/components/page-patterns/example-list-detail.html
@@ -20,11 +20,9 @@
 
           <button id="header-hamburger" class="btn-icon list-detail-back-button go-back" type="button">
             <span class="audible">Show navigation</span>
-            <span class="icon app-header">
-            <span class="one"></span>
-              <span class="two"></span>
-              <span class="three"></span>
-            </span>
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-menu"></use>
+            </svg>
           </button>
 
           <span>Auto Suite - PRD</span>

--- a/app/views/components/page-patterns/test-landmark-requisitions-screen.html
+++ b/app/views/components/page-patterns/test-landmark-requisitions-screen.html
@@ -5,11 +5,9 @@
       <div class="title">
         <button id="app-menu-trigger" class="btn-icon application-menu-trigger" type="button list-detail-back-button">
           <span class="audible" data-text="translate">AppMenuTriggerTextAlt</span>
-          <span class="icon app-header">
-            <span class="one"></span>
-            <span class="two"></span>
-            <span class="three"></span>
-          </span>
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-menu"></use>
+          </svg>
         </button>
         <h1>All Requisitions</h1>
       </div>

--- a/app/views/components/toolbar-flex/test-gauntlet.html
+++ b/app/views/components/toolbar-flex/test-gauntlet.html
@@ -13,11 +13,9 @@
       <div id="front-button-section" class="toolbar-section">
         <button id="btnIconHamburger" class="btn-icon application-menu-trigger" type="button">
           <span class="audible" data-text="translate">AppMenuTriggerTextAlt</span>
-          <span class="icon app-header">
-            <span class="one"></span>
-            <span class="two"></span>
-            <span class="three"></span>
-          </span>
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-menu"></use>
+          </svg>
         </button>
       </div>
 

--- a/app/views/components/toolbar-flex/test-toolbar-nav-badge.html
+++ b/app/views/components/toolbar-flex/test-toolbar-nav-badge.html
@@ -8,38 +8,30 @@
   <div class="twelve columns">
     <button id="header-hamburger" class="btn-icon application-menu-trigger" type="button" data-options="{notificationBadge: 'true', notificationBadgeOptions: {position: 'upper-right', color: 'alert'}}">
       <span class="audible" data-translate="text">AppMenuTriggerTextAlt</span>
-      <span class="icon app-header">
-        <span class="one"></span>
-        <span class="two"></span>
-        <span class="three"></span>
-      </span>
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use href="#icon-menu"></use>
+      </svg>
     </button>
 
     <button id="header-hamburger" class="btn-icon application-menu-trigger" type="button" data-options="{notificationBadge: 'true', notificationBadgeOptions: {position: 'upper-left', color: 'alert'}}">
       <span class="audible" data-translate="text">AppMenuTriggerTextAlt</span>
-      <span class="icon app-header">
-        <span class="one"></span>
-        <span class="two"></span>
-        <span class="three"></span>
-      </span>
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use href="#icon-menu"></use>
+      </svg>
     </button>
 
     <button id="header-hamburger" class="btn-icon application-menu-trigger" type="button" data-options="{notificationBadge: 'true', notificationBadgeOptions: {position: 'lower-right', color: 'alert'}}">
       <span class="audible" data-translate="text">AppMenuTriggerTextAlt</span>
-      <span class="icon app-header">
-        <span class="one"></span>
-        <span class="two"></span>
-        <span class="three"></span>
-      </span>
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use href="#icon-menu"></use>
+      </svg>
     </button>
 
     <button id="header-hamburger" class="btn-icon application-menu-trigger" type="button" data-options="{notificationBadge: 'true', notificationBadgeOptions: {position: 'lower-left', color: 'alert'}}">
       <span class="audible" data-translate="text">AppMenuTriggerTextAlt</span>
-      <span class="icon app-header">
-        <span class="one"></span>
-        <span class="two"></span>
-        <span class="three"></span>
-      </span>
+      <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+        <use href="#icon-menu"></use>
+      </svg>
     </button>
   </div>
 </div>

--- a/app/views/includes/header-appmenu-trigger.html
+++ b/app/views/includes/header-appmenu-trigger.html
@@ -1,8 +1,6 @@
 <button id="header-hamburger" class="btn-icon application-menu-trigger personalize-actionable" type="button">
   <span class="audible" data-translate="text">AppMenuTriggerTextAlt</span>
-  <span class="icon app-header">
-    <span class="one"></span>
-    <span class="two"></span>
-    <span class="three"></span>
-  </span>
+  <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+    <use href="#icon-menu"></use>
+  </svg>
 </button>

--- a/app/views/includes/header-svg-go-back-trigger.html
+++ b/app/views/includes/header-svg-go-back-trigger.html
@@ -1,0 +1,7 @@
+<button class="btn-icon application-menu-trigger" type="button">
+  <span class="audible" data-text="translate">AppMenuTriggerTextAlt</span>
+  <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+    <use href="#icon-arrow-left"></use>
+  </svg>
+</button>
+

--- a/app/views/includes/header.html
+++ b/app/views/includes/header.html
@@ -4,11 +4,9 @@
       {{#headerHamburger}}
       <button class="btn-icon application-menu-trigger" type="button">
         <span class="audible">Show navigation</span>
-        <span class="icon app-header">
-          <span class="one"></span>
-          <span class="two"></span>
-          <span class="three"></span>
-        </span>
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-menu"></use>
+          </svg>
       </button>
       {{/headerHamburger}}
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,7 +35,7 @@
 - `[Fileupload]` Icon adjustments in compact mode. ([#7149](https://github.com/infor-design/enterprise/issues/7149))
 - `[Fileupload]` Icon adjustments in classic mode. ([#7265](https://github.com/infor-design/enterprise/issues/7265))
 - `[Header]` Fixed a bug in subheader where the color its not appropriate on default theme. ([#7173](https://github.com/infor-design/enterprise/issues/7173))
-- `[Header]` Changed the header from pseudo elements to actual icon. ([#7163](https://github.com/infor-design/enterprise/issues/7163))
+- `[Header]` Changed the header from pseudo elements to actual icon. Please make the follow [change to your app menu icon](https://github.com/infor-design/enterprise/pull/7285/files#diff-4ee8ef8a5fe8ef128f558004ce5a73d8b2939256ea3c614ac26492078171529bL3-R5) to get the best output. ([#7163](https://github.com/infor-design/enterprise/issues/7163))
 - `[Homepage/Personalize/Page-Patterns]` Fixed homepage hero widget, builder header, and other section of tabs with the new design and color combination. ([#7136](https://github.com/infor-design/enterprise/issues/7136))
 - `[MenuButton]` Fixed some color on menu buttons. ([#7184](https://github.com/infor-design/enterprise/issues/7184))
 - `[Modal]` Fixed alignment of tooltip error in modal. ([#7125](https://github.com/infor-design/enterprise/issues/7125))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@
 - `[Fileupload]` Icon adjustments in compact mode. ([#7149](https://github.com/infor-design/enterprise/issues/7149))
 - `[Fileupload]` Icon adjustments in classic mode. ([#7265](https://github.com/infor-design/enterprise/issues/7265))
 - `[Header]` Fixed a bug in subheader where the color its not appropriate on default theme. ([#7173](https://github.com/infor-design/enterprise/issues/7173))
+- `[Header]` Changed the header from pseudo elements to actual icon. ([#7163](https://github.com/infor-design/enterprise/issues/7163))
 - `[Homepage/Personalize/Page-Patterns]` Fixed homepage hero widget, builder header, and other section of tabs with the new design and color combination. ([#7136](https://github.com/infor-design/enterprise/issues/7136))
 - `[MenuButton]` Fixed some color on menu buttons. ([#7184](https://github.com/infor-design/enterprise/issues/7184))
 - `[Modal]` Fixed alignment of tooltip error in modal. ([#7125](https://github.com/infor-design/enterprise/issues/7125))

--- a/src/components/button/_button-new.scss
+++ b/src/components/button/_button-new.scss
@@ -304,3 +304,27 @@
 .btn-icon .icon.app-header {
   top: 2px;
 }
+
+.btn-icon.application-menu-trigger {
+  svg.icon {
+    + .notification-badge-container {
+      .notification-dot.notification-dot-upper-left {
+        left: -19px;
+      }
+
+      .notification-dot.notification-dot-upper-right {
+        right: 8px;
+      }
+
+      .notification-dot.notification-dot-lower-left {
+        left: -19px;
+        top: 10px;
+      }
+
+      .notification-dot.notification-dot-lower-right {
+        left: -11px;
+        top: 10px;
+      }
+    }
+  }
+}

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -48,6 +48,36 @@ button {
       }
     }
   }
+
+  // Styles for svg hamburger menu
+  &.application-menu-trigger {
+    svg.icon {
+      height: 24px;
+      top: 1px;
+      width: 24px;
+
+      + .notification-badge-container {
+        .notification-dot.notification-dot-upper-left {
+          left: -22px;
+          top: 5px;
+        }
+
+        .notification-dot.notification-dot-upper-right {
+          right: 5px;
+          top: 5px;
+        }
+
+        .notification-dot.notification-dot-lower-left {
+          left: -22px;
+          top: 13px;
+        }
+
+        .notification-dot.notification-dot-lower-right {
+          top: 13px;
+        }
+      }
+    }
+  }
 }
 
 .btn-primary,

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -225,6 +225,17 @@ $subheader-height: 60px;
       }
     }
 
+    .application-menu-trigger,
+    .list-detail-back-button,
+    .back-button,
+    .go-back {
+      svg.icon {
+        height: 24px;
+        top: 1px;
+        width: 24px;
+      }
+    }
+
     .buttonset .toolbar-searchfield-wrapper {
       &.is-hovered {
         .btn-icon {

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -208,11 +208,9 @@ Header.prototype = {
       // Build Title Button
       const titleButton = $(`<button class="btn-icon back-button" type="button">
         <span class="audible">${Locale.translate('Drillup')}</span>
-        <span class="icon app-header go-back">
-          <span class="one"></span>
-          <span class="two"></span>
-          <span class="three"></span>
-        </span>
+        <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-arrow-left"></use>
+        </svg>
       </button>`);
 
       const titleElem = this.toolbarElem.find('.title');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR changes the header from a pseudo-element to an actual svg icon. Adjusted the width, height, and position of the notification dots.

**Related github/jira issue (required)**:

Closes #7163

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app

1.) Application Menu
- Go to
  - http://localhost:4000/components/applicationmenu/example-index
  - http://localhost:4000/components/applicationmenu/example-performance
  - Check the header/hamburger-menu
  - It should use the actual svg icon
  - The SVG icon should be `24x24`

2.) Builder
- Go to
  - http://localhost:4000/components/builder/example-builder-nosidebar (Resize the page to show the arrow back button)
  - http://localhost:4000/components/builder/example-builder-subtitle-test (No need to resize)
  - http://localhost:4000/components/builder/example-builder (Resize the page to show menu button)
  - http://localhost:4000/components/builder/example-builder-wizard (Resize the page to show menu button)
  - Inspect the element
  - It should use SVG icon and the size should be `24x24`

3.) Button
- Go to http://localhost:4000/components/button/example-badge
  - Inspect the appmenu icon with notification dots
  - It should use SVG icon and size should be `24x24`
  - Notification dots should be perfectly aligned in different positions
  - Test in classic 

4.) Form Compact
- Go to http://localhost:4000/components/form-compact/example-list-detail.html
- Inspect the menu button
- It should use SVG icon and size should be `24x24`

5.) Header
- Go to
  - http://localhost:4000/components/header/example-emphasize-id
  - http://localhost:4000/components/header/example-emphasize-page-title
  - http://localhost:4000/components/header/example-eyebrow
  - http://localhost:4000/components/header/example-record-id
  - http://localhost:4000/components/header/test-header-gauntlet
  - Inspect the back button/app menu button
  - It should use SVG icon and size should be `24x24`

6.) Page Patterns
- Go to
  - http://localhost:4000/components/page-patterns/example-list-detail-search-paging
  - http://localhost:4000/components/page-patterns/example-list-detail
  - http://localhost:4000/components/page-patterns/test-landmark-requisitions-screen
  - Inspect the back button/app menu button
  - It should use SVG icon and size should be `24x24`

7.) Toolbar-flex
- Go to
  - http://localhost:4000/components/toolbar-flex/test-gauntlet
  - Check the appmenu trigger element
  - It should use SVG icon and size should be `24x24`
  - http://localhost:4000/components/toolbar-flex/test-toolbar-nav-badge
  - Inspect the appmenu icon with notification dots
  - It should use SVG icon and size should be `24x24`
  - Notification dots should be perfectly aligned in different positions
  - Test in classic 

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
