### PR TITLE
NG1429 - textarea toggle dirty

### DIFF
--- a/app/views/components/textarea/test-toggle-track-dirty.html
+++ b/app/views/components/textarea/test-toggle-track-dirty.html
@@ -1,0 +1,28 @@
+
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="field">
+      <label for="description-dirty">Textarea</label>
+      <textarea id="description-dirty" class="textarea" data-trackdirty="true" name="description-dirty" readonly></textarea>
+    </div>
+
+    <button class="btn-primary" type="button" id="btn-toggle">Toggle TextArea Readonly</button>
+  </div>
+</div>
+
+<script>
+
+  $('body').one('initialized', function () {
+    $('#btn-toggle').on('click', () => {
+      const textEl = document.getElementById('description-dirty');
+      if (textEl.readOnly) {
+        textEl.readOnly='';
+      } else {
+        textEl.readOnly='true';
+      }
+
+      $('#description-dirty').data('textarea').updated();
+    })
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[Personalization]` Adjusted header text/tabs colors. ([#7319](https://github.com/infor-design/enterprise/issues/7319))
 - `[Tabs]` Fixed the alignment of focus in RTL view. ([#6992](https://github.com/infor-design/enterprise/issues/6992))
 - `[Tabs Header]` Fixed the alignment of close button. ([#7273](https://github.com/infor-design/enterprise/issues/7273))
+- `[Textarea]` Fixed track dirty when updated() method was triggered. ([NG#1429](https://github.com/infor-design/enterprise-ng/issues/1429))
 - `[Timeline]` Fixed the alignment when timeline is inside a card. ([#7278](https://github.com/infor-design/enterprise/issues/7278))
 - `[Timeline]` Fixed issue with timeline content exceeding allotted space when additional elements were added. ([#7299](https://github.com/infor-design/enterprise/issues/7299))
 

--- a/src/components/textarea/textarea.js
+++ b/src/components/textarea/textarea.js
@@ -270,6 +270,10 @@ Textarea.prototype = {
     this.destroy();
     this.init();
 
+    if (this.element.data('trackdirty')) {
+      this.element.data('trackdirty').updated();
+    }
+
     if (this.element.data('validate')) {
       this.element.validate();
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request fix track dirty when updated() method was triggered (EP).

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1429

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/textarea/test-toggle-track-dirty.html
- Click on `Toggle Textarea Readonly`
- Enter some characters on the textarea

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

