### PR TITLE
7373 - Weekview agenda variant

### DIFF
--- a/app/views/components/week-view/example-card.html
+++ b/app/views/components/week-view/example-card.html
@@ -1,0 +1,65 @@
+<div class="row">
+  <div class="two-thirds column">
+    <div class="card">
+      <div class="card-header">
+          <h2 class="widget-title">Stacked Week View</h2>
+      </div>
+      <div class="card-content">
+        <div id="week-view-stacked" class="week-view" data-init="false"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    // Get the Event Type and Events to show in the calendar
+    var eventTypes = [];
+    var events = [];
+
+    $.getJSON('{{basepath}}api/event-types', function(res) {
+    eventTypes = res;
+
+    $.getJSON('{{basepath}}api/events', function(res) {
+      events = res;
+
+      const opts = {
+        borderless: true,
+        eventTypes: eventTypes,
+        events: events,
+        showViewChanger: false,
+        showFooter: false,
+        startDate: new Date(2019, 9, 20),
+        endDate: new Date(2019, 9, 26),
+        stacked: false,
+        attributes: [
+          { name: 'id', value: 'custom-id' },
+          { name: 'data-automation-id', value: 'custom-automation-id' }
+        ]
+      }
+
+      $('#week-view-stacked').weekview({
+        ...opts,
+        stacked: true,
+        showFooter: true
+      });
+    });
+  });
+
+  const elem = $('#week-view-stacked')
+  elem.on('weekrendered', (evt, weekView) => {
+    const api = weekView.api;
+    const dayMap = api.dayMap;
+
+    // Example - Append element to footer
+    dayMap.forEach((day) => {
+      const events = day.events;
+      const footer = day.footer;
+
+      if (footer) {
+        footer.innerHTML = `<span>${events.length} Events</span>`
+      }
+    })
+  });
+ });
+</script>

--- a/app/views/components/week-view/example-card.html
+++ b/app/views/components/week-view/example-card.html
@@ -2,10 +2,32 @@
   <div class="two-thirds column">
     <div class="card">
       <div class="card-header">
+          <h2 class="widget-title">Week View</h2>
+      </div>
+      <div class="card-content">
+        <div id="week-view" class="week-view" data-init="false"></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="two-thirds column">
+    <div class="card">
+      <div class="card-header">
           <h2 class="widget-title">Stacked Week View</h2>
       </div>
       <div class="card-content">
         <div id="week-view-stacked" class="week-view" data-init="false"></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="two-thirds column">
+    <div class="card">
+      <div class="card-header">
+          <h2 class="widget-title">Stacked Week View (Hidden Toolbar/Footer)</h2>
+      </div>
+      <div class="card-content">
+        <div id="week-view-stacked-no-toolbar" class="week-view" data-init="false"></div>
       </div>
     </div>
   </div>
@@ -24,6 +46,7 @@
       events = res;
 
       const opts = {
+        hideToolbar: false,
         borderless: true,
         eventTypes: eventTypes,
         events: events,
@@ -31,6 +54,7 @@
         showFooter: false,
         startDate: new Date(2019, 9, 20),
         endDate: new Date(2019, 9, 26),
+        responsive: false,
         stacked: false,
         attributes: [
           { name: 'id', value: 'custom-id' },
@@ -38,10 +62,20 @@
         ]
       }
 
+      $('#week-view').weekview({...opts});
+
       $('#week-view-stacked').weekview({
         ...opts,
-        stacked: true,
-        showFooter: true
+        hideToolbar: false,
+        showFooter: true,
+        stacked: true
+      });
+
+      $('#week-view-stacked-no-toolbar').weekview({
+        ...opts,
+        hideToolbar: true,
+        showFooter: false,
+        stacked: true
       });
     });
   });

