### PR TITLE
7421 - Fix tab overflow error

### DIFF
--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -3689,6 +3689,10 @@ Tabs.prototype = {
       return false;
     }
 
+    if (!li) {
+      return false;
+    }
+
     if (this.tablist.scrollTop() > 0) {
       this.tablist.scrollTop(0);
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Supplemental fix for #7421 based on feedback. Will patch to 4.83

**Related github/jira issue (required)**:
Addition to https://github.com/infor-design/enterprise/issues/7421

**Steps necessary to review your pull request (required)**:
- build this branch and copy it to the NG project
- run http://localhost:4200/ids-enterprise-ng-demo/tabs-module
- click x on the first tab
- check console and should not be any error
