### PR TITLE
7282 - Fix to not re-render the grid when disableClientFilter is set to true

### DIFF
--- a/app/views/components/datagrid/test-filtering-violations.html
+++ b/app/views/components/datagrid/test-filtering-violations.html
@@ -1,0 +1,220 @@
+<div class="row">
+  <div class="twelve columns">
+    <h3>
+      Grid Example: Violation Issues
+    </h3>
+    <p>
+      Test by clicking "Load Data" and see how long it takes to render the rows.
+    </p>
+    <br>
+
+    <div class="field">
+      <label for="record-count">Record Count</label>
+      <input id="record-count" name="record-count" type="text" class="new-mask input-sm" value="200"
+        data-options='{ "process": "number", "pattern" : "#,###,###" }' />
+    </div>
+
+    <button type="button" id="load" class="btn-secondary"><span>Load Data</span></button>
+    <hr class="fieldset-hr">
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+    <div id="datagrid"></div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    var grid, columns = [];
+
+    var activities = [{
+        id: 'Assemble Paint',
+        value: 'Assemble Paint',
+        label: 'Assemble Paint'
+      },
+      {
+        id: '',
+        value: '',
+        label: 'Default Activity'
+      },
+      {
+        id: 'Inspect and Repair',
+        value: 'Inspect and Repair',
+        label: 'Inspect and Repair'
+      }
+    ];
+
+    //Define Columns for the Grid.
+    columns.push({
+      id: 'selectionCheckbox',
+      sortable: false,
+      resizable: false,
+      formatter: Soho.Formatters.SelectionCheckbox,
+      align: 'center'
+    });
+    columns.push({
+      id: 'productId',
+      name: 'Product #',
+      field: 'productId',
+      formatter: Soho.Formatters.Text,
+      align: 'right'
+    });
+    columns.push({
+      id: 'productName',
+      name: 'Product Name & Description',
+      field: 'productName',
+      formatter: Soho.Formatters.Text
+    });
+    columns.push({
+      id: 'quantityback',
+      name: 'Quantity Back Ordered',
+      field: 'quantity',
+      formatter: Soho.Formatters.Integer
+    });
+    columns.push({
+      id: 'quantity',
+      name: 'Quantity Available',
+      field: 'quantity',
+      formatter: Soho.Formatters.Integer,
+      align: 'right'
+    });
+    columns.push({
+      id: 'status',
+      name: 'Status Indicator',
+      field: 'status',
+      formatter: Soho.Formatters.Checkbox,
+      align: 'center'
+    });
+    columns.push({
+      id: 'badge',
+      name: 'Badge',
+      field: 'quantity',
+      align: 'center',
+      formatter: Soho.Formatters.Badge,
+      ranges: [{
+        'min': 0,
+        'max': 150,
+        'classes': 'azure07',
+        sortable: false
+      }]
+    });
+    columns.push({
+      id: 'tag',
+      name: 'Tag',
+      field: 'price',
+      align: 'center',
+      formatter: Soho.Formatters.Tag,
+      ranges: [{
+        'min': 151,
+        'max': 9999,
+        'classes': 'info'
+      }]
+    });
+    columns.push({
+      id: 'listprice',
+      name: 'List Price',
+      field: 'price',
+      align: 'right',
+      formatter: Soho.Formatters.Decimal,
+      filterType: 'decimal'
+    });
+    columns.push({
+      id: 'price',
+      name: 'Final Price',
+      field: 'price',
+      align: 'right',
+      formatter: Soho.Formatters.Decimal,
+      filterType: 'decimal'
+    });
+    columns.push({
+      id: 'orderDate',
+      name: 'Order Date',
+      field: 'orderDate',
+      formatter: Soho.Formatters.Date,
+      dateFormat: 'M/d/yyyy'
+    });
+    columns.push({
+      id: 'shipDate',
+      name: 'Estimated Ship Date',
+      field: 'orderDate',
+      formatter: Soho.Formatters.Date,
+      dateFormat: 'M/d/yyyy'
+    });
+    columns.push({
+      id: 'activity',
+      name: 'Activity',
+      field: 'activity',
+      formatter: Soho.Formatters.Dropdown,
+      filterType: 'multiselect',
+      options: activities,
+      editorOptions: {
+        showSelectAll: true
+      }
+    });
+
+    function loadDataIntoGrid() {
+      var data = [],
+        i;
+      var count = $('#record-count').val();
+      count = count ? Soho.Locale.parseNumber(count) : 0;
+
+      // Build Sample Data
+      for (i = 1; i <= count; i++) {
+        data.push({
+          id: i,
+          productId: i,
+          productName: 'Compressor',
+          activity: 'Assemble Paint',
+          quantity: 1,
+          price: 210.99,
+          status: 'OK',
+          orderDate: new Date(2014, 12, 8),
+          action: 'Action'
+        });
+      }
+
+      // Time the loadData call
+      var start = new Date().getTime();
+      grid.loadData(data);
+      var end = new Date().getTime();
+
+      $('body').toast({
+        title: 'Time to Load Data',
+        message: (end - start) / 1000 + ' seconds',
+        timeout: 8000
+      });
+    }
+
+    grid = $('#datagrid').datagrid({
+      columns: columns,
+      dataset: [],
+      isList: true,
+      selectable: 'multiple',
+      disableClientFilter: true,
+      filterWhenTyping: false,
+      redrawOnResize: false,
+      enableTooltips: true,
+      rowHeight: 'extra-small',
+      cellNavigation: true,
+      columnSizing: 'data',
+      filterable: true,
+      toolbar: {
+        title: 'Records',
+        results: true,
+        filterRow: true,
+        rowHeight: true,
+        collapsibleFilter: true
+      }
+    }).on('filtered', function (e, args) {
+      console.log('filtered', args);
+      loadDataIntoGrid();
+    }).data('datagrid');
+
+    // Load function
+    $('#load').click(function () {
+      loadDataIntoGrid();
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@
 - `[Button]` Button adjustments for compact mode. ([#7161](https://github.com/infor-design/enterprise/issues/7161))
 - `[Button]` Button adjustments for secondary menu in dark and contrast mode. ([#7221](https://github.com/infor-design/enterprise/issues/7221))
 - `[ContextMenu]` Fixed a bug where wrong menu is displayed in nested menus on mobile device. ([NG#1417](https://github.com/infor-design/enterprise-ng/issues/1417))
+- `[Datagrid]` Fixed re-rendering of the grid when `disableClientFilter` set to true. ([#7282](https://github.com/infor-design/enterprise/issues/7282))
 - `[Datagrid]` Fixed a bug in datagrid where sorting is not working properly. ([#6787](https://github.com/infor-design/enterprise/issues/6787))
 - `[Datagrid]` Fixed background color of lookups in filter row when in light mode. ([#7176](https://github.com/infor-design/enterprise/issues/7176))
 - `[Datagrid]` Fixed a bug in datagrid where custom toolbar is being replaced with data grid generated toolbar. ([NG#1434](https://github.com/infor-design/enterprise-ng/issues/1434))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -2835,7 +2835,7 @@ Datagrid.prototype = {
 
     this.setChildExpandOnMatch();
 
-    if (!this.settings.source) {
+    if (!this.settings.source && !this.settings.disableClientFilter) {
       this.clearCache();
       this.renderRows();
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR improves the `disableClientFilter` to not re-render the grid when it is activated.

**Related github/jira issue (required)**:

Closes #7282

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-filtering-violations
- Open the console tab in chrome developer tools
- Make sure to the `Custom Level` has `Verbose` checked. (Located in upper right section of Console Tab)
<img width="194" alt="Screen Shot 2023-03-10 at 6 28 31 PM" src="https://user-images.githubusercontent.com/8839327/224292742-7027aefc-7308-4b66-a4d6-273b9568a5f6.png">

- Click on `Load Data` button
- Open multi-select drop down for `Activity` column in the filter row & select `Assemble Paint`
- Initiate filter request by pressing enter key from the `List Price` filter row cell
- It should only log violation message regarding Forced Reflow

It's not noticeable in the UI if it's working or not. Might as well check the line of code and make sure that it will not hit the renderRows method.

- Another way to test it via debugging the line: `2838` in datagrid.js
- Follow again the steps above
- When you hit the line `2838`
- It should not go through to `this.renderRows()`

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