--- a/app/views/components/week-view/example-stacked.html
+++ b/app/views/components/week-view/example-stacked.html
@@ -19,6 +19,7 @@ $('body').one('initialized', function () {
         events: events,
         showViewChanger: false,
         showFooter: true,
+        responsive: true,
         startDate: new Date(2019, 9, 20),
         endDate: new Date(2019, 9, 26),
         stacked: true,

--- a/app/views/components/week-view/example-stacked.html
+++ b/app/views/components/week-view/example-stacked.html
@@ -18,6 +18,7 @@ $('body').one('initialized', function () {
         eventTypes: eventTypes,
         events: events,
         showViewChanger: false,
+        showFooter: true,
         startDate: new Date(2019, 9, 20),
         endDate: new Date(2019, 9, 26),
         stacked: true,
@@ -27,6 +28,22 @@ $('body').one('initialized', function () {
         ]
       });
     });
+  });
+
+  const elem = $('.week-view')
+  elem.on('weekrendered', (evt, weekView) => {
+    const api = weekView.api;
+    const dayMap = api.dayMap;
+
+    // Example - Append element to footer
+    dayMap.forEach((day) => {
+      const events = day.events;
+      const footer = day.footer;
+
+      if (footer) {
+        footer.innerHTML = `<span>${events.length} Events</span>`
+      }
+    })
   });
 });
 </script>

--- a/app/views/components/week-view/example-stacked.html
+++ b/app/views/components/week-view/example-stacked.html
@@ -1,0 +1,32 @@
+<div class="full-height full-width">
+  <div class="week-view" data-init="false">
+  </div>
+</div>
+
+<script id="test-script">
+$('body').one('initialized', function () {
+  // Get the Event Type and Events to show in the calendar
+  var eventTypes = [];
+  var events = [];
+
+  $.getJSON('{{basepath}}api/event-types', function(res) {
+    eventTypes = res;
+
+    $.getJSON('{{basepath}}api/events', function(res) {
+      events = res;
+      $('.week-view').weekview({
+        eventTypes: eventTypes,
+        events: events,
+        showViewChanger: false,
+        startDate: new Date(2019, 9, 20),
+        endDate: new Date(2019, 9, 26),
+        stacked: true,
+        attributes: [
+          { name: 'id', value: 'custom-id' },
+          { name: 'data-automation-id', value: 'custom-automation-id' }
+        ]
+      });
+    });
+  });
+});
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v4.84.0
 
