### PR TITLE
7320 - Change default color back to azure 

### DIFF
--- a/app/views/components/personalize/example-color-theme-api.html
+++ b/app/views/components/personalize/example-color-theme-api.html
@@ -1,3 +1,10 @@
+<style>
+  div.dropdown > .listoption-icon.swatch,
+  .dropdown-list li span.swatch {
+    border: 1px solid #B7B7BA;
+  }
+</style>
+
 <div class="page-container no-scroll">
   <header class="header is-personalizable">
     <div class="toolbar">

--- a/app/views/components/personalize/example-form-landmark.html
+++ b/app/views/components/personalize/example-form-landmark.html
@@ -37,7 +37,8 @@
           </div>
         </div>
       </div>
-      <div class="tab-container header-tabs personalize-header" data-options="{ containerElement: '#scrollable-tab-panels' }" style="position: sticky; top: 60px; z-index: 29">
+      <div class="tab-container alternate header-tabs personalize-header"
+        data-options="{ containerElement: '#scrollable-tab-panels' }" style="position: sticky; top: 60px; z-index: 29">
         <div class="tab-list-container">
           <ul class="tab-list">
             <li class="tab is-selected"><a id="detail" href="#composite-form-detail">Detail</a></li>
@@ -48,7 +49,8 @@
             <li class="tab"><a id="add-on-changes" href="#composite-form-addon-changes">Add-On Changes</a></li>
             <li class="tab"><a id="sources" href="#composite-form-sources">Sources</a></li>
             <li class="tab"><a id="optionsTwo" href="#composite-form-options">Options Two</a></li>
-            <li class="tab"><a id="quantity-detailTwo" href="#composite-form-quantity-detail">Quantity Detail Two</a></li>
+            <li class="tab"><a id="quantity-detailTwo" href="#composite-form-quantity-detail">Quantity Detail Two</a>
+            </li>
             <li class="tab"><a id="user-fieldsTwo" href="#composite-form-user-fields">User Fields Two</a></li>
             <li class="tab"><a id="messagesTwo" href="#composite-form-messages">Messages Two</a></li>
             <li class="tab"><a id="add-on-changesTwo" href="#composite-form-addon-changes">Add-On Changes Two</a></li>
@@ -63,13 +65,13 @@
               <div class="six columns">
                 <div class="field">
                   <label for="composite-form-detail-item">Item</label>
-                  <input id="composite-form-detail-item" class="lookup"/>
+                  <input id="composite-form-detail-item" class="lookup" />
                 </div>
               </div>
               <div class="six columns">
                 <div class="field">
                   <label for="composite-form-detail-quantity">Quantity</label>
-                  <input id="composite-form-detail-quantity" class="lookup"/>
+                  <input id="composite-form-detail-quantity" class="lookup" />
                 </div>
               </div>
             </div>
@@ -78,13 +80,13 @@
               <div class="six columns">
                 <div class="field">
                   <label for="composite-form-detail-entered-by-uom">Entered Buy UOM</label>
-                  <input id="composite-form-detail-entered-by-uom" class="lookup"/>
+                  <input id="composite-form-detail-entered-by-uom" class="lookup" />
                 </div>
               </div>
               <div class="six columns">
                 <div class="field">
                   <label for="composite-form-detail-item-type">Item Type</label>
-                  <input id="composite-form-detail-item-type" class="lookup"/>
+                  <input id="composite-form-detail-item-type" class="lookup" />
                 </div>
               </div>
             </div>
@@ -93,13 +95,13 @@
               <div class="six columns">
                 <div class="field">
                   <label for="composite-form-detail-description">Description</label>
-                  <input id="composite-form-detail-description" class="lookup"/>
+                  <input id="composite-form-detail-description" class="lookup" />
                 </div>
               </div>
               <div class="six columns">
                 <div class="field">
                   <label for="composite-form-detail-service-code">Service Code</label>
-                  <input id="composite-form-detail-service-code" class="lookup"/>
+                  <input id="composite-form-detail-service-code" class="lookup" />
                 </div>
               </div>
             </div>
@@ -108,13 +110,13 @@
               <div class="six columns">
                 <div class="field">
                   <label for="composite-form-detail-unit-cost">Item</label>
-                  <input id="composite-form-detail-unit-cost" class="lookup"/>
+                  <input id="composite-form-detail-unit-cost" class="lookup" />
                 </div>
               </div>
               <div class="six columns">
                 <div class="field">
                   <label for="composite-form-detail-late-delivery-date">Late Delivery Date</label>
-                  <input id="composite-form-detail-late-delivery-date" class="lookup"/>
+                  <input id="composite-form-detail-late-delivery-date" class="lookup" />
                 </div>
               </div>
             </div>
@@ -160,110 +162,111 @@
                 <h3>Sources</h3>
               </div>
             </div>
-          </div><div class="row form-responsive">
-              <div class="six columns">
-                <div class="field">
-                  <label for="fourteen">Fourteen</label>
-                  <input id="fourteen" class="lookup"/>
-                </div>
-              </div>
-              <div class="six columns">
-                <div class="field">
-                  <label for="thirteen">Thirteen</label>
-                  <input id="thirteen" class="lookup"/>
-                </div>
+          </div>
+          <div class="row form-responsive">
+            <div class="six columns">
+              <div class="field">
+                <label for="fourteen">Fourteen</label>
+                <input id="fourteen" class="lookup" />
               </div>
             </div>
+            <div class="six columns">
+              <div class="field">
+                <label for="thirteen">Thirteen</label>
+                <input id="thirteen" class="lookup" />
+              </div>
+            </div>
+          </div>
 
-            <div class="row form-responsive">
-              <div class="six columns">
-                <div class="field">
-                  <label for="twelve">Twelve</label>
-                  <input id="twelve" class="lookup"/>
-                </div>
-              </div>
-              <div class="six columns">
-                <div class="field">
-                  <label for="eleven">Eleven</label>
-                  <input id="eleven" class="lookup"/>
-                </div>
+          <div class="row form-responsive">
+            <div class="six columns">
+              <div class="field">
+                <label for="twelve">Twelve</label>
+                <input id="twelve" class="lookup" />
               </div>
             </div>
+            <div class="six columns">
+              <div class="field">
+                <label for="eleven">Eleven</label>
+                <input id="eleven" class="lookup" />
+              </div>
+            </div>
+          </div>
 
-            <div class="row form-responsive">
-              <div class="six columns">
-                <div class="field">
-                  <label for="ten">Ten</label>
-                  <input id="ten" class="lookup"/>
-                </div>
-              </div>
-              <div class="six columns">
-                <div class="field">
-                  <label for="nine">Nine</label>
-                  <input id="nine" class="lookup"/>
-                </div>
+          <div class="row form-responsive">
+            <div class="six columns">
+              <div class="field">
+                <label for="ten">Ten</label>
+                <input id="ten" class="lookup" />
               </div>
             </div>
+            <div class="six columns">
+              <div class="field">
+                <label for="nine">Nine</label>
+                <input id="nine" class="lookup" />
+              </div>
+            </div>
+          </div>
 
-            <div class="row form-responsive">
-              <div class="six columns">
-                <div class="field">
-                  <label for="eight">Eight</label>
-                  <input id="eight" class="lookup"/>
-                </div>
-              </div>
-              <div class="six columns">
-                <div class="field">
-                  <label for="seven">Seven</label>
-                  <input id="seven" class="lookup"/>
-                </div>
+          <div class="row form-responsive">
+            <div class="six columns">
+              <div class="field">
+                <label for="eight">Eight</label>
+                <input id="eight" class="lookup" />
               </div>
             </div>
-          </div>
-          <div id="six" class="tab-panel" role="tabpanel">
-            <div class="row">
-              <div class="twelve columns">
-                <h3>Six</h3>
-              </div>
-            </div>
-          </div>
-          <div id="five" class="tab-panel" role="tabpanel">
-            <div class="row">
-              <div class="twelve columns">
-                <h3>Five</h3>
-              </div>
-            </div>
-          </div>
-          <div id="four" class="tab-panel" role="tabpanel">
-            <div class="row">
-              <div class="twelve columns">
-                <h3>Four</h3>
-              </div>
-            </div>
-          </div>
-          <div id="three" class="tab-panel" role="tabpanel">
-            <div class="row">
-              <div class="twelve columns">
-                <h3>Three</h3>
-              </div>
-            </div>
-          </div>
-          <div id="two" class="tab-panel" role="tabpanel">
-            <div class="row">
-              <div class="twelve columns">
-                <h3>Two</h3>
-              </div>
-            </div>
-          </div>
-          <div id="one" class="tab-panel" role="tabpanel">
-            <div class="row">
-              <div class="twelve columns">
-                <h3>One</h3>
+            <div class="six columns">
+              <div class="field">
+                <label for="seven">Seven</label>
+                <input id="seven" class="lookup" />
               </div>
             </div>
           </div>
         </div>
