### PR TITLE
7516 - Add fixes to tab selected color

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `[Lookup]` Added undefined check for lookup values when updating grid. ([#7403](https://github.com/infor-design/enterprise/issues/7403))
 - `[Listview]` Fixed invisible button on hover. ([#7544](https://github.com/infor-design/enterprise/issues/7544))
 - `[Modal]` Fixed button alignment on modals. ([#7543](https://github.com/infor-design/enterprise/issues/7543))
+- `[Tabs/Module]` Fixed a bug the personalization color was the same as the tab color (again). ([#7516](https://github.com/infor-design/enterprise/issues/7516))
 - `[SearchField]` Fixed misaligned icons on toolbar search and pager buttons. ([#7527](https://github.com/infor-design/enterprise/issues/7527))
 - `[Textarea]` Fixed an issue where the textarea was throwing an error. ([#7536](https://github.com/infor-design/enterprise/issues/7536))
 

--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -288,6 +288,7 @@ Personalize.prototype = {
     colors.btnLinkColor = colors.light;
     colors.tabBottomBorderColor = colors.base;
     colors.btnActionsHoverColor = colors.base;
+    colors.moduleTabsSelectedTextColor = '#ffffff';
 
     const isAlabaster = colors.header === '#ffffff';
     const isNewDark = this.currentTheme.indexOf('new-dark') >= 0;
@@ -315,6 +316,7 @@ Personalize.prototype = {
       colors.btnLinkColor = '0072ED';
       colors.tabBottomBorderColor = '#B7B7BA';
       colors.btnActionsHoverColor = '#2F2F32';
+      colors.moduleTabsSelectedTextColor = colors.contrast;
 
       if (isNewDark) {
         colors.base = '#606066';

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -273,9 +273,13 @@ a.is-personalizable svg.ripple-effect {
 
 .module-tabs.is-personalizable .tab.is-selected {
   background-color: ${colors.base} !important;
+  color: ${colors.moduleTabsSelectedTextColor} !important;
 }
 
-.module-tabs.is-personalizable .tab.is-selected,
+.module-tabs.is-personalizable .tab:not(.is-selected) {
+  background-color: ${colors.dark} !important;
+}
+
 .module-tabs.is-personalizable .tab {
   color: ${colors.contrast};
 }

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -1201,6 +1201,8 @@ html[class*='theme-new-'] .header .toolbar .toolbar-searchfield-wrapper.has-cate
   height: 38px;
   border-bottom-right-radius: 8px;
   border-top-right-radius: 8px;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
 }
 
 html[class*='theme-classic-'] .header .toolbar .toolbar-searchfield-wrapper.has-go-button.has-categories .searchfield {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adds fixes for tab selected color (regressed)

**Related github/jira issue (required)**:
Fixes #7516

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/tabs-module/example-category-searchfield-go-button-home.html
- change color (fx amber) and make sure the selected color is discernable from the no/selected color
- also fixed the shape of the category button

**Included in this Pull Request**:
- [x] A note to the change log.
