### PR TITLE
7293- Add alabaster design for tabs module

### DIFF
--- a/app/views/components/compositeform/test-with-tab-headers-horizontal.html
+++ b/app/views/components/compositeform/test-with-tab-headers-horizontal.html
@@ -337,15 +337,15 @@
     data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity: 'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 2});
 
     //Define Columns for the Grid.
-    // columns.push({ id: 'rowStatus', sortable: false, resizable: false, formatter: Formatters.Status, align: 'center'});
-    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
-    columns.push({ id: 'id', name: 'Row Id', field: 'id', formatter: Formatters.Readonly});
-    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input});
-    columns.push({ id: 'activity', name: 'Activity', field: 'activity', required: true, editor: Editors.Input, validate: 'required'});  //maxLength: 2
-    columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', align: 'right', editor: Editors.Input, mask: '###', isEditable: isDisabled});
-    columns.push({ id: 'portable', name: 'Portable', field: 'portable', align: 'center', formatter: Formatters.Checkbox, editor: Editors.Checkbox});
-    columns.push({ id: 'price', name: 'Price', field: 'price', align: 'right', formatter: Formatters.Decimal, validate: 'required', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input});
-    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date, editorOptions: {
+    // columns.push({ id: 'rowStatus', sortable: false, resizable: false, formatter: Soho.Formatters.Status, align: 'center'});
+    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Soho.Formatters.SelectionCheckbox, align: 'center'});
+    columns.push({ id: 'id', name: 'Row Id', field: 'id', formatter: Soho.Formatters.Readonly});
+    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Soho.Formatters.Hyperlink, editor: Soho.Editors.Input});
+    columns.push({ id: 'activity', name: 'Activity', field: 'activity', required: true, editor: Soho.Editors.Input, validate: 'required'});  //maxLength: 2
+    columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', align: 'right', editor: Soho.Editors.Input, mask: '###', isEditable: isDisabled});
+    columns.push({ id: 'portable', name: 'Portable', field: 'portable', align: 'center', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox});
+    columns.push({ id: 'price', name: 'Price', field: 'price', align: 'right', formatter: Soho.Formatters.Decimal, validate: 'required', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Soho.Editors.Input});
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Soho.Formatters.Date, editor: Soho.Editors.Date, editorOptions: {
       showLegend: true, legend:
       [{name: 'Weekend', color: '#579E95', dayOfWeek: [0,6]}],
       disable: { years: [], dates: [], minDate: '01-01-2014', maxDate: `${month}-${day}-${year}`,
@@ -359,7 +359,7 @@
       todayWithKeyboard: true},
       validate: 'availableDate required date', width: 120
     });
