### PR TITLE
NG1477 - Improve some Enterprise components for better compatibility with Angular Module Nav

### DIFF
--- a/app/views/components/module-nav/example-hidden.html
+++ b/app/views/components/module-nav/example-hidden.html
@@ -1,9 +1,3 @@
-<style>
-  .test-spacer {
-    height: 2000px;
-  }
-</style>
-
 <section class="module-nav-container">
   <aside id="nav" class="module-nav">
     <div class="module-nav-bar">

--- a/app/views/components/module-nav/example-not-filterable.html
+++ b/app/views/components/module-nav/example-not-filterable.html
@@ -1,11 +1,5 @@
-<style>
-  .test-spacer {
-    height: 2000px;
-  }
-</style>
-
 <section class="module-nav-container mode-collapsed">
-  <aside id="nav" class="module-nav" data-options="{ 'filterable': true }">
+  <aside id="nav" class="module-nav" data-options="{ 'displayMode': 'expanded', 'filterable': false }">
     <div class="module-nav-bar">
       <!-- Module Nav's top-level navigation items are inside the accordion -->
       <div class="module-nav-accordion accordion panel" data-options="{'allowOnePane': false}">
@@ -270,82 +264,10 @@
       <div class="four columns">&nbsp;</div>
       <div class="four columns">&nbsp;</div>
       <div class="four columns">
