### PR TITLE
7383 - Fix on popupmenu more icon not visible when open

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@
 - `[Personalization]` Fixed color changing doesn't add CSS class to the header in Safari browser. ([#7338](https://github.com/infor-design/enterprise/issues/7338))
 - `[Personalization]` Adjusted header text/tabs colors. ([#7319](https://github.com/infor-design/enterprise/issues/7319))
 - `[Personalization]` Additional fixes for default color back to azure and added alabaster in personalization colors. ([#7340](https://github.com/infor-design/enterprise/issues/7340))
+- `[Popupmenu]` Fix on popupmenu more icon not visible when open. ([#7383](https://github.com/infor-design/enterprise/issues/7383))
 - `[Tabs]` Fixed the alignment of focus in RTL view. ([#6992](https://github.com/infor-design/enterprise/issues/6992))
 - `[Tabs Header]` Fixed the alignment of close button. ([#7273](https://github.com/infor-design/enterprise/issues/7273))
 - `[Textarea]` Fixed track dirty when updated() method was triggered. ([NG#1429](https://github.com/infor-design/enterprise-ng/issues/1429))

--- a/src/components/toolbar/_toolbar.scss
+++ b/src/components/toolbar/_toolbar.scss
@@ -144,6 +144,10 @@ $toolbar-buttonset-height: 40px;
     > * {
       margin-right: 1px;
     }
+
+    .btn-actions.is-open .icon {
+      color: $button-color-tertiary-initial-font;
+    }
   }
 
   &.do-resize {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Added color style for more icon

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #7383 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/contextualactionpanel/test-complex-toolbar.html?theme=classic&mode=dark&colors=50535A
- Click on Contextual Action Panel
- Click on more menu
- Icon should still be visible

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
