### PR TITLE
7724 - Fix circlepager inside of a card

### DIFF
--- a/app/views/components/circlepager/example-mobile.html
+++ b/app/views/components/circlepager/example-mobile.html
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="six columns">
-    <div class="card">
+    <div class="card auto-height">
       <div class="card-header">
           <h2 class="widget-title">Circle Pager Example</h2>
           <button type="button" class="btn-actions" type="button" id="btn-1">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## v4.87.0 Fixes
 
 - `[Badges/Alerts/Tags/Icons]` Added docs and clearer examples. ([#7661](https://github.com/infor-design/enterprise-ng/issues/7661))
+- `[Circlepager]` Fixed circlepager's position inside of a card. ([#7724](https://github.com/infor-design/enterprise/issues/7724))
 - `[ColorPicker]` Fixed color selection on color picker. ([#7760](https://github.com/infor-design/enterprise-ng/issues/7760))
 - `[Dropdown]` Adjusted dropdown text in Firefox. ([#7763](https://github.com/infor-design/enterprise/issues/7763))
 - `[Datagrid]` Fixed bug where default filter wasn't honored for date or time columns. ([#7766](https://github.com/infor-design/enterprise/issues/7766))


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the circlepager being inside a card. The issue arose due to recent changes in the card's height. I've added the `auto-height` class to rectify this.

**Related github/jira issue (required)**:

Closes #7724

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/circlepager/example-mobile.html
- Circlepager should be inside of the card

**Included in this Pull Request**:
~~- [] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