-      </section>
-    </section>
-  </section>
+        <div id="six" class="tab-panel" role="tabpanel">
+          <div class="row">
+            <div class="twelve columns">
+              <h3>Six</h3>
+            </div>
+          </div>
+        </div>
+        <div id="five" class="tab-panel" role="tabpanel">
+          <div class="row">
+            <div class="twelve columns">
+              <h3>Five</h3>
+            </div>
+          </div>
+        </div>
+        <div id="four" class="tab-panel" role="tabpanel">
+          <div class="row">
+            <div class="twelve columns">
+              <h3>Four</h3>
+            </div>
+          </div>
+        </div>
+        <div id="three" class="tab-panel" role="tabpanel">
+          <div class="row">
+            <div class="twelve columns">
+              <h3>Three</h3>
+            </div>
+          </div>
+        </div>
+        <div id="two" class="tab-panel" role="tabpanel">
+          <div class="row">
+            <div class="twelve columns">
+              <h3>Two</h3>
+            </div>
+          </div>
+        </div>
+        <div id="one" class="tab-panel" role="tabpanel">
+          <div class="row">
+            <div class="twelve columns">
+              <h3>One</h3>
+            </div>
+          </div>
+        </div>
+</div>
+</section>
+</section>
+</section>
 </div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## v4.82.0 Fixes
 
