### PR TITLE
7491/5886 - Add translation fixes

### DIFF
--- a/app/views/components/locale/test-extend-messages.html
+++ b/app/views/components/locale/test-extend-messages.html
@@ -22,9 +22,14 @@
       YourWelcome: { id: 'YourWelcome', value: '~You\'re Welcome~', comment: ''}
     };
     Soho.Locale.extendTranslations(Soho.Locale.currentLanguage.name, myStrings);
+    Soho.Locale.extendTranslations(Soho.Locale.currentLanguage.name, { testing: { id: 'testing', value: '~this is a test~' } })
+    Soho.Locale.extendTranslations('fr-CA', { testing: { id: 'testing', value: '~this is a test (fr-CA)~' } })
 
+    append(`Langauge Name: ${Soho.Locale.currentLanguage.name}`);
     append(Soho.Locale.translate('Comments') + '<br>');
+    append(Soho.Locale.translate('MonthWideMar') + '<br>');
     append(Soho.Locale.translate('Thanks') + '<br>');
     append(Soho.Locale.translate('YourWelcome') + '<br>');
+    append(Soho.Locale.translate('testing') + '<br>');
   });
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # What's New with Enterprise
 
+## v4.85.0
+
+## v4.85.0 Fixes
+
+- `[Locale]` Fixed a bug using extend translations on some languages (`fr-CA/pt-BR`). ([#7491](https://github.com/infor-design/enterprise/issues/7491))
+- `[Locale/Multiselect]` Changed text from selected to selection as requested by translators. ([#5886](https://github.com/infor-design/enterprise/issues/5886))
+
 ## v4.84.0
 
 ## v4.84.0 Features

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -803,7 +803,7 @@ Dropdown.prototype = {
     const showSelectAll = this.settings.showSelectAll === true;
     const headerText = {
       all: Locale.translate('All'),
-      selected: Locale.translate('Selected'),
+      selected: Locale.translate('Selection'),
       labelText: self.isInlineLabel ? self.inlineLabelText.text() : this.label.text()
     };
     headerText.all = (typeof s.allTextString === 'string' && s.allTextString !== '') ?

--- a/src/components/locale/cultures/fr-CA.js
+++ b/src/components/locale/cultures/fr-CA.js
@@ -1,7 +1,7 @@
 // Get Latest from http://www.unicode.org/Public/cldr/25/
 Soho.Locale.addCulture('fr-CA', {
   // layout/language
-  language: 'fr',
+  language: 'fr-CA',
   englishName: 'French (Canada)',
   nativeName: 'français (Canada)',
   // layout/orientation/@characters

--- a/src/components/locale/cultures/pt-BR.js
+++ b/src/components/locale/cultures/pt-BR.js
@@ -1,7 +1,7 @@
 // Get Latest from http://www.unicode.org/Public/cldr/25/
 Soho.Locale.addCulture('pt-BR', {
   // layout/language
-  language: 'pt',
+  language: 'pt-BR',
   englishName: 'Portuguese (Brazil)',
   nativeName: 'Português (Brasil)',
   // layout/orientation/@characters

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -239,7 +239,9 @@ const Locale = {  // eslint-disable-line
     if (lang === 'nb' || lang === 'nn' || lang === 'nb-NO' || lang === 'nn-NO') {
       correctLanguage = 'no';
     }
-    return correctLanguage;
+    if (this.translatedLocales.indexOf(lang) > -1) return this.translatedLocales[this.translatedLocales.indexOf(lang)];
+
+    return correctLanguage.substr(0, 2);
   },
 
   /**
@@ -251,7 +253,7 @@ const Locale = {  // eslint-disable-line
    * @returns {void}
    */
   addCulture(locale, data, langData) {
-    const lang = locale.substr(0, 2);
+    const lang = this.remapLanguage(locale);
 
     this.cultures[locale] = data;
     this.cultures[locale].name = locale;
@@ -488,7 +490,7 @@ const Locale = {  // eslint-disable-line
    * @returns {void}
    */
   setCurrentLocale(name, data) {
-    const lang = this.remapLanguage(name.substr(0, 2));
+    const lang = this.remapLanguage(name);
     this.currentLocale.name = name;
     const selectedLang = (this.languages[lang] !== undefined && this.languages[name] !== undefined) &&
       (this.languages[lang].nativeName !== this.languages[name].nativeName) ? name : lang;
@@ -1457,13 +1459,13 @@ const Locale = {  // eslint-disable-line
    * @returns {object} The language data.
    */
   useLanguage(options) {
-    let languageData = this.currentLanguage;
+    let languageData = this.languages[this.currentLanguage.name];
     if (options && options.locale) {
-      const lang = options.locale.split('-')[0];
+      const lang = this.remapLanguage(options.locale);
       languageData = this.languages[lang];
     }
     if (options && options.locale &&
-      this.currentLanguage.name !== this.currentLocale.name.substr(0, 2) &&
+      this.currentLanguage.name !== this.currentLocale.name &&
       this.languages[this.currentLanguage.name]) {
       languageData = this.languages[this.currentLanguage.name];
     }

--- a/test/components/locale/locale-func-test.js
+++ b/test/components/locale/locale-func-test.js
@@ -2128,16 +2128,28 @@ describe('Locale API', () => {
     Locale.set('fr-FR');
 
     expect(Locale.currentLocale.name).toEqual('fr-FR');
-    expect(Locale.currentLanguage.name).toEqual('fr');
+    expect(Locale.currentLanguage.name).toEqual('fr-FR');
 
     expect(Locale.translate('From')).toEqual('Début');
 
     Locale.set('fr-CA');
 
     expect(Locale.currentLocale.name).toEqual('fr-CA');
-    expect(Locale.currentLanguage.name).toEqual('fr');
+    expect(Locale.currentLanguage.name).toEqual('fr-CA');
     expect(Locale.translate('From')).toEqual('De');
   });
+
+  it('should be able to extend fr-CA and fr-FR', () => {
+    Locale.set('fr-FR');
+    Locale.extendTranslations('fr', { testing: { id: 'testing', value: 'this is a test 1' } });
+    Locale.extendTranslations('fr-FR', { testing: { id: 'testing', value: 'this is a test 2' } });
+    expect(Locale.translate('testing')).toEqual('this is a test 2');
+
+    Locale.set('fr-CA');
+    Locale.extendTranslations('fr-CA', { testing: { id: 'testing', value: 'this is a test fr-CA' } });
+    expect(Locale.translate('testing')).toEqual('this is a test fr-CA');
+  });
+
 
   it('should be able to set language to full code', () => {
     Locale.set('en-US');

--- a/test/components/locale/locale-func-test.js
+++ b/test/components/locale/locale-func-test.js
@@ -2150,7 +2150,6 @@ describe('Locale API', () => {
     expect(Locale.translate('testing')).toEqual('this is a test fr-CA');
   });
 
-
   it('should be able to set language to full code', () => {
     Locale.set('en-US');
     Locale.setLanguage('fr-CA');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes two issues that have to do with locale. As explained in the steps below.

**Related github/jira issue (required)**:
Fixes https://github.com/infor-design/enterprise/issues/7491
Fixes https://github.com/infor-design/enterprise/issues/5886

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/multiselect/example-index.html and open the dropdown. test should now say "Selection" instead of "Selected"
- also check another locale like http://localhost:4000/components/multiselect/example-index.html?locale=de-DE to see this new label is translated
- go to http://localhost:4000/components/locale/test-extend-messages.html?locale=fr-CA -> should be a label added that says `~this is a test (fr-CA)~` and language name is fr-CA instead of just fr
- go to http://localhost:4000/components/locale/test-extend-messages.html?locale=fr-FR -> does not have this special text added to fr-ca (just says `~this is a test~`

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
