### PR TITLE
7297/7304 - Border on Search Field in Tabs Module Header (2)

### DIFF
--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -601,7 +601,7 @@ $subheader-height: 60px;
         padding: 0;
       }
 
-      [class^='btn']:not(.searchfield-category-button) {
+      [class^='btn']:not(.searchfield-category-button):not(.btn-actions) {
         margin-right: 3px;
         min-width: 45px;
         text-overflow: ellipsis;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix the border in search field in the header in tabs module

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/7297
Closes https://github.com/infor-design/enterprise/issues/7304

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/tabs-module/example-category-searchfield-go-button-home.html?theme=new&mode=light&colors=BB5500
- Check the searchfield component (it should be white)
- Hover the `Go` Button
- Switch on the Modes and Colors

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
