### PR TITLE
7299 - Fix exceeding line on adding additional elements in timeline content

### DIFF
--- a/app/views/components/timeline/test-additional-height.html
+++ b/app/views/components/timeline/test-additional-height.html
@@ -1,0 +1,88 @@
+
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="timeline" id="timeline-id-1" data-automation-id="timeline-automation-id-1">
+
+      <div class="timeline-block" id="timeline-block-id-1" data-automation-id="timeline-block-automation-id-1">
+        <div class="indicator-container">
+          <div class="indicator complete"></div>
+        </div>
+        <div class="content">
+          <div class="heading">PO Created / Unreleased</div>
+          <div class="sub-heading">By: Buying Department | Sallie Langie</div>
+        </div>
+        <div class="date">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-calendar"></use>
+          </svg>
+          <span>January 23, 2015</span>
+          <span>1:15 pm</span>
+        </div>
+      </div>
+
+      <div class="timeline-block" id="timeline-block-id-2" data-automation-id="timeline-block-automation-id-2">
+        <div class="indicator-container">
+          <div class="indicator complete"></div>
+        </div>
+        <div class="content">
+          <div class="heading">PO Released</div>
+          <div class="sub-heading">By: Buying Department | Sallie Langie</div>
+        </div>
+        <div class="date">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-calendar"></use>
+          </svg>
+          <span>January 23, 2015</span>
+          <span>1:16 pm</span>
+        </div>
+      </div>
+
+      <div class="timeline-block" id="timeline-block-id-3" data-automation-id="timeline-block-automation-id-3">
+        <div class="indicator-container">
+          <div class="indicator processing"></div>
+        </div>
+        <div class="content">
+          <div class="heading">PO Accepted</div>
+          <div class="sub-heading">By: Buying Department | Sallie Langie</div>
+        </div>
+        <div class="date">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-calendar"></use>
+          </svg>
+          <span>January 23, 2015</span>
+          <span>1:17 pm</span>
+        </div>
+      </div>
+
+      <div class="timeline-block" id="timeline-block-id-4" data-automation-id="timeline-block-automation-id-4">
+        <div class="indicator-container">
+          <div class="indicator"></div>
+        </div>
+        <div class="content">
+          <div class="heading">3 Items in Progress</div>
+        </div>
+        <div class="date"></div>
+      </div>
+
+      <div class="timeline-block" id="timeline-block-id-5" data-automation-id="timeline-block-automation-id-5">
+        <div class="indicator-container">
+          <div class="indicator"></div>
+        </div>
+        <div class="content">
+          <div class="heading">Closed</div>
+          <br/>
+          <div class="sub-heading">By: Buying Department | Sallie Langie</div>
+        </div>
+        <div class="date ">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-calendar"></use>
+          </svg>
+          <span>January 23, 2015</span>
+          <span>ESTIMATED</span>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Tabs]` Fixed the alignment of focus in RTL view. ([#6992](https://github.com/infor-design/enterprise/issues/6992))
 - `[Tabs Header]` Fixed the alignment of close button. ([#7273](https://github.com/infor-design/enterprise/issues/7273))
 - `[Timeline]` Fixed the alignment when timeline is inside a card. ([#7278](https://github.com/infor-design/enterprise/issues/7278))
+- `[Timeline]` Fix exceeding line on adding additional elements in timeline content. ([#7299](https://github.com/infor-design/enterprise/issues/7299))
 
 ## v4.81.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,7 @@
 - `[Tabs]` Fixed the alignment of focus in RTL view. ([#6992](https://github.com/infor-design/enterprise/issues/6992))
 - `[Tabs Header]` Fixed the alignment of close button. ([#7273](https://github.com/infor-design/enterprise/issues/7273))
 - `[Timeline]` Fixed the alignment when timeline is inside a card. ([#7278](https://github.com/infor-design/enterprise/issues/7278))
-- `[Timeline]` Fix exceeding line on adding additional elements in timeline content. ([#7299](https://github.com/infor-design/enterprise/issues/7299))
+- `[Timeline]` Fixed issue with timeline content exceeding allotted space when additional elements were added. ([#7299](https://github.com/infor-design/enterprise/issues/7299))
 
 ## v4.81.0
 

--- a/src/components/timeline/_timeline-new.scss
+++ b/src/components/timeline/_timeline-new.scss
@@ -8,6 +8,16 @@
   }
 }
 
+.timeline-block {
+  &:nth-last-child(2)::before {
+    bottom: -20px;
+
+    @media (min-width: 767px) {
+      left: 20.3rem;
+    }
+  }
+}
+
 // Brings the dotted line into alignment with the text
 .indicator-container {
   top: 1px;

--- a/src/components/timeline/_timeline-new.scss
+++ b/src/components/timeline/_timeline-new.scss
@@ -12,7 +12,7 @@
   &:nth-last-child(2)::before {
     bottom: -20px;
 
-    @media (min-width: 767px) {
+    @media (min-width: $breakpoint-phone-to-tablet) {
       left: 20.3rem;
     }
   }

--- a/src/components/timeline/_timeline.scss
+++ b/src/components/timeline/_timeline.scss
@@ -15,6 +15,7 @@
     position: absolute;
     top: 0;
     width: 3px;
+    height: 70%;
   }
 
   .indicator {
@@ -44,6 +45,22 @@
 
   &:last-child {
     margin-bottom: 0;
+  }
+
+  &:nth-last-child(2) {
+    &::before {
+      border-left: 1px dashed $timeline-line-color;
+      content: '';
+      position: absolute;
+      width: 3px;
+      bottom: -18px;
+      height: 100%;
+      left: 1.22em;
+
+      @media (min-width: 767px) {
+        left: 15.27rem;
+      }
+    }
   }
 
   .date {
@@ -152,6 +169,10 @@
       }
 
       .timeline-block {
+        &:nth-last-child(2)::before {
+          visibility: hidden;
+        }
+
         .indicator-container {
           margin-left: 0;
         }

--- a/src/components/timeline/_timeline.scss
+++ b/src/components/timeline/_timeline.scss
@@ -57,7 +57,7 @@
       height: 100%;
       left: 1.22em;
 
-      @media (min-width: 767px) {
+      @media (min-width: $breakpoint-phone-to-tablet) {
         left: 15.27rem;
       }
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Style adjustments for timeline. Split the line into two, with one that starts in the second to the last node to use the height as reference for how long it should be.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #7299 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/timeline/test-additional-height.html
- Line should not exceend last node

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
