### PR TITLE
7561 - Page Pattern Search Field Full Width

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `[Homepage]` In some cases the new background color did not fill all the way in the page. ([#7696](https://github.com/infor-design/enterprise/issues/7696))
 
+## v4.86.0 Fixes
+
+- `[Page-Patterns]` In some cases the new background color did not fill all the way in the page. ([#7561](https://github.com/infor-design/enterprise/issues/7561))
+
 ## v4.85.0
 
 ## v4.85.0 Features

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## v4.86.0 Fixes
 
-- `[Page-Patterns]` In some cases the new background color did not fill all the way in the page. ([#7561](https://github.com/infor-design/enterprise/issues/7561))
+- `[Page-Patterns]` Fixed the width of the search field in page pattern example. ([#7561](https://github.com/infor-design/enterprise/issues/7561))
 
 ## v4.85.0
 

--- a/src/components/listview/_listview.scss
+++ b/src/components/listview/_listview.scss
@@ -888,6 +888,14 @@
   }
 }
 
+.sidebar.scrollable {
+  .listview-search .searchfield-wrapper {
+    display: inline-block;
+    margin: 0;
+    width: 100%
+  }
+}
+
 // RTL Styles
 html[dir='rtl'] {
   &.is-safari {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix the width of the search field in page pattern example.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/7561

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/page-patterns/example-list-detail-search-paging.html
- See the `searchfield`

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

