### PR TITLE
7616 - Adjusted width of icons

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `[FieldFilter]` Fixed Dropdown border not rendered properly. ([#7600](https://github.com/infor-design/enterprise/issues/7600))
 - `[FileuploadAdvanced]` Fixed Close Button not rendered properly. ([#7604](https://github.com/infor-design/enterprise/issues/7604))
+- `[Icon]` Adjusted width of icons. ([#7616](https://github.com/infor-design/enterprise/issues/7616))
 - `[ModuleNav]` Fixed missing tooltip on the settings button. ([#1525](https://github.com/infor-design/enterprise-ng/issues/1525))
 - `[ModuleNav]` Reduced item padding so more items can fit in the menu before scrolling occurs. ([#7770](https://github.com/infor-design/enterprise/issues/7770))
 - `[ModuleNav]` Fixed issues in dark mode. ([#7753](https://github.com/infor-design/enterprise/issues/7753))

--- a/src/components/icons/_icons-new.scss
+++ b/src/components/icons/_icons-new.scss
@@ -3,7 +3,6 @@
 
 .icon {
   fill: transparent;
-  width: 18px; // Normalize against `height: 18px`;
 
   &.icon-empty-state {
     fill: $ids-color-brand-primary-base;

--- a/src/components/icons/_icons.scss
+++ b/src/components/icons/_icons.scss
@@ -6,8 +6,8 @@
   color: $icon-color-fill;
   display: inline-block;
   height: 18px; //Older ones at 32 but now based on 40
+  width: 18px;
   position: relative;
-  width: 22px;
 
   &.icon-round {
     border-radius: 50%;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Adjusted width of icons so that borders can be even. In New, width is the same as height, moved the width styling so that both New and Classic will have it

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #7616 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/images/example-photos.html
- In both versions, the status icon borders should be aligned

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
