### PR TITLE
N/A - Fix datagrid example pages

### DIFF
--- a/app/views/components/datagrid/example-expandable-row-editable.html
+++ b/app/views/components/datagrid/example-expandable-row-editable.html
@@ -18,7 +18,7 @@
         field: 'productId',
         sortable: false,
         filterType: 'text',
-        formatter: Formatters.Expander,
+        formatter: Soho.Formatters.Expander,
       },
       {
         id: 'productName',
@@ -28,7 +28,7 @@
         filterType: 'text',
         filterConditions: ['equals', 'contains'],
         width: 150,
-        formatter: Formatters.Hyperlink,
+        formatter: Soho.Formatters.Hyperlink,
       },
       {
         id: 'activity',
@@ -44,8 +44,8 @@
         field: 'quantity',
         sortable: false,
         filterType: 'integer',
-        formatter: Formatters.Integer,
-        editor: Editors.Input,
+        formatter: Soho.Formatters.Integer,
+        editor: Soho.Editors.Input,
       },
       {
         id: 'price',
@@ -53,8 +53,8 @@
         field: 'price',
         sortable: false,
         filterType: 'decimal',
-        formatter: Formatters.Decimal,
-        editor: Editors.Input,
+        formatter: Soho.Formatters.Decimal,
+        editor: Soho.Editors.Input,
       },
       {
         id: 'orderDate',
@@ -62,7 +62,7 @@
         field: 'orderDate',
         sortable: false,
         filterType: 'date',
-        formatter: Formatters.Date,
+        formatter: Soho.Formatters.Date,
         dateFormat: 'M/d/yyyy',
       }];
 

--- a/app/views/components/datagrid/test-button-not-fully-rendered.html
+++ b/app/views/components/datagrid/test-button-not-fully-rendered.html
@@ -61,7 +61,7 @@
       var buttonFormatter = function (row, cell, value, col, dataView, dataGrid) {
          if (cell !== undefined) { // Cell may be zero here
            // Would have business logic here to determine whether the button is visible
-           return Formatters.Button(row, cell, 'Approval Group', col, dataView, dataGrid);
+           return Soho.Formatters.Button(row, cell, 'Approval Group', col, dataView, dataGrid);
          } else {
            return '';
          }

--- a/app/views/components/datagrid/test-columns-class.html
+++ b/app/views/components/datagrid/test-columns-class.html
@@ -38,7 +38,7 @@
       data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', ordered: 0});
       data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '100.99', status: 'OK', orderDate: new Date(2014, 6, 9, 12, 12, 12), action: 'On Hold', ordered: 0});
 
-      Formatters.classFormatter = function (row, cell, value) {
+      Soho.Formatters.classFormatter = function (row, cell, value) {
         return value <= 1 ? 'is-bold' : '';
       };
 
@@ -46,7 +46,7 @@
       columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Soho.Formatters.Readonly});
       columns.push({ id: 'productDesc', name: 'Product Desc', sortable: false, field: 'productName'});
       columns.push({ id: 'activity', name: 'Activity', field: 'activity', cssClass: 'azure01'});
