### PR TITLE
1489 - Android enterkeyhint

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[Button]` Adjusted alignment for popupmenu icon buttons. ([#7408](https://github.com/infor-design/enterprise/issues/7408))
 - `[Charts]` Improved the positioning of chart legend. ([#7452](https://github.com/infor-design/enterprise/issues/7452))
 - `[Datagrid]` Clear `rowstatus` in tree node for clearRowError to work correctly. ([#6033](https://github.com/infor-design/enterprise/issues/6033))
+- `[Datagrid]` Changed `enterkeykhint` behavior for filtering to filter with the virtual keyboard on mobile devices. ([#1489](https://github.com/infor-design/enterprise/issues/1489))
 - `[Dropdown]` Fixed the visibility of dropdown palette icons in dark mode. ([#7431](https://github.com/infor-design/enterprise/issues/7431))
 - `[Dropdown]` Removed overflow none style for dropdown modal. ([#6033](https://github.com/infor-design/enterprise/issues/6033))
 - `[Header]` Fix on header text not being readable due to color styles. ([#7466](https://github.com/infor-design/enterprise/issues/7466))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -1783,13 +1783,14 @@ Datagrid.prototype = {
       if (!attrs) {
         attrs = `id="${filterId}"`;
       }
+      const enterKeyHint = col.enterKeyHint ? ` enterkeyhint="${col.enterKeyHint}"` : ' enterkeyhint="enter"';
 
       switch (col.filterType) {
         case 'checkbox':
           // just the button
           break;
         case 'date':
-          filterMarkup += `<input ${col.filterDisabled ? ' disabled' : ''} type="text" class="datepicker" ${attrs}/>`;
+          filterMarkup += `<input ${col.filterDisabled ? ' disabled' : ''} type="text" class="datepicker" ${attrs} ${enterKeyHint}/>`;
           break;
         case 'integer': {
           integerDefaults = {
@@ -1814,7 +1815,7 @@ Datagrid.prototype = {
             col.maskOptions = utils.extend(true, {}, integerDefaults, col.maskOptions);
           }
 
-          filterMarkup += `<input${col.filterDisabled ? ' disabled' : ''} type="text" ${attrs} />`;
+          filterMarkup += `<input${col.filterDisabled ? ' disabled' : ''} type="text" ${attrs} ${enterKeyHint} />`;
           break;
         }
         case 'percent':
@@ -1866,7 +1867,7 @@ Datagrid.prototype = {
             }
           }
 
-          filterMarkup += `<input${col.filterDisabled ? ' disabled' : ''} type="text" ${attrs} />`;
+          filterMarkup += `<input${col.filterDisabled ? ' disabled' : ''} type="text" ${attrs} ${enterKeyHint} />`;
           break;
         }
         case 'contents':
@@ -1899,13 +1900,13 @@ Datagrid.prototype = {
 
           break;
         case 'time':
-          filterMarkup += `<input ${col.filterDisabled ? ' disabled' : ''} type="text" class="timepicker" ${attrs}/>`;
+          filterMarkup += `<input ${col.filterDisabled ? ' disabled' : ''} type="text" class="timepicker" ${attrs} ${enterKeyHint}/>`;
           break;
         case 'lookup':
-          filterMarkup += `<input ${col.filterDisabled ? ' disabled' : ''} type="text" class="lookup" ${attrs} >`;
+          filterMarkup += `<input ${col.filterDisabled ? ' disabled' : ''} type="text" class="lookup" ${attrs} ${enterKeyHint} >`;
           break;
         default:
-          filterMarkup += `<input${col.filterDisabled ? ' disabled' : ''} tabindex="0" type="text" ${attrs}/>`;
+          filterMarkup += `<input${col.filterDisabled ? ' disabled' : ''} tabindex="0" type="text" ${attrs} ${enterKeyHint}/>`;
           break;
       }
 

--- a/src/components/lookup/readme.md
+++ b/src/components/lookup/readme.md
@@ -64,6 +64,25 @@ grid = $('#product-lookup').lookup({
 });
 ```
 
+## Mobile Enter Key Behavior
+
+Note that you may want to further customize the enter key behavior for mobile devices. In order to do this you can set it via the attributes option that allows you to pass any option.
+
+```js
+$('#product-lookup, #product-mask').lookup({
+    ....
+    },
+    attributes: [
+    {
+        name: 'enterkeyhint',
+        value: 'go'
+    }
+    ]
+});
+```
+
+Please refer to the [enterkeyhint documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/enterkeyhint) for further details.
+
 ## Accessibility
 
 - This is a very complex control and interaction and is not currently accessible to screen readers


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes the enter key behavior on android/ios devices for datagrid.

**Related github/jira issue (required)**:
Fixes [#1489](https://github.com/infor-design/enterprise-ng/issues/1489)

**Steps necessary to review your pull request (required)**:
- open http://localhost:4000/components/datagrid/example-filter.html on an android device like pixel4
- test chrome and FF
- also try an IOS device
- in the header click into it and type a few characters
- hit the enter key on the virtual keyboard
- should filter not move to next field like before

<img width="386" alt="Screenshot 2023-05-24 at 11 07 05 AM" src="https://github.com/infor-design/enterprise/assets/814283/cfd0218b-cf2e-407c-b956-a5575b8f2bca">

(key on bottom right)

This may be hard to test on browser stack can use link: 

**Included in this Pull Request**:
- [x] A note to the change log.
