### PR TITLE
7557 - Adjusted overflow styles for listviews in cards

### DIFF
--- a/app/views/components/notification/example-widget.html
+++ b/app/views/components/notification/example-widget.html
@@ -15,8 +15,8 @@
           <li><a href="#" id="action-3">Action 3</a></li>
         </ul>
       </div>
-      <div class="notification-cointainer"></div>
       <div class="card-content">
+        <div class="notification-cointainer"></div>
         <div class="listview" id="task-listview"
           data-options="{'source': '{{basepath}}api/inventory-tasks', 'template': 'task-tmpl', 'selectable': 'false'}">
         </div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Homepage]` Fixed invisible edit options and vertical dragging/resizing. ([#7579](https://github.com/infor-design/enterprise/issues/7579))
 - `[Icons]` Fixed size of icons and made them 80x80. ([#1369](https://jira.infor.com/browse/IDS-1360))
 - `[Listview/Card]` Fixed the UI of listview search with filters. ([#7546](https://github.com/infor-design/enterprise/issues/7546))
+- `[Listview]` Adjusted overflow styles for listviews in cards. ([#7557](https://github.com/infor-design/enterprise/issues/7557))
 - `[Locale]` Fixed a bug using extend translations on some languages (`fr-CA/pt-BR`). ([#7491](https://github.com/infor-design/enterprise/issues/7491))
 - `[Locale/Multiselect]` Changed text from selected to selection as requested by translators. ([#5886](https://github.com/infor-design/enterprise/issues/5886))
 - `[Lookup]` Fixed a bug in lookup width not responsive in grid system. ([#7205](https://github.com/infor-design/enterprise/issues/7205))

--- a/src/components/cards/_cards-new.scss
+++ b/src/components/cards/_cards-new.scss
@@ -275,6 +275,8 @@
   .listview {
     border-bottom-left-radius: 8px;
     border-bottom-right-radius: 8px;
+    overflow: hidden;
+    height: auto;
   }
 }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Placing notifications in card content will put it in the right height and will overflow if needed. Set listview to have auto height and hidden overflow when it's in a card so that card can overflow and to avoid double scrolls

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #7557 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/notification/example-widget.html
- Listview in card shouldn't spill out

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
