### PR TITLE
7303 - Updated appmenu icon colors

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Actionsheet]` Updated font and icon colors for classic actionsheet. ([#7012](https://github.com/infor-design/enterprise/issues/7012))
 - `[Accordion]` Additional fix in accordion collapsing cards on expand bug. ([#6820](https://github.com/infor-design/enterprise/issues/6820))
 - `[Alerts/Badges/Tags]` Updated warning and alert colors. ([#7162](https://github.com/infor-design/enterprise/issues/7162))
+- `[App Menu]` Updated appmenu icon colors. ([#7303](https://github.com/infor-design/enterprise/issues/7303))
 - `[Background]` Updated default background color in high contrast. ([#7261](https://github.com/infor-design/enterprise/issues/7261))
 - `[Bar]` Fixed bug introduced by d3 changes with bar selection. ([#7182](https://github.com/infor-design/enterprise/issues/7182))
 - `[Button]` Fixed icon button size and icon centering. ([#7201](https://github.com/infor-design/enterprise/issues/7201))

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -521,6 +521,10 @@ $subheader-height: 60px;
 
       &.application-menu-trigger {
         top: 0;
+
+        &:not(:focus) .icon {
+          color: $header-button-color;
+        }
       }
 
       &.is-open .icon,

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -363,7 +363,7 @@ a.is-personalizable svg.ripple-effect {
 .header.is-personalizable button:not(:disabled):hover .app-header.icon > span,
 .header.is-personalizable .toolbar [class^='btn']:hover:not(.go-button):not(.searchfield-category-button):not([disabled]) {
   color: ${colors.contrast};
-  background-color: ${colors.darker};
+  background-color: ${colors.darker} !important;
   opacity: 1;
 }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Updated appmenu icon colors.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #7303 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: 
   - http://localhost:4000/components/applicationmenu/test-six-levels-icons.html
   - http://localhost:4000/components/applicationmenu/example-index.html
- Appmenu hamburger should not have focus color if not focused
- Select a color theme
- Hover background should not be a tiny square

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
