### PR TITLE
NG1499 - Tooltip Script Error

### DIFF
--- a/app/views/components/tooltip/test-irregular-string.html
+++ b/app/views/components/tooltip/test-irregular-string.html
@@ -1,0 +1,15 @@
+<div class="row">
+  <div class="six columns">
+    <h2>Tooltip Example: Standard Text Tooltip</h2>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+
+    <button id="tooltip-btn" class="btn-secondary" type="button" title="#12345/6789" data-options="{ 'attributes': [ { 'name': 'data-automation-id', 'value': 'test-tooltip' } ]}">
+      Normal Tooltip
+    </button>
+
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Editor]` Fixed an issue where an editor with an initial value containing `<br \>` tags were being seen as dirty when resetdirty is called. ([#7483](https://github.com/infor-design/enterprise/issues/7483))
 - `[Homepage]` In some cases the new background color did not fill all the way in the page. ([#7696](https://github.com/infor-design/enterprise/issues/7696))
 - `[Page-Patterns]` Fixed the width of the search field in page pattern example. ([#7561](https://github.com/infor-design/enterprise/issues/7561))
+- `[Tooltip]` Fixed an error in tooltip where some string is unrecognizable. ([NG#1499](https://github.com/infor-design/enterprise-ng/issues/1499))
 
 ## v4.85.0
 

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -500,7 +500,7 @@ Tooltip.prototype = {
       // If it matches an element already on the page, grab that element's content
       // and store the reference only.
       // Adding a condition if it's really uses the ID attribute.
-      if (content.indexOf('#') === 0) {
+      if (content.indexOf('#') === 0 && content.indexOf('/') < 0) { // Needs to check / before puting it in a content check because it breaks the string and makes jQuery think that it is an expression
         const contentCheck = $(`${content}`);
         if (contentCheck.length) {
           this.content = contentCheck;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix an error in tooltip where some string is unrecognizable.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1499

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/tooltip/test-irregular-string.html
- Open `Developer Console`
- Hover the button
- See the console, no errors

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

