### PR TITLE
1360 - Fix empty message size

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[Datagrid]` Fixed disabled filter columns in datagrid. ([#7467](https://github.com/infor-design/enterprise/issues/7467))
 - `[Editor]` Fixed an xss issue in editor (iframes not permitted). ([#7590](https://github.com/infor-design/enterprise/issues/7590))
 - `[Homepage]` Fixed invisible edit options and vertical dragging/resizing. ([#7579](https://github.com/infor-design/enterprise/issues/7579))
+- `[Icons]` Fixed size of icons and made them 80x80. ([#1369](https://jira.infor.com/browse/IDS-1360))
 - `[Locale]` Fixed a bug using extend translations on some languages (`fr-CA/pt-BR`). ([#7491](https://github.com/infor-design/enterprise/issues/7491))
 - `[Locale/Multiselect]` Changed text from selected to selection as requested by translators. ([#5886](https://github.com/infor-design/enterprise/issues/5886))
 - `[MonthView]` Added event triggers for when monthview is expanded and collapsed. ([#7605](https://github.com/infor-design/enterprise/issues/7605))

--- a/src/components/icons/_icons-new.scss
+++ b/src/components/icons/_icons-new.scss
@@ -7,7 +7,7 @@
 
   &.icon-empty-state {
     fill: $ids-color-brand-primary-base;
-    width: 65px;
+    width: 80px;
   }
 }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->

**Related github/jira issue (required)**:
Fixes https://jira.infor.com/browse/IDS-1360
Fixes https://github.com/infor-design/enterprise/issues/7655

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/icons/example-empty-widgets.html
- check size is 80x780 not 65x80
- note that classic is unchanged
- check related page http://localhost:4000/components/emptymessage

**Included in this Pull Request**:
- [x] A note to the change log.