-      columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', cssClass: Formatters.classFormatter});
+      columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', cssClass: Soho.Formatters.classFormatter});
 
       //Init and get the api for the grid
       $('#readonly-datagrid').datagrid({

--- a/app/views/components/datagrid/test-columns-colors.html
+++ b/app/views/components/datagrid/test-columns-colors.html
@@ -23,7 +23,7 @@
         columns = [],
         data = [];
 
-      Formatters.customColors = function (row, cell, value, col, item) {
+      Soho.Formatters.customColors = function (row, cell, value, col, item) {
         var strFormat = '<div class="colored-cell" style="background-color:' + item.backColor + '">' + value + '</div>';
         return strFormat;
       };

--- a/app/views/components/datagrid/test-contextmenu-on-specific-columns.html
+++ b/app/views/components/datagrid/test-contextmenu-on-specific-columns.html
@@ -28,7 +28,7 @@
       if (dataView.linkHref && dataView.linkHref.length > 0 ) {
         column.href = dataView.linkHref;
       }
-      return Formatters.Hyperlink(row, cell, value, column, dataView, dataGrid);
+      return Soho.Formatters.Hyperlink(row, cell, value, column, dataView, dataGrid);
     }
 
     // Some Sample Data

--- a/app/views/components/datagrid/test-editable-inline-editor.html
+++ b/app/views/components/datagrid/test-editable-inline-editor.html
@@ -18,12 +18,12 @@
     }
 
     // Custom Formatters
-    Formatters.LinkText = function (row, cell, value, col, item, api) {
-      var link = Formatters.Hyperlink(row, cell, item[col.fields[0]] + ' ' + item[col.fields[1]], col, item, api);
+    Soho.Formatters.LinkText = function (row, cell, value, col, item, api) {
+      var link = Soho.Formatters.Hyperlink(row, cell, item[col.fields[0]] + ' ' + item[col.fields[1]], col, item, api);
       return '<p class="word-wrap">' + link + '<br><small class="micro-text">'+ item[col.fields[2]] +'</small></p>';
     };
 
-    Formatters.PriceText = function (row, cell, value, col, item, api) {
+    Soho.Formatters.PriceText = function (row, cell, value, col, item, api) {
       Soho.Locale.currentLocale.data.currencySign = '£';
       var formatted = Soho.Locale.formatNumber(value, (col.numberFormat ? col.numberFormat : {style: 'currency'}));
 
@@ -31,7 +31,7 @@
       return '<p><b> Trade: ' + formatted + '</b><br><a href="#" class="hyperlink micro-text">Price Details</a></p>';
     };
 
-    Formatters.BadgeDecimal = function (row, cell, value, col, item, api) {
+    Soho.Formatters.BadgeDecimal = function (row, cell, value, col, item, api) {
       var colorClass = 'good';
       return '<span class="badge ' + colorClass +'">' + value +' </span>';
       return link;

--- a/app/views/components/datagrid/test-expandable-row-custom-formatter.html
+++ b/app/views/components/datagrid/test-expandable-row-custom-formatter.html
@@ -30,7 +30,7 @@
                     '<span>' + value + '</span>' +
                   '</svg>';
          }
-         return Formatters.Expander(row, cell, value, col, item, api);
+         return Soho.Formatters.Expander(row, cell, value, col, item, api);
       };
 
       columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: customErrorFormatter, filterType: 'text', textOverflow: 'ellipsis', width: 150, hideable: false});

--- a/app/views/components/datagrid/test-grouping-aggregators-list.html
+++ b/app/views/components/datagrid/test-grouping-aggregators-list.html
@@ -52,7 +52,7 @@
         data = [];
 
       //Custom Formatter for vehical columns
-      Formatters.VehicalsOnScene = function(row, cell, value, column, rowData, api) {
+      Soho.Formatters.VehicalsOnScene = function(row, cell, value, column, rowData, api) {
         var vehicals = rowData.list,
           html = '';
 

--- a/app/views/components/datagrid/test-memory.html
+++ b/app/views/components/datagrid/test-memory.html
@@ -45,7 +45,7 @@
       data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '123.99', status: 'OK', orderDate: null, action: 'On Hold'});
 
       var buttonFormatter = function (row, cell, value, col, dataView, dataGrid) {
-        return cell !== undefined ? Formatters.Button(row, cell, 'Approval Group', col, dataView, dataGrid) : '';
+        return cell !== undefined ? Soho.Formatters.Button(row, cell, 'Approval Group', col, dataView, dataGrid) : '';
       };
 
       //Define Columns for the Grid.

--- a/app/views/components/datagrid/test-multiple-grids-in-tab-with-dropdown.html
+++ b/app/views/components/datagrid/test-multiple-grids-in-tab-with-dropdown.html
@@ -145,39 +145,39 @@
     data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '123.99', status: 'OK', orderDate: null, multiDropDown: 'R', action: 'On Hold'});
 
     // Define Columns for the Grid - Top grid in Top Bottom tab
