### PR TITLE
7786 - Module Nav: Add `enableOutsideClick` setting for collapse/hide when page content is clicked

### DIFF
--- a/app/views/components/module-nav/example-index.html
+++ b/app/views/components/module-nav/example-index.html
@@ -368,6 +368,11 @@
           <input type="checkbox" checked="true" class="checkbox" name="offset-check" id="offset-check" />
           <label for="offset-check" class="checkbox-label">Offset the page container (don't hide any content)</label>
         </div>
+
+        <div class="field">
+          <input type="checkbox" class="checkbox" name="collapse-click-check" id="collapse-click-check" />
+          <label for="collapse-click-check" class="checkbox-label">Collapse/Hide when clicking outside an expanded menu</label>
+        </div>
       </div>
     </div>
     <div class="row test-spacer">&nbsp;</div>
@@ -385,12 +390,14 @@
     $('html').personalize({ colors: '#fff' });
     $('[data-theme-name="theme-classic"]').parent().addClass('is-disabled');
 
-    const navAPI = $('#nav').data('modulenav');
+    const navEl = $('#nav');
+    const navAPI = navEl.data('modulenav');
     const containerEl = $('.module-nav-container');
     const dropdownEl = $('#display-mode-dropdown')
     const dropdownAPI = $('#display-mode-dropdown').data('dropdown');
     const displayCheckEl = $('#display-detail-check');
     const offsetCheckEl = $('#offset-check');
+    const collapseCheckEl = $('#collapse-click-check');
     const hamburgerBtnEl = $('#header-hamburger');
     const pinSectionsCheckEl = $('#pin-sections');
 
@@ -425,6 +432,16 @@
         }
       });
     }
+
+    collapseCheckEl.on('change.test', (e) => {
+      navAPI.updated({ enableOutsideClick: collapseCheckEl[0].checked });
+    });
+
+    navEl.on('displaymodechange', (e, mode) => {
+      if (dropdownAPI.value !== mode) {
+        dropdownAPI.selectValue(mode);
+      }
+    });
 
     // Connect component event handling
     const roleSwitcherEl = $('.role-dropdown');

--- a/app/views/components/module-nav/example-index.html
+++ b/app/views/components/module-nav/example-index.html
@@ -437,10 +437,8 @@
       navAPI.updated({ enableOutsideClick: collapseCheckEl[0].checked });
     });
 
-    navEl.on('displaymodechange', (e, mode) => {
-      if (dropdownAPI.value !== mode) {
-        dropdownAPI.selectValue(mode);
-      }
+    navEl.on('displaymodechange.test', (e, mode) => {
+      dropdownAPI.selectValue(mode === false ? '' : mode);
     });
 
     // Connect component event handling

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[FieldFilter]` Fixed Dropdown border not rendered properly. ([#7600](https://github.com/infor-design/enterprise/issues/7600))
 - `[FileuploadAdvanced]` Fixed Close Button not rendered properly. ([#7604](https://github.com/infor-design/enterprise/issues/7604))
 - `[ModuleNav]` Fixed missing tooltip on the settings button. ([#1525](https://github.com/infor-design/enterprise-ng/issues/1525))
+- `[ModuleNav]` Addded `enableOutsideClick()` feature to collapse/hide menu via content click. ([#7786](https://github.com/infor-design/enterprise/issues/7786))
 - `[ModuleNav]` Reduced item padding so more items can fit in the menu before scrolling occurs. ([#7770](https://github.com/infor-design/enterprise/issues/7770))
 - `[ModuleNav]` Fixed issues in dark mode. ([#7753](https://github.com/infor-design/enterprise/issues/7753))
 - `[WeekView]` Fixed bug where going to next didn't render the complete week. ([#7684](https://github.com/infor-design/enterprise/issues/7684))

--- a/src/components/module-nav/module-nav.js
+++ b/src/components/module-nav/module-nav.js
@@ -203,11 +203,18 @@ ModuleNav.prototype = {
    * @private
    */
   enableOutsideClickEvent() {
-    if (this.settings.enableOutsideClick) {
+    if (this.settings.enableOutsideClick && this.settings.displayMode === 'expanded') {
       $(this.containerEl).on(`click.${COMPONENT_NAME}`, (e) => {
         this.checkOutsideClick(e.target);
       });
     }
+  },
+
+  /**
+   * @private
+   */
+  disableOutsideClick() {
+    $(this.containerEl).off(`click.${COMPONENT_NAME}`);
   },
 
   /**
@@ -219,6 +226,7 @@ ModuleNav.prototype = {
       const target = targetEl;
       if (target && !$(target).is('.application-menu-trigger') && !this.element[0].contains(target)) {
         this.setDisplayMode(this.previousDisplayMode);
+        this.disableOutsideClick();
       }
     }
   },
@@ -466,8 +474,8 @@ ModuleNav.prototype = {
    * @private
    */
   teardownEvents() {
+    this.disableOutsideClick();
     this.element.off(`updated.${COMPONENT_NAME}`);
-    $(this.containerEl).off(`click.${COMPONENT_NAME}`);
     $(this.accordionEl).off(`rendered.${COMPONENT_NAME}`);
     $(this.accordionEl).off(`beforeexpand.${COMPONENT_NAME}`);
     $(this.accordionEl).off(`afterexpand.${COMPONENT_NAME}`);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR adds a setting to the Module Nav component, `enableOutsideClick`.  When enabled, a click event handler is added to the Module Nav container element that wraps both the bar and the content, and listens for clicks within the content area.  When triggered, the event will collapse or hide the Module Nav bar if it's in `expanded` display mode.  Whether the bar completely hides, or just collapses, depends on what state it was in before it was switched to `expanded` mode.

**Related github/jira issue (required)**:
- Closes #7786
- Related to infor-design/enterprise-ng#1539

**Steps necessary to review your pull request (required)**:
- Pull/build/run
- Open http://localhost:4000/components/module-nav/example-index.html?colors=fff
- Check the box labelled "Collapse/hide when clicking outside an expanded menu"
- Use the hamburger or the in-page dropdown to change from collapsed mode to expanded mode.
- Click the page content.  The Module Nav bar should switch its display mode to "collapsed".
- Use the in-page dropdown to switch to "hidden" display mode.
- Use the same dropdown again to switch to "expanded" display mode".
- Click the page content.  The Module Nav bar should switch its display mode to "hidden".
- Uncheck the box, and use the dropdown to switch to "expanded" display mode.
- Click the page content.  The Module Nav bar should stay as-is.

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
