### PR TITLE
7623 - Updated color styles when notification is in subheader

### DIFF
--- a/app/views/components/notification/test-insert-subheader.html
+++ b/app/views/components/notification/test-insert-subheader.html
@@ -1,0 +1,92 @@
+<div class="header is-personalizable">
+  <div class="flex-toolbar personalize-header">
+    <div class="toolbar-section title">
+      <h2>Header</h2>
+    </div>
+
+    <div class="toolbar-section buttonset">
+      <button class="btn">
+        <span>Text Button</span>
+      </button>
+    </div>
+
+    <div id="more-button" class="toolbar-section more">
+      {{> includes/header-actionbutton}}
+    </div>
+  </div>
+</div>
+<div class="is-personalizable">
+  <div class="personalize-subheader">
+    <div class="flex-toolbar" style="height: 60px" id="mock-header">
+      <div class="toolbar-section title">
+        <h2>&nbsp;&nbsp;&nbsp;&nbsp;Sub Header</h2>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').on('initialized', () => {
+    $('#mock-header').notification({
+      type: 'error',
+      message: 'DTO rejected by your manager for Sept 30, 2018.',
+      parent: '#mock-header',
+      link: '#',
+      linkText: 'Click to view',
+      attributes: [
+        { name: 'id', value: 'notification-id-1'},
+        { name: 'data-automation-id', value: 'notification-automation-id-1' }
+      ]
+    });
+  });
+</script>
+
+<script>
+  $('body').on('initialized', () => {
+    $('#mock-header').notification({
+      type: 'info',
+      message: 'DTO rejected by your manager for Sept 30, 2018. Please login to your Human Resources (HR) portal for an explanation on why. If you believe there was a mistake or wish to appeal the rejection, you can now also do that in the new HR portal. ',
+      parent: '#mock-header',
+      link: '#',
+      linkText: 'Click to view',
+      attributes: [
+        { name: 'id', value: 'notification-id-2'},
+        { name: 'data-automation-id', value: 'notification-automation-id-2' }
+      ]
+    });
+  });
+</script>
+
+
+<script>
+  $('body').on('initialized', () => {
+    $('#mock-header').notification({
+      type: 'alert',
+      message: 'DTO rejected by your manager for Sept 30, 2018.',
+      parent: '#mock-header',
+      link: '#',
+      linkText: 'Click to view',
+      attributes: [
+        { name: 'id', value: 'notification-id-3'},
+        { name: 'data-automation-id', value: 'notification-automation-id-3' }
+      ]
+    });
+  });
+</script>
+
+
+<script>
+  $('body').on('initialized', () => {
+    $('#mock-header').notification({
+      type: 'success',
+      message: 'DTO rejected by your manager for Sept 30, 2018.',
+      parent: '#mock-header',
+      link: '#',
+      linkText: 'Click to view',
+      attributes: [
+        { name: 'id', value: 'notification-id-4'},
+        { name: 'data-automation-id', value: 'notification-automation-id-4' }
+      ]
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[Homepage]` In some cases the new background color did not fill all the way in the page. ([#7696](https://github.com/infor-design/enterprise/issues/7696))
 - `[Modal]` On some devices the overflow/scrolling is still missing on modal and contents can break out the bottom of the modal. ([#7711](https://github.com/infor-design/enterprise/issues/7711))
 - `[ModuleNav]` Fixed rounding and zindex issues. ([#7654](https://github.com/infor-design/enterprise/issues/7654))
+- `[Notification]` Updated color styles when notification is in subheader. ([#7623](https://github.com/infor-design/enterprise/issues/7623))
 - `[Page-Patterns]` Fixed the width of the search field in page pattern example. ([#7561](https://github.com/infor-design/enterprise/issues/7561))
 - `[WeekView]` Fixed bug where agenda variant ignored `showAllDay` setting. ([#7700](https://github.com/infor-design/enterprise/issues/7700))
 

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -339,7 +339,7 @@ a.is-personalizable svg.ripple-effect {
 .subheader.is-personalizable button:not(:disabled):not(.searchfield-category-button) .icon,
 .subheader.is-personalizable button:not(:disabled):not(.searchfield-category-button) .app-header.icon > span,
 .is-personalizable .personalize-subheader button:not(:disabled),
-.is-personalizable .personalize-subheader button:not(:disabled):not(.close) .icon,
+.is-personalizable .personalize-subheader button:not(:disabled):not(.close):not(.notification-close) .icon,
 .is-personalizable .personalize-subheader button:not(:disabled) .app-header.icon > span  {
   color: ${colors.contrast} !important;
 }
@@ -988,8 +988,8 @@ html[class*="theme-classic-"] .tab-container.is-personalizable .tab-list-contain
   background-color: ${colors.lighter} !important;
 }
 
-.is-personalizable .personalize-subheader  p,
-.personalize-subheader.is-personalizable p {
+.is-personalizable .personalize-subheader  p:not(.notification-text),
+.personalize-subheader.is-personalizable p:not(.notification-text) {
   color: ${colors.contrast} !important;
 }
 
@@ -1010,8 +1010,8 @@ html[class*="-dark"] .is-personalizable .subheader h2 {
   color: #fff !important;
 }
 
-.is-personalizable .personalize-subheader  .icon,
-.personalize-subheader.is-personalizable .icon {
+.is-personalizable .personalize-subheader button:not(.notification-close) .icon:not(.notification-icon),
+.personalize-subheader.is-personalizable button:not(.notification-close) .icon:not(.notification-icon) {
   color: ${colors.contrast} !important;
 }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Updated color styles when notification is in subheader

Note: Still unsure what "banner" is from the issue, but based on the screenshot of the css, it's likely subheader. When notifications (or "message" as mentioned) is in a personalizable subheader the same bug appears.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #7623 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/notification/test-insert-subheader.html
- Notifications should have readable text and icons
- Change Colors
- Text and icons should not be white/still be readable

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
