### PR TITLE
7508 - adjust left and right padding of button to 32px

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## v4.85.0 Fixes
 
+- `[Button]` Adjusted the left and right paddings of the button from `30px` to `32px`. ([#7508](https://github.com/infor-design/enterprise/issues/7508))
 - `[Locale]` Fixed a bug using extend translations on some languages (`fr-CA/pt-BR`). ([#7491](https://github.com/infor-design/enterprise/issues/7491))
 - `[Locale/Multiselect]` Changed text from selected to selection as requested by translators. ([#5886](https://github.com/infor-design/enterprise/issues/5886))
 - `[SearchField]` Fix x alignment on older toolbar example. ([#7572](https://github.com/infor-design/enterprise/issues/58875726))

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -345,7 +345,7 @@ button {
 .btn-primary,
 .btn-secondary {
   border-radius: 2px;
-  padding: 0 30px;
+  padding: 0 32px;
 }
 
 // standard, primary, destructive


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the left and right paddings of button component from `30px` to `32px`.

**Related github/jira issue (required)**:

Closes #7508 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/button/example-index.html
- Check the button primary and secondary button
- Button padding left and right should be `32px`

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
