### PR TITLE
7353 - Fix success badge color in new light theme

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## v4.82.0 Fixes
 
+- `[Badge]` Fixed success state badge color in new light theme. ([#7353](https://github.com/infor-design/enterprise/issues/7353))
 - `[Datagrid]` Fixed paging source argument is empty when re-assigning grid options. ([6947](https://github.com/infor-design/enterprise/issues/6947))
 - `[Editor]` Fixed links are not readable in dark mode. ([#7331](https://github.com/infor-design/enterprise/issues/7331))
 - `[Header]` Fixed border in search field in the header. ([#7297](https://github.com/infor-design/enterprise/issues/7297))

--- a/src/themes/theme-new-light.scss
+++ b/src/themes/theme-new-light.scss
@@ -222,7 +222,7 @@ $badge-secondary-disabled-border-color: $ids-color-palette-slate-40;
 $badge-alert-color: $ids-color-palette-slate-100;
 $badge-alert-bg-color: #ffd726;
 $badge-alert-icon-color: $ids-color-palette-slate-100;
-$badge-good-bg-color: $ids-color-palette-emerald-90;
+$badge-good-bg-color: $status-04-color;
 $badge-good-hover-icon-color: $ids-color-palette-white;
 $badge-disabled-bg-color: $ids-color-palette-slate-20;
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the success state badge color in new light theme.

**Related github/jira issue (required)**:

Closes #7353 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/badges/example-index.html
- Inspect the element of success badge color
- background color should be `#2AC371`

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
