### PR TITLE
7463 - Fix missing borders when pasting html table inside of the editor

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Button]` Fixed a bug where submenu icons were not aligned correctly. ([#7626](https://github.com/infor-design/enterprise/issues/7626))
 - `[Column-Stacked]` Fixed a regression bug where the stacked column chart was not rendering correctly. ([#7644](https://github.com/infor-design/enterprise/issues/7644))
 - `[Editor]` Fixed an issue where an editor with an initial value containing `<br \>` tags were being seen as dirty when resetdirty is called. ([#7483](https://github.com/infor-design/enterprise/issues/7483))
+- `[Editor]` Fixed a bug where pasting an html table into the editor wouldn't show the borders. ([#7463](https://github.com/infor-design/enterprise/issues/7463))
 - `[Homepage]` In some cases the new background color did not fill all the way in the page. ([#7696](https://github.com/infor-design/enterprise/issues/7696))
 - `[ModuleNav]` Fixed rounding and zindex issues. ([#7654](https://github.com/infor-design/enterprise/issues/7654))
 - `[Page-Patterns]` Fixed the width of the search field in page pattern example. ([#7561](https://github.com/infor-design/enterprise/issues/7561))

--- a/src/components/editor/_editor.scss
+++ b/src/components/editor/_editor.scss
@@ -806,7 +806,6 @@ html.is-firefox {
 }
 
 // Reset for editor (table)
-
 .editor {
   table,
   thead,
@@ -818,7 +817,7 @@ html.is-firefox {
   }
 
   th {
-    font-weight: bold;
+    font-weight: 700;
   }
 }
 

--- a/src/components/editor/_editor.scss
+++ b/src/components/editor/_editor.scss
@@ -805,7 +805,7 @@ html.is-firefox {
   top: 33px;
 }
 
-// Reset for editor ()
+// Reset for editor (table)
 
 .editor {
   table,

--- a/src/components/editor/_editor.scss
+++ b/src/components/editor/_editor.scss
@@ -814,6 +814,7 @@ html.is-firefox {
   tr,
   td {
     border: inherit;
+    border-color: $datagrid-cell-border-color;
   }
 
   th {

--- a/src/components/editor/_editor.scss
+++ b/src/components/editor/_editor.scss
@@ -805,6 +805,23 @@ html.is-firefox {
   top: 33px;
 }
 
+// Reset for editor ()
+
+.editor {
+  table,
+  thead,
+  tbody,
+  th,
+  tr,
+  td {
+    border: inherit;
+  }
+
+  th {
+    font-weight: bold;
+  }
+}
+
 // RTL Styles
 html[dir='rtl'] {
   .editor-container {

--- a/src/core/_reset.scss
+++ b/src/core/_reset.scss
@@ -41,14 +41,14 @@ input,
 textarea,
 select,
 button,
-table,
+.editor:not(.editor) table,
 caption,
-thead,
-tbody,
+.editor:not(.editor) thead,
+.editor:not(.editor) tbody,
 tfoot,
-tr,
-th,
-td {
+.editor:not(.editor) tr,
+.editor:not(.editor) th,
+.editor:not(.editor) td {
   border: 0;
   margin: 0;
   padding: 0;
@@ -110,7 +110,7 @@ input,
 textarea,
 select,
 button,
-th {
+.editor:not(.editor) th {
   border: 0;
   font-family: inherit;
   font-weight: inherit;

--- a/src/core/_reset.scss
+++ b/src/core/_reset.scss
@@ -41,14 +41,14 @@ input,
 textarea,
 select,
 button,
-.editor:not(.editor) table,
+table,
 caption,
-.editor:not(.editor) thead,
-.editor:not(.editor) tbody,
+thead,
+tbody,
 tfoot,
-.editor:not(.editor) tr,
-.editor:not(.editor) th,
-.editor:not(.editor) td {
+tr,
+th,
+td {
   border: 0;
   margin: 0;
   padding: 0;
@@ -110,7 +110,7 @@ input,
 textarea,
 select,
 button,
-.editor:not(.editor) th {
+th {
   border: 0;
   font-family: inherit;
   font-weight: inherit;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the missing borders when pasting html table inside of the editor.

**Related github/jira issue (required)**:

Closes #7463 

**Steps necessary to review your pull request (required)**:
- Go to http://localhost:4000/components/editor/example-index
- Click HTML from the toolbar
- Paste the html string from this file ([table-border-not-rendering.txt](https://github.com/infor-design/enterprise/files/11329042/table-border-not-rendering.txt))
- Then go back to visual
- Table should have borders

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
