### PR TITLE
7369 - Fix activated and non activated rows background color when hovering

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - `[Badge]` Fixed success state badge color in new light theme. ([#7353](https://github.com/infor-design/enterprise/issues/7353))
 - `[Card]` Fixed group-action unnecessary scroll bar. ([#7343](https://github.com/infor-design/enterprise/issues/7343))
-- `[Datagrid]` Fixed row hover background color of activated and not activated rows. ([#7320](https://github.com/infor-design/enterprise/issues/7369))
+- `[Datagrid]` Fixed table layout with a distinct hover background color for both activated and non-activated rows. ([#7320](https://github.com/infor-design/enterprise/issues/7369))
 - `[Datagrid]` Fixed header icon tooltip showing when undefined. ([#6929](https://github.com/infor-design/enterprise/issues/6929))
 - `[Datagrid]` Fix on styling in row status icon when first column is not a select column. ([NG#5913](https://github.com/infor-design/enterprise-ng/issues/5913))
 - `[Datagrid]` Fixed paging source argument is empty when re-assigning grid options. ([6947](https://github.com/infor-design/enterprise/issues/6947))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,9 +8,10 @@
 
 ## v4.82.0 Fixes
 
-- `[Datagrid]` Fixed header icon tooltip showing when undefined. ([#6929](https://github.com/infor-design/enterprise/issues/6929))
 - `[Badge]` Fixed success state badge color in new light theme. ([#7353](https://github.com/infor-design/enterprise/issues/7353))
 - `[Card]` Fixed group-action unnecessary scroll bar. ([#7343](https://github.com/infor-design/enterprise/issues/7343))
+- `[Datagrid]` Fixed row hover background color of activated and not activated rows. ([#7320](https://github.com/infor-design/enterprise/issues/7369))
+- `[Datagrid]` Fixed header icon tooltip showing when undefined. ([#6929](https://github.com/infor-design/enterprise/issues/6929))
 - `[Datagrid]` Fix on styling in row status icon when first column is not a select column. ([NG#5913](https://github.com/infor-design/enterprise-ng/issues/5913))
 - `[Datagrid]` Fixed paging source argument is empty when re-assigning grid options. ([6947](https://github.com/infor-design/enterprise/issues/6947))
 - `[Editor]` Fixed links are not readable in dark mode. ([#7331](https://github.com/infor-design/enterprise/issues/7331))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -4433,7 +4433,7 @@ td .btn-actions {
 }
 
 // Change BG color of hovered Datagrid row cell icons
-.is-hover-row:not(.hide-selected-color) {
+.is-hover-row:not(.hide-selected-color):not(.is-rowactivated) {
   .datagrid-trigger-cell {
     .icon:not(.icon-rowstatus) {
       @include trigger-icon-background($datagrid-row-hover-color);

--- a/src/themes/theme-new-light.scss
+++ b/src/themes/theme-new-light.scss
@@ -113,7 +113,7 @@ $datagrid-header-checkbox-border-color: $ids-color-palette-slate-30;
 $datagrid-cell-readonly-bg-color: rgba(239, 239, 240, 0.5);
 $datagrid-cell-border-color: $ids-color-palette-slate-30;
 $datagrid-group-row-border-color: $ids-color-palette-slate-30;
-$datagrid-row-hover-color: #d8e7f7;
+$datagrid-row-hover-color: $ids-color-palette-azure-10;
 $datagrid-row-icon-color: $ids-color-palette-slate-60;
 $datagrid-row-selected-color: #d8e7f7;
 $datagrid-row-selected-color-dark: $datagrid-row-selected-color;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes row background color of activated and non activated rows. Regressed on this issue https://github.com/infor-design/enterprise/issues/5913.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/7369
Related PR https://github.com/infor-design/enterprise/pull/7341

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app

1.)
- Go to http://localhost:4000/components/datagrid/example-editable.html
- Click any row
- Hover on other row that is not activated
- Hover background color should be different

2.)
- Go to http://localhost:4000/components/datagrid/test-selected-rows-addnew.html
- Click any row to get activated
- Hover on other row that is not activated under `Action` column
- Dropdown icon should have the same background color


**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
