### PR TITLE
7199 - Column Fix data chart and legend doesn't match up

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Bar]` Fixed items not being selected/deselected from the legend. ([#7330](https://github.com/infor-design/enterprise/issues/7330))
 - `[Breadcrumb]` Updated breadcrumb hover color. ([#7337](https://github.com/infor-design/enterprise/issues/7337))
 - `[Card]` Fixed group-action unnecessary scroll bar. ([#7343](https://github.com/infor-design/enterprise/issues/7343))
+- `[Column]` Fixed data chart and legend doesn't match up. ([#7199](https://github.com/infor-design/enterprise/issues/7199))
 - `[Datagrid]` Fixed table layout with a distinct hover background color for both activated and non-activated rows. ([#7320](https://github.com/infor-design/enterprise/issues/7369))
 - `[Datagrid]` Fixed header icon tooltip showing when undefined. ([#6929](https://github.com/infor-design/enterprise/issues/6929))
 - `[Datagrid]` Fix on styling in row status icon when first column is not a select column. ([NG#5913](https://github.com/infor-design/enterprise-ng/issues/5913))

--- a/src/components/column/column.js
+++ b/src/components/column/column.js
@@ -626,6 +626,9 @@ Column.prototype = {
                   (pnPatterns.positive ? `url(#${pnPatterns.positive})` : null))
               );
           })
+          .attr('data-index', function (d, i) {
+            return i;
+          })
           .style('cursor', !self.settings.selectable ? 'inherit' : 'pointer')
           .style('fill', function (d) {
             return !isPositiveNegative ? null :
@@ -1213,7 +1216,7 @@ Column.prototype = {
           timer = setTimeout(function () {
             if (!prevent) {
               // Run click action
-              i = $(selector).index();
+              i = s.isSingle || s.isPositiveNegative ? $(selector).data('index') : $(selector).index();
               self.doClickAction(event, d, i, selector, clickedLegend);
             }
             prevent = false;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes incorrect index after legend being clicked in single column chart

**Related github/jira issue (required)**:
Closes #7199

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4000/components/column-stacked/example-singular-get-selected.html
- click on a legend item
- see the data bar is being highlighted according to the legend clicked

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.
