### PR TITLE
7785 - Bump `ids-identity` version (accept new icons)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "ids-enterprise",
-  "version": "4.86.0-beta.0",
+  "version": "4.87.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ids-enterprise",
-      "version": "4.86.0-beta.0",
+      "version": "4.87.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "d3": "^7.8.5",
-        "ids-identity": "4.14.10",
+        "ids-identity": "4.14.11",
         "jquery": "^3.7.0",
         "promise-polyfill": "^8.3.0"
       },
@@ -10287,9 +10287,9 @@
       }
     },
     "node_modules/ids-identity": {
-      "version": "4.14.10",
-      "resolved": "https://registry.npmjs.org/ids-identity/-/ids-identity-4.14.10.tgz",
-      "integrity": "sha512-M66VCZfbskBW5mJ/9V5a0dzWGyhPsZqMrMBy9wuuXNaoS/9b3HqiWBLj51n2XUuK73pqMTzgFyyMdVyhwsNR2w=="
+      "version": "4.14.11",
+      "resolved": "https://registry.npmjs.org/ids-identity/-/ids-identity-4.14.11.tgz",
+      "integrity": "sha512-Zb1cHUgSfQqmD5uz0ui1NMCXNO5VHCW4ghX2eyTa/AHkY4rCYVfNK7zBppTYRVi+1kP0iYkgLBqh67k1tj/6DA=="
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -29743,9 +29743,9 @@
       }
     },
     "ids-identity": {
-      "version": "4.14.10",
-      "resolved": "https://registry.npmjs.org/ids-identity/-/ids-identity-4.14.10.tgz",
-      "integrity": "sha512-M66VCZfbskBW5mJ/9V5a0dzWGyhPsZqMrMBy9wuuXNaoS/9b3HqiWBLj51n2XUuK73pqMTzgFyyMdVyhwsNR2w=="
+      "version": "4.14.11",
+      "resolved": "https://registry.npmjs.org/ids-identity/-/ids-identity-4.14.11.tgz",
+      "integrity": "sha512-Zb1cHUgSfQqmD5uz0ui1NMCXNO5VHCW4ghX2eyTa/AHkY4rCYVfNK7zBppTYRVi+1kP0iYkgLBqh67k1tj/6DA=="
     },
     "ieee754": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   ],
   "dependencies": {
     "d3": "^7.8.5",
-    "ids-identity": "4.14.10",
+    "ids-identity": "4.14.11",
     "jquery": "^3.7.0",
     "promise-polyfill": "^8.3.0"
   },


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This PR updates to the latest `ids-identity` version, with the purpose of adding a missing empty state icon.

**Related github/jira issue (required)**:
Closes #7785 

**Steps necessary to review your pull request (required)**:
- Pull/build/run
- Open http://localhost:4000/components/icons/example-empty-states.html
- Under "new empty states", compare the number of icons.  There should be one more compared to https://main-enterprise.demo.design.infor.com/components/icons/example-empty-states.html (the "no images" icon)

<img width="206" alt="Screenshot 2023-08-11 at 9 17 44 AM" src="https://github.com/infor-design/enterprise/assets/3249601/e78e4b8b-bd7e-4f38-8693-d214ee3e1137">