-    columns.push({ id: 'action', name: 'Action', field: 'action', formatter: Formatters.Dropdown, editor: Editors.Dropdown, validate: 'required', isEditable: isDisabled,
+    columns.push({ id: 'action', name: 'Action', field: 'action', formatter: Soho.Formatters.Dropdown, editor: Soho.Editors.Dropdown, validate: 'required', isEditable: isDisabled,
     options: [{id: '', label: '', value: -1}, {id: 'oh1', label: 'On Hold', value: 1}, {id: 'sh1', label: 'Shipped', value: 2} , {id: 'ac1', label: 'Action', value: 3}, {id: 'pen', label: 'Pending', value: 4}, {id: 'bk1', label: 'Backorder', value: 5}, {id: 'can', label: 'Cancelled', value: 6}, {id: 'pro', label: 'Processing', value: 7}]
     });
 

--- a/app/views/components/compositeform/test-with-tab-headers-vertical.html
+++ b/app/views/components/compositeform/test-with-tab-headers-vertical.html
@@ -337,15 +337,15 @@
     data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity: 'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 2});
 
     //Define Columns for the Grid.
-    // columns.push({ id: 'rowStatus', sortable: false, resizable: false, formatter: Formatters.Status, align: 'center'});
-    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
-    columns.push({ id: 'id', name: 'Row Id', field: 'id', formatter: Formatters.Readonly});
-    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input});
-    columns.push({ id: 'activity', name: 'Activity', field: 'activity', required: true, editor: Editors.Input, validate: 'required'});  //maxLength: 2
-    columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', align: 'right', editor: Editors.Input, mask: '###', isEditable: isDisabled});
-    columns.push({ id: 'portable', name: 'Portable', field: 'portable', align: 'center', formatter: Formatters.Checkbox, editor: Editors.Checkbox});
-    columns.push({ id: 'price', name: 'Price', field: 'price', align: 'right', formatter: Formatters.Decimal, validate: 'required', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input});
-    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date, editorOptions: {
+    // columns.push({ id: 'rowStatus', sortable: false, resizable: false, formatter: Soho.Formatters.Status, align: 'center'});
+    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Soho.Formatters.SelectionCheckbox, align: 'center'});
+    columns.push({ id: 'id', name: 'Row Id', field: 'id', formatter: Soho.Formatters.Readonly});
+    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Soho.Formatters.Hyperlink, editor: Soho.Editors.Input});
+    columns.push({ id: 'activity', name: 'Activity', field: 'activity', required: true, editor: Soho.Editors.Input, validate: 'required'});  //maxLength: 2
+    columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', align: 'right', editor: Soho.Editors.Input, mask: '###', isEditable: isDisabled});
+    columns.push({ id: 'portable', name: 'Portable', field: 'portable', align: 'center', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox});
+    columns.push({ id: 'price', name: 'Price', field: 'price', align: 'right', formatter: Soho.Formatters.Decimal, validate: 'required', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Soho.Editors.Input});
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Soho.Formatters.Date, editor: Soho.Editors.Date, editorOptions: {
       showLegend: true, legend:
       [{name: 'Weekend', color: '#579E95', dayOfWeek: [0,6]}],
       disable: { years: [], dates: [], minDate: '01-01-2014', maxDate: `${month}-${day}-${year}`,
@@ -359,7 +359,7 @@
       todayWithKeyboard: true},
       validate: 'availableDate required date', width: 120
     });
-    columns.push({ id: 'action', name: 'Action', field: 'action', formatter: Formatters.Dropdown, editor: Editors.Dropdown, validate: 'required', isEditable: isDisabled,
+    columns.push({ id: 'action', name: 'Action', field: 'action', formatter: Soho.Formatters.Dropdown, editor: Soho.Editors.Dropdown, validate: 'required', isEditable: isDisabled,
     options: [{id: '', label: '', value: -1}, {id: 'oh1', label: 'On Hold', value: 1}, {id: 'sh1', label: 'Shipped', value: 2} , {id: 'ac1', label: 'Action', value: 3}, {id: 'pen', label: 'Pending', value: 4}, {id: 'bk1', label: 'Backorder', value: 5}, {id: 'can', label: 'Cancelled', value: 6}, {id: 'pro', label: 'Processing', value: 7}]
     });
 

--- a/app/views/components/datagrid/example-expandable-row-editable.html
+++ b/app/views/components/datagrid/example-expandable-row-editable.html
@@ -18,7 +18,7 @@
         field: 'productId',
         sortable: false,
         filterType: 'text',
-        formatter: Formatters.Expander,
+        formatter: Soho.Formatters.Expander,
       },
       {
         id: 'productName',
@@ -28,7 +28,7 @@
         filterType: 'text',
         filterConditions: ['equals', 'contains'],
         width: 150,
-        formatter: Formatters.Hyperlink,
+        formatter: Soho.Formatters.Hyperlink,
       },
       {
         id: 'activity',
@@ -44,8 +44,8 @@
         field: 'quantity',
         sortable: false,
         filterType: 'integer',
-        formatter: Formatters.Integer,
-        editor: Editors.Input,
+        formatter: Soho.Formatters.Integer,
+        editor: Soho.Editors.Input,
       },
       {
         id: 'price',
@@ -53,8 +53,8 @@
         field: 'price',
         sortable: false,
         filterType: 'decimal',
-        formatter: Formatters.Decimal,
-        editor: Editors.Input,
+        formatter: Soho.Formatters.Decimal,
+        editor: Soho.Editors.Input,
       },
       {
         id: 'orderDate',
@@ -62,7 +62,7 @@
         field: 'orderDate',
         sortable: false,
         filterType: 'date',
-        formatter: Formatters.Date,
+        formatter: Soho.Formatters.Date,
         dateFormat: 'M/d/yyyy',
       }];
 

