### PR TITLE
7770 - Adjust padding in module nav

### DIFF
--- a/app/views/components/module-nav/example-index.html
+++ b/app/views/components/module-nav/example-index.html
@@ -345,7 +345,7 @@
       <div class="four columns">
         <p>Displays top-level navigation in a flyout menu</p>
 
-        <div class="field">
+        <div class="field field-checkbox">
           <label for="display-mode-dropdown" class="label">Display Mode</label>
           <select id="display-mode-dropdown" class="dropdown">
             <option value="">Hidden</option>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[FieldFilter]` Fixed Dropdown border not rendered properly. ([#7600](https://github.com/infor-design/enterprise/issues/7600))
 - `[FileuploadAdvanced]` Fixed Close Button not rendered properly. ([#7604](https://github.com/infor-design/enterprise/issues/7604))
 - `[ModuleNav]` Fixed missing tooltip on the settings button. ([#1525](https://github.com/infor-design/enterprise-ng/issues/1525))
+- `[ModuleNav]` Reduced item padding so more items can fit in the menu before scrolling occurs. ([#7770](https://github.com/infor-design/enterprise/issues/7770))
 - `[ModuleNav]` Fixed issues in dark mode. ([#7753](https://github.com/infor-design/enterprise/issues/7753))
 - `[WeekView]` Fixed bug where going to next didn't render the complete week. ([#7684](https://github.com/infor-design/enterprise/issues/7684))
 

--- a/src/components/module-nav/module-nav.accordion.scss
+++ b/src/components/module-nav/module-nav.accordion.scss
@@ -265,7 +265,7 @@
     .module-nav-footer {
       .accordion-header {
         &:last-of-type {
-          margin-block-end: 8px;
+          margin-block-end: 4px;
         }
       }
     }

--- a/src/components/module-nav/module-nav.scss
+++ b/src/components/module-nav/module-nav.scss
@@ -267,5 +267,5 @@
 .module-nav-settings {
   flex-shrink: 0;
   overflow: hidden;
-  margin-block-start: $module-nav-accordion-gutter-size;
+  margin-block-start: 0;
 }

--- a/src/components/module-nav/module-nav.scss
+++ b/src/components/module-nav/module-nav.scss
@@ -110,7 +110,7 @@
     }
 
     .module-nav-settings {
-      padding-block-end: 28px;
+      padding-block-end: $module-nav-bottom-margin;
     }
 
     &.show-detail {

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -740,6 +740,7 @@ $module-nav-collapsed-size: 56px;
 $module-nav-gutter-size: 4px;
 $module-nav-expanded-size: 320px;
 $module-nav-submenu-size: 300px;
+$module-nav-bottom-margin: 8px;
 
 // Module Nav Input Field (Search/Role Dropdown)
 $module-nav-input-border-width: 1px;

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -757,8 +757,8 @@ $module-nav-item-icon-start-spacing: 11px;
 $module-nav-item-icon-end-spacing: 19px;
 $module-nav-item-dropdown-icon-size: 13px; // 10px in Figma
 $module-nav-item-collapsed-size: 40px;
-$module-nav-item-collapsed-general-spacing-size: 8px;
-$module-nav-item-collapsed-first-last-spacing-size: 5px;
+$module-nav-item-collapsed-general-spacing-size: 4px;
+$module-nav-item-collapsed-first-last-spacing-size: 4px;
 $module-nav-item-text-color: $ids-color-palette-slate-100;
 $module-nav-item-hover-bg-color: $ids-color-palette-slate-20;
 $module-nav-item-hover-text-color: $ids-color-palette-slate-100;
@@ -793,7 +793,7 @@ $module-nav-search-close-icon-x-offset: 12px;
 $module-nav-settings-menu-item-height: 40px;
 $module-nav-settings-menu-item-text-color: $ids-color-palette-slate-80;
 $module-nav-settings-menu-separator-color: $ids-color-palette-slate-20;
-$module-nav-accordion-gutter-size: 8px;
+$module-nav-accordion-gutter-size: 4px;
 $module-nav-footer-gutter-size: 12px;
 
 // Contextual Action Panel


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Reduced spacing between menu items fro 8px to 4px

**Related github/jira issue (required)**:
Fixes #7770 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/module-nav/example-index.html?colors=fff
- expand the menu
- notice in both collapsed and expanded states the padding is reduced from 8px to 4px

**Included in this Pull Request**:
- [x] A note to the change log.
