### PR TITLE
7428 - Fix on showColumn not working properly with frozen columns

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[Button]` Adjusted alignment for popupmenu icon buttons. ([#7408](https://github.com/infor-design/enterprise/issues/7408))
 - `[Charts]` Improved the positioning of chart legend. ([#7452](https://github.com/infor-design/enterprise/issues/7452))
 - `[Datagrid]` Clear `rowstatus` in tree node for clearRowError to work correctly. ([#6033](https://github.com/infor-design/enterprise/issues/6033))
+- `[Datagrid]` Fix on `showColumn` not working properly with frozen columns. ([#7428](https://github.com/infor-design/enterprise/issues/7428))
 - `[Dropdown]` Fixed the visibility of dropdown palette icons in dark mode. ([#7431](https://github.com/infor-design/enterprise/issues/7431))
 - `[Dropdown]` Removed overflow none style for dropdown modal. ([#6033](https://github.com/infor-design/enterprise/issues/6033))
 - `[Header]` Fix on header text not being readable due to color styles. ([#7466](https://github.com/infor-design/enterprise/issues/7466))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@
 - `[Button]` Adjusted alignment for popupmenu icon buttons. ([#7408](https://github.com/infor-design/enterprise/issues/7408))
 - `[Charts]` Improved the positioning of chart legend. ([#7452](https://github.com/infor-design/enterprise/issues/7452))
 - `[Datagrid]` Clear `rowstatus` in tree node for clearRowError to work correctly. ([#6033](https://github.com/infor-design/enterprise/issues/6033))
-- `[Datagrid]` Fix on `showColumn` not working properly with frozen columns. ([#7428](https://github.com/infor-design/enterprise/issues/7428))
+- `[Datagrid]` Fix an issue where `showColumn` was not functioning correctly with frozen columns. ([#7428](https://github.com/infor-design/enterprise/issues/7428))
 - `[Dropdown]` Fixed the visibility of dropdown palette icons in dark mode. ([#7431](https://github.com/infor-design/enterprise/issues/7431))
 - `[Dropdown]` Removed overflow none style for dropdown modal. ([#6033](https://github.com/infor-design/enterprise/issues/6033))
 - `[Header]` Fix on header text not being readable due to color styles. ([#7466](https://github.com/infor-design/enterprise/issues/7466))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1132,6 +1132,16 @@ $datagrid-small-row-height: 25px;
   &.right {
     flex-shrink: 0;
     overflow-x: auto;
+
+    + .datagrid-wrapper.center {
+      td.is-hidden:first-child + td {
+        border-left: 1px solid $datagrid-cell-border-color;
+      }
+
+      th.is-hidden:first-child + th {
+        border-left: 1px solid $datagrid-header-border-color;
+      }
+    }
   }
 
   .datagrid-row.is-selected.is-hover-row {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -6270,7 +6270,10 @@ Datagrid.prototype = {
     }
 
     this.settings.columns[idx].hidden = true;
-    this.headerNodeCheckbox = this.headerNodes().eq(idx);
+
+    const hideColumn = this.headerNodes().eq(idx);
+    this.headerNodeCheckbox = hideColumn.find('.datagrid-checkbox').length > 0 ? hideColumn : undefined;
+
     if (!this.settings?.frozenColumns?.left.length) this.headerNodes().eq(idx).addClass('is-hidden');
 
     if (idx === 0 && id === 'selectionCheckbox' && this.settings?.frozenColumns?.left.length) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

showColumn was inserting another column in the datagrid for the given column, under the assumption that it's a hidden checkbox column. Added an additional check when assigning headerNodeCheckbox so that the Activity header in the example won't be inserted on the first column.

**Related github/jira issue (required)**:

Closes #7428 
Closes #7541

**Steps necessary to review your pull request (required)**:

- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datagrid/example-frozen-columns.html
- Click on Personalize Columns
- Deselect and select Activity so that the column will disappear and appear
- Columns should render correctly (Activity should not be pushed on the first column and values should be correct)

**Included in this Pull Request**:
- [ ] A note to the change log.
