### PR TITLE
Card/Widget fixes in NG

### DIFF
--- a/src/components/cards/cards.js
+++ b/src/components/cards/cards.js
@@ -102,7 +102,7 @@ Cards.prototype = {
     const isSingle = this.settings.selectable === 'single';
     const isBordered = this.settings.bordered === true;
     const isBorderLess = this.settings.bordered === false;
-    const hasCustomAction = this.element.find('.card-header .card-header-section.custom-action, .widget-header .widget-header-section.custom-action').length > 0;
+    const hasCustomAction = this.element.find('.card-header-section.custom-action, .widget-header-section.custom-action').length > 0;
     // Apply content padding if provided
     const { contentPaddingX, contentPaddingY } = this.settings;
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the visibility of the custom action to work with the Angular wrapper. It reduces specificity in the jQuery component to align with Angular's lifecycle. Essentially, the jQuery instance is now executed after the Angular component, ensuring that the condition is met.

**Related github/jira issue (required)**:

N/A

**Steps necessary to review your pull request (required)**:
- Go to NG project and get the jquery fix via copying the dist or just change directly in the node_modules -> ids-enterprise -> dist -> js ->sohoxi.js
- Go to http://localhost:4200/ids-enterprise-ng-demo/cards-workspace-widgets
- Button `more` should be visible under `Bordered with Actions` card

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