+- `[Personalization]` Changed default color back to azure and add alabaster in personalization colors. ([#7320](https://github.com/infor-design/enterprise/issues/7320))
 - `[Tabs]` Fixed the alignment of focus in RTL view. ([#6992](https://github.com/infor-design/enterprise/issues/6992))
 
 ## v4.81.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ## v4.82.0 Fixes
 
-- `[Personalization]` Changed default color back to azure and add alabaster in personalization colors. ([#7320](https://github.com/infor-design/enterprise/issues/7320))
 - `[Lookup]` Fix in keyword search not filtering single comma. ([#7165](https://github.com/infor-design/enterprise/issues/7165))
+- `[Personalization]` Changed default color back to azure and add alabaster in personalization colors. ([#7320](https://github.com/infor-design/enterprise/issues/7320))
 - `[Tabs]` Fixed the alignment of focus in RTL view. ([#6992](https://github.com/infor-design/enterprise/issues/6992))
 - `[Tabs Header]` Fixed the alignment of close button. ([#7273](https://github.com/infor-design/enterprise/issues/7273))
 

--- a/src/components/colors/_colors.scss
+++ b/src/components/colors/_colors.scss
@@ -21,7 +21,7 @@
 
 // Css variables for Primary Colors
 .primary-bg-color {
-  background: #fff;
+  background: $ids-color-brand-primary-base;
 }
 
 html.theme-new-light .primary-bg-color {

--- a/src/components/colors/_colors.scss
+++ b/src/components/colors/_colors.scss
@@ -25,7 +25,7 @@
 }
 
 .alabaster {
-  background: $ids-color-palette-white;
+  background: $ids-color-palette-alabaster !important;
 }
 
 html.theme-new-light .primary-bg-color {

--- a/src/components/colors/_colors.scss
+++ b/src/components/colors/_colors.scss
@@ -24,12 +24,16 @@
   background: $ids-color-brand-primary-base;
 }
 
+.alabaster {
+  background: $ids-color-palette-white;
+}
+
 html.theme-new-light .primary-bg-color {
-  background: #fff;
+  background: $ids-color-palette-azure-60;
 }
 
 html.theme-new-contrast .primary-bg-color {
-  background: #fff;
+  background: $ids-color-palette-azure-60;
 }
 
 html.theme-new-dark .primary-bg-color {

--- a/src/components/counts/_counts.scss
+++ b/src/components/counts/_counts.scss
@@ -75,6 +75,10 @@
   width: auto;
 }
 
+.object-count.personalize-text {
+  color: $ids-color-palette-white;
+}
+
 .object-count {
   color: $font-color-descriptive;
   display: inline-block;

--- a/src/components/dropdown/_dropdown-new.scss
+++ b/src/components/dropdown/_dropdown-new.scss
@@ -655,7 +655,6 @@ div.multiselect > .listoption-icon,
     html.theme-new-light &.primary-bg-color,
     html.theme-new-contrast &.primary-bg-color {
       border: 1px solid $ids-color-palette-slate-30;
-      background-color: $ids-color-palette-white;
     }
 
     html.theme-new-dark &.primary-bg-color {

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -552,7 +552,7 @@ $subheader-height: 60px;
       }
 
       .icon {
-        color: $header-button-color;
+        color: $header-button-color !important;
       }
 
       &.application-menu-trigger {

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -18,6 +18,42 @@ $subheader-height: 60px;
     color: $inverse-color;
   }
 
+  // Header with color personalization classes
+  &.default {
+    background-color: $header-default-bg-color;
+
+    .toolbar [class^='btn'] {
+      &:hover {
+        background-color: $header-default-bg-hover-color;
+
+        .icon {
+          color: $ids-color-palette-white;
+        }
+      }
+
+      &.is-open {
+        .icon {
+          color: $ids-color-palette-white;
+          opacity: 1;
+        }
+      }
+    }
+  }
+
+  &.alabaster {
+    background-color: $ids-color-palette-white;
+
+    .toolbar [class^='btn'] {
+      &:hover {
+        background-color: $header-toolbar-button-hover-color;
+
+        .icon {
+          background-color: $header-toolbar-button-hover-color;
+        }
+      }
+    }
+  }
+
   .searchfield {
     background-color: transparent;
     border: 1px solid transparent;

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -24,7 +24,7 @@ $subheader-height: 60px;
 
     .toolbar [class^='btn'] {
       &:hover {
-        background-color: $header-default-bg-hover-color;
+        background-color: $header-default-bg-hover-color !important;
 
         .icon {
           color: $ids-color-palette-white;
@@ -600,7 +600,7 @@ $subheader-height: 60px;
         }
 
         &:not(.collapse-button) {
-          box-shadow: 0 0 0 2px transparent, 0 0 0 1px $header-button-focus-color, $header-focus-box-shadow !important;
+          box-shadow: 0 0 0 2px transparent, 0 0 0 0 $header-button-focus-color, $header-focus-box-shadow !important;
         }
 
         .icon {

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -128,6 +128,12 @@ Header.prototype = {
 
     this.titleText = this.element.find('.title > h1');
 
+    const headerElem = document.querySelector('header.header');
+
+    if (headerElem && !headerElem.classList.contains('default')) {
+      this.setHeaderColorClass();
+    }
+
     // Used to track levels deep
     this.levelsDeep = [];
     this.levelsDeep.push(`${this.titleText.text()}`);
@@ -194,6 +200,64 @@ Header.prototype = {
     }
 
     return this;
+  },
+
+  /**
+   * @param {Object} colorsObj - list of personalization colors
+   * @returns {Object} list of personalization color names including default
+   */
+  personalizationColors(colorsObj) {
+    const colorNamesAndIds = Object.values(colorsObj)
+      .reduce((acc, { id }) => {
+        acc[id] = id;
+        return acc;
+      }, {});
+
+    return colorNamesAndIds;
+  },
+
+  /**
+   * Removes one or more classes from an element's classlist.
+   * @private
+   * @param {HTMLElement} elem - The DOM element whose classList we want to modify.
+   * @param {(string|string[])} classes - The class or classes to remove from the element's classList.
+   * Can be a string representing a single class name, or an array of strings representing multiple classes to remove.
+   * @returns {boolean} Returns `false` if `elem` or `classes` are falsy, otherwise returns `true`.
+   */
+  removeClasses(elem, classes) {
+    if (!elem || !classes) return false;
+
+    const classList = elem.classList;
+    if (classList) {
+      if (typeof classes === 'string') {
+        classList.remove(classes);
+      } else if (Array.isArray(classes)) {
+        classes.forEach(className => classList.remove(className));
+      } else {
+        throw new TypeError('Classes parameter must be a string or an array of strings.');
+      }
+    }
+
+    return true;
+  },
+
+  /**
+   * Appending personalization color class
+   * @private
+   * @returns {void}
+   */
+  setHeaderColorClass() {
+    const colorSelected = document.querySelector('.submenu:last-child ul li.is-checked')?.innerText.toLowerCase() || 'default';
+    const headerElement = document.querySelector('header.header');
+    const colors = theme.personalizationColors();
+    const colorArr = Object.keys(colors);
+
+    const colorMap = this.personalizationColors(colors);
+
+    const colorToRemove = [...colorArr, 'default'];
+    this.removeClasses(headerElement, colorToRemove);
+    const colorToAdd = colorMap[colorSelected];
+    headerElement.classList.add(colorToAdd);
   },
 
   /**
@@ -471,6 +535,7 @@ Header.prototype = {
 
     $('html').on(`themechanged.${COMPONENT_NAME}`, () => {
       this.updatePageChanger();
+      this.setHeaderColorClass();
     });
 
     // Events for the title button.  e.preventDefault(); stops Application Menu
@@ -573,10 +638,13 @@ Header.prototype = {
       const isDefault = link.parent().hasClass('is-default');
       if (isDefault) {
         personalization.setColorsToDefault();
+        this.setHeaderColorClass();
         return;
       }
       const color = link.attr('data-rgbcolor');
       personalization.setColors(color);
+
+      this.setHeaderColorClass();
     });
 
     // Mark theme as checked
@@ -597,6 +665,8 @@ Header.prototype = {
 
       $('body').find('.popupmenu [data-rgbcolor]').parent().removeClass('is-checked');
       $('body').find(`.popupmenu [data-rgbcolor="#${colors}"]`).parent().addClass('is-checked');
+
+      this.setHeaderColorClass();
     }
   },
 

--- a/src/components/hyperlinks/_hyperlinks.scss
+++ b/src/components/hyperlinks/_hyperlinks.scss
@@ -17,6 +17,14 @@
     color: $hyperlink-hover-color;
   }
 
+  &.personalize-actionable {
+    color: rgba(255, 255, 255, 0.8);
+
+    &:hover {
+      color: $ids-color-palette-white;
+    }
+  }
+
   &.show-visited:visited,
   &.force-visited {
     color: $hyperlink-visited-color;

--- a/src/components/locale/cultures/en-US.js
+++ b/src/components/locale/cultures/en-US.js
@@ -70,6 +70,7 @@ Soho.Locale.addCulture('en-US', {
     AdministrativeLeave: { id: 'AdministrativeLeave', value: 'Administrative Leave', comment: 'As in vacation time from work' },
     AdvancedFilter: { id: 'AdvancedFilter', value: 'Create Advanced Filter', comment: 'In a data grid active an advanced filtering feature' },
     Afrikaans: { id: 'Afrikaans', value: 'Afrikaans', comment: 'Language name for Afrikaans (South Africa)' },
+    Alabaster: { id: 'Alabaster', value: 'Alabaster', comment: 'Color in our color palette' },
     Alert: { id: 'Alert', value: 'Alert', comment: 'Alert' },
     AlertOnPage: { id: 'AlertOnPage', value: 'Alert message(s) on page', comment: 'Alert message(s) on page n' },
     AlignCenterHorizontally: { id: 'AlignCenterHorizontally', value: 'Horizontal Align Center', comment: 'Align Center Horizontally tooltip' },

--- a/src/components/personalize/_personalize.scss
+++ b/src/components/personalize/_personalize.scss
@@ -98,6 +98,13 @@
   }
 }
 
+
+html[class*='new-'] {
+  .personalize-text .object-count {
+    color: $ids-color-palette-white;
+  }
+}
+
 // Classic themes default color personalization
 html[class*='classic-'] {
   & .is-personalizable {

--- a/src/components/personalize/_personalize.scss
+++ b/src/components/personalize/_personalize.scss
@@ -100,19 +100,34 @@
 
 
 html[class*='new-'] {
-  .personalize-text .object-count {
+  .header:not(.alabaster) + .page-container {
+    .personalize-text,
+    .personalize-text .object-count,
+    .hyperlink.is-personalizable {
+      color: $ids-color-palette-white;
+    }
+  }
+}
+
+.header:not(.alabaster) + .page-container .content.personalize-header {
+  .personalize-text {
     color: $ids-color-palette-white;
+  }
+}
+
+html.theme-classic-contrast {
+  .header.alabaster {
+    + .page-container {
+      .is-personalizable .personalize-text {
+        color: $ids-color-palette-graphite-80;
+      }
+    }
   }
 }
 
 // Classic themes default color personalization
 html[class*='classic-'] {
   & .is-personalizable {
-    & .personalize-text,
-    & .hyperlink:not(.today) {
-      color: $ids-color-palette-white;
-    }
-
     .personalize-header {
       .personalize-chart-targeted .label,
       .info-message .icon,

--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -358,7 +358,8 @@ Personalize.prototype = {
 
     // Hyperlink/Text Selection
     colors.hyperlinkText = colors.text;
-    colors.hyperlinkTextHover = defaultColors.subtext;
+    colors.hyperlinkTextHover = colorUtils.getContrastColor(colors.text);
+    console.log(colorUtils.getContrastColor(colors.text))
     colors.selection = defaultColors.subtext;
 
     const tooltipContrast = colorUtils.getContrastColor(colors.darkest);
@@ -613,7 +614,7 @@ Personalize.prototype = {
     }
 
     // Copy the old settings to compare
-    const prevSettings = utils.extend({ }, this.settings);
+    const prevSettings = utils.extend({}, this.settings);
 
     // Merge in the new settings
     this.settings = utils.mergeSettings(this.element[0], settings, this.settings);

--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -358,8 +358,7 @@ Personalize.prototype = {
 
     // Hyperlink/Text Selection
     colors.hyperlinkText = colors.text;
-    colors.hyperlinkTextHover = colorUtils.getContrastColor(colors.text);
-    console.log(colorUtils.getContrastColor(colors.text))
+    colors.hyperlinkTextHover = defaultColors.subtext;
     colors.selection = defaultColors.subtext;
 
     const tooltipContrast = colorUtils.getContrastColor(colors.darkest);

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -216,7 +216,7 @@ a.btn-close.is-personalizable:focus:not(.hide-focus) {
 
 .is-personalizable .hyperlink:not(.today),
 .hyperlink:not(.today).is-personalizable {
-  color: ${colors.hyperlinkText}
+  color: ${colors.hyperlinkText};
 }
 .is-personalizable .hyperlink:not(.today):hover,
 .hyperlink:not(.today).is-personalizable:hover {
@@ -374,6 +374,26 @@ html.theme-new-dark .header.alabaster.is-personalizable {
   background-color: #606066;
 }
 
+html.theme-classic-dark .header.alabaster.is-personalizable {
+  background-color: #50535A !important;
+}
+
+html.theme-classic-dark .header.alabaster.is-personalizable .title h1 {
+  color: #fff;
+}
+
+html.theme-classic-dark .header.alabaster.is-personalizable button:not(:disabled) .icon {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+html.theme-classic-dark .header.alabaster.is-personalizable button:not(:disabled):hover .icon {
+  color: #fff !important;
+}
+
+html.theme-classic-dark .header.alabaster.is-personalizable .toolbar [class^='btn']:hover:not(.go-button):not(.searchfield-category-button):not([disabled]) {
+  background-color: #313236 !important;
+}
+
 html.theme-new-dark .header.alabaster.is-personalizable .title h1 {
   color: #ffffff;
 }
@@ -443,6 +463,76 @@ html.theme-new-dark .header.is-personalizable.has-tabs .tab-container.header-tab
 .personalize-header.tab-container.header-tabs:not(.alternate) > .tab-list-container .tab {
   color: ${colors.contrast} !important;
   opacity: .8;
+}
+
+html.theme-new-dark .header.alabaster + .page-container .is-personalizable.tab-container.header-tabs:not(.alternate) > .tab-list-container .tab {
+  color: #ffffff !important;
+}
+
+html.theme-new-dark .header.alabaster + .page-container .is-personalizable.tab-container.header-tabs:not(.alternate) > .tab-list-container .tab:not(.is-disabled) {
+  opacity: 0.8;
+}
+
+html.theme-new-dark .header.alabaster + .page-container .is-personalizable.tab-container.header-tabs:not(.alternate) > .tab-list-container .tab:not(.is-disabled):hover {
+  opacity: 1;
+}
+
+html.theme-new-dark .header.alabaster + .page-container .is-personalizable.tab-container.header-tabs:not(.alternate) > .tab-list-container .tab:not(.is-disabled).is-selected {
+  border-color: #fff !important;
+}
+
+html.theme-new-dark .header.alabaster + .page-container .tab-container.header-tabs:not(.alternate) {
+  border-bottom: 1px solid #3E3E42 !important;
+}
+
+html.theme-new-dark .header.alabaster + .page-container .is-personalizable .hyperlink:not(.today),
+html.theme-new-dark .header.alabaster + .page-container .hyperlink:not(.today).is-personalizable {
+  color: #55A3F3 !important;
+}
+
+html.theme-new-dark .header.alabaster + .page-container .is-personalizable .hyperlink:hover:not([disabled]) {
+  color: #1C86EF !important;
+}
+
+html.theme-new-dark .header.alabaster + .page-container .tab-container.is-personalizable.header-tabs:not(.alternate) > .tab-list-container .tab:hover:not(.is-disabled), .tab-container.is-personalizable.header-tabs:not(.alternate) > .tab-list-container .tab:hover:not(.is-disabled) {
+  background-color: transparent;
+  border-color: #fff;
+}
+
+html.theme-new-dark .header.alabaster + .page-container .tab-container.is-personalizable.header-tabs:not(.alternate) .tab-focus-indicator.is-visible {
+  border-color: #fff !important;
+}
+
+html.theme-new-contrast:not(.theme-new-dark) .header.alabaster + .page-container .hyperlink:not([disabled]),
+html.theme-new-contrast:not(.theme-new-dark) .header.alabaster + .page-container .hyperlink:not(.today).is-personalizable {
+  color: #004A99 !important;
+}
+
+html.theme-new-contrast:not(.theme-new-dark) .header.alabaster + .page-container .hyperlink:hover:not([disabled]),
+html.theme-new-contrast:not(.theme-new-dark) .header.alabaster + .page-container .hyperlink:not(.today).is-personalizable:hover {
+  color: #003876 !important;
+}
+
+html.theme-classic-contrast .header.alabaster + .page-container .hyperlink:not(.today).is-personalizable,
+html.theme-classic-contrast .header.alabaster + .page-container .hyperlink:not(.today).personalize-actionable {
+  color: #55A3F3 !important;
+  opacity: 1;
+}
+
+html.theme-classic-contrast .header.alabaster + .page-container .hyperlink:not(.today).is-personalizable:hover,
+html.theme-classic-contrast .header.alabaster + .page-container .hyperlink:not(.today).personalize-actionable:hover {
+  color: #003876 !important;
+}
+
+html.theme-new-light .header.alabaster + .page-container .is-personalizable .hyperlink:not(.today),
+html.theme-new-light .header.alabaster + .page-container  .hyperlink:not(.today).is-personalizable {
+  color: #0072ED !important;
+  opacity: 1;
+}
+
+html.theme-new-light .header.alabaster + .page-container .is-personalizable .hyperlink:not(.today):hover,
+html.theme-new-light .header.alabaster + .page-container  .hyperlink:not(.today).is-personalizable:hover {
+  color: #0054B1 !important;
 }
 
 .header.is-personalizable.has-tabs .tab-container.header-tabs:not(.alternate) > .tab-list-container .tab:hover:not(.is-disabled),
@@ -977,6 +1067,10 @@ html[class*="theme-new-"] .application-menu.is-personalizable .accordion.panel.i
   background-color: ${colors.base} !important;
 }
 
+html.theme-new-dark .header.alabaster + .page-container .is-personalizable.tab-container {
+  background-color: #606066 !important;
+}
+
 .is-personalizable .tab-container.header-tabs:not(.alternate) > .tab-list-container .tab-list .tab.is-disabled,
 .is-personalizable.tab-container.header-tabs:not(.alternate) > .tab-list-container .tab-list .tab.is-disabled {
   opacity: .6;
@@ -1033,6 +1127,61 @@ html[class*="-dark"] .header.alabaster + .is-personalizable .personalize-header 
 .is-personalizable .personalize-actionable:hover:not([disabled]) .icon  {
   color: ${colors.contrast} !important;
   opacity: 1;
+}
+
+.header.alabaster + .content.personalize-header .is-personalizable .personalize-text {
+  color: #fff;
+}
+
+html.theme-new-dark .header.alabaster + .page-container .is-personalizable .personalize-header {
+  background-color: #606066 !important;
+}
+
+html.theme-classic-dark .header.alabaster + .page-container .is-personalizable .personalize-header {
+  background-color: #50535A !important;
+}
+
+html.theme-classic-dark header.alabaster + .page-container .is-personalizable .personalize-header,
+html.theme-classic-dark header.alabaster + .page-container .is-personalizable.tab-container {
+  background-color: #50535A !important;
+  border-bottom-color: #414247;
+}
+
+html.theme-classic-dark header.alabaster + .page-container .is-personalizable.tab-container.header-tabs:not(.alternate) > .tab-list-container .tab:not(.is-disabled) {
+  color: #fff !important;
+}
+
+html.theme-classic-dark .header.alabaster + .page-container .tab-container.header-tabs > .tab-list-container .tab.is-disabled {
+  color: rgba(255, 255, 255, 0.8) !important;
+}
+
+html.theme-classic-dark .header.alabaster + .page-container .tab-container.is-personalizable.header-tabs:not(.alternate) > .tab-list-container .tab:not(.is-disabled).is-selected,
+html.theme-classic-dark .header.alabaster + .page-container .tab-container.is-personalizable.header-tabs:not(.alternate) .tab-focus-indicator.is-visible {
+  border-color: #fff !important;
+}
+
+html.theme-classic-dark .header.alabaster + .page-container .is-personalizable .personalize-actionable {
+  color: #55A3F3 !important;
+}
+
+html.theme-classic-dark .header.alabaster + .page-container .hyperlink:not(.today).is-personalizable {
+  opacity: 0.8 !important;
+}
+
+html.theme-classic-light .header.alabaster + .page-container .hyperlink:not(.today).is-personalizable {
+  opacity: 0.8 !important;
+}
+
+html.theme-classic-light .header.alabaster + .page-container .hyperlink:not(.today).is-personalizable:hover {
+  opacity: 1 !important;
+}
+
+html.theme-classic-dark .header.alabaster + .page-container .hyperlink:not(.today).is-personalizable:hover {
+  opacity: 1 !important;
+}
+
+html.theme-classic-light .header.alabaster + .page-container .is-personalizable .personalize-actionable {
+  color: #55A3F3 !important;
 }
 
 .header.alabaster + .is-personalizable .personalize-actionable:hover:not([disabled]) {

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -216,11 +216,11 @@ a.btn-close.is-personalizable:focus:not(.hide-focus) {
 
 .is-personalizable .hyperlink:not(.today),
 .hyperlink:not(.today).is-personalizable {
-  color: ${colors.hyperlinkText};
+  color: ${colors.hyperlinkText} !important;
 }
 .is-personalizable .hyperlink:not(.today):hover,
 .hyperlink:not(.today).is-personalizable:hover {
-  color: ${colors.hyperlinkTextHover};
+  color: ${colors.hyperlinkTextHover} !important;
 }
 .is-personalizable .hyperlink:not(.today):focus:not(.hide-focus),
 .hyperlink:not(.today).is-personalizable:focus:not(.hide-focus) {
@@ -326,6 +326,10 @@ a.is-personalizable svg.ripple-effect {
   color: ${colors.contrast};
 }
 
+.object-count.personalize-text {
+  color: ${colors.contrast};
+}
+
 .header.is-personalizable button svg.ripple-effect {
   background-color: ${colors.contrast} !important;
 }
@@ -371,7 +375,7 @@ a.is-personalizable svg.ripple-effect {
 }
 
 html.theme-new-dark .header.alabaster.is-personalizable {
-  background-color: #606066;
+  background-color: #606066 !important;
 }
 
 html.theme-classic-dark .header.alabaster.is-personalizable {
@@ -437,6 +441,12 @@ html.theme-new-dark .header.alabaster.is-personalizable button:not(.searchfield-
 .header.is-personalizable.has-tabs .tab-container.header-tabs:not(.alternate) > .tab-list-container .tab.is-selected:not(.is-disabled),
 .personalize-header.tab-container.header-tabs:not(.alternate) > .tab-list-container .tab.is-selected:not(.is-disabled) {
   color: ${colors.contrast} !important;
+  opacity: 1;
+}
+
+.header.alabaster.is-personalizable.has-tabs .tab-container.header-tabs:not(.alternate) > .tab-list-container .tab.is-selected:not(.is-disabled),
+.personalize-header.tab-container.header-tabs:not(.alternate) > .tab-list-container .tab.is-selected:not(.is-disabled) {
+  color: #fff !important;
   opacity: 1;
 }
 
@@ -1200,7 +1210,7 @@ html.theme-classic-light .header.alabaster + .page-container .is-personalizable 
 }
 
 .header.alabaster + .is-personalizable .personalize-actionable:hover:not([disabled]) {
-  color: #fff !important;
+  color: #000 !important;
 }
 
 .is-personalizable .personalize-actionable.is-focused:not(.hide-focus),

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -359,12 +359,48 @@ a.is-personalizable svg.ripple-effect {
 }
 
 .header.is-personalizable button:not(.go-button):not(.searchfield-category-button):not(:disabled):hover,
-.header.is-personalizable button:not(.searchfield-category-button):not(:disabled):hover .icon,
 .header.is-personalizable button:not(:disabled):hover .app-header.icon > span,
 .header.is-personalizable .toolbar [class^='btn']:hover:not(.go-button):not(.searchfield-category-button):not([disabled]) {
   color: ${colors.contrast};
   background-color: ${colors.darker} !important;
   opacity: 1;
+}
+
+.header.is-personalizable button:not(.searchfield-category-button):not(:disabled):hover .icon {
+  background-color: transparent !important;
+}
+
+html.theme-new-dark .header.alabaster.is-personalizable {
+  background-color: #606066;
+}
+
+html.theme-new-dark .header.alabaster.is-personalizable .title h1 {
+  color: #ffffff;
+}
+
+html.theme-new-dark .header.alabaster.is-personalizable button:not(:disabled) .icon {
+  color: #ffffff !important;
+}
+
+html.theme-new-dark .header.alabaster.is-personalizable .personalize-actionable:focus:not(.hide-focus) {
+  border-color: #ffffff !important;
+}
+
+html.theme-new-dark .header.alabaster.is-personalizable button:not(.go-button):not(.searchfield-category-button):not(:disabled):hover,
+html.theme-new-dark .header.alabaster.is-personalizable button:not(:disabled):hover .app-header.icon > span,
+html.theme-new-dark .header.alabaster.is-personalizable .toolbar [class^='btn']:hover:not(.go-button):not(.searchfield-category-button):not([disabled]) {
+  background-color: #47474C !important;
+}
+
+html.theme-new-dark .header.alabaster.is-personalizable button:not(.searchfield-category-button):not(:disabled):hover .icon {
+  background-color: transparent !important;
+}
+
+
+.header.alabaster.is-personalizable button:not(.go-button):not(.searchfield-category-button):not(:disabled):hover,
+.header.alabaster.is-personalizable button:not(:disabled):hover .app-header.icon > span,
+.header.alabaster.is-personalizable .toolbar [class^='btn']:hover:not(.go-button):not(.searchfield-category-button):not([disabled]) {
+  background-color: #E6F1FD !important;
 }
 
 .header.is-personalizable button:not(:disabled) .app-header.icon > span {
@@ -458,8 +494,15 @@ html[class*="theme-new-"] .personalize-header.tab-container.header-tabs:not(.alt
 }
 
 .header.is-personalizable .toolbar-searchfield-wrapper:not(.non-collapsible):not(.is-open) .icon:not(.close),
+.header .toolbar-searchfield-wrapper .searchfield,
+.masthead .toolbar-searchfield-wrapper .searchfield,
 .header.is-personalizable .toolbar [class^='btn']:focus .icon {
   color: ${colors.contrast};
+}
+
+html[class*="-dark"] .header.alabaster.is-personalizable .toolbar-searchfield-wrapper:not(.non-collapsible):not(.is-open) .icon:not(.close),
+html[class*="-dark"] .header.alabaster .toolbar-searchfield-wrapper .searchfield {
+  color: #ffffff;
 }
 
 .header .toolbar [class^='btn']:hover:not(.go-button):not(.searchfield-category-button) {
@@ -1133,7 +1176,7 @@ html[class*="theme-classic-"] .tab-container.is-personalizable .tab-list-contain
     0 0 2px 1px ${colors.subtext};
 }
 
-.header.is-personalizable .toolbar [class^='btn']:focus:not(.hide-focus),
+.header.is-personalizable:not(.alabaster) .toolbar [class^='btn']:focus:not(.hide-focus),
 .header.is-personalizable .flex-toolbar [class^='btn']:focus:not(.hide-focus) {
   box-shadow: 0 0 0 2px transparent,
   0 0 0 1px ${colors.subtext},

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -470,6 +470,10 @@ html.theme-new-dark .header.is-personalizable.has-tabs .tab-container.header-tab
   background-color: ${colors.contrast};
 }
 
+.tab-container.header-tabs.alternate::after {
+  background-image: linear-gradient(to right, rgba(28, 24, 25, 0), ${colors.base});
+}
+
 .is-personalizable .tab-container.header-tabs:not(.alternate) > .tab-list-container .tab:not(.is-disabled),
 .header.is-personalizable .tab-container.header-tabs:not(.alternate) .tab-more svg.icon,
 .tab-container.is-personalizable .tab-more svg.icon,

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -444,11 +444,7 @@ html.theme-new-dark .header.alabaster.is-personalizable button:not(.searchfield-
   opacity: 1;
 }
 
-.header.alabaster.is-personalizable.has-tabs .tab-container.header-tabs:not(.alternate) > .tab-list-container .tab.is-selected:not(.is-disabled),
-.personalize-header.tab-container.header-tabs:not(.alternate) > .tab-list-container .tab.is-selected:not(.is-disabled) {
-  color: #fff !important;
-  opacity: 1;
-}
+//xxxx
 
 .header.is-personalizable .flex-toolbar .has-collapse-button .collapse-button {
   background-color: transparent;
@@ -480,6 +476,12 @@ html.theme-new-dark .header.is-personalizable.has-tabs .tab-container.header-tab
 .is-personalizable.tab-container.header-tabs:not(.alternate) > .tab-list-container .tab:not(.is-disabled),
 .personalize-header.tab-container.header-tabs:not(.alternate) > .tab-list-container .tab:not(.is-disabled)  {
   color: ${colors.contrast} !important;
+  opacity: .8;
+}
+
+html.theme-new-dark .personalize-header.tab-container.header-tabs:not(.alternate) > .tab-list-container .tab:not(.is-disabled),
+html.theme-classic-dark .personalize-header.tab-container.header-tabs:not(.alternate) > .tab-list-container .tab:not(.is-disabled) {
+  color: #fff !important;
   opacity: .8;
 }
 

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -991,6 +991,10 @@ html[class*="theme-classic-"] .tab-container.is-personalizable .tab-list-contain
   background-color: ${colors.base} !important;
 }
 
+html[class*="-dark"] .header.alabaster + .is-personalizable .personalize-header {
+  background-color: #606066 !important;
+}
+
 .is-personalizable .personalize-subheader {
   background-color: ${colors.lighter} !important;
 }
@@ -1017,14 +1021,10 @@ html[class*="theme-classic-"] .tab-container.is-personalizable .tab-list-contain
   color: ${colors.theme.text} !important;
 }
 
-.is-personalizable .personalize-text {
-  color: ${colors.contrast} !important;
-}
-
 .is-personalizable .personalize-actionable,
 .is-personalizable .personalize-actionable svg,
 .is-personalizable .personalize-actionable .icon {
-  color: ${colors.contrast} !important;
+  color: rgba(255, 255, 255, 0.8) !important;
   opacity: .8;
 }
 
@@ -1033,6 +1033,10 @@ html[class*="theme-classic-"] .tab-container.is-personalizable .tab-list-contain
 .is-personalizable .personalize-actionable:hover:not([disabled]) .icon  {
   color: ${colors.contrast} !important;
   opacity: 1;
+}
+
+.header.alabaster + .is-personalizable .personalize-actionable:hover:not([disabled]) {
+  color: #fff !important;
 }
 
 .is-personalizable .personalize-actionable.is-focused:not(.hide-focus),
@@ -1049,10 +1053,6 @@ html[class*="theme-classic-"] .tab-container.is-personalizable .tab-list-contain
 
 .is-personalizable .personalize-vertical-border {
   border-color: ${colors.light};
-}
-
-.is-personalizable .personalize-horizontal-bottom-border {
-  border-bottom: 1px solid ${colors.darkest};
 }
 
 .is-personalizable .personalize-horizontal-top-border {

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -1332,6 +1332,33 @@ html.theme-classic-light .header.alabaster + .page-container .is-personalizable 
   0 0 2px 1px ${colors.subtext} !important;
 }
 
+html.theme-new-dark .header.alabaster.is-personalizable .flex-toolbar [class^='btn']:focus:not(.hide-focus) .icon {
+  color: #fff !important;
+}
+
+html.theme-new-dark .header.alabaster.is-personalizable .btn-tertiary:not(.destructive):not(.is-select):not(.is-select-month-pane):not(.is-cancel):not(.is-cancel-month-pane):not(:disabled),
+html.theme-new-dark .header.alabaster.is-personalizable .btn-tertiary:not(.destructive):not(.is-select):not(.is-select-month-pane):not(.is-cancel):not(.is-cancel-month-pane):not(:disabled) svg.icon {
+  color: #fff !important;
+}
+
+html[class*="theme-new-"]:not(.theme-new-dark) .header.alabaster.is-personalizable button:not(:disabled) {
+  color: #000 !important;
+}
+
+html[class*="theme-new-"]:not(.theme-new-dark) .header.alabaster.is-personalizable .flex-toolbar [class^='btn'][disabled] span,
+html[class*="theme-new-"]:not(.theme-new-dark) .header.alabaster.is-personalizable .flex-toolbar [class^='btn'][disabled] .icon {
+  color: #B7B7BA !important;
+}
+
+html[class*="theme-classic-"]:not(.theme-classic-dark) .header.alabaster.is-personalizable .flex-toolbar [class^='btn'][disabled] span,
+html[class*="theme-classic-"]:not(.theme-classic-dark) .header.alabaster.is-personalizable .flex-toolbar [class^='btn'][disabled] .icon {
+  color: #888B94 !important;
+}
+
+html[class*="theme-classic-"]:not(.theme-classic-dark) .header.alabaster.is-personalizable button:not(:disabled) {
+  color: #000 !important;
+}
+
 /*
 .tooltip.is-personalizable {
   background-color: ${colors.darkest};

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -649,6 +649,21 @@ $toolbarsearchfield-category-empty-width: 51px;
   }
 }
 
+:not(.alabaster) {
+  &.header,
+  &.masthead {
+    .toolbar-searchfield-wrapper {
+      &.is-hovered {
+        &:not(.active) {
+          .icon {
+            color: $header-toolbar-searchfield-icon-color;
+          }
+        }
+      }
+    }
+  }
+}
+
 .header,
 .masthead {
   .toolbar-searchfield-wrapper {
@@ -824,7 +839,8 @@ $toolbarsearchfield-category-empty-width: 51px;
     &.is-open {
       .icon {
         color: $searchfield-header-icon-color;
-        top: 1px;
+        transform: translateY(-50%);
+        top: 50%;
       }
     }
   }

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -95,6 +95,7 @@ $toolbarsearchfield-category-empty-width: 51px;
     }
 
     .icon:not(.close) {
+      color: $searchfield-icon-color !important;
       height: 18px;
       width: 18px;
 
@@ -690,13 +691,6 @@ $toolbarsearchfield-category-empty-width: 51px;
       }
     }
 
-    &.has-collapse-button:not(.is-open) {
-      .searchfield {
-        background-color: transparent;
-        border-color: transparent;
-      }
-    }
-
     .go-button {
       background-color: $button-color-secondary-initial-background;
       border-color: $button-color-secondary-initial-background;
@@ -853,7 +847,7 @@ $toolbarsearchfield-category-empty-width: 51px;
 
     &.is-open {
       :not(.collapse-button) .icon {
-        color: $searchfield-header-icon-color;
+        color: $searchfield-header-icon-color !important;
         transform: translateY(-50%);
         top: 50%;
       }
@@ -1009,7 +1003,7 @@ html.is-firefox {
 
       &.is-open {
         .icon {
-          color: $searchfield-header-icon-color;
+          color: $searchfield-header-icon-color !important;
         }
 
         &.is-hovered {

--- a/src/components/tabs-header/_tabs-header.scss
+++ b/src/components/tabs-header/_tabs-header.scss
@@ -343,3 +343,7 @@ html[dir='rtl'] {
     }
   }
 }
+
+html.theme-classic-dark .tab-container.header-tabs.alternate::after {
+  background-image: linear-gradient(to right, rgba(28, 24, 25, 0), #50535A);
+}

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -726,7 +726,7 @@
 }
 
 .tab-container.header-tabs > .tab-list-container .tab.is-disabled {
-  color: rgba($ids-color-palette-white, 0.4) !important;
+  color: rgba($ids-color-palette-white, 0.4);
 }
 
 html.theme-classic-dark .tab-container.header-tabs > .tab-list-container .tab.is-disabled {

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -726,7 +726,7 @@
 }
 
 .tab-container.header-tabs > .tab-list-container .tab.is-disabled {
-  color: rgba($ids-color-palette-white, 0.4);
+  color: rgba($ids-color-palette-white, 0.4) !important;
 }
 
 html.theme-classic-dark .tab-container.header-tabs > .tab-list-container .tab.is-disabled {

--- a/src/components/theme/theme.js
+++ b/src/components/theme/theme.js
@@ -70,32 +70,33 @@ const theme = {
     const palette = this.themeColors().palette;
     const personalize = {};
     const opts = { showBrackets: false };
-    let defaulColor = '#ffffff';
+    let defaulColor = '#0066D4';
 
     switch (this.currentTheme.id) {
       case 'theme-new-light':
-        defaulColor = '#ffffff';
+        defaulColor = '#0066D4';
         break;
       case 'theme-new-contrast':
-        defaulColor = '#ffffff';
+        defaulColor = '#0066D4';
         break;
       case 'theme-new-dark':
-        defaulColor = '#606066';
+        defaulColor = '#0066D4';
         break;
       case 'theme-classic-light':
-        defaulColor = '#368ac0';
+        defaulColor = '#2578a9';
         break;
       case 'theme-classic-contrast':
         defaulColor = '#134d71';
         break;
       case 'theme-classic-dark':
-        defaulColor = '#50535a';
+        defaulColor = '#50535A';
         break;
       default:
-        defaulColor = '#ffffff';
+        defaulColor = '#0066D4';
         break;
     }
     personalize.default = { id: 'default', name: Locale.translate('Default', opts), backgroundColorClass: 'primary-bg-color', value: defaulColor };
+    personalize.alabaster = { id: 'alabaster', name: Locale.translate('Alabaster', opts), backgroundColorClass: 'alabaster', value: palette.white.value };
     personalize.amber = { id: 'amber', name: Locale.translate('Amber', opts), backgroundColorClass: 'amber09', value: palette.amber['90'].value };
     personalize.amethyst = { id: 'amethyst', name: Locale.translate('Amethyst', opts), backgroundColorClass: 'amethyst06', value: palette.amethyst['60'].value };
     personalize.azure = { id: 'azure', name: Locale.translate('Azure', opts), backgroundColorClass: 'azure07', value: palette.azure['70'].value };

--- a/src/components/toolbar-flex/_toolbar-flex-searchfield.scss
+++ b/src/components/toolbar-flex/_toolbar-flex-searchfield.scss
@@ -33,7 +33,7 @@ $responsive-searchfield-filled-out-width: 34px;
     &.non-collapsible.has-close-icon-button {
       .btn-icon.close {
         .icon.close {
-          top: 0;
+          top: 8px;
         }
       }
     }

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -2,20 +2,24 @@
 //================================================== //
 
 // Form Background Color
-$header-bg-color: $ids-color-palette-white;
+$header-bg-color: $ids-color-brand-primary-alt;
 $subhead-bg-color: $ids-color-palette-white;
 $transparent: transparent;
 
 $header-border-color: $ids-color-palette-azure-80;
-$header-button-color: rgba($ids-color-palette-slate-100, 0.7);
-$header-button-focus-color: rgba($ids-color-palette-azure-60, 1);
+$header-button-color: rgba($ids-color-palette-white, 0.7);
+$header-button-focus-color: rgba($ids-color-palette-white, 1);
 $header-button-hover-color: rgba($ids-color-palette-slate-100, 0.7);
 $header-button-disabled-color: $ids-color-palette-slate-40;
 $header-primary-btn-background-color: $ids-color-palette-azure-50;
 $header-primary-btn-background-hover-color: $ids-color-brand-primary-base;
-$header-text-color: $ids-color-palette-slate-100;
+$header-text-color: $ids-color-palette-white;
 $header-disabled-color: $ids-color-palette-slate-50;
 $header-focus-box-shadow: 0 0 4px 3px rgba(255, 255, 255, 0.3);
+
+// Color Personalization in header
+$header-default-bg-color: $ids-color-palette-azure-60;
+$header-default-bg-hover-color: $ids-color-palette-azure-80;
 
 $header-hero-text-color: $ids-color-palette-slate-100;
 $header-hero-widget-bg-color: $subhead-bg-color;
@@ -915,7 +919,7 @@ $searchfield-header-color: $ids-color-palette-slate-100;
 $searchfield-header-bg-color: $ids-color-palette-white;
 $searchfield-header-border-color: $ids-color-palette-slate-90;
 $searchfield-header-border-color-new: $ids-color-palette-slate-30;
-$searchfield-header-text-color: $ids-color-palette-slate-60;
+$searchfield-header-text-color: $ids-color-palette-white;
 $searchfield-header-placeholder-text-color: rgba(255, 255, 255, 0.5);
 $searchfield-header-icon-color: $ids-color-palette-slate-60;
 $searchfield-header-hover-icon-color: $ids-color-palette-slate-100;
@@ -966,7 +970,7 @@ $subheader-searchfield-category-button-font-color: $ids-color-palette-slate-80;
 $header-searchfield-input-border-color: $ids-color-palette-slate-40;
 $header-searchfield-input-border-hover-color: $ids-color-palette-slate-100;
 $header-searchfield-btn-font-color: $ids-color-palette-slate-80;
-$header-toolbar-searchfield-icon-color: $ids-color-palette-slate-100;
+$header-toolbar-searchfield-icon-color: $ids-color-palette-white;
 $header-toolbar-button-hover-color: $ids-color-palette-azure-10;
 
 // Header Tabs

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -2,7 +2,7 @@
 //================================================== //
 
 // Form Background Color
-$header-bg-color: $ids-color-brand-primary-alt;
+$header-bg-color: $ids-color-palette-azure-60;
 $subhead-bg-color: $ids-color-palette-white;
 $transparent: transparent;
 

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -7,15 +7,17 @@ $subhead-bg-color: $ids-color-palette-white;
 $transparent: transparent;
 
 $header-border-color: $ids-color-palette-azure-80;
-$header-button-color: rgba($ids-color-palette-white, 0.7);
+$header-button-color: rgba($ids-color-palette-white, 1);
 $header-button-focus-color: rgba($ids-color-palette-white, 1);
-$header-button-hover-color: rgba($ids-color-palette-slate-100, 0.7);
-$header-button-disabled-color: $ids-color-palette-slate-40;
+$header-button-hover-color: rgba($ids-color-palette-white, 0.7);
+$header-button-disabled-color: rgba($ids-color-palette-white, 0.3);
 $header-primary-btn-background-color: $ids-color-palette-azure-50;
 $header-primary-btn-background-hover-color: $ids-color-brand-primary-base;
 $header-text-color: $ids-color-palette-white;
 $header-disabled-color: $ids-color-palette-slate-50;
 $header-focus-box-shadow: 0 0 4px 3px rgba(255, 255, 255, 0.3);
+
+$ids-color-palette-alabaster: $ids-color-palette-white;
 
 // Color Personalization in header
 $header-default-bg-color: $ids-color-palette-azure-60;
@@ -971,7 +973,7 @@ $header-searchfield-input-border-color: $ids-color-palette-slate-40;
 $header-searchfield-input-border-hover-color: $ids-color-palette-slate-100;
 $header-searchfield-btn-font-color: $ids-color-palette-slate-80;
 $header-toolbar-searchfield-icon-color: $ids-color-palette-white;
-$header-toolbar-button-hover-color: $ids-color-palette-azure-10;
+$header-toolbar-button-hover-color: $ids-color-palette-azure-80;
 
 // Header Tabs
 $header-tabcontainer-border-color: $ids-color-palette-graphite-30;

--- a/src/themes/theme-classic-contrast.scss
+++ b/src/themes/theme-classic-contrast.scss
@@ -33,6 +33,8 @@ $header-focus-box-shadow: 0 0 4px 3px rgba(255, 255, 255, 0.3);
 $header-toolbar-searchfield-icon-color: $ids-color-palette-white;
 $header-toolbar-button-hover-color: transparent;
 
+$header-default-bg-color: $ids-color-palette-azure-90;
+
 $header-hero-text-color: rgba($ids-color-palette-white, 1);
 $header-hero-widget-bg-color: $subhead-bg-color;
 

--- a/src/themes/theme-classic-contrast.scss
+++ b/src/themes/theme-classic-contrast.scss
@@ -22,9 +22,9 @@ $header-bg-color: $ids-color-palette-white;
 $subhead-bg-color: $ids-color-palette-azure-80;
 $header-border-color: $ids-color-palette-slate-100;
 $header-text-color: $ids-color-palette-white;
-$header-button-color: rgba($ids-color-palette-slate-100, 0.7);
+$header-button-color: rgba($ids-color-palette-white, 0.7);
 $header-button-focus-color: rgba($ids-color-palette-azure-60, 1);
-$header-button-hover-color: rgba($ids-color-palette-slate-100, 0.7);
+$header-button-hover-color: rgba($ids-color-palette-white, 0.7);
 $header-button-disabled-color: rgba($ids-color-palette-white, 0.3);
 $header-primary-btn-background-color: $ids-color-brand-primary-base;
 $header-primary-btn-background-hover-color: $ids-color-palette-azure-50;
@@ -33,7 +33,7 @@ $header-focus-box-shadow: 0 0 4px 3px rgba(255, 255, 255, 0.3);
 $header-toolbar-searchfield-icon-color: $ids-color-palette-white;
 $header-toolbar-button-hover-color: transparent;
 
-$header-default-bg-color: $ids-color-palette-azure-90;
+$header-default-bg-color: $ids-color-palette-azure-80;
 
 $header-hero-text-color: rgba($ids-color-palette-white, 1);
 $header-hero-widget-bg-color: $subhead-bg-color;

--- a/src/themes/theme-classic-dark.scss
+++ b/src/themes/theme-classic-dark.scss
@@ -17,6 +17,9 @@
 // Override Config
 //================================================== //
 
+$header-default-bg-color: $ids-color-palette-slate-60;
+$header-default-bg-hover-color: $ids-color-palette-slate-80;
+
 // Form Background Color
 $header-bg-color: $ids-color-palette-slate-60;
 $subhead-bg-color: $ids-color-palette-slate-50;

--- a/src/themes/theme-classic-dark.scss
+++ b/src/themes/theme-classic-dark.scss
@@ -752,7 +752,7 @@ $header-tab-normal-color: $ids-color-palette-slate-30;
 $header-tab-hover-color: $ids-color-palette-white;
 $header-tab-indicator-hover-color: $ids-color-palette-white;
 $header-tab-selected-color: $inverse-color;
-$header-tab-alt-bg-color: $ids-color-palette-slate-100;
+$header-tab-alt-bg-color: $ids-color-palette-slate-60;
 $header-tab-alt-separator: $ids-color-palette-white;
 $header-tab-alt-normal-color: $ids-color-palette-slate-30;
 $header-tab-alt-hover-color: $inverse-color;

--- a/src/themes/theme-new-contrast.scss
+++ b/src/themes/theme-new-contrast.scss
@@ -23,7 +23,7 @@ $header-border-color: $ids-color-palette-slate-100;
 $header-button-color: $ids-color-palette-white;
 $header-button-focus-color: $ids-color-palette-white;
 $header-button-hover-color: rgba($ids-color-palette-slate-70, 0.85);
-$header-button-disabled-color: rgba($ids-color-palette-slate-50, 0.3);
+$header-button-disabled-color: rgba($ids-color-palette-white, 0.3);
 $header-primary-btn-background-color: $ids-color-brand-primary-base;
 $header-primary-btn-background-hover-color: $ids-color-palette-azure-50;
 $header-disabled-color: $ids-color-palette-slate-50;

--- a/src/themes/theme-new-contrast.scss
+++ b/src/themes/theme-new-contrast.scss
@@ -719,7 +719,7 @@ $searchfield-card-text-color: $font-color;
 
 $searchfield-header-bg-color: $ids-color-palette-white;
 $searchfield-header-border-color: $ids-color-palette-slate-90;
-$searchfield-header-text-color: $ids-color-palette-white;;
+$searchfield-header-text-color: $ids-color-palette-white;
 $searchfield-header-placeholder-text-color: rgba(255, 255, 255, 0.7);
 $searchfield-header-icon-color: $ids-color-palette-slate-60;
 

--- a/src/themes/theme-new-contrast.scss
+++ b/src/themes/theme-new-contrast.scss
@@ -17,7 +17,7 @@
 @import '../core/config';
 
 // Form Background Color
-$header-bg-color: $ids-color-brand-primary-base;
+$header-bg-color: $ids-color-palette-azure-60;
 $subhead-bg-color: $ids-color-palette-white;
 $header-border-color: $ids-color-palette-slate-100;
 $header-button-color: $ids-color-palette-white;

--- a/src/themes/theme-new-contrast.scss
+++ b/src/themes/theme-new-contrast.scss
@@ -17,11 +17,11 @@
 @import '../core/config';
 
 // Form Background Color
-$header-bg-color: $ids-color-palette-white;
+$header-bg-color: $ids-color-brand-primary-base;
 $subhead-bg-color: $ids-color-palette-white;
 $header-border-color: $ids-color-palette-slate-100;
-$header-button-color: $ids-color-palette-slate-100;
-$header-button-focus-color: $ids-color-palette-slate-70;
+$header-button-color: $ids-color-palette-white;
+$header-button-focus-color: $ids-color-palette-white;
 $header-button-hover-color: rgba($ids-color-palette-slate-70, 0.85);
 $header-button-disabled-color: rgba($ids-color-palette-slate-50, 0.3);
 $header-primary-btn-background-color: $ids-color-brand-primary-base;

--- a/src/themes/theme-new-contrast.scss
+++ b/src/themes/theme-new-contrast.scss
@@ -17,7 +17,9 @@
 @import '../core/config';
 
 // Form Background Color
-$header-bg-color: $ids-color-palette-azure-60;
+$header-bg-color: $ids-color-palette-azure-80;
+$header-default-bg-color: $ids-color-palette-azure-80;
+$header-default-bg-hover-color: rgba(0, 0, 0, .3);
 $subhead-bg-color: $ids-color-palette-white;
 $header-border-color: $ids-color-palette-slate-100;
 $header-button-color: $ids-color-palette-white;
@@ -717,7 +719,7 @@ $searchfield-card-text-color: $font-color;
 
 $searchfield-header-bg-color: $ids-color-palette-white;
 $searchfield-header-border-color: $ids-color-palette-slate-90;
-$searchfield-header-text-color: $ids-color-palette-slate-90;
+$searchfield-header-text-color: $ids-color-palette-white;;
 $searchfield-header-placeholder-text-color: rgba(255, 255, 255, 0.7);
 $searchfield-header-icon-color: $ids-color-palette-slate-60;
 

--- a/src/themes/theme-new-dark.scss
+++ b/src/themes/theme-new-dark.scss
@@ -20,7 +20,7 @@ $body-color-primary-background: $ids-color-palette-slate-100;
 $header-default-bg-color: $ids-color-palette-slate-60;
 $header-default-bg-hover-color: $ids-color-palette-slate-80;
 
-$ids-color-palette-alabaster: $ids-color-palette-slate-60;
+$ids-color-palette-alabaster: $ids-color-palette-white;
 
 // Form Background Color
 $header-toolbar-button-hover-color: transparent;

--- a/src/themes/theme-new-dark.scss
+++ b/src/themes/theme-new-dark.scss
@@ -17,6 +17,9 @@
 // Theme Overrides
 $body-color-primary-background: $ids-color-palette-slate-100;
 
+$header-default-bg-color: $ids-color-palette-slate-60;
+$header-default-bg-hover-color: $ids-color-palette-slate-80;
+
 // Form Background Color
 $header-toolbar-button-hover-color: transparent;
 $subhead-bg-color: $ids-color-brand-primary-alt;
@@ -784,7 +787,6 @@ $subheader-input-text-color-focus: $ids-color-palette-slate-20;
 $subheader-searchfield-category-button-font-color: $subheader-input-text-color-focus;
 
 // Header
-$header-bg-color: $ids-color-brand-primary-base;
 $header-text-color: $ids-color-palette-white;
 $header-toolbar-searchfield-icon-color: rgba($ids-color-palette-white, 1);
 $header-button-hover-color: rgba($ids-color-palette-white, 1);

--- a/src/themes/theme-new-dark.scss
+++ b/src/themes/theme-new-dark.scss
@@ -20,6 +20,8 @@ $body-color-primary-background: $ids-color-palette-slate-100;
 $header-default-bg-color: $ids-color-palette-slate-60;
 $header-default-bg-hover-color: $ids-color-palette-slate-80;
 
+$ids-color-palette-alabaster: $ids-color-palette-slate-60;
+
 // Form Background Color
 $header-toolbar-button-hover-color: transparent;
 $subhead-bg-color: $ids-color-brand-primary-alt;

--- a/src/themes/theme-new-light.scss
+++ b/src/themes/theme-new-light.scss
@@ -26,6 +26,8 @@ $drop-shadow-depth: rgba($ids-color-boxshadow-base, 0.2);
 
 $application-menu-border-color: $ids-color-palette-slate-90;
 
+$header-default-bg-color: $ids-color-palette-azure-60;
+
 // Icons
 $icon-color: $icon-color-fill;
 $icon-empty-bg-color: $ids-color-palette-slate-60;

--- a/src/themes/theme-new-light.scss
+++ b/src/themes/theme-new-light.scss
@@ -15,7 +15,6 @@
 @import '../core/config';
 
 // New Theme Light Overrides
-$header-bg-color: $ids-color-palette-white;
 $subhead-bg-color: $ids-color-palette-white;
 $disabled-color: $ids-color-palette-slate-30;
 $label-disabled-color: $input-color-disabled-border;

--- a/src/themes/theme-new-light.scss
+++ b/src/themes/theme-new-light.scss
@@ -200,7 +200,7 @@ $timepicker-disabled-color: $ids-color-palette-slate-30;
 $timepicker-readonly-icon-color: $ids-color-palette-slate-40;
 
 // Buttons
-$header-button-disabled-color: $ids-color-palette-slate-30;
+$header-button-disabled-color: rgba($ids-color-palette-white, 0.6);
 $button-color-primary-disabled-font-new: $ids-color-palette-white;
 $button-color-tertiary-initial-font: $ids-color-palette-slate-60;
 $button-color-tertiary-actionsheet-hover-font: $button-color-tertiary-hover-font-new;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the default color back to azure and add alabaster in personalization colors.

The focus areas of these changes, for now, are the header, masthead, and personalize components. I anticipate that some components will be affected by this revert, but we can fix those next time.

For patch `[4.80.x, 4.81.x]`

**Related github/jira issue (required)**:

Closes #7320 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/header/example-index.html
- Default color should be azure
- Check the `Colors`
- Alabaster should be available
- Test all elements in different colors
- Test all example pages
  - http://localhost:4000/components/header
  - http://localhost:4000/components/masthead
  - http://localhost:4000/components/personalize

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
