### PR TITLE
7165 - Fix in keyword search not filtering single quote

### DIFF
--- a/app/views/components/lookup/example-index.html
+++ b/app/views/components/lookup/example-index.html
@@ -38,6 +38,7 @@
   data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
   data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
   data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+  data.push({ id: 7, productId: 2642207, productName: "Someone's Compressor", activity:  "Inspect's and Repair's", quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
 
   //Define Columns for the Grid.
   columns.push({ id: 'productId', name: 'Product Id', field: 'productId'});

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## v4.82.0 Fixes
 
+- `[Lookup]` Fix in keyword search not filtering single comma. ([#7165](https://github.com/infor-design/enterprise/issues/7165))
 - `[Tabs]` Fixed the alignment of focus in RTL view. ([#6992](https://github.com/infor-design/enterprise/issues/6992))
 
 ## v4.81.0

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -8122,7 +8122,7 @@ Datagrid.prototype = {
         // Strip any html markup that might be in the formatted value
         value = value.replace(/(<([^>]+)>)|(amp;)|(&lt;([^>]+)&gt;)/ig, '');
 
-        return value.indexOf(filterExpr.value) > -1;
+        return value.indexOf(xssUtils.escapeHTML(filterExpr.value)) > -1;
       };
 
       // Check in all visible columns


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
escapeHtml is used for the dataset and replaces special characters, so a search value with a single quote and data value  with the same thing were not equal when checking for substring. Added escapeHtml on search value.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #7165 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/lookup/example-index.html
- Open Products lookup
- Type single quote on searchfield and enter
- Should show one result

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
