### PR TITLE
7693 - Added fix for stacked legend

### DIFF
--- a/app/views/kitchen-sink.html
+++ b/app/views/kitchen-sink.html
@@ -433,14 +433,6 @@
 <div class="row">
   <div class="twelve columns">
   <hr class="fieldset-hr"/>
-      <h2 class="fieldset-title">Stacked Column Chart</h2>
-  </div>
-</div>
-{{>components/column-stacked/example-index}}
-
-<div class="row">
-  <div class="twelve columns">
-  <hr class="fieldset-hr"/>
       <h2 class="fieldset-title">Sparklines</h2>
   </div>
 </div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,14 +2,12 @@
 
 ## v4.86.0
 
-## v4.86.0 Features
-
-- `[Homepage]` In some cases the new background color did not fill all the way in the page. ([#7696](https://github.com/infor-design/enterprise/issues/7696))
-
 ## v4.86.0 Fixes
 
 - `[Column-Stacked]` Fixed a regression bug where the stacked column chart was not rendering correctly. ([#7644](https://github.com/infor-design/enterprise/issues/7644))
 - `[Bar]` Fixed a bug where the bottom axis label was cut off. ([#7612](https://github.com/infor-design/enterprise/issues/7612))
+- `[Bar]` Fixed incorrect legend position on stacked charts. ([#7693](https://github.com/infor-design/enterprise/issues/7693))
+- `[Homepage]` In some cases the new background color did not fill all the way in the page. ([#7696](https://github.com/infor-design/enterprise/issues/7696))
 
 ## v4.85.0
 

--- a/src/components/bar/bar.js
+++ b/src/components/bar/bar.js
@@ -316,6 +316,10 @@ Bar.prototype = {
       h += 30;
     }
 
+    if (s.isStacked) {
+      h -= (legendHeight - 8);
+    }
+
     self.svg = d3.select(this.element[0])
       .append('svg')
       .attr('width', w + (isAxisLabels.atLeastOne ? 20 : 0))


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes the legend position as it was too far down causing a scrollbar. cc @yohannahbautista check this out as i wanted to get a jump on this fix. If you see something better please let me know or update.

**Related github/jira issue (required)**:
Fixes #7693 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/
- scroll down to the chart section
- check all charts show the legend with no scrollbar and look decent

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.
