### PR TITLE
7331 - Editor Fix links are not readable in dark mode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## v4.82.0 Fixes
 
+- `[Editor]` Fixed links are not readable in dark mode. ([#7331](https://github.com/infor-design/enterprise/issues/7331))
 - `[Lookup]` Fix in keyword search not filtering single quote. ([#7165](https://github.com/infor-design/enterprise/issues/7165))
 - `[Personalization]` Changed default color back to azure and add alabaster in personalization colors. ([#7320](https://github.com/infor-design/enterprise/issues/7320))
 - `[Tabs]` Fixed the alignment of focus in RTL view. ([#6992](https://github.com/infor-design/enterprise/issues/6992))

--- a/src/components/editor/_editor.scss
+++ b/src/components/editor/_editor.scss
@@ -47,7 +47,7 @@
       display: none;
     }
 
-    .hyperlink {
+    a {
       cursor: pointer;
     }
   }
@@ -63,7 +63,7 @@
     color: $input-readonly-color;
     cursor: text;
 
-    .hyperlink {
+    a {
       color: $hyperlink-color !important;
     }
   }
@@ -124,7 +124,7 @@
       display: none;
     }
 
-    .hyperlink {
+    a {
       cursor: pointer;
     }
 
@@ -251,7 +251,7 @@
     color: $editor-color;
     font-size: $input-size-regular-font-size;
 
-    .hyperlink {
+    a {
       color: $hyperlink-color;
       font-size: $input-size-regular-font-size !important;
       margin-left: -1px;
@@ -259,6 +259,11 @@
       padding: 0;
       white-space: pre-wrap;
       word-wrap: break-word;
+      border: 1px solid transparent;
+
+      &:hover:not([disabled]) {
+        color: $hyperlink-hover-color;
+      }
     }
   }
 
@@ -271,7 +276,7 @@
     color: $editor-color;
     line-height: normal;
 
-    .hyperlink {
+    a {
       font-size: inherit;
     }
   }
@@ -345,7 +350,7 @@
     font-weight: inherit;
   }
 
-  .hyperlink {
+  a {
     cursor: auto;
     font-size: $input-size-regular-font-size;
     position: static;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes the issue with not readable links in editor by applying hyperlink styles to all links in the editor

**Related github/jira issue (required)**:
Closes #7331

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4000/components/editor/example-customize-buttons.html?theme=new&mode=dark&colors=default
- see the link is readable and the color is consistent with other editor examples
- test modes
- test disabled, readonly, preview states

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.
