### PR TITLE
6033 - Clear rowstatus in tree node for clearRowError to work correctly

### DIFF
--- a/app/views/components/datagrid/test-tree-rowstatus.html
+++ b/app/views/components/datagrid/test-tree-rowstatus.html
@@ -6,9 +6,12 @@
       <span class="datagrid-result-count">(N Results)</span>
     </div>
 
-    <div class="buttonset" style="padding-right: 175px;">
+    <div class="buttonset">
         <button type="button" id="toggle-row-status" class="btn">
           <span>Add Row Status</span>
+        </button>
+        <button type="button" id="toggle-row-error" class="btn">
+          <span>Add Row Error</span>
         </button>
     </div>
 
@@ -39,6 +42,7 @@
   $('body').one('initialized', function () {
 
       var grid,
+        gridApi,
         columns = [];
 
       //Define Columns for the Grid.
@@ -64,14 +68,14 @@
           }).on('rowactivated', function (e, args) {
             console.log(args);
           });
+
+        gridApi = $('#datagrid').data('datagrid');
       });
 
     //Example row status
     $('#toggle-row-status').on('click', function () {
-      var gridApi = $('#datagrid').data('datagrid');
-
-      var btn = $(this).find('span');
-      var status = {
+      const btn = $(this).find('span');
+      const status = {
         add: 'Add Row Status',
         remove: 'Remove Row Status'
       };
@@ -92,5 +96,33 @@
       }
     });
 
+    $('#toggle-row-error').on('click', () => {
+      const btn = $('#toggle-row-error').find('span');
+      const status = {
+        add: 'Add Row Error',
+        remove: 'Remove Row Error'
+      };
+
+      if (btn.text() === status.add) {
+        btn.text(status.remove);
+        gridApi.rowStatus(0, 'error', 'Error');
+        gridApi.rowStatus(0, 'error', 'Error 2');
+        gridApi.rowStatus(0, 'error', 'Error 3');
+        gridApi.rowStatus(1, 'error', 'Error 4');
+        gridApi.rowStatus(2, 'error', 'Error 5');
+        gridApi.rowStatus(3, 'error', 'Error 6');
+        gridApi.rowStatus(4, 'error', 'Error 7');
+        gridApi.rowStatus(6, 'error', 'Error 8');
+        gridApi.rowStatus(6, 'error', 'This row has errors');
+      } else {
+        btn.text(status.add);
+        gridApi.clearRowError(0);
+        gridApi.clearRowError(1);
+        gridApi.clearRowError(2);
+        gridApi.clearRowError(3);
+        gridApi.clearRowError(4);
+        gridApi.clearRowError(6);
+      }
+    });
   });
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## v4.84.0 Fixes
 
 - `[Button]` Adjusted alignment for popupmenu icon buttons. ([#7408](https://github.com/infor-design/enterprise/issues/7408))
+- `[Datagrid]` Clear rowstatus in tree node for clearRowError to work correctly. ([#6033](https://github.com/infor-design/enterprise/issues/6033))
 
 ## v4.83.0
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9572,6 +9572,11 @@ Datagrid.prototype = {
 
     if (!status) {
       delete arrayToUse[idx].rowStatus;
+
+      if (this.settings.treeGrid) {
+        delete arrayToUse[idx].node.rowStatus;
+      }
+
       this.updateRow(idx);
       return;
     }
@@ -10901,6 +10906,8 @@ Datagrid.prototype = {
     for (let cell = 0; cell < this.settings.columns.length; cell++) {
       this.clearAllCellError(row, cell);
     }
+
+    this.render();
   },
 
   /**

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10906,8 +10906,6 @@ Datagrid.prototype = {
     for (let cell = 0; cell < this.settings.columns.length; cell++) {
       this.clearAllCellError(row, cell);
     }
-
-    this.render();
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Clear rowstatus for node if grid is tree.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #6033 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datagrid/test-tree-rowstatus.html
- Click on Add Row Error
- Click on Remove Row Error
- Error statuses should be removed

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