-    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
-    columns.push({ id: 'productId', name: 'Product Id', field: 'productId', filterType: 'text', formatter: Formatters.Readonly});
-    columns.push({ id: 'productName', name: 'Product Name', field: 'productName', filterType: 'text', formatter: Formatters.Hyperlink});
+    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Soho.Formatters.SelectionCheckbox, align: 'center'});
+    columns.push({ id: 'productId', name: 'Product Id', field: 'productId', filterType: 'text', formatter: Soho.Formatters.Readonly});
+    columns.push({ id: 'productName', name: 'Product Name', field: 'productName', filterType: 'text', formatter: Soho.Formatters.Hyperlink});
     columns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', filterType: 'text'});
     columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', filterType: 'integer'});
-    columns.push({ id: 'price', name: 'Price', field: 'price', filterType: 'text', formatter: Formatters.Decimal});
-    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', filterType: 'text', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
-    columns.push({ id: 'status', name: 'Status', field: 'status', filterType: 'text', formatter: Formatters.Text});
+    columns.push({ id: 'price', name: 'Price', field: 'price', filterType: 'text', formatter: Soho.Formatters.Decimal});
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', filterType: 'text', formatter: Soho.Formatters.Date, dateFormat: 'M/d/yyyy'});
+    columns.push({ id: 'status', name: 'Status', field: 'status', filterType: 'text', formatter: Soho.Formatters.Text});
     columns.push({ id: 'action', name: 'Action Item', field: 'action', filterType: 'text'});
 
     // Define Columns2 for the Grid - Bottom grid in Top Bottom tab
-    columns2.push({ id: 'selectionCheckbox', width: 50, sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
-    columns2.push({ id: 'productId', name: 'Product Id', width: 50, field: 'productId', filterType: 'text', formatter: Formatters.Readonly});
-    columns2.push({ id: 'productName', name: 'Product Name', width: 50, field: 'productName', filterType: 'text', formatter: Formatters.Hyperlink});
+    columns2.push({ id: 'selectionCheckbox', width: 50, sortable: false, resizable: false, formatter: Soho.Formatters.SelectionCheckbox, align: 'center'});
+    columns2.push({ id: 'productId', name: 'Product Id', width: 50, field: 'productId', filterType: 'text', formatter: Soho.Formatters.Readonly});
+    columns2.push({ id: 'productName', name: 'Product Name', width: 50, field: 'productName', filterType: 'text', formatter: Soho.Formatters.Hyperlink});
     columns2.push({ id: 'quantity', name: 'Quantity', width: 50, field: 'quantity', filterType: 'integer'});
-    columns2.push({ id: 'price', name: 'Price', field: 'price', filterType: 'text', formatter: Formatters.Decimal});
-    columns2.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', filterType: 'text', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
-    columns2.push({ id: 'status', name: 'Status', field: 'status', filterType: 'text', formatter: Formatters.Text});
-    columns2.push({ id: 'multiDropDown', name: 'Multiple Selection', width: 50, field: 'multiDropDown', sortable: false, align: 'center', textOverflow: 'ellipsis', filterType: 'multiselect', formatter: Formatters.Dropdown, editor: Editors.Dropdown, editorOptions: { showSelectAll: true },
+    columns2.push({ id: 'price', name: 'Price', field: 'price', filterType: 'text', formatter: Soho.Formatters.Decimal});
+    columns2.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', filterType: 'text', formatter: Soho.Formatters.Date, dateFormat: 'M/d/yyyy'});
+    columns2.push({ id: 'status', name: 'Status', field: 'status', filterType: 'text', formatter: Soho.Formatters.Text});
+    columns2.push({ id: 'multiDropDown', name: 'Multiple Selection', width: 50, field: 'multiDropDown', sortable: false, align: 'center', textOverflow: 'ellipsis', filterType: 'multiselect', formatter: Soho.Formatters.Dropdown, editor: Soho.Editors.Dropdown, editorOptions: { showSelectAll: true },
       filterRowEditorOptions: [{ label: 'Not Entered', value: 'Not Entered' }, { label: 'Active', value: 'A' }, { label: 'Ready For Completion', value: 'R' }, { label: 'Draft', value: 'D' }, { label: 'No longer meets eligibility requirements', value: 'X' } ],
       options: [{ label: 'Not Entered', value: 'Not Entered' }, { label: 'Active', value: 'A' }, { label: 'Ready For Completion', value: 'R' }, { label: 'Draft', value: 'D' }, { label: 'No longer meets eligibility requirements', value: 'X' } ]});
 
     // Define Columns for the Grid - only grid in Single Tab
-    columns3.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Formatters.SelectionCheckbox, align: 'center'});
-    columns3.push({ id: 'productId', name: 'Product Id', field: 'productId', filterType: 'text', formatter: Formatters.Readonly});
-    columns3.push({ id: 'productName', name: 'Product Name', field: 'productName', filterType: 'text', formatter: Formatters.Hyperlink});
+    columns3.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Soho.Formatters.SelectionCheckbox, align: 'center'});
+    columns3.push({ id: 'productId', name: 'Product Id', field: 'productId', filterType: 'text', formatter: Soho.Formatters.Readonly});
+    columns3.push({ id: 'productName', name: 'Product Name', field: 'productName', filterType: 'text', formatter: Soho.Formatters.Hyperlink});
     columns3.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', filterType: 'text'});
     columns3.push({ id: 'quantity', name: 'Quantity', field: 'quantity', filterType: 'integer'});