--- a/app/views/components/datagrid/test-multiple-grids-in-tab-with-dropdown.html
+++ b/app/views/components/datagrid/test-multiple-grids-in-tab-with-dropdown.html
@@ -145,39 +145,39 @@
     data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '123.99', status: 'OK', orderDate: null, multiDropDown: 'R', action: 'On Hold'});
 
     // Define Columns for the Grid - Top grid in Top Bottom tab
-    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
-    columns.push({ id: 'productId', name: 'Product Id', field: 'productId', filterType: 'text', formatter: Formatters.Readonly});
-    columns.push({ id: 'productName', name: 'Product Name', field: 'productName', filterType: 'text', formatter: Formatters.Hyperlink});
+    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Soho.Formatters.SelectionCheckbox, align: 'center'});
+    columns.push({ id: 'productId', name: 'Product Id', field: 'productId', filterType: 'text', formatter: Soho.Formatters.Readonly});
+    columns.push({ id: 'productName', name: 'Product Name', field: 'productName', filterType: 'text', formatter: Soho.Formatters.Hyperlink});
     columns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', filterType: 'text'});
     columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', filterType: 'integer'});
-    columns.push({ id: 'price', name: 'Price', field: 'price', filterType: 'text', formatter: Formatters.Decimal});
-    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', filterType: 'text', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
-    columns.push({ id: 'status', name: 'Status', field: 'status', filterType: 'text', formatter: Formatters.Text});
+    columns.push({ id: 'price', name: 'Price', field: 'price', filterType: 'text', formatter: Soho.Formatters.Decimal});
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', filterType: 'text', formatter: Soho.Formatters.Date, dateFormat: 'M/d/yyyy'});
+    columns.push({ id: 'status', name: 'Status', field: 'status', filterType: 'text', formatter: Soho.Formatters.Text});
     columns.push({ id: 'action', name: 'Action Item', field: 'action', filterType: 'text'});
 
     // Define Columns2 for the Grid - Bottom grid in Top Bottom tab
