### PR TITLE
6947 - Datagrid paging when updated (follow up)

### DIFF
--- a/app/views/components/datagrid/test-paging-source-arguments.html
+++ b/app/views/components/datagrid/test-paging-source-arguments.html
@@ -8,7 +8,7 @@
   <div class="six columns">
     <div class="field">
       <button id="apply" class="btn-primary">
-        <span>Apply</span>
+        <span>Load Data With Paging</span>
       </button>
     </div>
   </div>
@@ -59,36 +59,26 @@
     columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, formatter: Soho.Formatters.Decimal});
     columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Soho.Formatters.Date, dateFormat: 'M/d/yyyy'});
 
+    function source(req, done) {
+      console.info('paging', req);
+
+      var url = '{{basepath}}api/compressors?pageNum='+ req.activePage +'&pageSize='+ req.pagesize;
+
+      return $.getJSON(url, function(res) {
+        req.total = res.total;
+        done(res.data, req);
+      });
+    }
+
     const datagrid = $('#datagrid').datagrid({
       columns: columns,
-      paging: true,
-      source: function (req, done) {
-        console.info('paging initial argument', req);
-
-        var url = '{{basepath}}api/compressors?pageNum=1&pageSize=10';
-
-        return $.getJSON(url, function(res) {
-          done(res.data, req);
-        });
-      }
     }).data('datagrid');
 
     function loadActiveGrid() {
-      function source(req, done) {
-        console.info('paging argument', req);
-
-        var url = '{{basepath}}api/compressors?pageNum='+ req.activePage +'&pageSize='+ req.pagesize;
-
-        return $.getJSON(url, function(res) {
-          req.total = res.total;
-          done(res.data, req);
-        });
-      }
-
       const settings = {
         paging: true,
-        pagesize: 10,
-        pagesizes: [10, 25, 50, 75, 150],
+        pagesize: 5,
+        pagesizes: [5, 10, 25, 50, 100],
         clickToSelect: false,
         saveUserSettings: {
           activePage: true,

--- a/app/views/components/datagrid/test-paging-source-arguments.html
+++ b/app/views/components/datagrid/test-paging-source-arguments.html
@@ -59,9 +59,23 @@
     columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, formatter: Soho.Formatters.Decimal});
     columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Soho.Formatters.Date, dateFormat: 'M/d/yyyy'});
 
+    const datagrid = $('#datagrid').datagrid({
+      columns: columns,
+      paging: true,
+      source: function (req, done) {
+        console.info('paging initial argument', req);
+
+        var url = '{{basepath}}api/compressors?pageNum=1&pageSize=10';
+
+        return $.getJSON(url, function(res) {
+          done(res.data, req);
+        });
+      }
+    }).data('datagrid');
+
     function loadActiveGrid() {
       function source(req, done) {
-        console.info('paging', req);
+        console.info('paging argument', req);
 
         var url = '{{basepath}}api/compressors?pageNum='+ req.activePage +'&pageSize='+ req.pagesize;
 
@@ -71,28 +85,23 @@
         });
       }
 
-      // Init and get the api for the grid
-      gridApi = $('#datagrid').datagrid({
-        columns: columns,
-        selectable: 'multiple',
+      const settings = {
         paging: true,
-        pagesize: 5,
-        source: source,
-        toolbar: {
-          title: 'Data Grid Header Title',
-          results: true,
-          dateFilter: false,
-          keywordFilter: true,
-          advancedFilter: true,
-          actions: true,
-          views: true,
-          rowHeight: true,
-          collapsibleFilter: true
-        }
-      }).data('datagrid');
-    }
+        pagesize: 10,
+        pagesizes: [10, 25, 50, 75, 150],
+        clickToSelect: false,
+        saveUserSettings: {
+          activePage: true,
+          columns: true,
+          filter: true,
+          pagesize: true,
+          sortOrder: true
+        },
+        source: source
+      }
 
-    loadActiveGrid();
+      datagrid.updated(settings);
+    }
 
     $('#apply').on('click', function() {
       loadActiveGrid();

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -13343,9 +13343,9 @@ Datagrid.prototype = {
     }
 
     this.setRowHeightClass();
+    this.handlePaging();
     this.render(null, pagingInfo);
     this.renderHeader();
-    this.handlePaging();
     return this;
   }
 };

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7051,26 +7051,7 @@ Datagrid.prototype = {
         }
       });
 
-    // Handle Paging
-    if (this.settings.paging) {
-      // Need to store the original id to work the wrapping and unwrapping in popupmenu
-      // before the paging initiate
-      this.pagerId = $('.pager-toolbar .btn-menu').attr('aria-controls');
-      this.tableBody.on(`page.${COMPONENT_NAME}`, (e, pagingInfo) => {
-        if (pagingInfo.type === 'filtered' && this.settings.source) {
-          return;
-        }
-        self.closePopupmenuOnPaging();
-        self.saveUserSettings();
-        self.render(null, pagingInfo);
-        self.afterPaging(pagingInfo);
-      }).on(`pagesizechange.${COMPONENT_NAME}`, (e, pagingInfo) => {
-        pagingInfo.preserveSelected = true;
-        self.closePopupmenuOnPaging();
-        self.render(null, pagingInfo);
-        self.afterPaging(pagingInfo);
-      });
-    }
+    this.attachPagingEvents();
 
     // Handle Hover States
     if (self.settings.showHoverState) {
@@ -7631,6 +7612,39 @@ Datagrid.prototype = {
         self.commitCellEdit();
       }
     });
+  },
+
+  /**
+   * Handle paging events
+   * @private
+   * @returns {void}
+   */
+  attachPagingEvents() {
+    const self = this;
+
+    if (this.settings.paging) {
+      // Need to store the original id to work the wrapping and unwrapping in popupmenu
+      // before the paging initiate
+      this.pagerId = $('.pager-toolbar .btn-menu').attr('aria-controls');
+      this.tableBody
+        .off(`page.${COMPONENT_NAME}`)
+        .on(`page.${COMPONENT_NAME}`, (e, pagingInfo) => {
+          if (pagingInfo.type === 'filtered' && this.settings.source) {
+            return;
+          }
+          self.closePopupmenuOnPaging();
+          self.saveUserSettings();
+          self.render(null, pagingInfo);
+          self.afterPaging(pagingInfo);
+        })
+        .off(`pagesizechange.${COMPONENT_NAME}`)
+        .on(`pagesizechange.${COMPONENT_NAME}`, (e, pagingInfo) => {
+          pagingInfo.preserveSelected = true;
+          self.closePopupmenuOnPaging();
+          self.render(null, pagingInfo);
+          self.afterPaging(pagingInfo);
+        });
+    }
   },
 
   /**
@@ -13344,6 +13358,7 @@ Datagrid.prototype = {
 
     this.setRowHeightClass();
     this.handlePaging();
+    this.attachPagingEvents();
     this.render(null, pagingInfo);
     this.renderHeader();
     return this;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
The issue: if the datagrid initializes with `paging: false` and you trying to update it with data containing paging, not only the `source` arguments are empty but the pager appears broken. This PR fixes the issue.

**Related github/jira issue (required)**:
Closes #6947

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4000/components/datagrid/test-paging-source-arguments.html
- click `Load Data With Paging`
- see the data with paging appears and pagination works
- see the paging argument in browser's console is not empty

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
~- [ ] A note to the change log.~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
