### PR TITLE
7747 - Add fix for missing icon

### DIFF
--- a/app/views/components/cards/example-variations-hitboxes.html
+++ b/app/views/components/cards/example-variations-hitboxes.html
@@ -26,7 +26,7 @@
             </svg>
           </button>
           <ul class="popupmenu actions top" id="popupmenu" role="menu">
-            <li role="presentation"><a href="#" role="menuitem" id="sales"><span>Action 1</span></a></li> 
+            <li role="presentation"><a href="#" role="menuitem" id="sales"><span>Action 1</span></a></li>
             <li role="presentation"><a href="#" tabindex="-1" role="menuitem" id="filter">Action 2</a></li>
           </ul>
         </div>
@@ -54,7 +54,7 @@
             </svg>
           </button>
           <ul class="popupmenu actions top" id="popupmenu" role="menu">
-            <li role="presentation"><a href="#" role="menuitem" id="sales"><span>Action 1</span></a></li> 
+            <li role="presentation"><a href="#" role="menuitem" id="sales"><span>Action 1</span></a></li>
             <li role="presentation"><a href="#" tabindex="-1" role="menuitem" id="filter">Action 2</a></li>
           </ul>
         </div>
@@ -82,7 +82,7 @@
             </svg>
           </button>
           <ul class="popupmenu actions top" id="popupmenu" role="menu">
-            <li role="presentation"><a href="#" role="menuitem" id="sales"><span>Action 1</span></a></li> 
+            <li role="presentation"><a href="#" role="menuitem" id="sales"><span>Action 1</span></a></li>
             <li role="presentation"><a href="#" tabindex="-1" role="menuitem" id="filter">Action 2</a></li>
           </ul>
         </div>
@@ -190,7 +190,7 @@
             </svg>
           </button>
           <ul class="popupmenu actions top" id="popupmenu" role="menu">
-            <li role="presentation"><a href="#" role="menuitem" id="sales"><span>Action 1</span></a></li> 
+            <li role="presentation"><a href="#" role="menuitem" id="sales"><span>Action 1</span></a></li>
             <li role="presentation"><a href="#" tabindex="-1" role="menuitem" id="filter">Action 2</a></li>
           </ul>
         </div>
@@ -210,7 +210,7 @@
         <div class="card-content-action">
           <button class="btn" id="btn-5" type="button">
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-              <use href="#icon-phone-linear"></use>
+              <use href="#icon-phone"></use>
             </svg>
           </button>
         </div>
@@ -230,7 +230,7 @@
         <div class="card-content-action">
           <button class="btn" id="btn-6" type="button">
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-              <use href="#icon-phone-linear"></use>
+              <use href="#icon-phone"></use>
             </svg>
             <span>Call</span>
           </button>
@@ -245,4 +245,4 @@
       alert('Test Click Card.');
     });
 </script>
-  
+

--- a/app/views/components/notification-badge/example-badge-placement.html
+++ b/app/views/components/notification-badge/example-badge-placement.html
@@ -14,7 +14,7 @@
     </div>
     <div id="notification-badge-2" class="container-spacer">
       <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-        <use href="#icon-phone-linear"></use>
+        <use href="#icon-phone"></use>
       </svg>
     </div>
     <div id="notification-badge-3" class="container-spacer">

--- a/app/views/components/notification-badge/example-index.html
+++ b/app/views/components/notification-badge/example-index.html
@@ -13,7 +13,7 @@
     </div>
     <div id="notification-badge-2" class="container-spacer">
       <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-        <use href="#icon-phone-linear"></use>
+        <use href="#icon-phone"></use>
       </svg>
     </div>
     <div id="notification-badge-3" class="container-spacer">

--- a/app/views/components/personalize/example-form2.html
+++ b/app/views/components/personalize/example-form2.html
@@ -28,7 +28,7 @@
             <button type="button" class="btn-icon personalize-actionable">
               <span>Phone</span>
               <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
-                <use href="#icon-phone-linear"></use>
+                <use href="#icon-phone"></use>
               </svg>
             </button>
             <button type="button" class="btn-icon personalize-actionable">

--- a/app/views/components/personalize/test-form2-short.html
+++ b/app/views/components/personalize/test-form2-short.html
@@ -28,7 +28,7 @@
             <button type="button" class="btn-icon personalize-actionable">
               <span>Phone</span>
               <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
-                <use href="#icon-phone-linear"></use>
+                <use href="#icon-phone"></use>
               </svg>
             </button>
             <button type="button" class="btn-icon personalize-actionable">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[Editor]` Fixed a bug where pasting an html table into the editor wouldn't show the borders. ([#7463](https://github.com/infor-design/enterprise/issues/7463))
 - `[FileUpload]` Fixed the alignment of the close button and file icon button. ([#7570](https://github.com/infor-design/enterprise/issues/7570))
 - `[Homepage]` In some cases the new background color did not fill all the way in the page. ([#7696](https://github.com/infor-design/enterprise/issues/7696))
+- `[Icons]` Removed `phone-linear` in some examples as the icon is now called `phone`. ([#7747](https://github.com/infor-design/enterprise/issues/7747))
 - `[Locale]` Updated all internal strings in local files to sentence case. Updated translations will follow in a month. ([#7683](https://github.com/infor-design/enterprise/issues/7711))
 - `[Modal]` On some devices the overflow/scrolling is still missing on modal and contents can break out the bottom of the modal. ([#7711](https://github.com/infor-design/enterprise/issues/7711))
 - `[ModuleNav]` Fixed rounding and `zindex` issues. ([#7654](https://github.com/infor-design/enterprise/issues/7654))


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Removed `phone-linear` from some examples replace it with `phone` since the icon only exists in one theme. To avoid QA issues.

**Related github/jira issue (required)**:
Closes #7747

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/personalize/example-form2
- phone icon should appear in both new and classic

**Included in this Pull Request**:
- [x] A note to the change log.
