### PR TITLE
7302 - Removed color style for other appmenu icons

### DIFF
--- a/src/components/applicationmenu/_applicationmenu-new.scss
+++ b/src/components/applicationmenu/_applicationmenu-new.scss
@@ -72,6 +72,12 @@
         background-color: $new-appmenu-hover-bg-color;
       }
     }
+
+    .flex-toolbar:not(.editor-toolbar):not(.formatter-toolbar):not(.contextual-toolbar) .toolbar-section {
+      [class^='btn']:not(:disabled):not(.searchfield-category-button):not(.collapse-button):hover {
+        background-color: $new-appmenu-hover-bg-color;
+      }
+    }
   }
 
   .accordion-static-panel {

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -870,12 +870,6 @@ html[dir='rtl'] .is-personalizable.tab-container.header-tabs:not(.alternate)::af
   background-color: ${colors.darkestPalette} !important;
 }
 
-html[class*="theme-new-"] .application-menu.is-personalizable button .icon,
-html[class*="theme-new-"] .application-menu.is-personalizable button span,
-html[class*="theme-new-"] .application-menu.is-personalizable .hyperlink {
-  color: ${colors.contrast} !important;
-}
-
 html[class*="-dark"] .is-personalizable .btn-tertiary:not(.destructive):not(:disabled):hover,
 html[class*="-dark"] .is-personalizable .btn-link:not(:disabled):hover,
 html[class*="-dark"] .is-personalizable:not(.header) .btn-tertiary:not(.destructive):not(.is-select):not(.is-select-month-pane):not(.is-cancel):not(.is-cancel-month-pane):hover:not(:disabled) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Additional updates for appmenu, removing color styles for appmenu icons (icons were not showing in alabaster)

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #7302 
Related to https://github.com/infor-design/enterprise/issues/7361

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/applicationmenu/test-all-chevrons.html?colors=ffffff
- Icons in appmenu should be visible

For NG:
- Use this version of IDS for IDS NG
- Go to: http://localhost:4200/ids-enterprise-ng-demo/personalize-color-api
- Check the appmenu is the same when switching to different themes and colors

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
