### PR TITLE
7717 - Sparkline Highlight Dark Mode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[FileuploadAdvanced]` Fixed Close Button not rendered properly. ([#7604](https://github.com/infor-design/enterprise/issues/7604))
 - `[ModuleNav]` Fixed missing tooltip on the settings button. ([#1525](https://github.com/infor-design/enterprise-ng/issues/1525))
 - `[ModuleNav]` Fixed issues in dark mode. ([#7753](https://github.com/infor-design/enterprise/issues/7753))
+- `[Sparkline]` Fixed median fill on dark theme. ([#7717](https://github.com/infor-design/enterprise/issues/7717))
 - `[WeekView]` Fixed bug where going to next didn't render the complete week. ([#7684](https://github.com/infor-design/enterprise/issues/7684))
 
 ## v4.86.0

--- a/src/components/sparkline/sparkline.js
+++ b/src/components/sparkline/sparkline.js
@@ -134,6 +134,8 @@ Sparkline.prototype = {
       const scaleMedianRange = d3.scaleLinear().domain([min, max]).range([0, h]);
       const top = h - scaleMedianRange(median > range ? median : range);
       const bot = h - scaleMedianRange(median < range ? median : range);
+      const isDark = $('html').is('[class*="dark"]');
+      const medianFill = $('html').is('[class*="dark"]') ? '#F0F0F0' : '#525257';
 
       svg.append('g')
         .attr('class', 'medianrange')
@@ -142,6 +144,7 @@ Sparkline.prototype = {
         .attr('width', maxWidth)
         .attr('height', bot)
         .style('opacity', '0.06')
+        .style('fill', medianFill)
         .call((d) => {
           d._groups.forEach((medianranges) => {
             medianranges.forEach((medianrange) => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix median fill on dark theme.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/7717

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/sparkline/example-contextmenu.html?theme=new&mode=dark&colors=default
- Go to http://localhost:4000/components/sparkline/example-index.html?theme=new&mode=dark&colors=default
- Highlight should be seen

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

