### PR TITLE
7684 - Fixed bug where going to next didn't render the complete week

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise
 
+## v4.87.0
+
+## v4.87.0 Fixes
+
+- `[WeekView]` Fixed bug where going to next didn't render the complete week. ([#7684](https://github.com/infor-design/enterprise/issues/7684))
+
 ## v4.86.0
 
 ## v4.86.0 Features
@@ -40,7 +46,6 @@
 - `[Tooltip]` Fixed an error in tooltip where some string is unrecognizable. ([NG#1499](https://github.com/infor-design/enterprise-ng/issues/1499))
 - `[Tooltip]` Fixed invisible links on hover on tooltips in contrast mode. ([7737](https://github.com/infor-design/enterprise/issues/7737))
 - `[WeekView]` Fixed bug where agenda variant ignored `showAllDay` setting. ([#7700](https://github.com/infor-design/enterprise/issues/7700))
-- `[WeekView]` Fixed bug where going to next didn't render the complete week. ([#7684](https://github.com/infor-design/enterprise/issues/7684))
 
 ## v4.85.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@
 - `[Tooltip]` Fixed an error in tooltip where some string is unrecognizable. ([NG#1499](https://github.com/infor-design/enterprise-ng/issues/1499))
 - `[Tooltip]` Fixed invisible links on hover on tooltips in contrast mode. ([7737](https://github.com/infor-design/enterprise/issues/7737))
 - `[WeekView]` Fixed bug where agenda variant ignored `showAllDay` setting. ([#7700](https://github.com/infor-design/enterprise/issues/7700))
+- `[WeekView]` Fixed bug where going to next didn't render the complete week. ([#7684](https://github.com/infor-design/enterprise/issues/7684))
 
 ## v4.85.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ## v4.87.0 Fixes
 
-- `[WeekView]` Fixed bug where going to next didn't render the complete week. ([#7684](https://github.com/infor-design/enterprise/issues/7684))
 - `[ModuleNav]` Fixed missing tooltip on the settings button. ([#1525](https://github.com/infor-design/enterprise-ng/issues/1525))
 - `[ModuleNav]` Fixed issues in dark mode. ([#7753](https://github.com/infor-design/enterprise/issues/7753))
+- `[WeekView]` Fixed bug where going to next didn't render the complete week. ([#7684](https://github.com/infor-design/enterprise/issues/7684))
 
 ## v4.86.0
 

--- a/src/components/week-view/week-view.js
+++ b/src/components/week-view/week-view.js
@@ -93,6 +93,8 @@ WeekView.prototype = {
 
     if (!this.settings.endDate) {
       this.settings.endDate = dateUtils.lastDayOfWeek(new Date(), this.settings.firstDayOfWeek);
+    } else {
+      this.settings.endDate.setHours(23, 59, 59, 999);
     }
 
     return this.setLocaleThenBuild();

--- a/test/components/week-view/week-view-api-func-test.js
+++ b/test/components/week-view/week-view-api-func-test.js
@@ -99,8 +99,8 @@ describe('WeekView API', () => {
   it('should move to next week and back', () => {
     document.body.querySelector('.btn-icon.next').click();
 
-    expect(document.body.querySelector('thead tr th:nth-child(2)').textContent.trim()).toEqual('7Sat');
-    expect(document.body.querySelector('thead tr th:nth-child(8)').textContent.trim()).toEqual('13Fri');
+    expect(document.body.querySelector('thead tr th:nth-child(2)').textContent.trim()).toEqual('8Sun');
+    expect(document.body.querySelector('thead tr th:nth-child(8)').textContent.trim()).toEqual('14Sat');
     document.body.querySelector('.btn-icon.prev').click();
 
     expect(document.body.querySelector('thead tr th:nth-child(2)').textContent.trim()).toEqual('1Sun');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
endDate hours is also set on initialization

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #7684 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to the ff. pages (these also had the same bug):
   - http://localhost:4000/components/week-view/test-updated.html
   - http://localhost:4000/components/week-view/test-ajax-events.html
- Click on next > button
- Should not have the last day of the previous week be the first day 

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
