### PR TITLE
Fix: Fix page background color

### DIFF
--- a/src/components/homepage/_homepage.scss
+++ b/src/components/homepage/_homepage.scss
@@ -6,6 +6,7 @@
 // Different Widget Heights and Widths
 
 .homepage {
+  background-color: $homepage-background-color;
   height: inherit;
   margin: 0 auto;
   padding: 32px 0;

--- a/src/components/typography/_typography.scss
+++ b/src/components/typography/_typography.scss
@@ -40,6 +40,13 @@ html {
   }
 }
 
+html.theme-new-light {
+  &.darker-background,
+  &.slate05 {
+    background-color: rgba($ids-color-palette-slate-10, 0.5);
+  }
+}
+
 // Text Elements
 h1,
 h2,

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -21,6 +21,9 @@ $header-full-searchfield-hyperlink-color: $ids-color-palette-white;
 
 $ids-color-palette-alabaster: $ids-color-palette-white;
 
+// home pages
+$homepage-background-color: $body-color-primary-background;
+
 // Color Personalization in header
 $header-default-bg-color: $ids-color-palette-azure-60;
 $header-default-bg-hover-color: $ids-color-palette-azure-80;

--- a/src/themes/theme-new-contrast.scss
+++ b/src/themes/theme-new-contrast.scss
@@ -32,7 +32,8 @@ $header-primary-btn-background-hover-color: $ids-color-palette-azure-50;
 $header-disabled-color: $ids-color-palette-slate-50;
 $header-focus-box-shadow: 0 0 4px 3px rgba(255, 255, 255, 0.3);
 
-$body-color-primary-background: $ids-color-palette-slate-10;
+$body-color-primary-background: rgba($ids-color-palette-slate-10, 0.5);
+$homepage-background-color: $body-color-primary-background;
 $header-hero-widget-bg-color: $subhead-bg-color;
 
 $dropdown-search-bg-color: $ids-color-palette-white;

--- a/src/themes/theme-new-dark.scss
+++ b/src/themes/theme-new-dark.scss
@@ -17,6 +17,7 @@
 
 // Theme Overrides
 $body-color-primary-background: $ids-color-palette-slate-100;
+$homepage-background-color: $body-color-primary-background;
 
 $header-default-bg-color: $ids-color-palette-slate-60;
 $header-default-bg-hover-color: $ids-color-palette-slate-80;

--- a/src/themes/theme-new-light.scss
+++ b/src/themes/theme-new-light.scss
@@ -22,7 +22,8 @@ $label-disabled-color: $input-color-disabled-border;
 $input-disabled-color: $input-color-disabled-font;
 $dropdown-search-bg-color: $ids-color-palette-slate-10;
 
-$body-color-primary-background: rgba($ids-color-palette-slate-10, 0.5);
+$body-color-primary-background: $ids-color-palette-white;
+$homepage-background-color: rgba($ids-color-palette-slate-10, 0.5);
 $drop-shadow-depth: rgba($ids-color-boxshadow-base, 0.2);
 
 $application-menu-border-color: $ids-color-palette-slate-90;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

We incorrectly changed every background color to slate 0.5 by mistake. This corrects that and isolates it to the home page component (in new light). Minor regression but impacted https://github.com/infor-design/enterprise/issues/7386

**Related github/jira issue (required)**:
#7379 

**Steps necessary to review your pull request (required)**:
- take a page like http://localhost:4000/components/cards -> background should be white
- test all themes and modes and should be ok as before
- http://localhost:4000/components/cards/example-workspace-widgets.html -> should have the new slate 05
- test all themes and modes and should be ok as before
- NOTE: changed contrast new to slate 05 as a trial and noted this in https://github.com/infor-design/enterprise-wc/issues/413

cc @talkaboutdesign