### PR TITLE
7136 - Follow-up fix in hero color issues in alabaster classic

### DIFF
--- a/src/components/toolbar-flex/_toolbar-flex-searchfield.scss
+++ b/src/components/toolbar-flex/_toolbar-flex-searchfield.scss
@@ -69,13 +69,21 @@ $responsive-searchfield-filled-out-width: 34px;
     &.has-collapse-button.is-open:not(.non-collapsible) {
       .icon:not(.close):not(.icon-error) {
         color: $searchfield-header-icon-color;
-        top: 0;
+        top: 50%;
       }
     }
 
     &.searchfield-wrapper > svg.icon:not(.icon-error) {
       width: 18px;
       height: 18px;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+
+    &.has-collapse-button.has-close-icon-button.is-hovered:not(.is-open) {
+      svg.close.icon {
+        opacity: 0;
+      }
     }
   }
 }

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -9,7 +9,7 @@ $transparent: transparent;
 $header-border-color: $ids-color-palette-azure-80;
 $header-button-color: rgba($ids-color-palette-slate-100, 0.7);
 $header-button-focus-color: rgba($ids-color-palette-azure-60, 1);
-$header-button-hover-color: rgba($ids-color-palette-azure-60, 1);
+$header-button-hover-color: rgba($ids-color-palette-slate-100, 0.7);
 $header-button-disabled-color: $ids-color-palette-slate-40;
 $header-primary-btn-background-color: $ids-color-palette-azure-50;
 $header-primary-btn-background-hover-color: $ids-color-brand-primary-base;

--- a/src/themes/theme-classic-light.scss
+++ b/src/themes/theme-classic-light.scss
@@ -14,9 +14,7 @@
 // Local vars
 @import '../core/config';
 
-$header-toolbar-searchfield-icon-color: $ids-color-palette-white;
 $header-toolbar-button-hover-color: transparent;
-
 $header-tab-normal-color: rgba($ids-color-palette-white, 0.7);
 $header-tab-hover-color: $ids-color-palette-white;
 

--- a/src/themes/theme-classic-light.scss
+++ b/src/themes/theme-classic-light.scss
@@ -14,12 +14,6 @@
 // Local vars
 @import '../core/config';
 
-$header-bg-color: $ids-color-palette-azure-70;
-$header-text-color: $ids-color-palette-white;
-$header-button-color: $ids-color-palette-white;
-$header-button-focus-color: $ids-color-palette-white;
-$header-button-hover-color: $ids-color-palette-white;
-
 $header-toolbar-searchfield-icon-color: $ids-color-palette-white;
 $header-toolbar-button-hover-color: transparent;
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This is a follow-up fix for color issues (texts and icons) in alabaster/default classic.

**Related github/jira issue (required)**:

Closes #7136 
Related PR #7238 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/homepage/example-hero-widget.html?theme=classic&mode=light&colors=default
- Check all the texts and icons
- It should complement with the alabaster color (white)

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
