### PR TITLE
7836 - Fix image size

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[FileuploadAdvanced]` Changed file upload copy. ([#7787](https://github.com/infor-design/enterprise/issues/7787))
 - `[Hyperlink]` Fixed hyperlink focus style in completion chart. ([#7731](https://github.com/infor-design/enterprise/issues/7731))
 - `[Icon]` Adjusted width of icons. ([#7616](https://github.com/infor-design/enterprise/issues/7616))
+- `[Images]` Fixed incorrect image size. ([#7616](https://github.com/infor-design/enterprise/issues/7616))
 - `[ModuleNav]` Added css to constrain images to 32px. ([#7820](https://github.com/infor-design/enterprise-ng/issues/7820))
 - `[ModuleNav]` Fixed missing tooltip on the settings button. ([#1525](https://github.com/infor-design/enterprise-ng/issues/1525))
 - `[ModuleNav]` Added `enableOutsideClick()` feature to collapse/hide menu via content click. ([#7786](https://github.com/infor-design/enterprise/issues/7786))

--- a/src/components/images/_images.scss
+++ b/src/components/images/_images.scss
@@ -71,8 +71,8 @@ $images-size: (
   border: 1px solid transparent; // to prevent jump on focus
   border-radius: 50%;
   display: inline-block;
-  height: 50px;
-  width: 50px;
+  height: 48px;
+  width: 48px;
 
   &:focus {
     @include focus-state();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Some image icons (avatars) where 50x50 and should be 48x48

**Related github/jira issue (required)**:
Fixes #7836

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/images/example-photos.html
- inspect each image / avatar and should be 48x48 now

**Included in this Pull Request**:
- [x] A note to the change log.