-    columns2.push({ id: 'selectionCheckbox', width: 50, sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
-    columns2.push({ id: 'productId', name: 'Product Id', width: 50, field: 'productId', filterType: 'text', formatter: Formatters.Readonly});
-    columns2.push({ id: 'productName', name: 'Product Name', width: 50, field: 'productName', filterType: 'text', formatter: Formatters.Hyperlink});
+    columns2.push({ id: 'selectionCheckbox', width: 50, sortable: false, resizable: false, formatter: Soho.Formatters.SelectionCheckbox, align: 'center'});
+    columns2.push({ id: 'productId', name: 'Product Id', width: 50, field: 'productId', filterType: 'text', formatter: Soho.Formatters.Readonly});
+    columns2.push({ id: 'productName', name: 'Product Name', width: 50, field: 'productName', filterType: 'text', formatter: Soho.Formatters.Hyperlink});
     columns2.push({ id: 'quantity', name: 'Quantity', width: 50, field: 'quantity', filterType: 'integer'});
-    columns2.push({ id: 'price', name: 'Price', field: 'price', filterType: 'text', formatter: Formatters.Decimal});
-    columns2.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', filterType: 'text', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
-    columns2.push({ id: 'status', name: 'Status', field: 'status', filterType: 'text', formatter: Formatters.Text});
-    columns2.push({ id: 'multiDropDown', name: 'Multiple Selection', width: 50, field: 'multiDropDown', sortable: false, align: 'center', textOverflow: 'ellipsis', filterType: 'multiselect', formatter: Formatters.Dropdown, editor: Editors.Dropdown, editorOptions: { showSelectAll: true },
+    columns2.push({ id: 'price', name: 'Price', field: 'price', filterType: 'text', formatter: Soho.Formatters.Decimal});
+    columns2.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', filterType: 'text', formatter: Soho.Formatters.Date, dateFormat: 'M/d/yyyy'});
+    columns2.push({ id: 'status', name: 'Status', field: 'status', filterType: 'text', formatter: Soho.Formatters.Text});
+    columns2.push({ id: 'multiDropDown', name: 'Multiple Selection', width: 50, field: 'multiDropDown', sortable: false, align: 'center', textOverflow: 'ellipsis', filterType: 'multiselect', formatter: Soho.Formatters.Dropdown, editor: Soho.Editors.Dropdown, editorOptions: { showSelectAll: true },
       filterRowEditorOptions: [{ label: 'Not Entered', value: 'Not Entered' }, { label: 'Active', value: 'A' }, { label: 'Ready For Completion', value: 'R' }, { label: 'Draft', value: 'D' }, { label: 'No longer meets eligibility requirements', value: 'X' } ],
       options: [{ label: 'Not Entered', value: 'Not Entered' }, { label: 'Active', value: 'A' }, { label: 'Ready For Completion', value: 'R' }, { label: 'Draft', value: 'D' }, { label: 'No longer meets eligibility requirements', value: 'X' } ]});
 
     // Define Columns for the Grid - only grid in Single Tab
-    columns3.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
-    columns3.push({ id: 'productId', name: 'Product Id', field: 'productId', filterType: 'text', formatter: Formatters.Readonly});
-    columns3.push({ id: 'productName', name: 'Product Name', field: 'productName', filterType: 'text', formatter: Formatters.Hyperlink});
+    columns3.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Soho.Formatters.SelectionCheckbox, align: 'center'});
+    columns3.push({ id: 'productId', name: 'Product Id', field: 'productId', filterType: 'text', formatter: Soho.Formatters.Readonly});
+    columns3.push({ id: 'productName', name: 'Product Name', field: 'productName', filterType: 'text', formatter: Soho.Formatters.Hyperlink});
     columns3.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', filterType: 'text'});
     columns3.push({ id: 'quantity', name: 'Quantity', field: 'quantity', filterType: 'integer'});
-    columns3.push({ id: 'price', name: 'Price', field: 'price', filterType: 'text', formatter: Formatters.Decimal});
-    columns3.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', filterType: 'text', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
-    columns3.push({ id: 'status', name: 'Status', field: 'status', filterType: 'text', formatter: Formatters.Text});
+    columns3.push({ id: 'price', name: 'Price', field: 'price', filterType: 'text', formatter: Soho.Formatters.Decimal});
+    columns3.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', filterType: 'text', formatter: Soho.Formatters.Date, dateFormat: 'M/d/yyyy'});
+    columns3.push({ id: 'status', name: 'Status', field: 'status', filterType: 'text', formatter: Soho.Formatters.Text});
     columns3.push({ id: 'action', name: 'Action Item', field: 'action', filterType: 'text'});
-    columns3.push({ id: 'multiDropDown', name: 'Multiple Selection', width: 50, field: 'multiDropDown', sortable: false, align: 'center', textOverflow: 'ellipsis', filterType: 'multiselect', formatter: Formatters.Dropdown, editor: Editors.Dropdown, editorOptions: { showSelectAll: true },
+    columns3.push({ id: 'multiDropDown', name: 'Multiple Selection', width: 50, field: 'multiDropDown', sortable: false, align: 'center', textOverflow: 'ellipsis', filterType: 'multiselect', formatter: Soho.Formatters.Dropdown, editor: Soho.Editors.Dropdown, editorOptions: { showSelectAll: true },
       filterRowEditorOptions: [{ label: 'Not Entered', value: 'Not Entered' }, { label: 'Active', value: 'A' }, { label: 'Ready For Completion', value: 'R' }, { label: 'Draft', value: 'D' }, { label: 'No longer meets eligibility requirements', value: 'X' } ],
       options: [{ label: 'Not Entered', value: 'Not Entered' }, { label: 'Active', value: 'A' }, { label: 'Ready For Completion', value: 'R' }, { label: 'Draft', value: 'D' }, { label: 'No longer meets eligibility requirements', value: 'X' } ]});
 

--- a/app/views/components/page-patterns/test-landmark-requisitions-screen.html
+++ b/app/views/components/page-patterns/test-landmark-requisitions-screen.html
@@ -299,15 +299,15 @@
     data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity: 'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 2});
 
     //Define Columns for the Grid.
-    // columns.push({ id: 'rowStatus', sortable: false, resizable: false, formatter: Formatters.Status, align: 'center'});
-    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
-    columns.push({ id: 'id', name: 'Row Id', field: 'id', formatter: Formatters.Readonly});
-    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Formatters.Hyperlink, editor: Editors.Input});
-    columns.push({ id: 'activity', name: 'Activity', field: 'activity', required: true, editor: Editors.Input, validate: 'required'});  //maxLength: 2
-    columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', align: 'right', editor: Editors.Input, mask: '###', isEditable: isDisabled});
-    columns.push({ id: 'portable', name: 'Portable', field: 'portable', align: 'center', formatter: Formatters.Checkbox, editor: Editors.Checkbox});
-    columns.push({ id: 'price', name: 'Price', field: 'price', align: 'right', formatter: Formatters.Decimal, validate: 'required', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Editors.Input});
-    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Formatters.Date, editor: Editors.Date, editorOptions: {
+    // columns.push({ id: 'rowStatus', sortable: false, resizable: false, formatter: Soho.Formatters.Status, align: 'center'});
+    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Soho.Formatters.SelectionCheckbox, align: 'center'});
+    columns.push({ id: 'id', name: 'Row Id', field: 'id', formatter: Soho.Formatters.Readonly});
+    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Soho.Formatters.Hyperlink, editor: Soho.Editors.Input});
+    columns.push({ id: 'activity', name: 'Activity', field: 'activity', required: true, editor: Soho.Editors.Input, validate: 'required'});  //maxLength: 2
+    columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', align: 'right', editor: Soho.Editors.Input, mask: '###', isEditable: isDisabled});
+    columns.push({ id: 'portable', name: 'Portable', field: 'portable', align: 'center', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox});
+    columns.push({ id: 'price', name: 'Price', field: 'price', align: 'right', formatter: Soho.Formatters.Decimal, validate: 'required', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Soho.Editors.Input});
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Soho.Formatters.Date, editor: Soho.Editors.Date, editorOptions: {
       showLegend: true, legend:
       [{name: 'Weekend', color: '#579E95', dayOfWeek: [0,6]}],
       disable: { years: [], dates: [], minDate: '01-01-2014', maxDate: `${month}-${day}-${year}`,
@@ -321,7 +321,7 @@
       todayWithKeyboard: true},
       validate: 'availableDate required date', width: 120
     });