+## v4.84.0 Features
+
+- `[WeekView]` Added stacked view template for week view agenda variant. ([#7373](https://github.com/infor-design/enterprise/issues/7373))
+
 ## v4.84.0 Fixes
 
 - `[Button]` Adjusted alignment for popupmenu icon buttons. ([#7408](https://github.com/infor-design/enterprise/issues/7408))

--- a/src/components/datepicker/_datepicker.scss
+++ b/src/components/datepicker/_datepicker.scss
@@ -252,15 +252,6 @@ html[dir='rtl'] {
   }
 }
 
-html.is-safari {
-  .datepicker {
-    + .trigger {
-      position: relative;
-      margin-top: 2px;
-    }
-  }
-}
-
 @include respond-to(tabletdown) {
   .monthview-popup.popover .monthview {
     min-width: 310px;

--- a/src/components/datepicker/datepicker.js
+++ b/src/components/datepicker/datepicker.js
@@ -781,6 +781,7 @@ DatePicker.prototype = {
     if (this.settings.onOpenCalendar) {
       // In some cases, month picker wants to set a specifc time.
       this.settings.activeDate = this.settings.onOpenCalendar();
+      this.currentDate = this.settings.activeDate;
       if (this.isIslamic) {
         this.settings.activeDateIslamic = Locale.gregorianToUmalqura(this.settings.activeDate);
         this.settings.year = this.settings.activeDateIslamic[0];

--- a/src/components/monthview/_monthview.scss
+++ b/src/components/monthview/_monthview.scss
@@ -110,7 +110,6 @@
   // Collapsible Month/Year Pane
   .monthview-monthyear-pane {
     background-color: $popover-bg-color;
-    margin: 0 -1px;
     max-height: calc(100% - 50px);
     overflow: hidden;
     position: absolute;

--- a/src/components/monthview/_monthview.scss
+++ b/src/components/monthview/_monthview.scss
@@ -138,7 +138,7 @@
         border-left: 1px solid $popover-separator-color;
         content: ' ';
         height: calc(100% - 20px);
-        left: 166px;
+        left: calc(50% + 1px);
         position: absolute;
         top: 15px;
       }

--- a/src/components/week-view/_week-view.scss
+++ b/src/components/week-view/_week-view.scss
@@ -24,92 +24,91 @@ $week-view-cell-height: 25px;
     }
   }
 
-  .week-view-table-header {
-    th {
-      background-clip: padding-box;
-      border-top: 0;
-      font-size: $ids-size-font-md;
-      height: 2.4rem;
-      line-height: 2.4rem;
-      text-align: left;
-      z-index: 3;
+  th.week-view-header-cell {
+    background-clip: padding-box;
+    border-top: 0;
+    font-size: $ids-size-font-md;
+    height: 2.4rem;
+    line-height: 2.4rem;
+    text-align: left;
+    z-index: 3;
+  }
 
-      // Style todays date
-      .week-view-header-wrapper.is-today {
-        box-shadow: 0 4px 0 0 $ids-color-brand-primary-base;
-        color: $ids-color-brand-primary-base;
-        font-weight: $ids-number-font-weight-bold;
+  // Style todays date
+  .week-view-header-wrapper.is-today {
+    border-bottom-color: $ids-color-brand-primary-base;
+    color: $ids-color-brand-primary-base;
+    font-weight: $ids-number-font-weight-bold;
+  }
+
+  // Times on the right
+  .week-view-header-wrapper {
+    padding: 4px 5px 0 4px;
+    border-bottom: 4px solid transparent;
+
+    .week-view-header-day-of-week {
+      display: block;
+      line-height: 2.5rem;
+      text-align: center;
+
+      &.is-emphasis {
+        font-size: 2rem;
       }
     }
+  }
 
-    // Times on the right
-    .week-view-header-wrapper {
-      padding: 0 5px;
+  // All day section
+  .week-view-all-day-wrapper {
+    border-top: 1px solid $calendar-line-color;
+    height: 44px;
+    position: relative;
 
-      .week-view-header-day-of-week {
-        display: block;
-        line-height: 2.5rem;
-        text-align: center;
-
-        &.is-emphasis {
-          font-size: 2rem;
-        }
-      }
+    &.is-disabled {
+      background-color: $calendar-disabled-bg-color;
+      opacity: 0.5;
     }
 
-    // All day section
-    .week-view-all-day-wrapper {
-      border-top: 1px solid $calendar-line-color;
-      height: 44px;
-      position: relative;
+    .calendar-event {
+      height: 20px;
+      top: 1px;
 
-      &.is-disabled {
-        background-color: $calendar-disabled-bg-color;
-        opacity: 0.5;
+      .calendar-event-content {
+        line-height: normal;
+        white-space: nowrap;
       }
 
-      .calendar-event {
-        height: 20px;
-        top: 1px;
+      &.calendar-event-start {
+        border-radius: 3px 0 0 3px;
+      }
 
-        .calendar-event-content {
-          line-height: normal;
-          white-space: nowrap;
-        }
+      &.calendar-event-continue {
+        border-left: 0;
+        border-radius: 0;
+        left: -1px;
+        width: calc(100% + 1px);
 
-        &.calendar-event-start {
-          border-radius: 3px 0 0 3px;
-        }
-
-        &.calendar-event-continue {
-          border-left: 0;
-          border-radius: 0;
-          left: -1px;
-          width: calc(100% + 1px);
-
-          .calendar-event-title {
-            color: transparent;
-          }
-        }
-
-        &.calendar-event-ends {
-          border-left: 0;
-          border-radius: 0 3px 3px 0;
+        .calendar-event-title {
           color: transparent;
-          left: -1px;
-          width: calc(100% + 1px);
+        }
+      }
 
-          .calendar-event-title {
-            color: transparent;
-          }
+      &.calendar-event-ends {
+        border-left: 0;
+        border-radius: 0 3px 3px 0;
+        color: transparent;
+        left: -1px;
+        width: calc(100% + 1px);
+
+        .calendar-event-title {
+          color: transparent;
         }
       }
     }
+  }
 
-    th:nth-child(1) .week-view-all-day-wrapper {
-      border-top-color: transparent;
-      padding: 5px;
-    }
+  th:nth-child(1) .week-view-all-day-wrapper {
+    border-top-color: transparent;
+    padding: 5px;
   }
 
   .week-view-table {
@@ -236,6 +235,86 @@ $week-view-cell-height: 25px;
           line-height: 4rem;
         }
       }
+    }
+  }
+}
+
+.week-view.stacked-view {
+  overflow: hidden;
+
+  .week-view-container {
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 1;
+    overflow: auto;
+    height: 100%;
+  }
+
+  .week-view-stacked-header,
+  .week-view-stacked-body,
+  .week-view-stacked-footer {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+  }
+
+  .week-view-header-cell,
+  .week-view-body-cell {
+    width: 100%;
+    box-sizing: border-box;
+    overflow: hidden;
+
+    &:not(:last-child) {
+      border-inline-end: 1px solid $calendar-line-color;
+    }
+  }
+
+  .week-view-stacked-header {
+    position: sticky;
+    align-self: flex-start;
+    top: 0;
+    width: 100%;
+    //min-height: 100px; // needed?
+    background-color: $calendar-bg-color;
+    border-bottom: 1px solid $calendar-line-color;
+    z-index: 2;
+  }
+
+  .week-view-stacked-body {
+    flex-grow: 1;
+
+    .week-view-body-cell {
+      padding: 0 2px;
+    }
+
+    // Stacked Calendar Events
+    .calendar-event {
+      display: block;
+      position: relative;
+      margin-block: 4px;
+      height: 52px;
+
+      .calendar-event-time {
+        display: block;
+      }
+    }
+  }
+
+  .week-view-stacked-footer {
+    position: sticky;
+    bottom: 0;
+    width: 100%;
+    min-height: 24px;
+    background-color: $calendar-bg-color;
+    border-top: 1px solid $calendar-line-color;
+    z-index: 2;
+
+    .week-view-footer-cell {
+      width: 100%;
+      text-align: center;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 }

--- a/src/components/week-view/_week-view.scss
+++ b/src/components/week-view/_week-view.scss
@@ -176,6 +176,16 @@ $week-view-cell-height: 25px;
     }
   }
 
+  &.toolbar-hidden {
+    .week-view-container .week-view-header-cell {
+      top: 0;
+    }
+
+    &.is-borderless .week-view-container .week-view-header-cell {
+      border-top: 1px solid $calendar-line-color;
+    }
+  }
+
   .week-view-cell-wrapper {
     height: $week-view-cell-height;
     min-width: 50px;
@@ -309,9 +319,6 @@ $week-view-cell-height: 25px;
     z-index: 2;
 
     .week-view-footer-cell {
-      display: flex;
-      justify-content: center;
-      align-items: center;
       width: 100%;
       text-align: center;
       white-space: nowrap;

--- a/src/components/week-view/_week-view.scss
+++ b/src/components/week-view/_week-view.scss
@@ -256,6 +256,7 @@ $week-view-cell-height: 25px;
     display: flex;
     flex-direction: row;
     justify-content: space-evenly;
+    background-color: $calendar-bg-color;
   }
 
   .week-view-header-cell,
@@ -274,8 +275,6 @@ $week-view-cell-height: 25px;
     align-self: flex-start;
     top: 0;
     width: 100%;
-    //min-height: 100px; // needed?
-    background-color: $calendar-bg-color;
     border-bottom: 1px solid $calendar-line-color;
     z-index: 2;
   }
@@ -292,24 +291,22 @@ $week-view-cell-height: 25px;
       display: block;
       position: relative;
       margin-block: 4px;
-      height: 52px;
-
-      .calendar-event-time {
-        display: block;
-      }
+      min-height: 52px;
+      height: unset;
     }
   }
 
   .week-view-stacked-footer {
     position: sticky;
     bottom: 0;
-    width: 100%;
     min-height: 24px;
-    background-color: $calendar-bg-color;
     border-top: 1px solid $calendar-line-color;
     z-index: 2;
 
     .week-view-footer-cell {
+      display: flex;
+      justify-content: center;
+      align-items: center;
       width: 100%;
       text-align: center;
       white-space: nowrap;

--- a/src/components/week-view/_week-view.scss
+++ b/src/components/week-view/_week-view.scss
@@ -9,7 +9,12 @@ $week-view-cell-height: 25px;
   display: flex;
   flex-direction: column;
   height: 100%;
+  width: 100%;
   overflow: auto;
+
+  &.is-borderless {
+    border: none;
+  }
 
   .week-view-header {
     background-color: $calendar-bg-color;

--- a/src/components/week-view/week-view.js
+++ b/src/components/week-view/week-view.js
@@ -51,6 +51,7 @@ const COMPONENT_NAME_DEFAULTS = {
  * @param {string} [settings.language] The name of the language to use for this instance. If not set the current locale will be used or the passed locale will be used.
  * @param {date} [settings.startDate] Start of the week to show.
  * @param {date} [settings.endDate] End of the week to show.
+ * @param {boolean} [settings.borderless] If true, week view is rendered without border.
  * @param {boolean} [settings.firstDayOfWeek=0] Set first day of the week. '1' would be Monday.
  * @param {boolean} [settings.showAllDay=true] Detemines if the all day events row should be shown.
  * @param {boolean} [settings.showTimeLine=true] Shows a bar across the current time.
@@ -551,6 +552,10 @@ WeekView.prototype = {
     this.dayMap = [];
     this.isDayView = false;
     this.element.removeClass('is-day-view stacked-view');
+
+    if (this.settings.borderless) {
+      this.element.addClass('is-borderless');
+    }
 
     if (this.numberOfDays === 0 || this.numberOfDays === 1) {
       this.element.addClass('is-day-view');

--- a/src/components/week-view/week-view.js
+++ b/src/components/week-view/week-view.js
@@ -924,6 +924,7 @@ WeekView.prototype = {
       showToday: this.settings.showToday,
       isAlternate: false,
       isMenuButton: true,
+      isMonthPicker: true,
       showViewChanger: this.settings.showViewChanger,
       hitbox: this.settings.hitbox,
       onChangeView: this.settings.onChangeView,

--- a/src/components/week-view/week-view.js
+++ b/src/components/week-view/week-view.js
@@ -571,7 +571,7 @@ WeekView.prototype = {
     this.hasIrregularDays = this.numberOfDays !== 7;
 
     // switch to one day view if responsive is enabled and in stacked view mode
-    if (this.settings.responsive && !this.isDayView && this.settings.stacked && this.isMobileWidth) {
+    if (this.settings.responsive && !this.isDayView && this.isStackedView() && this.isMobileWidth) {
       this.showWeek(startDate, startDate);
       return;
     }
@@ -732,7 +732,7 @@ WeekView.prototype = {
    * @returns {boolean} true if stack view enabled
    */
   isStackedView() {
-    return !!this.settings.stacked && !this.isDayView;
+    return !!this.settings.stacked;
   },
 
   renderDisable() {
@@ -1064,7 +1064,7 @@ WeekView.prototype = {
     this.isMobileWidth = breakpoints.isBelow('phone-to-tablet');
 
     // only stacked view monitors breakpoint changes
-    if (this.settings.stacked && this.settings.responsive) {
+    if (this.isStackedView() && this.settings.responsive) {
       if (!this.isDayView && this.isMobileWidth) {
         const today = new Date();
         const isCurrentWeek = dateUtils.isWithinRange(this.settings.startDate, this.settings.endDate, today);

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -133,7 +133,7 @@ dateUtils.isDaylightSavingTime = function (date) {
  * @param {date} targetDate target date
  * @returns {boolean} true if targetDate is within range
  */
-dateUtils.isWithinRange = function(startDate, endDate, targetDate) {
+dateUtils.isWithinRange = function (startDate, endDate, targetDate) {
   return startDate <= targetDate && targetDate <= endDate;
 };
 

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -127,6 +127,17 @@ dateUtils.isDaylightSavingTime = function (date) {
 };
 
 /**
+ * Check if date is within range
+ * @param {date} startDate start of date range
+ * @param {date} endDate end of date range
+ * @param {date} targetDate target date
+ * @returns {boolean} true if targetDate is within range
+ */
+dateUtils.isWithinRange = function(startDate, endDate, targetDate) {
+  return startDate <= targetDate && targetDate <= endDate;
+};
+
+/**
  * Convert 12/24 hour format to 24 hour format based on a day period
  * @param {number} hours in 12 or 24 hour format
  * @param {number} dayPeriodIndex 0 or 1 if time format with a day period

--- a/test/components/week-view/week-view-api-func-test.js
+++ b/test/components/week-view/week-view-api-func-test.js
@@ -207,30 +207,55 @@ describe('WeekView API', () => {
   });
 
   it('should render stacked view', () => {
+    const startDate = new Date(2019, 11, 1);
+    const endDate = new Date(2019, 11, 7);
+
     weekViewAPI?.destroy();
     weekViewAPI = new WeekView(weekViewEl, {
       eventTypes,
       events,
       showViewChanger: false,
-      startDate: new Date(2019, 11, 1),
-      endDate: new Date(2019, 11, 7),
+      startDate,
+      endDate,
       showAllDay: true,
       stacked: true
     });
 
-    expect(weekViewAPI.settings.stacked).toEqual(true);
-    const event1 = document.body.querySelectorAll('.week-view .calendar-event')[0];
-    const event2 = document.body.querySelectorAll('.week-view .calendar-event')[1];
-    const event3 = document.body.querySelectorAll('.week-view .calendar-event')[2];
-    const event4 = document.body.querySelectorAll('.week-view .calendar-event')[3];
-    const event5 = document.body.querySelectorAll('.week-view .calendar-event')[4];
+    // forces stacked view layout in jsdom
+    weekViewAPI.isMobileWidth = false;
+    weekViewAPI.showWeek(startDate, endDate);
 
-    expect(event1.getAttribute('data-key')).toEqual('20191204');
-    expect(event2.getAttribute('data-key')).toEqual('20191204');
-    expect(event3.getAttribute('data-key')).toEqual('20191202');
-    expect(event4.getAttribute('data-key')).toEqual('20191203');
-    expect(event5.getAttribute('data-key')).toEqual('20191204');
+    const eventElems = document.body.querySelectorAll('.week-view.stacked-view .calendar-event');
+    const footerElem = document.body.querySelector('.week-view.stacked-view .week-view-stacked-footer');
+    expect(weekViewAPI.settings.stacked).toEqual(true);
+    expect(footerElem).toBeNull();
+    expect(eventElems[0].getAttribute('data-key')).toEqual('20191204');
+    expect(eventElems[1].getAttribute('data-key')).toEqual('20191204');
+    expect(eventElems[2].getAttribute('data-key')).toEqual('20191202');
+    expect(eventElems[3].getAttribute('data-key')).toEqual('20191203');
+    expect(eventElems[4].getAttribute('data-key')).toEqual('20191204');
     expect(document.body.querySelectorAll('.calendar-event').length).toEqual(5);
+  });
+
+  it('can render a footer in stacked view mode', () => {
+    const startDate = new Date(2019, 11, 1);
+    const endDate = new Date(2019, 11, 7);
+
+    weekViewAPI?.destroy();
+    weekViewAPI = new WeekView(weekViewEl, {
+      eventTypes,
+      events,
+      showViewChanger: false,
+      startDate,
+      endDate,
+      showAllDay: true,
+      stacked: true,
+      showFooter: true,
+    });
+
+    const footerElem = document.body.querySelector('.week-view.stacked-view .week-view-stacked-footer');
+    expect(weekViewAPI.settings.showFooter).toEqual(true);
+    expect(footerElem).toBeDefined();
   });
 
   it('should render events', () => {
@@ -246,11 +271,13 @@ describe('WeekView API', () => {
       endHour: 17
     });
 
-    const event1 = document.body.querySelectorAll('.week-view .calendar-event')[0];
-    const event2 = document.body.querySelectorAll('.week-view .calendar-event')[1];
-    const event3 = document.body.querySelectorAll('.week-view .calendar-event')[2];
-    const event4 = document.body.querySelectorAll('.week-view .calendar-event')[3];
-    const event5 = document.body.querySelectorAll('.week-view .calendar-event')[4];
+    const eventElems = document.body.querySelectorAll('.week-view .calendar-event');
+
+    const event1 = eventElems[0];
+    const event2 = eventElems[1];
+    const event3 = eventElems[2];
+    const event4 = eventElems[3];
+    const event5 = eventElems[4];
 
     expect(event1.getAttribute('data-key')).toEqual('20191204');
     expect(event2.getAttribute('data-key')).toEqual('20191204');

--- a/test/components/week-view/week-view-api-func-test.js
+++ b/test/components/week-view/week-view-api-func-test.js
@@ -199,6 +199,40 @@ describe('WeekView API', () => {
     expect(document.body.querySelectorAll('thead tr th').length).toEqual(15);
   });
 
+  it('can set week start and end dates from target date', () => {
+    const targetDate = new Date(2019, 11, 5);
+    weekViewAPI.setWeekFromDate(targetDate);
+    expect(weekViewAPI.settings.startDate.getDate()).toEqual(1);
+    expect(weekViewAPI.settings.endDate.getDate()).toEqual(7);
+  });
+
+  it('should render stacked view', () => {
+    weekViewAPI?.destroy();
+    weekViewAPI = new WeekView(weekViewEl, {
+      eventTypes,
+      events,
+      showViewChanger: false,
+      startDate: new Date(2019, 11, 1),
+      endDate: new Date(2019, 11, 7),
+      showAllDay: true,
+      stacked: true
+    });
+
+    expect(weekViewAPI.settings.stacked).toEqual(true);
+    const event1 = document.body.querySelectorAll('.week-view .calendar-event')[0];
+    const event2 = document.body.querySelectorAll('.week-view .calendar-event')[1];
+    const event3 = document.body.querySelectorAll('.week-view .calendar-event')[2];
+    const event4 = document.body.querySelectorAll('.week-view .calendar-event')[3];
+    const event5 = document.body.querySelectorAll('.week-view .calendar-event')[4];
+
+    expect(event1.getAttribute('data-key')).toEqual('20191204');
+    expect(event2.getAttribute('data-key')).toEqual('20191204');
+    expect(event3.getAttribute('data-key')).toEqual('20191202');
+    expect(event4.getAttribute('data-key')).toEqual('20191203');
+    expect(event5.getAttribute('data-key')).toEqual('20191204');
+    expect(document.body.querySelectorAll('.calendar-event').length).toEqual(5);
+  });
+
   it('should render events', () => {
     weekViewAPI?.destroy();
     weekViewAPI = new WeekView(weekViewEl, {

--- a/test/components/week-view/week-view-api-func-test.js
+++ b/test/components/week-view/week-view-api-func-test.js
@@ -206,6 +206,17 @@ describe('WeekView API', () => {
     expect(weekViewAPI.settings.endDate.getDate()).toEqual(7);
   });
 
+  it('can hide toolbar', () => {
+    weekViewAPI?.destroy();
+    weekViewAPI = new WeekView(weekViewEl, {
+      hideToolbar: true
+    });
+
+    const toolbarElem = document.body.querySelector('.week-view .calendar-toolbar');
+    expect(weekViewAPI.settings.hideToolbar).toEqual(true);
+    expect(toolbarElem).toBeNull();
+  });
+
   it('should render stacked view', () => {
     const startDate = new Date(2019, 11, 1);
     const endDate = new Date(2019, 11, 7);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added stacked view layout for weekview agenda variant.
Added settings for `stacked` and `showFooter`.
Added breakpoint listener to switch stacked view to one day view in phone-to-tablet widths.

**Related github/jira issue (required)**:
Closes #7373 

**Steps necessary to review your pull request (required)**:
1. Checkout branch, `npm install`, `npm run start`
2. Go to [stacked example](http://localhost:4000/components/week-view/example-stacked.html)
3. Check that design matches [figma](https://www.figma.com/file/BVwSQAZwE8m1swXPNw93kh/Calendar-Enhancement?type=design&node-id=0-1&t=N8POS7ZictwKHLOr-0)
4. Check that vertical scrolling works and that header/footer remain sticky
5. Check that weekview switches to one day view for mobile widths
6. Check that footer is toggleable by setting `showFooter` settings to true/false
7. Check different themes
8. Check different languages
9. Check that calendar component is unaffected by changes and still works as expected
10. Check http://localhost:4000/components/week-view/example-card.html -> for in a card

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

