### PR TITLE
7499 - Added z-index for empty filter wrapper

### DIFF
--- a/app/views/components/datagrid/test-change-show-select-all-checkbox.html
+++ b/app/views/components/datagrid/test-change-show-select-all-checkbox.html
@@ -27,9 +27,9 @@
 
       // Define Columns for the Grid.
       columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Soho.Formatters.SelectionCheckbox, align: 'center'});
-      columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Soho.Formatters.Readonly});
-      columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Soho.Formatters.Hyperlink, href: '/home/detail/{{value}}'});
-      columns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity'});
+      columns.push({ id: 'productId', name: 'Product Id', field: 'productId', filterType: 'text',  formatter: Soho.Formatters.Readonly});
+      columns.push({ id: 'productName', name: 'Product Name', field: 'productName', filterType: 'text',  formatter: Soho.Formatters.Hyperlink, href: '/home/detail/{{value}}'});
+      columns.push({ id: 'activity', hidden: true, name: 'Activity', filterType: 'text',  field: 'activity'});
       columns.push({ id: 'quantity', name: 'Accuml. Quantity', field: 'quantity'});
       columns.push({ id: 'price', name: 'Status', field: 'price', formatter: Soho.Formatters.Alert, ranges: [{'min': 0, 'max': 150, 'classes': 'success', text: 'Confirmed'}, {'min': 151, 'max': 9999, 'classes': 'error', text: 'Error'}]});
       columns.push({ id: 'quantity', name: 'Badge', field: 'quantity', align: 'center', formatter: Soho.Formatters.Badge, sortable: false, ranges: [{'min': 0, 'max': 2, 'classes': 'error'}, {'value': 3, 'classes': 'alert'}, {'value': 41, 'classes': 'good'}]});

--- a/app/views/components/datagrid/test-change-show-select-all-checkbox.html
+++ b/app/views/components/datagrid/test-change-show-select-all-checkbox.html
@@ -2,6 +2,7 @@
 <div class="row">
   <div class="full-width">
     <button class="btn-secondary" type="button" id="toggle-select-all">Toggle Select All</button>
+    <button class="btn-secondary" type="button" id="toggle-filter">Toggle Filter</button>
     <div id="datagrid">
     </div>
   </div>
@@ -41,11 +42,16 @@
         dataset: data,
         showSelectAllCheckBox: false,
         selectable: 'multiple',
+        filterable: false,
         toolbar: {title: 'Data Grid Header Title', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: true,  collapsibleFilter: true}
       }).data('datagrid');
 
       $('#toggle-select-all').on('click', function () {
         dg.updated({ showSelectAllCheckBox: !dg.settings.showSelectAllCheckBox }, { preserveSelected: true });
+      });
+
+      $('#toggle-filter').on('click', function () {
+        dg.updated({ filterable: !dg.settings.filterable });
       });
  });
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[ContextualActionPanel]` Fixed overflow issues on mobile view. ([#7585](https://github.com/infor-design/enterprise/issues/7585))
 - `[Datagrid]` Fixed on incorrect row updates on adding a new row to the next page. ([#7486](https://github.com/infor-design/enterprise/issues/7486))
 - `[Datagrid]` Fixed disabled filter columns in datagrid. ([#7467](https://github.com/infor-design/enterprise/issues/7467))
+- `[Datagrid]` Fixed a bug where the select all checkbox was not clickable. ([#7499](https://github.com/infor-design/enterprise/issues/7499))
 - `[Editor]` Fixed an xss issue in editor (iframes not permitted). ([#7590](https://github.com/infor-design/enterprise/issues/7590))
 - `[Homepage]` Fixed invisible edit options and vertical dragging/resizing. ([#7579](https://github.com/infor-design/enterprise/issues/7579))
 - `[Locale]` Fixed a bug using extend translations on some languages (`fr-CA/pt-BR`). ([#7491](https://github.com/infor-design/enterprise/issues/7491))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -353,6 +353,7 @@ $datagrid-small-row-height: 25px;
 
       + .datagrid-filter-wrapper.is-empty {
         left: -60px;
+        z-index: -1;
       }
     }
   }

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -595,7 +595,7 @@ html[class*='theme-classic-'] {
     }
   }
 
-  .searchfield-wrapper > .icon {
+  .searchfield-wrapper > .close.icon {
     top: 7px;
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Added z-index for empty filter wrapper so that it won't overlap with checkbox.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #7499 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datagrid/test-change-show-select-all-checkbox.html
- Click on Toggle Filter
- Click on Toggle Select All
- In Personalize Columns, uncheck everything except Product ID and Checked
- Hover on lower half of Select All checkbox, should be able to click

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
