### PR TITLE
7645 - Trigger the validation after clearing the input field

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[Editor]` Added swatch bar on colorpicker button. ([#7571](https://github.com/infor-design/enterprise/issues/7571))
 - `[Editor]` Fixed fonts selection selection on editor. ([#7762](https://github.com/infor-design/enterprise-ng/issues/7762))
 - `[FieldFilter]` Fixed Dropdown border not rendered properly. ([#7600](https://github.com/infor-design/enterprise/issues/7600))
+- `[Fileupload]` Fixed a bug where validation is not triggered after clearing the input. ([#7645](https://github.com/infor-design/enterprise/issues/7645))
 - `[FileuploadAdvanced]` Fixed Close Button not rendered properly. ([#7604](https://github.com/infor-design/enterprise/issues/7604))
 - `[FileuploadAdvanced]` Changed file upload copy. ([#7787](https://github.com/infor-design/enterprise/issues/7787))
 - `[Homepage]` Changed selector so multiple hero banners in a page will work. ([#7819](https://github.com/infor-design/enterprise/issues/7819))

--- a/src/components/fileupload/fileupload.js
+++ b/src/components/fileupload/fileupload.js
@@ -122,6 +122,7 @@ FileUpload.prototype = {
       if (hasInlineLabel) {
         this.fileInput.data(`handleEvent +${[(e.type || '')]}`, e.handleObj);
       }
+      self.textInput.trigger('change');
     });
 
     if (this.fileInput.is(':disabled')) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the file upload where the validation is not triggered after clearing the input field.

**Related github/jira issue (required)**:

Closes #7645 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/fileupload/test-required.html
- Upload a file to any input field
- Click clear button
- Validation should show

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
