### PR TITLE
NG1477 - Add more Module Nav API improvements

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@
 - `[Lookup]` Fixed a bug in lookup width not responsive in grid system. ([#7205](https://github.com/infor-design/enterprise/issues/7205))
 - `[MonthView]` Added event triggers for when monthview is expanded and collapsed. ([#7605](https://github.com/infor-design/enterprise/issues/7605))
 - `[Modal]` Fixed icon alignment in the title. ([#7639](https://github.com/infor-design/enterprise/issues/7639))
+- `[Module Nav]` Added new settings for configuration of accordion, and auto-initialization of child components. ([NG#1477](https://github.com/infor-design/enterprise-ng/issues/1477))
 - `[Module Nav Switcher]` Made compatibility improvements for the Module Nav Switcher NG component. ([NG#1477](https://github.com/infor-design/enterprise-ng/issues/1477))
 - `[Multiselect]` Fixed a bug where the multiselect dropdown icon was overlapping the field. ([#7502](https://github.com/infor-design/enterprise/issues/7502))
 - `[Popupmenu]` Fixed the placement of popup when parent element is outside of viewport. ([#5018](https://github.com/infor-design/enterprise/issues/5018))

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -800,7 +800,7 @@ Accordion.prototype = {
    * @returns {void}
    */
   deselectAll() {
-    this.headers.removeClass('child-selected').removeClass('is-selected');
+    this.headers?.removeClass('child-selected').removeClass('is-selected');
   },
 
   /**

--- a/src/components/module-nav/module-nav.common.js
+++ b/src/components/module-nav/module-nav.common.js
@@ -85,3 +85,21 @@ export const setDisplayMode = (val, el) => {
   el.classList.remove('mode-collapsed', 'mode-expanded');
   if (isValidDisplayMode(val) && val) el.classList.add(`mode-${val}`);
 };
+
+/**
+ * Establishes/destroys a Tooltip attached to a Module Nav Item
+ * @param {HTMLElement} el target element to receive the tooltip
+ * @param {string} displayMode current display mode
+ * @param {HTMLElement} textContentEl target element to use for detection of Tooltip text
+ */
+export const configureNavItemTooltip = (el, displayMode, textContentEl) => {
+  if (displayMode === 'collapsed') {
+    $(el).tooltip({
+      placementOpts: { x: 16 },
+      placement: 'right',
+      title: (textContentEl || el).textContent.trim()
+    });
+  } else {
+    $(el).data('tooltip')?.destroy();
+  }
+};

--- a/src/components/module-nav/module-nav.js
+++ b/src/components/module-nav/module-nav.js
@@ -11,6 +11,7 @@ import '../tooltip/tooltip.jquery';
 
 import {
   MODULE_NAV_DISPLAY_MODES,
+  configureNavItemTooltip,
   setDisplayMode,
   isValidDisplayMode,
   separatorTemplate
@@ -20,7 +21,9 @@ import {
 const COMPONENT_NAME = 'modulenav';
 
 const MODULE_NAV_DEFAULTS = {
-  accordionSettings: null,
+  accordionSettings: {
+    expanderDisplay: 'classic'
+  },
   displayMode: MODULE_NAV_DISPLAY_MODES[0],
   filterable: false,
   initChildren: true,
@@ -143,7 +146,9 @@ ModuleNav.prototype = {
     if (this.settings.initChildren) {
       if (!this.switcherAPI) $(this.switcherEl).modulenavswitcher({ displayMode: this.settings.displayMode });
       if (!this.settingsAPI) $(this.settingsEl).modulenavsettings({ displayMode: this.settings.displayMode });
-      if (!this.accordionAPI) $(this.accordionEl).accordion(this.settings.accordionSettings);
+      if (!this.accordionAPI) {
+        $(this.accordionEl).accordion(this.settings.accordionSettings);
+      }
     }
 
     if (this.accordionEl) this.configureAccordion();
@@ -238,15 +243,7 @@ ModuleNav.prototype = {
     const headers = this.accordionEl.querySelectorAll('.accordion-section > .accordion-header');
     if (headers.length) {
       [...headers].forEach((header) => {
-        if (this.settings.displayMode === 'collapsed') {
-          $(header).tooltip({
-            placementOpts: { x: 16 },
-            placement: 'right',
-            title: header.textContent.trim()
-          });
-        } else {
-          $(header).data('tooltip')?.destroy();
-        }
+        configureNavItemTooltip(header, this.settings.displayMode);
       });
     }
   },

--- a/src/components/module-nav/module-nav.js
+++ b/src/components/module-nav/module-nav.js
@@ -20,8 +20,10 @@ import {
 const COMPONENT_NAME = 'modulenav';
 
 const MODULE_NAV_DEFAULTS = {
+  accordionSettings: null,
   displayMode: MODULE_NAV_DISPLAY_MODES[0],
   filterable: false,
+  initChildren: true,
   pinSections: false,
   showDetailView: false,
 };
@@ -127,24 +129,25 @@ ModuleNav.prototype = {
 
     // Sections
     this.switcherEl = this.element[0].querySelector('.module-nav-switcher');
-    if (!this.switcherAPI) $(this.switcherEl).modulenavswitcher({ displayMode: this.settings.displayMode });
     this.itemMenuEl = this.element[0].querySelector('.module-nav-main');
     this.settingsEl = this.element[0].querySelector('.module-nav-settings');
-    if (!this.settingsAPI) $(this.settingsEl).modulenavsettings({ displayMode: this.settings.displayMode });
     this.footerEl = this.element[0].querySelector('.module-nav-footer');
 
     // Components
     this.accordionEl = this.element[0].querySelector('.accordion');
-    if (!this.accordionAPI) {
-      $(this.accordionEl).accordion();
-      this.configureAccordion();
-    }
     this.searchEl = this.element[0].querySelector('.searchfield');
-    if (this.searchEl) {
-      this.configureSearch();
-    }
 
     this.renderSeparators();
+
+    // Auto-init child components, if applicable
+    if (this.settings.initChildren) {
+      if (!this.switcherAPI) $(this.switcherEl).modulenavswitcher({ displayMode: this.settings.displayMode });
+      if (!this.settingsAPI) $(this.settingsEl).modulenavsettings({ displayMode: this.settings.displayMode });
+      if (!this.accordionAPI) $(this.accordionEl).accordion(this.settings.accordionSettings);
+    }
+
+    if (this.accordionEl) this.configureAccordion();
+    if (this.searchEl) this.configureSearch();
   },
 
   /**
@@ -227,7 +230,9 @@ ModuleNav.prototype = {
       }
     };
 
+    this.accordionAPI.settings = this.settings.accordionSettings;
     this.accordionAPI.settings.accordionFocusCallback = navFocusCallback;
+    this.accordionAPI.updated();
 
     // Build tooltips on top-level accordion headers in collapsed mode
     const headers = this.accordionEl.querySelectorAll('.accordion-section > .accordion-header');

--- a/src/components/module-nav/module-nav.switcher.js
+++ b/src/components/module-nav/module-nav.switcher.js
@@ -11,7 +11,8 @@ import {
   isValidDisplayMode,
   MODULE_NAV_DISPLAY_MODES,
   SWITCHER_ICON_HTML,
-  setDisplayMode
+  setDisplayMode,
+  configureNavItemTooltip
 } from './module-nav.common';
 
 // Settings and Options
@@ -132,13 +133,11 @@ ModuleNavSwitcher.prototype = {
       const key = e.key;
 
       if (key === 'ArrowUp') {
-        // console.info('navigate to Module Nav Settings component');
         this.accordionAPI?.prevHeader(this.element);
         return;
       }
 
       if (key === 'ArrowDown') {
-        // console.info('navigate to first accordion item');
         this.accordionAPI?.nextHeader(this.element);
       }
     });
@@ -162,6 +161,7 @@ ModuleNavSwitcher.prototype = {
       $(this.moduleButtonEl).button({
         ripple: false
       });
+      configureNavItemTooltip(this.element, this.settings.displayMode, this.moduleButtonEl);
     }
   },
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR further improves the Module Nav API and removes gaps as reported by the Landmark team:
- Adds some settings to the Module Nav for disabling automatic initialization of child components, as well as direct settings for the child Accordion component.
- Extends the Nav Item tooltip feature to the Module Switcher component

**Related github/jira issue (required)**:
Related to infor-design/enterprise-ng#1521
Related to infor-design/enterprise-ng#1477
Related to #7386 

**Steps necessary to review your pull request (required)**:
- Pull/Build/Run
- Open http://localhost:4000/components/module-nav/example-index.html
- While the Module Nav remains in collapsed mode, hover the Module Button (purple icon).  A tooltip should appear that says "Standard Module" (pulls text from the Module Switcher's "moduleButtonText" attribute)
- Switch to expanded mode, and test the accordion's expand/collapse functionality to make sure it still behaves as expected.
- Smoke test all examples for accuracy: http://localhost:4000/components/module-nav

**Included in this Pull Request**:
- [x] A note to the change log.