-        <h2 class="fieldset-title">Module Nav</h2>
-        <p>Displays top-level navigation in a flyout menu</p>
-
-        <div class="field">
-          <label for="display-mode-dropdown" class="label">Display Mode</label>
-          <select id="display-mode-dropdown" class="dropdown">
-            <option value="">Hidden</option>
-            <option value="collapsed" selected>Collapsed</option>
-            <option value="expanded">Expanded</option>
-          </select>
-        </div>
-
-        <div class="field">
-          <input type="checkbox" class="checkbox" name="display-detail-check" id="display-detail-check" />
-          <label for="display-detail-check" class="checkbox-label">Display Detail View</label>
-        </div>
-
-        <div class="field">
-          <input type="checkbox" class="checkbox" name="pin-sections" id="pin-sections" />
-          <label for="pin-sections" class="checkbox-label">Pin "optionally-pinned" Sections</label>
-        </div>
-
-        <div class="field">
-          <input type="checkbox" class="checkbox" name="offset-check" id="offset-check" />
-          <label for="offset-check" class="checkbox-label">Offset the page container (don't hide any content)</label>
-        </div>
+        <h2 class="fieldset-title">Module Nav (Not Filterable)</h2>
+        <p>Demonstrates Module Nav behavior when a searchfield is present but built-in filtering is disabled.</p>
+        <p>In this configuration, the default behavior will be to invoke a searchfield with default settings, and to rely on searchfield events/external config for Module Nav behavior.</p>
       </div>
-    </div>
-    <div class="row test-spacer">&nbsp;</div>
-    <div class="row">
-      <div class="four columns">&nbsp;</div>
-      <div class="four columns">&nbsp;</div>
-      <div class="four columns">Scrolling this area shouldn't affect the navigation columns.</div>
     </div>
   </div>
 </section>
-
-<script>
-  $('body').on('initialized', () => {
-    const navAPI = $('#nav').data('modulenav');
-    const containerEl = $('.module-nav-container');
-    const dropdownAPI = $('#display-mode-dropdown').data('dropdown');
-    const displayCheckEl = $('#display-detail-check');
-    const offsetCheckEl = $('#offset-check');
-    const hamburgerBtnEl = $('#header-hamburger');
-    const pinSectionsCheckEl = $('#pin-sections');
-
-    dropdownAPI.element.on('change.test', (e) => {
-      let val = dropdownAPI.value;
-      if (val === 'Hidden') val = false;
-      navAPI.updated({ displayMode: val });
-    });
-
-    displayCheckEl.on('change.test', (e) => {
-      navAPI.updated({ showDetailView: displayCheckEl[0].checked });
-    });
-
-    offsetCheckEl.on('change.test', (e) => {
-      const pageContainer = containerEl.find('.page-container');
-      pageContainer[0].classList[ offsetCheckEl[0].checked ? 'add' : 'remove' ]('has-module-nav-offset');
-    });
-
-    pinSectionsCheckEl.on('change.test', (e) => {
-      navAPI.updated({ pinSections: pinSectionsCheckEl[0].checked });
-    });
-
-    if (hamburgerBtnEl.length) {
-      hamburgerBtnEl.on('click.test', (e) => {
-        if (!dropdownAPI.value === 'collapsed') {
-          dropdownAPI.selectListItem($('option[value="expanded"]'));
-        } else {
-          dropdownAPI.selectListItem($('option[value="collapsed"]'));
-        }
-      });
-    }
-
-    navAPI.updated({ displayMode: 'collapsed' });
-  });
-</script>

--- a/app/views/components/module-nav/example-six-levels-icons.html
+++ b/app/views/components/module-nav/example-six-levels-icons.html
@@ -1,5 +1,5 @@
 <section class="module-nav-container mode-expanded">
-  <aside id="nav" class="module-nav" data-options="{ displayMode: 'expanded' }">
+  <aside id="nav" class="module-nav" data-options="{ 'displayMode': 'expanded', 'filterable': true }">
     <div class="module-nav-bar">
       <!-- Module Nav's top-level navigation items are inside the accordion -->
       <div class="module-nav-accordion accordion panel" data-options="{'allowOnePane': false}">

--- a/app/views/components/module-nav/example-six-levels.html
+++ b/app/views/components/module-nav/example-six-levels.html
@@ -1,5 +1,5 @@
 <section class="module-nav-container mode-expanded">
-  <aside id="nav" class="module-nav" data-options="{ displayMode: 'expanded' }">
+  <aside id="nav" class="module-nav" data-options="{ 'displayMode': 'expanded', 'filterable': true }">
     <div class="module-nav-bar">
       <!-- Module Nav's top-level navigation items are inside the accordion -->
       <div class="module-nav-accordion accordion panel" data-options="{'allowOnePane': false}">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,15 @@
 - `[Locale/Multiselect]` Changed text from selected to selection as requested by translators. ([#5886](https://github.com/infor-design/enterprise/issues/5886))
 - `[SearchField]` Fix x alignment on older toolbar example. ([#7572](https://github.com/infor-design/enterprise/issues/7572))
 
+
+## v4.84.1
+
+## v4.84.1 Fixes
+
+- `[Module Nav]` Fixed an issue where it was not possible to disable filtering events. ([NG #1477](https://github.com/infor-design/enterprise-ng/issues/1477))
+- `[Popupmenu]` Fixed some styling bugs when attached as a menu button menu in Module Nav components. ([NG #1477](https://github.com/infor-design/enterprise-ng/issues/1477))
+- `[Dropdown]` Fixed an issue where Module Nav Role Switcher wasn't properly rendering the Dropdown pseudo-elements in Angular environments. ([NG #1477](https://github.com/infor-design/enterprise-ng/issues/1477))
+
 ## v4.84.0
 
 ## v4.84.0 Features

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,6 @@
 - `[Locale/Multiselect]` Changed text from selected to selection as requested by translators. ([#5886](https://github.com/infor-design/enterprise/issues/5886))
 - `[SearchField]` Fix x alignment on older toolbar example. ([#7572](https://github.com/infor-design/enterprise/issues/7572))
 
-
 ## v4.84.1
 
 ## v4.84.1 Fixes

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -235,12 +235,20 @@ Dropdown.prototype = {
     this.isHidden = style && style.indexOf('display: none') >= 0;
 
     // Build the wrapper if it doesn't exist
-    const baseElement = this.isInlineLabel ? this.inlineLabel : this.element;
-    this.wrapper = baseElement.next('.dropdown-wrapper');
+    let baseElement;
+    if (this.isInlineLabel) {
+      baseElement = this.inlineLabel.next('.dropdown-wrapper');
+    } else {
+      baseElement = this.element.parent('.dropdown-wrapper');
+      if (!baseElement.length) {
+        baseElement = this.element.next('.dropdown-wrapper');
+      }
+    }
+    this.wrapper = baseElement;
     this.isWrapped = this.wrapper.length > 0;
 
     if (!this.isWrapped) {
-      this.wrapper = $('<div class="dropdown-wrapper"></div>').insertAfter(baseElement);
+      this.wrapper = $('<div class="dropdown-wrapper"></div>').insertAfter(this.element);
     }
 
     if (this.isWrapped) {

--- a/src/components/module-nav/module-nav.js
+++ b/src/components/module-nav/module-nav.js
@@ -141,7 +141,6 @@ ModuleNav.prototype = {
     }
     this.searchEl = this.element[0].querySelector('.searchfield');
     if (this.searchEl) {
-      this.settings.filterable = true;
       this.configureSearch();
     }
 
@@ -269,8 +268,16 @@ ModuleNav.prototype = {
    * @private
    */
   configureSearch() {
-    accordionSearchUtils.attachFilter.apply(this, [COMPONENT_NAME]);
-    accordionSearchUtils.attachFilterEvents.apply(this, [COMPONENT_NAME]);
+    // If the filterable setting is disabled, no events should be applied automatically
+    // (This behavior is intended for allowing custom filtering applications)
+    if (this.settings.filterable) {
+      accordionSearchUtils.attachFilter.apply(this, [COMPONENT_NAME]);
+      accordionSearchUtils.attachFilterEvents.apply(this, [COMPONENT_NAME]);
+    } else {
+      // Invoke searchfield with default settings here since we found one
+      // (main init process ignores searchfields inside nav menus)
+      $(this.searchEl).searchfield();
+    }
 
     this.searchEl.classList.add('module-nav-search');
     $(this.searchEl).parents('.accordion-section')?.[0].classList.add('module-nav-search-container');

--- a/src/components/module-nav/module-nav.settings.scss
+++ b/src/components/module-nav/module-nav.settings.scss
@@ -3,6 +3,10 @@
 // Module Nav Settings Component
 //================================================== //
 
+.module-nav-settings-btn.btn-menu {
+  padding-inline: 0;
+}
+
 .popupmenu.module-nav-settings-menu {
   @include settings-menu-box-shadow;
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR fixes a couple issues in IDS Components related to behavior in the Angular Module Nav component wrapper:
- Fixes a bug where the `filterable` setting was always on
- Adds a new demo page with a disabled `filterable` setting
- Fixes a dropdown bug that was causing Module Nav Role Switcher to render its Dropdown wrapper element twice
- Fixes some styling bugs and consistency issues in demo examples

**Related github/jira issue (required)**:
Related to #7386
Related to infor-design/enterprise-ng#1477

**Steps necessary to review your pull request (required)**:
- Open https://ng1477-module-nav-patch-enterprise.demo.design.infor.com/components/module-nav/example-index.html
- Everything should behave as expected (the example has been updated to enable filtering explicitly).  Specifically check filtering, dropdown behavior, and settings menu behavior
- Open https://ng1477-module-nav-patch-enterprise.demo.design.infor.com/components/module-nav/example-not-filterable.html
- See that using the Searchfield on this example does nothing (this is for custom search behaviors)

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

** EXTRA NOTE:** @tmcconechy this will need patching back into the `v4.84.x` branch, and a patch release is needed.
