### PR TITLE
7338 - Personalization Fix color changing doesn't add CSS class to the header in Safari

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `[Lookup]` Fix in keyword search not filtering single quote. ([#7165](https://github.com/infor-design/enterprise/issues/7165))
 - `[Personalization]` Changed default color back to azure and add alabaster in personalization colors. ([#7320](https://github.com/infor-design/enterprise/issues/7320))
+- `[Personalization]` Fixed color changing doesn't add CSS class to the header in Safari browser. ([#7338](https://github.com/infor-design/enterprise/issues/7338))
 - `[Tabs]` Fixed the alignment of focus in RTL view. ([#6992](https://github.com/infor-design/enterprise/issues/6992))
 - `[Tabs Header]` Fixed the alignment of close button. ([#7273](https://github.com/infor-design/enterprise/issues/7273))
 - `[Timeline]` Fixed the alignment when timeline is inside a card. ([#7278](https://github.com/infor-design/enterprise/issues/7278))

--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -247,7 +247,7 @@ Header.prototype = {
    * @returns {void}
    */
   setHeaderColorClass() {
-    const colorSelected = document.querySelector('.submenu:last-child ul li.is-checked')?.innerText.toLowerCase() || 'default';
+    const colorSelected = document.querySelector('.submenu:last-child ul li.is-checked')?.innerText.toLowerCase().trim() || 'default';
     const headerElement = document.querySelectorAll('header.header');
     const subheaderElement = document.querySelectorAll('.subheader');
     const personalizeSubheaderElement = document.querySelectorAll('.personalize-subheader');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes color changing doesn't add CSS class due to the selected color string contains special character in Safari

**Related github/jira issue (required)**:
Closes #7338 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4000/components/builder/example-builder-wizard.html?colors=default&theme=new&mode=light in **Safari**
- shrink the browser so `Sidebar Popup` is visible
- change color to alabaster and change it back to default
- see the `Sidebar Popup` is visible and has correct hover bg color

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.