-    columns3.push({ id: 'price', name: 'Price', field: 'price', filterType: 'text', formatter: Formatters.Decimal});
-    columns3.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', filterType: 'text', formatter: Formatters.Date, dateFormat: 'M/d/yyyy'});
-    columns3.push({ id: 'status', name: 'Status', field: 'status', filterType: 'text', formatter: Formatters.Text});
+    columns3.push({ id: 'price', name: 'Price', field: 'price', filterType: 'text', formatter: Soho.Formatters.Decimal});
+    columns3.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', filterType: 'text', formatter: Soho.Formatters.Date, dateFormat: 'M/d/yyyy'});
+    columns3.push({ id: 'status', name: 'Status', field: 'status', filterType: 'text', formatter: Soho.Formatters.Text});
     columns3.push({ id: 'action', name: 'Action Item', field: 'action', filterType: 'text'});
-    columns3.push({ id: 'multiDropDown', name: 'Multiple Selection', width: 50, field: 'multiDropDown', sortable: false, align: 'center', textOverflow: 'ellipsis', filterType: 'multiselect', formatter: Formatters.Dropdown, editor: Editors.Dropdown, editorOptions: { showSelectAll: true },
+    columns3.push({ id: 'multiDropDown', name: 'Multiple Selection', width: 50, field: 'multiDropDown', sortable: false, align: 'center', textOverflow: 'ellipsis', filterType: 'multiselect', formatter: Soho.Formatters.Dropdown, editor: Soho.Editors.Dropdown, editorOptions: { showSelectAll: true },
       filterRowEditorOptions: [{ label: 'Not Entered', value: 'Not Entered' }, { label: 'Active', value: 'A' }, { label: 'Ready For Completion', value: 'R' }, { label: 'Draft', value: 'D' }, { label: 'No longer meets eligibility requirements', value: 'X' } ],
       options: [{ label: 'Not Entered', value: 'Not Entered' }, { label: 'Active', value: 'A' }, { label: 'Ready For Completion', value: 'R' }, { label: 'Draft', value: 'D' }, { label: 'No longer meets eligibility requirements', value: 'X' } ]});
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Upon checking the datagrid's example pages, I bumped into
This PR resolves the issue where the `Soho` object was missing, leading to the failure of the page to load the datagrid.

**Related github/jira issue (required)**:

N/A

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to
   - http://localhost:4000/components/datagrid/example-expandable-row-editable.html
   - http://localhost:4000/components/datagrid/test-button-not-fully-rendered.html
   - http://localhost:4000/components/datagrid/test-columns-class.html
   - http://localhost:4000/components/datagrid/test-columns-colors.html
   - http://localhost:4000/components/datagrid/test-contextmenu-on-specific-columns.html
   - http://localhost:4000/components/datagrid/test-editable-inline-editor.html
   - http://localhost:4000/components/datagrid/test-expandable-row-custom-formatter.html
   - http://localhost:4000/components/datagrid/test-grouping-aggregators-list.html
   - http://localhost:4000/components/datagrid/test-memory.html
   - http://localhost:4000/components/datagrid/test-multiple-grids-in-tab-with-dropdown.html
- It should show the datagrid and no console errors


~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
