### PR TITLE
7811 - Fix on Slate's personalization header text color

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## v4.87.0 Fixes
 
 - `[Badges/Alerts/Tags/Icons]` Added docs and clearer examples. ([#7661](https://github.com/infor-design/enterprise-ng/issues/7661))
+- `[Color]` Fix on Slate's personalization header text color. ([#7811](https://github.com/infor-design/enterprise-ng/issues/7811))
 - `[ColorPicker]` Fixed color selection on color picker. ([#7760](https://github.com/infor-design/enterprise-ng/issues/7760))
 - `[Dropdown]` Adjusted dropdown text in Firefox. ([#7763](https://github.com/infor-design/enterprise/issues/7763))
 - `[Datagrid]` Fixed bug where default filter wasn't honored for date or time columns. ([#7766](https://github.com/infor-design/enterprise/issues/7766))

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -418,7 +418,6 @@ html[class*="theme-new"] .header.is-personalizable:not(.has-alternate-tabs) .tab
   background-color: ${colors.contrast} !important;
 }
 
-html[class*="theme-new-"] .header.is-personalizable button:not(.go-button):not(.close):not(.searchfield-category-button):not(:disabled):hover,
 html[class*="theme-new-"] .header.is-personalizable button:not(:disabled):hover .app-header.icon > span,
 html[class*="theme-new-"] .header.is-personalizable .toolbar [class^='btn']:hover:not(.go-button):not(.close):not(.searchfield-category-button):not([disabled]),
 html[class*="theme-new-"] .subheader.is-personalizable button:not(.go-button):not(.close):not(.searchfield-category-button):not(:disabled):hover,
@@ -430,6 +429,10 @@ html[class*="theme-new-"] .personalize-subheader .toolbar [class^='btn']:hover:n
   color: ${colors.btnTertiaryHoverColor} !important;
   background-color: ${colors.btnTertiaryBgHoverColor} !important;
   opacity: 1;
+}
+
+html[class*="theme-new-"] .header.is-personalizable button:not(.go-button):not(.close):not(.searchfield-category-button):not(:disabled):hover {
+  background-color: ${colors.darkest} !important;
 }
 
 .header .flex-toolbar [class^='btn'][disabled] {
@@ -793,7 +796,7 @@ html[dir='rtl'] .scrollable-flex-header.is-personalizable .breadcrumb.truncated:
   border-right: 1px solid ${colors.hover} !important;
 }
 
-.module-tabs.is-personalizable .tab:not(.is-selected):hover, 
+.module-tabs.is-personalizable .tab:not(.is-selected):hover,
 .module-tabs.is-personalizable .tab-more:hover {
   background-color: ${colors.tabHoverColor} !important;
   color: ${colors.contrast};

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -256,7 +256,7 @@ colorUtils.getContrastColor = function getContrastColor(hex, light, dark) {
   const g = parse(2);
   const b = parse(4);
   const diff = ((r * 299) + (g * 587) + (b * 114)) / 1000;
-  return (diff >= 128) ? (dark || 'black') : (light || 'white');
+  return (diff >= 146) ? (dark || 'black') : (light || 'white');
 };
 
 /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fix on Slate's personalization header text color

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #7811 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/header/example-index.html?colors=606066
- Text color on header should be white

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