-    columns.push({ id: 'action', name: 'Action', field: 'action', formatter: Formatters.Dropdown, editor: Editors.Dropdown, validate: 'required', isEditable: isDisabled,
+    columns.push({ id: 'action', name: 'Action', field: 'action', formatter: Soho.Formatters.Dropdown, editor: Soho.Editors.Dropdown, validate: 'required', isEditable: isDisabled,
     options: [{id: '', label: '', value: -1}, {id: 'oh1', label: 'On Hold', value: 1}, {id: 'sh1', label: 'Shipped', value: 2} , {id: 'ac1', label: 'Action', value: 3}, {id: 'pen', label: 'Pending', value: 4}, {id: 'bk1', label: 'Backorder', value: 5}, {id: 'can', label: 'Cancelled', value: 6}, {id: 'pro', label: 'Processing', value: 7}]
     });
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## v4.84.0 Features
 
 - `[Line Chart]` Added short and abbreviated name options for the data. ([#5906](https://github.com/infor-design/enterprise/issues/5906))
+- `[Tabs Module]` Added alabaster design for tabs module. ([#7293](https://github.com/infor-design/enterprise/issues/7293))
 - `[WeekView]` Added stacked view template for week view agenda variant. ([#7373](https://github.com/infor-design/enterprise/issues/7373))
 
 ## v4.84.0 Fixes

--- a/src/components/header/_header-new.scss
+++ b/src/components/header/_header-new.scss
@@ -34,6 +34,7 @@
         button.btn-icon.close {
           svg.close.icon {
             top: 10px !important;
+            transform: translateY(0);
           }
         }
       }

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -272,11 +272,20 @@ a.is-personalizable svg.ripple-effect {
 }
 
 .module-tabs.is-personalizable .tab.is-selected {
-  background-color: ${colors.base} !important;
+  background-color: ${colors.darker};
 }
 
 .module-tabs.is-personalizable .tab.is-selected,
 .module-tabs.is-personalizable .tab {
+  color: ${colors.contrast};
+}
+
+.is-personalizable.tab-container.module-tabs .tab-focus-indicator.is-visible {
+  border-color: ${colors.darkest};
+}
+
+.is-personalizable.tab-container.module-tabs .tab.is-selected {
+  background-color: ${colors.darker};
   color: ${colors.contrast};
 }
 
@@ -370,8 +379,8 @@ html[class*="-dark"] .is-personalizable .subheader button:not(:disabled) .icon {
 }
 
 .header.is-personalizable .searchfield-wrapper.has-categories button.btn-icon:not(:disabled):hover,
-.header.is-personalizable .searchfield-wrapper.has-categories button:not(.searchfield-category-button):not(:disabled):hover .icon {
-  background-color: ${colors.contrast} !important;
+.header.is-personalizable .searchfield-wrapper.has-categories button:not(.searchfield-category-button):not(.close):not(:disabled):hover .icon {
+  background-color: ${colors.contrast};
 }
 
 html[class*="theme-new-"] .header.is-personalizable button:not(.go-button):not(.close):not(.searchfield-category-button):not(:disabled):hover,
@@ -393,7 +402,7 @@ html[class*="theme-new-"] .personalize-subheader .toolbar [class^='btn']:hover:n
 }
 
 .header.is-personalizable .buttonset .searchfield-wrapper.non-collapsible.toolbar-searchfield-wrapper.has-categories .btn-icon.close:hover {
-  background-color: ${colors.contrast} !important;
+  background-color: transparent;
 }
 
 html.theme-new-dark .header.is-personalizable .buttonset .searchfield-wrapper.non-collapsible.toolbar-searchfield-wrapper.has-categories .btn-icon.close,

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -1201,6 +1201,8 @@ html[class*='theme-new-'] .header .toolbar .toolbar-searchfield-wrapper.has-cate
   height: 38px;
   border-bottom-right-radius: 8px;
   border-top-right-radius: 8px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
 }
 
 html[class*='theme-classic-'] .header .toolbar .toolbar-searchfield-wrapper.has-go-button.has-categories .searchfield {

--- a/src/components/toolbar/_toolbar-new.scss
+++ b/src/components/toolbar/_toolbar-new.scss
@@ -35,11 +35,6 @@
     height: 41px;
   }
 
-  // Buttons hover
-  .more .btn-actions:hover:not(:disabled) {
-    background-color: $toolbar-btn-actions-hover-bg-color;
-  }
-
   &:not(.standalone) {
     .searchfield-wrapper.toolbar-searchfield-wrapper:not(.has-categories):not(.is-open) {
       height: 34px;

--- a/src/components/toolbar/_toolbar.scss
+++ b/src/components/toolbar/_toolbar.scss
@@ -29,8 +29,6 @@ $toolbar-buttonset-height: 40px;
     }
 
     .searchfield-category-button {
-      background-color: transparent;
-
       .icon {
         transform: translateY(0);
       }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR adds the Alabaster design for the tabs module. Additionally, I have fixed some test pages in the datagrid and composite form.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/7293

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to 
  - http://localhost:4000/components/tabs-module/example-index.html?colors=ffffff
  - http://localhost:4000/components/tabs-module/example-category-searchfield-go-button-home.html?colors=ffffff
  - http://localhost:4000/components/tabs-module/example-category-searchfield.html?colors=ffffff
  - http://localhost:4000/components/tabs-module/example-hidden-module-tabs.html?colors=ffffff
- Test every element states, color combination, etc.

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
