### PR TITLE
Fix: Add regression fix for icons in menus

### DIFF
--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -285,7 +285,8 @@
     }
 
     &.is-selectable > li {
-      .icon + a {
+      .icon + a,
+      > a {
         overflow: auto;
         padding-left: 57px;
       }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Noticed a bug in data grid menu and fixed it. Needs to be merged into 4.83.0 as well.

**Related github/jira issue (required)**:
Fixes https://github.com/infor-design/enterprise/issues/7408
Fixes https://github.com/infor-design/enterprise/issues/7517

**Steps necessary to review your pull request (required)**:
- open menus and submenus in http://localhost:4000/components/button/example-menubutton-submenu-icons.html
- check icons are not overlapped
- open filter menus http://localhost:4000/components/datagrid/example-filter.html
- check icons are not overlaped
