### PR TITLE
7711 - Re fix for modal overflow issues

### DIFF
--- a/app/views/components/modal/example-slider.html
+++ b/app/views/components/modal/example-slider.html
@@ -6,7 +6,7 @@
     <!-- Modal Example -->
     <div id="modal-add-context" class="hidden">
       <div class="container">
-        <div class="row">
+        <div class="row no-bottom-margin">
           <div class="twelve columns">
 
               <div class="field">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,8 @@
 - `[Column-Stacked]` Fixed a regression bug where the stacked column chart was not rendering correctly. ([#7644](https://github.com/infor-design/enterprise/issues/7644))
 - `[Editor]` Fixed an issue where an editor with an initial value containing `<br \>` tags were being seen as dirty when resetdirty is called. ([#7483](https://github.com/infor-design/enterprise/issues/7483))
 - `[Homepage]` In some cases the new background color did not fill all the way in the page. ([#7696](https://github.com/infor-design/enterprise/issues/7696))
-- `[Page-Patterns]` Fixed the width of the search field in page pattern example. ([#7561](https://github.com/infor-design/enterprise/issues/7561))
+- `[Bar]` Fixed incorrect legend position on stacked charts. ([#7693](https://github.com/infor-design/enterprise/issues/7693))
+- `[Modal]` On some devices the overflow/scrolling is still missing on modal and contents can break out the bottom of the modal. ([#7711](https://github.com/infor-design/enterprise/issues/7711))
 
 ## v4.85.0
 

--- a/src/components/modal/_modal.scss
+++ b/src/components/modal/_modal.scss
@@ -467,6 +467,7 @@ body.modal-engaged {
   }
 
   .modal-body-wrapper {
+    overflow: auto;
     padding: 32px 16px;
 
     .field:not(.label-left).last-child {

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -1252,10 +1252,6 @@ Modal.prototype = {
       }
     }
 
-    if (calcHeight < this.element.find('.modal-body').height()) {
-      wrapper[0].style.overflow = 'auto';
-    }
-
     const toolbars = this.element.find('.toolbar');
     if (toolbars.length) {
       toolbars.triggerHandler('recalculate-buttons');

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -290,6 +290,7 @@ $button-color-secondary-disabled-border-new: $ids-color-palette-slate-30;
 $button-color-secondary-disabled-font-new: $ids-color-palette-slate-30;
 $button-color-secondary-hover-background-new: $ids-color-palette-azure-10;
 $button-color-secondary-hover-border-new: $ids-color-palette-azure-60;
+$button-color-secondary-initial-background: transparent;
 
 $button-color-tertiary-disabled-background-new: transparent;
 $button-color-tertiary-hover-background-new: $ids-color-palette-azure-10;

--- a/src/themes/theme-classic-contrast.scss
+++ b/src/themes/theme-classic-contrast.scss
@@ -61,6 +61,7 @@ $inverse-color: $ids-color-palette-white;
 
 // Buttons
 $button-disabled-background-color: transparent;
+$button-color-secondary-initial-background: $ids-color-palette-graphite-70;
 
 // Text Color
 $font-color-extrahighcontrast: $ids-color-palette-graphite-100;

--- a/src/themes/theme-classic-dark.scss
+++ b/src/themes/theme-classic-dark.scss
@@ -103,8 +103,9 @@ $button-hyperlink-color: $ids-color-palette-slate-50;
 $button-hyperlink-hover-color: $ids-color-palette-slate-40;
 $button-color-tertiary-hover-background-new: transparent;
 $button-icon-disabled-color: $ids-color-palette-slate-60;
-$button-color-secondary-initial-font: $ids-color-palette-slate-30;
+$button-color-secondary-initial-font: $ids-color-palette-slate-10;
 $button-color-secondary-hover-background: $ids-color-palette-slate-50;
+$button-color-secondary-initial-background: $ids-color-palette-slate-40;
 
 // Button Ripple
 $secondary-btn-ripple-color: $ids-color-palette-slate-60;

--- a/src/themes/theme-classic-light.scss
+++ b/src/themes/theme-classic-light.scss
@@ -24,6 +24,7 @@ $accordion-selected-bg-color: $ids-color-palette-slate-50;
 // Buttons
 $button-disabled-background-color: transparent;
 $button-icon-disabled-color: $ids-color-palette-slate-30;
+$button-color-secondary-initial-background: $ids-color-palette-graphite-30;
 
 //================================================== //
 // Core Components

--- a/src/themes/theme-new-contrast.scss
+++ b/src/themes/theme-new-contrast.scss
@@ -187,6 +187,7 @@ $button-color-secondary-hover-background-new: $ids-color-palette-azure-10;
 $button-color-secondary-disabled-background-new: $ids-color-palette-slate-10;
 $button-color-secondary-disabled-border-new: $ids-color-palette-slate-50;
 $button-color-secondary-disabled-font-new: $ids-color-palette-slate-50;
+$button-color-secondary-initial-background: transparent;
 $button-disabled-background-color: transparent;
 
 $button-color-tertiary-hover-background-new: $ids-color-palette-azure-20;
@@ -196,7 +197,6 @@ $button-color-tertiary-hover-font-new: $ids-color-palette-azure-80;
 $button-color-tertiary-initial-font: $ids-color-palette-slate-80;
 $button-color-tertiary-actionsheet-hover-font: $button-color-tertiary-hover-font-new;
 $tertiary-btn-ripple-color: $ids-color-brand-primary-alt;
-
 $button-editor-color-hover-background-new: rgba(0, 0, 0, .7);
 
 // Secondary with Border

--- a/src/themes/theme-new-dark.scss
+++ b/src/themes/theme-new-dark.scss
@@ -101,6 +101,7 @@ $button-color-secondary-hover-background-new: $ids-color-palette-slate-90;
 $button-color-secondary-disabled-background-new: $ids-color-palette-slate-80;
 $button-color-secondary-disabled-border-new: $ids-color-palette-slate-50;
 $button-color-secondary-disabled-font-new: $ids-color-palette-slate-40;
+$button-color-secondary-initial-background: transparent;
 
 $button-color-tertiary-disabled-background-new: $ids-color-palette-slate-90;
 $button-color-tertiary-hover-background-new: rgba(0, 0, 0, .3);

--- a/src/themes/theme-new-light.scss
+++ b/src/themes/theme-new-light.scss
@@ -211,6 +211,7 @@ $header-button-disabled-color: rgba($ids-color-palette-white, 0.6);
 $button-color-tertiary-initial-font: $ids-color-palette-slate-60;
 $button-color-tertiary-actionsheet-hover-font: $button-color-tertiary-hover-font-new;
 $button-disabled-background-color: transparent;
+$button-color-secondary-initial-background: transparent;
 
 // Badges
 $badge-neutral-color: $ids-color-palette-slate-100;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Refixed the modal issues by adding back the css overflow. I remove the JS sizing part and added back the css. I tested all related issues and everything seems fixed.

Do check for any uses cases i might not know. @ericangeles @yohannahbautista 

**Related github/jira issue (required)**:
Fixes #7711 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/modal/example-slider.html
- In dev tools select "surface duo" mobile emulator
- open Modal and content should scroll not break out
- test https://github.com/infor-design/enterprise/issues/7698 is still fixed
- test https://github.com/infor-design/enterprise/issues/7660 is still fixed
- test https://github.com/infor-design/enterprise/issues/6956 is still fixed (for some reason can not long reproduce it ~ so thats good)

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

