### PR TITLE
7234 - Added example page for widget count with color background

### DIFF
--- a/app/views/components/counts/example-header.html
+++ b/app/views/components/counts/example-header.html
@@ -1,0 +1,84 @@
+<div class="is-personalizable">
+  <div class="card" style="height: 155px; min-height: 155px; border: none; border-radius: 0;">
+    <div class="card-content l-center personalize-header" style="height: 155px; min-height: 155px;">
+      <div class="instance-count">
+        <span class="count ruby06">5352</span>
+        <svg class="icon icon-alert ruby06" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-alert"></use>
+        </svg>
+        <span class="title">High</span>
+      </div>
+
+      <div class="instance-count">
+        <span class="count amber06">10021</span>
+        <svg class="icon icon-alert" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-alert"></use>
+        </svg>
+        <span class="title">Medium</span>
+      </div>
+
+      <div class="instance-count">
+        <span class="count amber03">4k</span>
+        <svg class="icon icon-alert amber03" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-alert"></use>
+        </svg>
+        <span class="title">Low</span>
+      </div>
+
+      <div class="instance-count">
+        <span class="count azure06">103910</span>
+        <svg class="icon icon-alert azure06" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-alert"></use>
+        </svg>
+        <span class="title">Info</span>
+      </div>
+
+      <div class="instance-count">
+        <span class="count turquoise05">5352</span>
+        <svg class="icon icon-alert turquoise05" focusable="false" aria-hidden="true" role="presentation">
+          <use href="#icon-alert"></use>
+        </svg>
+        <span class="title">Unknown</span>
+      </div>
+
+      <div class="instance-count">
+          <span class="count slate06">5352</span>
+          <svg class="icon icon-alert slate06" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-alert"></use>
+          </svg>
+          <span class="title">Standard</span>
+        </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  const addFilled = (color) => {
+    if (color !== 'default') {
+      $('.instance-count').addClass('filled');
+    } else {
+      $('.instance-count').removeClass('filled');
+    }
+  };
+
+  $('body').on('initialized', () => {
+    const url = location.href.split('?');
+
+    if (url.length > 1) {
+      const query = url[1].split('&');
+
+      for (let i = 0; i < query.length; i++) {
+        const pair = query[i].split('=');
+
+        if (pair[0] === 'colors') {
+          addFilled(pair[1]);
+          break;
+        }
+      }
+    }
+  });
+
+  $('html').on('colorschanged', (e, a) => {
+    addFilled(a.colors)
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -152,6 +152,7 @@
 
 - `[Accordion]` Fixed a bug where expanded card closes in NG when opening accordion. ([#6820](https://github.com/infor-design/enterprise/issues/6820))
 - `[Counts]` Fixed a bug in counts where two rows of labels cause misalignment. ([#6845](https://github.com/infor-design/enterprise/issues/6845))
+- `[Counts]` Added example page for widget count with color background. ([#7234](https://github.com/infor-design/enterprise/issues/7234))
 - `[Datagrid]` Fixed a bug in datagrid where expandable row input cannot edit the value. ([#6781](https://github.com/infor-design/enterprise/issues/6781))
 - `[Datagrid]` Fixed a bug in datagrid where clear dirty cell does not work properly in frozen columns. ([#6952](https://github.com/infor-design/enterprise/issues/6952))
 - `[Datagrid]` Adjusted date and timepicker icons in datagrid filter. ([#6917](https://github.com/infor-design/enterprise/issues/6917))

--- a/src/components/counts/_counts.scss
+++ b/src/components/counts/_counts.scss
@@ -14,6 +14,22 @@
   position: relative;
   width: 120px;
 
+  &.filled {
+    background-color: inherit;
+
+    svg.icon {
+      background-color: inherit;
+    }
+
+    .count {
+      color: $ids-color-palette-slate-10;
+    }
+
+    .title {
+      color: $ids-color-palette-slate-20;
+    }
+  }
+
   .count {
     @include font-size(16);
     @include colorPalettesProperty(border-color);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Added filled class that can be added in instance-count: Sets instance-count icon background color to inherit so it can get the background color of parent class. Also included setting font color to lighter colors so that text can be readable.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #7234

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/counts/example-header.html
- Change theme color
- Alert icon background should inherit color

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
