### PR TITLE
7700 - WeekView Agenda Variant hide allDay row

### DIFF
--- a/app/views/components/week-view/example-card.html
+++ b/app/views/components/week-view/example-card.html
@@ -53,7 +53,7 @@
         showViewChanger: false,
         showFooter: false,
         startDate: new Date(2019, 9, 20),
-        endDate: new Date(2019, 9, 26),
+        endDate: new Date(2019, 9, 26, 23, 59, 59, 59),
         responsive: false,
         stacked: false,
         attributes: [
@@ -68,6 +68,7 @@
         ...opts,
         hideToolbar: false,
         showFooter: true,
+        showAllDay: false,
         stacked: true
       });
 

--- a/app/views/components/week-view/example-stacked.html
+++ b/app/views/components/week-view/example-stacked.html
@@ -21,7 +21,7 @@ $('body').one('initialized', function () {
         showFooter: true,
         responsive: true,
         startDate: new Date(2019, 9, 20),
-        endDate: new Date(2019, 9, 26),
+        endDate: new Date(2019, 9, 26, 23, 59, 59, 59),
         stacked: true,
         attributes: [
           { name: 'id', value: 'custom-id' },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## v4.86.0 Features
 
 - `[Homepage]` In some cases the new background color did not fill all the way in the page. ([#7696](https://github.com/infor-design/enterprise/issues/7696))
+- `[WeekView]` Fixed bug where agenda variant ignored `showAllDay` setting. ([#7700](https://github.com/infor-design/enterprise/issues/7700))
 
 ## v4.85.0
 

--- a/src/components/week-view/week-view.js
+++ b/src/components/week-view/week-view.js
@@ -712,7 +712,7 @@ WeekView.prototype = {
           <span class="week-view-header-day-of-week is-emphasis">${dayValue}</span>
           <span class="week-view-header-day-of-week">${dayNameValue}</span>
         </div>
-        <div class="week-view-all-day-wrapper"></div>
+        ${this.settings.showAllDay ? '<div class="week-view-all-day-wrapper"></div>' : ''}
       </div>`;
 
       body += `<div data-key="${daykey}" class="week-view-body-cell"></div>`;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixed bug where week view stacked/agenda variant ignored `showAllDay` option

**Related github/jira issue (required)**:
#7700 

**Steps necessary to review your pull request (required)**:
1. Checkout branch, `npm run build`, `npm run start`
2. Go to http://localhost:4000/components/week-view/example-card.html
3. The second example shows agenda variant with `showAllDay: false` setting
4. Open `week-view/example-stacked.html` file and add `showAllDay: false` setting
5. It should properly hide the all day row

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.


