### PR TITLE
7629 - Pager Pagesizes Overwrite

### DIFF
--- a/app/views/components/datagrid/example-paging.html
+++ b/app/views/components/datagrid/example-paging.html
@@ -33,6 +33,7 @@
         editable: true,
         filterable: true,
         pagesize: 10,
+        pagesizes: [10, 50, 100],
         resultsText: function (grid, count, filterCount) {
           console.log('ResultsText:', grid, count, filterCount);
           if (filterCount > 0) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,7 @@
 - `[ModuleNav]` Added option/example to disable search in the dropdown menu ([NG#1535](https://github.com/infor-design/enterprise-ng/issues/1535))
 - `[ModuleNav]` Added option/example to disable search in the dropdown menu ([#1535](https://github.com/infor-design/enterprise-ng/issues/1535))
 - `[Number]` Added additional check for `formatNumber`. ([#7752](https://github.com/infor-design/enterprise/issues/7752))
+- `[Pager]` Fixed pager pagesizes default settings cannot be overridden with custom settings. ([#7629](https://github.com/infor-design/enterprise/issues/7629))
 - `[Popover]` Fixed popover having issues on simulatenous clicks. ([#7679](https://github.com/infor-design/enterprise/issues/7679))
 - `[Sparkline]` Fixed median fill on dark theme. ([#7717](https://github.com/infor-design/enterprise/issues/7717))
 - `[Searchfield]` Adjusted height for go button. ([#6695](https://github.com/infor-design/enterprise/issues/6695))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -93,7 +93,7 @@ const COMPONENT_NAME = 'datagrid';
  * @param {array}    [settings.columnIds=[]] An array of column IDs used to define aria descriptors for selection checkboxes.
  * @param {boolean}  [settings.paging=false] Enable paging mode
  * @param {number}   [settings.pagesize=25] Number of rows per page
- * @param {array}    [settings.pagesizes=[10, 25, 50, 75]] Array of page sizes to show in the page size dropdown.
+ * @param {array}    [settings.pagesizes=[]] Array of page sizes to show in the page size dropdown.
  * @param {boolean}  [settings.indeterminate=false] Disable the ability to go to a specific page when paging.
  * @param {Function} [settings.source=false]  Callback function for paging
  * @param {boolean}  [settings.hidePagerOnOnePage=false]  If true, hides the pager if there's only one page worth of results.
@@ -207,7 +207,7 @@ const DATAGRID_DEFAULTS = {
   // Paging settings
   paging: false,
   pagesize: 25,
-  pagesizes: [10, 25, 50, 75],
+  pagesizes: [],
   showPageSizeSelector: true, // Will show page size selector
   indeterminate: false, // removed ability to go to a specific page.
   source: null, // callback for paging

--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -120,6 +120,7 @@ const PAGER_DEFAULTS = {
 function Pager(element, settings) {
   this.settings = utils.mergeSettings(element, settings, PAGER_DEFAULTS);
   this.settings.dataset = settings.dataset; // by pass deep copy
+  this.settings.pagesizes = settings.pagesizes.length > 0 ? settings.pagesizes : this.settings.pagesizes;
   this.element = $(element);
   debug.logTimeStart(COMPONENT_NAME);
   this.init();

--- a/src/components/pager/pager.js
+++ b/src/components/pager/pager.js
@@ -120,7 +120,7 @@ const PAGER_DEFAULTS = {
 function Pager(element, settings) {
   this.settings = utils.mergeSettings(element, settings, PAGER_DEFAULTS);
   this.settings.dataset = settings.dataset; // by pass deep copy
-  this.settings.pagesizes = settings.pagesizes.length > 0 ? settings.pagesizes : this.settings.pagesizes;
+  this.settings.pagesizes = settings.pagesizes?.length > 0 ? settings.pagesizes : this.settings.pagesizes;
   this.element = $(element);
   debug.logTimeStart(COMPONENT_NAME);
   this.init();

--- a/test/components/datagrid/datagrid-settings-func-test.js
+++ b/test/components/datagrid/datagrid-settings-func-test.js
@@ -102,7 +102,7 @@ describe('Datagrid Settings', () => {
       columnIds: [],
       paging: false,
       pagesize: 25,
-      pagesizes: [10, 25, 50, 75],
+      pagesizes: [],
       showPageSizeSelector: true,
       indeterminate: false,
       source: null,


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix pager pagesizes default settings cannot be overridden with custom settings.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/7629

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/example-paging.html
- Open Pager on the lower right bottom
- It should be `10, 50 and 100` instead of `25, 50, 75, 100`

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

