### PR TITLE
N/A - Fix d3.values is not a function in line chart

### DIFF
--- a/app/views/components/line/example-axis-ticks.html
+++ b/app/views/components/line/example-axis-ticks.html
@@ -68,8 +68,8 @@ $('body').on('initialized', function () {
     });
 
     // Get min and max dates
-    var minDate = (d3.min(d3.values(dates))),
-        maxDate = d3.max(d3.values(dates));
+    var minDate = (d3.min(Object.values(dates))),
+        maxDate = d3.max(Object.values(dates));
 
     // Invoke
     $('#line-example').chart({

--- a/app/views/components/line/test-axis-ticks-date-range.html
+++ b/app/views/components/line/test-axis-ticks-date-range.html
@@ -135,8 +135,8 @@ var parseDate = d3.timeParse('%m/%d/%Y'),
   });
 
   // Get min and max dates
-  var minDate = (d3.min(d3.values(dates))),
-      maxDate = d3.max(d3.values(dates));
+  var minDate = (d3.min(Object.values(dates))),
+      maxDate = d3.max(Object.values(dates));
 
   // Invoke
   $('#line-example').chart({


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes an error related to `d3.values` that caused the line chart to not render. In `d3 ver. 7`, `d3.values` is not supported, so it needs to be changed to `Object.values`.

**Related github/jira issue (required)**:

N/A

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/line/test-axis-ticks-date-range.html & http://localhost:4000/components/line/example-axis-ticks.html
- There should be no errors in the log, and the line chart should render successfully

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
