### PR TITLE
Allow defaultFilterOperator to be honored for date and time columns

### DIFF
--- a/app/views/components/datagrid/test-filter-with-default-operator.html
+++ b/app/views/components/datagrid/test-filter-with-default-operator.html
@@ -61,7 +61,8 @@
         filterConditions: ['contains', 'does-not-contain', 'equals', 'does-not-equal', 'is-empty', 'is-not-empty', 'end-with', 'does-not-end-with', {value: 'start-with', selected: true}, 'does-not-end-with']});
       columns.push({ id: 'activity', name: 'Activity', field: 'activity', formatter: Soho.Formatters.Dropdown, filterType: 'multiselect', options: activities, editorOptions: {showSelectAll: true}});
       columns.push({ id: 'quantity', name: 'Qty', field: 'quantity', align: 'right', filterType: 'integer', minWidth: 95});
-      columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Soho.Formatters.Date, dateFormat: 'MM/dd/yyyy', filterType: 'date', editorOptions: {showMonthYearPicker: true}});
+      columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Soho.Formatters.Date, dateFormat: 'MM/dd/yyyy', filterType: 'date', editorOptions: {showMonthYearPicker: true}, defaultFilterOperator:'less-equals',
+        filterConditions: ['equals', 'does-not-equal', 'in-range', 'less-than', {value: 'less-equals', selected: true}, 'greater-than', 'greater-equals']});
 
 
       // Init and get the api for the grid

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[ModuleNav]` Fixed missing tooltip on the settings button. ([#1525](https://github.com/infor-design/enterprise-ng/issues/1525))
 - `[ModuleNav]` Fixed issues in dark mode. ([#7753](https://github.com/infor-design/enterprise/issues/7753))
 - `[WeekView]` Fixed bug where going to next didn't render the complete week. ([#7684](https://github.com/infor-design/enterprise/issues/7684))
+- `[Datagrid]` Fixed bug where default filter wasn't honored for date or time columns. ([#7766](https://github.com/infor-design/enterprise/issues/7766))
 
 ## v4.86.0
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -2373,11 +2373,11 @@ Datagrid.prototype = {
       btnDefault = determineFilterDefaultValue(filterConditions, filterConditions.length ? filterConditions[0] : 'equals');
       if (filterConditions.length === 0) {
         btnMarkup = renderButton(btnDefault) +
-          render( 'less-than', 'EarlyThan' ) +
-          render( 'less-equals', 'EarlyOrEquals' ) +
-          render( 'greater-than', 'LaterThan' ) +
-          render( 'greater-equals', 'LaterOrEquals' );
-        btnMarkup = btnMarkup.replace( '{{icon}}', btnDefault );
+          render( 'less-than', 'EarlyThan') +
+          render( 'less-equals', 'EarlyOrEquals') +
+          render( 'greater-than', 'LaterThan') +
+          render( 'greater-equals', 'LaterOrEquals');
+        btnMarkup = btnMarkup.replace('{{icon}}', btnDefault);
       } else {
         btnMarkup = renderButton(btnDefault) +
           filterConditions.map(filter => render(filter, formatFilterText(filter))).join('');

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -2373,10 +2373,10 @@ Datagrid.prototype = {
       btnDefault = determineFilterDefaultValue(filterConditions, filterConditions.length ? filterConditions[0] : 'equals');
       if (filterConditions.length === 0) {
         btnMarkup = renderButton(btnDefault) +
-          render( 'less-than', 'EarlyThan') +
-          render( 'less-equals', 'EarlyOrEquals') +
-          render( 'greater-than', 'LaterThan') +
-          render( 'greater-equals', 'LaterOrEquals');
+          render('less-than', 'EarlyThan') +
+          render('less-equals', 'EarlyOrEquals') +
+          render('greater-than', 'LaterThan') +
+          render('greater-equals', 'LaterOrEquals');
         btnMarkup = btnMarkup.replace('{{icon}}', btnDefault);
       } else {
         btnMarkup = renderButton(btnDefault) +

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -2370,12 +2370,19 @@ Datagrid.prototype = {
     }
 
     if (/\b(date|time)\b/g.test(col.filterType)) {
-      btnMarkup += `${
-        render('less-than', 'EarlyThan')
-      }${render('less-equals', 'EarlyOrEquals')
-      }${render('greater-than', 'LaterThan')
-      }${render('greater-equals', 'LaterOrEquals')}`;
-      btnMarkup = btnMarkup.replace('{{icon}}', 'less-than');
+      btnDefault = determineFilterDefaultValue(filterConditions, filterConditions.length ? filterConditions[0] : 'equals');
+      if (filterConditions.length === 0) {
+        btnMarkup = renderButton(btnDefault) +
+          render( 'less-than', 'EarlyThan' ) +
+          render( 'less-equals', 'EarlyOrEquals' ) +
+          render( 'greater-than', 'LaterThan' ) +
+          render( 'greater-equals', 'LaterOrEquals' );
+        btnMarkup = btnMarkup.replace( '{{icon}}', btnDefault );
+      } else {
+        btnMarkup = renderButton(btnDefault) +
+          filterConditions.map(filter => render(filter, formatFilterText(filter))).join('');
+        btnMarkup = btnMarkup.replace('{{icon}}', btnDefault);
+      }
     }
 
     if (/\b(integer|decimal|percent)\b/g.test(col.filterType)) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fixes bug where defaultFilterOperator wasn't being honored for date and time columns.

**Related github/jira issue (required)**:
 "Closes #7766 "

**Steps necessary to review your pull request (required)**:
1. Pull and build the code
2. Navigate to /components/datagrid/test-filter-with-default-operator.html
3. See that the filter type for Ordered Date default to less than or equals

<img width="987" alt="image" src="https://github.com/infor-design/enterprise/assets/22107636/296d1c17-29fd-4dc4-9565-60bfe7870fdf">


**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
