### PR TITLE
6695 - Adjusted height for go button

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,8 +15,8 @@
 - `[ModuleNav]` Fixed missing tooltip on the settings button. ([#1525](https://github.com/infor-design/enterprise-ng/issues/1525))
 - `[ModuleNav]` Reduced item padding so more items can fit in the menu before scrolling occurs. ([#7770](https://github.com/infor-design/enterprise/issues/7770))
 - `[ModuleNav]` Fixed issues in dark mode. ([#7753](https://github.com/infor-design/enterprise/issues/7753))
-- `[Searchfield]` Adjusted height for go button. ([#6695](https://github.com/infor-design/enterprise/issues/6695))
 - `[ModuleNav]` Added option/example to disable search in the dropdown menu ([#1535](https://github.com/infor-design/enterprise-ng/issues/1535))
+- `[Searchfield]` Adjusted height for go button. ([#6695](https://github.com/infor-design/enterprise/issues/6695))
 - `[WeekView]` Fixed bug where going to next didn't render the complete week. ([#7684](https://github.com/infor-design/enterprise/issues/7684))
 - `[Datagrid]` Fixed bug where default filter wasn't honored for date or time columns. ([#7766](https://github.com/infor-design/enterprise/issues/7766))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[ModuleNav]` Fixed missing tooltip on the settings button. ([#1525](https://github.com/infor-design/enterprise-ng/issues/1525))
 - `[ModuleNav]` Reduced item padding so more items can fit in the menu before scrolling occurs. ([#7770](https://github.com/infor-design/enterprise/issues/7770))
 - `[ModuleNav]` Fixed issues in dark mode. ([#7753](https://github.com/infor-design/enterprise/issues/7753))
+- `[Searchfield]` Adjusted height for go button. ([#6695](https://github.com/infor-design/enterprise/issues/6695))
 - `[WeekView]` Fixed bug where going to next didn't render the complete week. ([#7684](https://github.com/infor-design/enterprise/issues/7684))
 
 ## v4.86.0

--- a/src/components/header/_header-new.scss
+++ b/src/components/header/_header-new.scss
@@ -193,7 +193,7 @@
         .btn-icon.close {
           right: 100px;
           top: 8px;
-          width: 34px;
+          width: 24px;
 
           &:hover svg {
             color: $header-flex-toolbar-close-icon-color-hover;
@@ -201,7 +201,7 @@
         }
 
         &.show-category .btn-icon.close {
-          right: 50px;
+          right: 54px;
         }
       }
     }

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -519,6 +519,10 @@ $subheader-height: 60px;
     &.has-focus {
       box-shadow: none;
     }
+
+    .go-button {
+      height: 38px;
+    }
   }
 
   .toolbar {

--- a/src/components/searchfield/_searchfield.scss
+++ b/src/components/searchfield/_searchfield.scss
@@ -349,7 +349,6 @@
 
   //Call to action button
   .go-button {
-    height: 38px;
     margin-left: 10px;
     margin-top: 0;
     min-width: 0;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Height style was meant for the case when searchfield is in subheader, so moved styling to subheader class only.

**Related github/jira issue (required)**:
Fixes #6695 

**Steps necessary to review your pull request (required)**:

- Pull this branch, build and run the app
- Go to the ff. and check both versions:
   - http://localhost:4000/components/searchfield/example-go-button.html
   - http://localhost:4000/components/searchfield/example-categories-and-go-button.html
   - http://localhost:4000/components/header/example-searchfield-full.html
- Go button should be the same height as searchfield

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
