### PR TITLE
7149 - Fix spinbox UI on the iOS mobile classic theme

### DIFF
--- a/src/components/spinbox/_spinbox-new.scss
+++ b/src/components/spinbox/_spinbox-new.scss
@@ -31,10 +31,10 @@ input.spinbox,
   }
 
   .spinbox-control {
-    padding: 2px 8px;
+    padding: 3px 8px;
 
     &.down {
-      padding: 1px 10px 0;
+      padding: 2px 10px 0;
     }
   }
 }

--- a/src/components/spinbox/_spinbox.scss
+++ b/src/components/spinbox/_spinbox.scss
@@ -326,3 +326,17 @@ html[dir='rtl'] {
     }
   }
 }
+
+// iOS fix
+html[class*='theme-classic'].ios {
+  .field-short,
+  .form-layout-compact .field {
+    .spinbox-control {
+      padding: 3px 7px;
+    }
+
+    .spinbox {
+      height: 2.6rem;
+    }
+  }
+}

--- a/src/components/spinbox/_spinbox.scss
+++ b/src/components/spinbox/_spinbox.scss
@@ -240,7 +240,7 @@ input::-webkit-inner-spin-button {
 
   .spinbox-control {
     height: inherit;
-    padding: 3px 0 5px 0;
+    padding: 3px 0 5px;
     width: 25px;
   }
 }
@@ -332,7 +332,7 @@ html[class*='theme-classic'].ios {
   .field-short,
   .form-layout-compact .field {
     .spinbox-control {
-      padding: 2px 0 4px 0;
+      padding: 2px 0 4px;
     }
 
     .spinbox {

--- a/src/components/spinbox/_spinbox.scss
+++ b/src/components/spinbox/_spinbox.scss
@@ -240,7 +240,7 @@ input::-webkit-inner-spin-button {
 
   .spinbox-control {
     height: inherit;
-    padding: 4px 7px;
+    padding: 3px 0 5px 0;
     width: 25px;
   }
 }
@@ -332,7 +332,7 @@ html[class*='theme-classic'].ios {
   .field-short,
   .form-layout-compact .field {
     .spinbox-control {
-      padding: 3px 7px;
+      padding: 2px 0 4px 0;
     }
 
     .spinbox {

--- a/src/themes/theme-classic-dark.scss
+++ b/src/themes/theme-classic-dark.scss
@@ -93,6 +93,7 @@ $button-color-primary-active-background: $ids-color-palette-slate-60;
 $button-color-tertiary-hover-font-new: $ids-color-palette-white;
 $button-hyperlink-color: $ids-color-palette-slate-50;
 $button-hyperlink-hover-color: $ids-color-palette-slate-40;
+$button-color-tertiary-hover-background-new: transparent;
 
 // Button Ripple
 $secondary-btn-ripple-color: $ids-color-palette-slate-60;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR addresses the spinbox UI issue on mobile iOS when using the classic theme. Additionally, I've noticed and fixed an issue with the trigger icon hover color in the classic dark theme, which was incorrect.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/7149
Related PR https://github.com/infor-design/enterprise/pull/7248

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- If you have browserstack, change the localhost to your connected IP address e.g., mine is http://10.88.66.132:4000/components/form/example-compact-mode.html?theme=classic&mode=light&colors=default
- Check the spinbox UI
- The height of spinbox input field and spinbox control should be the same

Here are the screenshots of the fixed version of the issue.

<img width="549" alt="Screen Shot 2023-03-07 at 8 05 50 PM" src="https://user-images.githubusercontent.com/8839327/223418213-75ab6fff-1502-4bf4-b2dd-9b87ec180ca1.png">

<img width="528" alt="Screen Shot 2023-03-07 at 8 05 35 PM" src="https://user-images.githubusercontent.com/8839327/223418223-de9059d4-efc3-42ed-ba58-3c273926bad3.png">

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
