### PR TITLE
5018 - Popupmenu Placement when Parent Element is outside of viewport

### DIFF
--- a/app/views/components/popupmenu/test-menubutton-viewport.html
+++ b/app/views/components/popupmenu/test-menubutton-viewport.html
@@ -1,0 +1,37 @@
+<div class="row">
+  <div class="six columns">
+    <h2>Popupmenu Test: Menu Button</h2>
+    <p>Common configuration for popupmenus attached to buttons.</p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+
+    <!-- Normal Menu -->
+    <div class="field">
+      <button id="popupmenu-trigger" class="btn-menu">
+        <span>Normal Menu</span>
+        <svg role="presentation" aria-hidden="true" focusable="false" class="icon icon-dropdown">
+          <use href="#icon-dropdown"></use>
+        </svg>
+      </button>
+      <ul class="popupmenu">
+        <li><a href="#">Menu Option #1</a></li>
+        <li><a href="#">Menu Option #2</a></li>
+        <li><a href="#">Menu Option #3</a></li>
+      </ul>
+    </div>
+
+  </div>
+</div>
+
+<style>
+  #maincontent {
+    min-width: 105%
+  }
+
+  #popupmenu-trigger {
+    float: right;
+  }
+</style>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `[MonthView]` Added event triggers for when monthview is expanded and collapsed. ([#7605](https://github.com/infor-design/enterprise/issues/7605))
 - `[Multiselect]` Fixed a bug where the multiselect dropdown icon was overlapping the field. ([#7502](https://github.com/infor-design/enterprise/issues/7502))
 - `[Lookup]` Fixed a bug in lookup width not responsive in grid system. ([#7205](https://github.com/infor-design/enterprise/issues/7205))
+- `[Popupmenu]` Fixed the placement of popup when parent element is outside of viewport. ([#5018](https://github.com/infor-design/enterprise/issues/5018))
 - `[SearchField]` Fixed x alignment on older toolbar example. ([#7572](https://github.com/infor-design/enterprise/issues/58875726))
 - `[SearchField]` Fix x alignment on older toolbar example. ([#7572](https://github.com/infor-design/enterprise/issues/7572))
 - `[Splitter]` Added new design changes and more examples. Note that the collapse button is no longer supported for now. ([#7542](https://github.com/infor-design/enterprise/issues/7542))

--- a/src/components/place/place.js
+++ b/src/components/place/place.js
@@ -551,13 +551,32 @@ Place.prototype = {
   },
 
   /**
+   * Checks if the parent element is in viewport
+   * @param {Object} parentElement element to be checked
+   * @returns {boolean}
+   */
+  isParentElementinViewport(parentElement) {
+    if (typeof jQuery === "function" && parentElement instanceof jQuery) {
+      parentElement = parentElement[0];
+    }
+
+    var rect = parentElement.getBoundingClientRect();
+    return (
+        rect.top >= 0 &&
+        rect.left >= 0 &&
+        rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) && /* or $(window).height() */
+        rect.right <= (window.innerWidth || document.documentElement.clientWidth) /* or $(window).width() */
+    );
+  },
+
+  /**
    * Re-adjust a previously-placed element to account for bleeding off the edges.
    * Element must fit within the boundaries of the page or it's current scrollable pane.
    * @param {PlacementObject} placementObj settings for the placement routine.
    * @returns {PlacementObject} modified placementObject with updated settings.
    */
   checkBleeds(placementObj) {
-    const containerBleed = this.settings.bleedFromContainer;
+    const containerBleed = this.settings.bleedFromContainer === false ? !this.isParentElementinViewport(this.element) : this.settings.bleedFromContainer;
     const container = this.getContainer(placementObj);
     const containerIsBody = container.length && container[0] === document.body;
     const BoundingRect = this.element[0].getBoundingClientRect();
@@ -721,6 +740,7 @@ Place.prototype = {
     // Gets the distance between an edge on the target element, and its opposing viewport border
     function getDistance(dir) {
       let d = 0;
+      console.log('getDistance');
 
       switch (dir) {
         case 'left':
@@ -819,6 +839,7 @@ Place.prototype = {
     const windowH = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
     const windowW = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
 
+    console.log('shrink');
     // Figure out the viewport boundaries
     const leftViewportEdge = (accountForScrolling ? scrollX : 0) +
       (containerBleed ? 0 : containerRect.left) + placementObj.containerOffsetX;

--- a/src/components/place/place.js
+++ b/src/components/place/place.js
@@ -556,16 +556,16 @@ Place.prototype = {
    * @returns {boolean}
    */
   isParentElementinViewport(parentElement) {
-    if (typeof jQuery === "function" && parentElement instanceof jQuery) {
+    if (typeof jQuery === 'function' && parentElement instanceof jQuery) {
       parentElement = parentElement[0];
     }
 
-    var rect = parentElement.getBoundingClientRect();
+    const rect = parentElement.getBoundingClientRect();
     return (
-        rect.top >= 0 &&
-        rect.left >= 0 &&
-        rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) && /* or $(window).height() */
-        rect.right <= (window.innerWidth || document.documentElement.clientWidth) /* or $(window).width() */
+      rect.top >= 0 &&
+      rect.left >= 0 &&
+      rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) && 
+      rect.right <= (window.innerWidth || document.documentElement.clientWidth)
     );
   },
 
@@ -576,7 +576,8 @@ Place.prototype = {
    * @returns {PlacementObject} modified placementObject with updated settings.
    */
   checkBleeds(placementObj) {
-    const containerBleed = this.settings.bleedFromContainer === false ? !this.isParentElementinViewport(this.element) : this.settings.bleedFromContainer;
+    const containerBleed = this.settings.bleedFromContainer === false ? 
+      !this.isParentElementinViewport(this.element) : this.settings.bleedFromContainer;
     const container = this.getContainer(placementObj);
     const containerIsBody = container.length && container[0] === document.body;
     const BoundingRect = this.element[0].getBoundingClientRect();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix the placement of popup when parent element is outside of viewport.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/5018

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/popupmenu/test-menubutton-viewport.html
- Shrink the page till the `Normal Menu` is somewhat outside of the viewport
- Click the Menu
- See the popup

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

