### PR TITLE
7740 - Added an option to not set an initial icon

### DIFF
--- a/app/views/components/module-nav/example-no-icon.html
+++ b/app/views/components/module-nav/example-no-icon.html
@@ -1,0 +1,41 @@
+<section class="module-nav-container mode-expanded">
+  <aside id="nav" class="module-nav" data-options="{ displayMode: 'expanded' }">
+    <div class="module-nav-bar">
+      <!-- Module Nav's top-level navigation items are inside the accordion -->
+      <div class="module-nav-accordion accordion panel" data-options="{'allowOnePane': false}">
+        <!-- Module switcher -->
+        <div class="module-nav-header accordion-section">
+          <div id="switcher" class="module-nav-switcher"  data-options="{'icon': false}">
+            <div class="module-nav-section module-btn">
+              <button id="module-nav-homepage-btn" class="btn-icon">
+                <span class="audible">Standard Module</span>
+              </button>
+            </div>
+            <div class="module-nav-section role-dropdown">
+              <label for="module-nav-role-switcher" class="label audible">Roles</label>
+              <select id="module-nav-role-switcher" name="module-nav-role-switcher" class="dropdown"
+                data-automation-id="custom-automation-dropdown-id">
+                <option value="admin">Admin Console</option>
+                <option value="job-console">Job Console</option>
+                <option value="landing-page-designer">Landing Page Designer</option>
+                <option value="process-server-admin">Process Server Administrator</option>
+                <option value="proxy-management">Proxy Management</option>
+                <option value="security-system-management">Security System Management</option>
+                <option value="user-management">User Management</option>
+                </select>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="module-nav-detail"></div>
+  </aside>
+  <div class="page-container scrollable">
+    <div class="row">
+      <div class="four columns">&nbsp;</div>
+      <div class="four columns">&nbsp;</div>
+      <div class="four columns">
+        <p>This example demonstrates how to provide no icons in the Module Switcher component</p>
+    </div>
+  </div>
+</section>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `[Layouts]` Removed some older layouts and examples from page layouts. ([#7733](https://github.com/infor-design/enterprise/issues/7733))
 - `[Message]` Fixed alignment issue on the icons. ([#7746](https://github.com/infor-design/enterprise/issues/7746))
 - `[ModuleNav]` Fixed rounding and `zindex` issues. ([#7654](https://github.com/infor-design/enterprise/issues/7654))
+- `[ModuleNav]` Added an option to set the icon to false initially. ([#7740](https://github.com/infor-design/enterprise/issues/7740))
 - `[Notification]` Updated color styles when notification is in subheader. ([#7623](https://github.com/infor-design/enterprise/issues/7623))
 - `[Page-Patterns]` Fixed the width of the search field in page pattern example. ([#7561](https://github.com/infor-design/enterprise/issues/7561))
 - `[Popupmenu]` Fixed the behavior of the component when having submenus in NG. ([#7556](https://github.com/infor-design/enterprise/issues/7556))

--- a/src/components/module-nav/module-nav.js
+++ b/src/components/module-nav/module-nav.js
@@ -29,7 +29,7 @@ const MODULE_NAV_DEFAULTS = {
   filterable: false,
   initChildren: true,
   pinSections: false,
-  showDetailView: false,
+  showDetailView: false
 };
 
 const toggleScrollbar = (el, doToggle) => {

--- a/src/components/module-nav/module-nav.switcher.js
+++ b/src/components/module-nav/module-nav.switcher.js
@@ -253,7 +253,7 @@ ModuleNavSwitcher.prototype = {
     }
 
     // if Icon HTML exists, replace the current one
-    if (iconHTML.length) {
+    if (iconHTML.length && !this.settings.icon === false) {
       const iconEl = this.moduleButtonIconEl;
       iconEl?.remove();
       this.moduleButtonEl.insertAdjacentHTML('afterbegin', iconHTML);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Added the ability to set the default icon to false. To have no icon.

**Related github/jira issue (required)**:
Fixes #7740

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/module-nav/example-no-icon.html (no icon should show)
- go to http://localhost:4000/components/module-nav/example-icon.html (still works)

**Included in this Pull Request**:
- [x] A note to the change log.
