### PR TITLE
7550 - Fix x alignment on old toolbar

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@
 - `[Modal]` Fixed button alignment on modals. ([#7543](https://github.com/infor-design/enterprise/issues/7543))
 - `[SearchField]` Fixed misaligned icons on toolbar search and pager buttons. ([#7527](https://github.com/infor-design/enterprise/issues/7527))
 - `[Textarea]` Fixed an issue where the textarea was throwing an error. ([#7536](https://github.com/infor-design/enterprise/issues/7536))
+- `[Toolbar]` Fixed x alignment on old toolbars. ([#7550](https://github.com/infor-design/enterprise/issues/7550))
 
 ## v4.83.0
 

--- a/src/components/toolbar/_toolbar-new.scss
+++ b/src/components/toolbar/_toolbar-new.scss
@@ -15,6 +15,7 @@
   &.do-resize {
     .toolbar-searchfield-wrapper {
       > svg.icon.close {
+        margin-top: -11px;
         top: 50%;
       }
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

The x is misaligned on the old toolbar (not toolbar flex)

**Related github/jira issue (required)**:
Fixes #7550 

**Steps necessary to review your pull request (required)**:
- open http://localhost:4000/components/masthead/example-banner-detail.html
- expand the search and type
- x should be aligned ok

**Included in this Pull Request**:
- [x] A note to the change log.
