### PR TITLE
7397 - Align Icon Buttons in Listbuilder to center of the hitbox

### DIFF
--- a/src/components/listbuilder/_listbuilder.scss
+++ b/src/components/listbuilder/_listbuilder.scss
@@ -27,6 +27,10 @@
   .toolbar.formatter-toolbar {
     margin-bottom: -1px;
 
+    &:not(.standalone) .buttonset [class^='btn']:not(:disabled):hover {
+      background-color: transparent;
+    }
+
     .buttonset {
       [class^='btn'] {
         height: 24px;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Addresses comment in the alignment issue where the button icons aren't centered: The hover color is off.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Addresses comment in #7397 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/listbuilder/example-index.html
- Hover on buttons
- Color should be okay
- Additionally, icons should be centered

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
