### PR TITLE
7536 - Fix textarea throwing error

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `[Header]` Fix on header text not being readable due to color styles. ([#7466](https://github.com/infor-design/enterprise/issues/7466))
 - `[Locale]` Added Comma translate option for locale for generating lists. ([#5887](https://github.com/infor-design/enterprise/issues/5887))
 - `[Lookup]` Added undefined check for lookup values when updating grid. ([#7403](https://github.com/infor-design/enterprise/issues/7403))
+- `[Textarea]` Fixed an issue where the textarea was throwing an error. ([#7536](https://github.com/infor-design/enterprise/issues/7536))
 
 ## v4.83.0
 

--- a/src/components/textarea/textarea.js
+++ b/src/components/textarea/textarea.js
@@ -270,7 +270,7 @@ Textarea.prototype = {
     this.destroy();
     this.init();
 
-    if (this.element.data('trackdirty')) {
+    if (this.element.data('trackdirty') && this.element.data('trackdirty') instanceof Object) {
       this.element.data('trackdirty').updated();
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the issue where the textarea was throwing an error when the `trackdirty` component is being updated. It adds more type-checking to ensure that it belongs to a specific constructor function before updating it.

**Related github/jira issue (required)**:

Closes #7536 

**Steps necessary to review your pull request (required)**:

N/A

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
