### PR TITLE
7483 - Removed second call to trimEditorText when determining the original string for editors when resetdirty is called

### DIFF
--- a/app/views/components/editor/test-dirty-tracking-reset-with-br-tags.html
+++ b/app/views/components/editor/test-dirty-tracking-reset-with-br-tags.html
@@ -1,0 +1,23 @@
+<div class="row">
+  <div class="twelve columns">
+    <div class="field">
+      <div class="field">
+        <button class="btn-secondary" type="button" id="reset-dirty">Reset Dirty</button>
+      </div>
+    </div>
+
+    <div class="field">
+      <span class="label">Comments</span>
+      <div class="editor" id="editor1" role="textbox" aria-multiline="true" aria-label="Comments" data-trackdirty="true">
+        <p>&nbsp;</p>
+        Company Welcome Text...        Competencies and skills:<br />Essential:<br />* Customer Relations<br />* Flexibility<br /> Credentials:<br />Essential:<br />* Law Basics<br /> Education:<br />Essential:<br />* Associate of Arts<br />   EOE M/F/V/D
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  $( '#reset-dirty' ).on( 'click', function ( e ) {
+    $( '.editor' ).trigger( 'resetdirty' );
+  } );
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `[Homepage]` In some cases the new background color did not fill all the way in the page. ([#7696](https://github.com/infor-design/enterprise/issues/7696))
 
+## v4.86.0 Fixes
+
+- `[Editor]` Fixed an issue where an editor with an initial value containing `<br \>` tags were being seen as dirty when resetdirty is called. ([#7483](https://github.com/infor-design/enterprise/issues/7483))
+
 ## v4.85.0
 
 ## v4.85.0 Features

--- a/src/components/trackdirty/trackdirty.js
+++ b/src/components/trackdirty/trackdirty.js
@@ -244,7 +244,8 @@ Trackdirty.prototype = {
           // editors values are further down it's tree in a textarea,
           // so get the elements with the value
           const textArea = field.find('textarea');
-          original = this.trimEditorText(textArea.data('original'));
+          // trimEditorText has already been called when setting original, so don't need to call it again
+          original = textArea.data('original');
           current = field.find('.editor-source').is(':visible') ? textArea.val() : textArea.text();
           current = this.trimEditorText(current);
         }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes an issue where an editor was being marked as dirty incorrectly when resetdirty was called on it.

**Related github/jira issue (required)**:
"Closes #7483 "

**Steps necessary to review your pull request (required)**:
1. Pull and run npm run start
2. Navigate to '/components/editor/test-dirty-tracking-reset-with-br-tags.html'
3. Press the Reset Dirty button
4. See that the dirty indicator isn't displayed

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
