### PR TITLE
 7747 - Set masthead height to 40px / remove info

### DIFF
--- a/app/views/components/icons/example-status-colors.html
+++ b/app/views/components/icons/example-status-colors.html
@@ -5,14 +5,7 @@
 </style>
 
 <div class="row top-padding">
-  <div class="four columns">
-    <h2 class="page-margin">Neutral</h2>
-      <div class="icon-status slate02" role="presentation">
-        <svg class="icon slate07-color" focusable="false" aria-hidden="true">
-          <use href="#icon-building"></use>
-        </svg>
-      </div>
-      <br /><br />
+  <div class="three columns l-center">
       <h2 class="page-margin">Info</h2>
       <div class="icon-status azure01" role="presentation">
         <svg class="icon icon-info" focusable="false" aria-hidden="true">
@@ -26,7 +19,7 @@
       </div>
       <br /><br />
   </div>
-  <div class="four columns">
+  <div class="three columns l-center">
     <h2 class="page-margin">Error</h2>
     <div class="icon-status ruby01" role="presentation">
       <svg class="icon icon-error" focusable="false" aria-hidden="true">
@@ -39,6 +32,8 @@
       </svg>
     </div>
     <br /><br />
+  </div>
+  <div class="three columns l-center">
     <h2 class="page-margin">Alert / Warning</h2>
     <div class="icon-status amber01" role="presentation">
       <svg class="icon amber05-color" focusable="false" aria-hidden="true"  role="presentation">
@@ -52,7 +47,7 @@
     </div>
     <br /><br />
   </div>
-  <div class="four columns">
+  <div class="three columns l-center">
     <h2 class="page-margin">Good / Success</h2>
     <div class="icon-status emerald01" role="presentation">
       <svg class="icon emerald05-color" focusable="false" aria-hidden="true">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## v4.87.0 Features
 
 - `[Icons]` Fixed shape and markup of status icons. Note: May need to update your code. ([#7747](https://github.com/infor-design/enterprise/issues/7661))
+- `[Masthead]` Set height of masthead to 40px. ([#7747](https://github.com/infor-design/enterprise/issues/7857))
 - `[Typography]` Added `text-wrap` class. ([#7497](https://github.com/infor-design/enterprise/issues/7497))
 
 ## v4.87.0 Fixes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## v4.87.0 Features
 
 - `[Icons]` Fixed shape and markup of status icons. Note: May need to update your code. ([#7747](https://github.com/infor-design/enterprise/issues/7661))
-- `[Masthead]` Set height of masthead to 40px. ([#7747](https://github.com/infor-design/enterprise/issues/7857))
+- `[Masthead]` Set height of masthead to 40px. ([#7857](https://github.com/infor-design/enterprise/issues/7857))
 - `[Typography]` Added `text-wrap` class. ([#7497](https://github.com/infor-design/enterprise/issues/7497))
 
 ## v4.87.0 Fixes

--- a/src/components/grid/_grid.scss
+++ b/src/components/grid/_grid.scss
@@ -172,6 +172,8 @@ $gutter-neg-size: -20px;
   width: 100%;
 
   &.l-center {
+    text-align: center;
+
     .field,
     .image-round {
       text-align: center;

--- a/src/components/masthead/_masthead-new.scss
+++ b/src/components/masthead/_masthead-new.scss
@@ -11,12 +11,12 @@
 
 .masthead .masthead-icon > .icon {
   border-radius: 4px;
-  margin: 0 8px;
+  margin-inline-start: 6px;
 }
 
 .masthead .flex-toolbar .toolbar-section {
   .masthead-icon > .icon {
-    margin: 1px 6px;
+    margin: 0 6px;
   }
 
   &.title h1 {

--- a/src/components/masthead/_masthead.scss
+++ b/src/components/masthead/_masthead.scss
@@ -4,20 +4,19 @@
 .masthead {
   background-color: $masthead-bg-color;
   border-bottom: 1px solid $masthead-border-color;
-  height: 38px;
+  height: 40px;
   width: 100%;
   z-index: 9000;
 
   .masthead-icon {
     border-radius: 0;
-    height: 32px;
-    margin: 4px 2px !important;
-    padding: 0;
-    width: 32px;
+    height: 28px;
+    width: 28px;
+    margin-top: 3px;
 
     > .icon {
-      height: 30px;
-      width: 30px;
+      height: 32px;
+      width: 32px;
     }
 
     .ripple-effect {
@@ -144,10 +143,6 @@
           margin-right: -3px;
           vertical-align: top;
         }
-      }
-
-      .masthead-icon > .icon {
-        margin: 1px 0;
       }
     }
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fix height of masthead

**Related github/jira issue (required)**:
Fixes #7747

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/masthead/example-index.html
- confirm height is 40px
- things should be centered in it

**Included in this Pull Request**:
- [x] A note to the change log.
