### PR TITLE
7659 - Add hitbox in radio component

### DIFF
--- a/app/views/components/radios/example-hitbox.html
+++ b/app/views/components/radios/example-hitbox.html
@@ -1,0 +1,27 @@
+<style>
+  .hitbox-style {
+    border: 1px dashed #0072ed;
+  }
+</style>
+
+
+<div class="row top-padding">
+  <div class="twelve columns">
+
+    <fieldset class="radio-group">
+      <legend>Radio with Hitboxes</legend>
+      <input type="radio" class="radio hitbox" name="options" id="option1" data-automation-id="option1-automation" value="option1" />
+      <label for="option1" class="radio-label hitbox-style">Option one</label>
+      <br/>
+      <input type="radio" class="radio hitbox" name="options" id="option2" data-automation-id="option2-automation" value="option1" checked="true" />
+      <label for="option2"  class="radio-label hitbox-style">Option two</label>
+      <br/>
+      <input type="radio" class="radio hitbox" name="options" id="option3" data-automation-id="option3-automation" value="option3" />
+      <label for="option3" class="radio-label hitbox-style">Option three</label>
+      <br/>
+      <input type="radio" class="radio hitbox" name="options" id="option4" data-automation-id="option4-automation" value="delivery" disabled="true" />
+      <label for="option4" class="radio-label hitbox-style">Option four</label>
+    </fieldset>
+
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## v4.87.0 Features
 
 - `[Icons]` Fixed shape and markup of status icons. Note: May need to update your code. ([#7747](https://github.com/infor-design/enterprise/issues/7661))
+- `[Radios]` Added hitbox feature for mobile devices. ([#7659](https://github.com/infor-design/enterprise/issues/7659))
 - `[Typography]` Added `text-wrap` class. ([#7497](https://github.com/infor-design/enterprise/issues/7497))
 
 ## v4.87.0 Fixes

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -56,6 +56,7 @@
     &::before {
       margin-top: 0;
     }
+
     &::after {
       left: 17px;
       top: 40%;

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -39,6 +39,30 @@
   width: 0;
 }
 
+// Radio with hitbox
+.radio.hitbox {
+  + .radio-label {
+    display: inline-flex;
+    -webkit-box-align: center;
+    align-items: center;
+    vertical-align: middle;
+    min-width: 44px;
+    height: 44px;
+    padding-left: 38px;
+    padding-right: 14px;
+  }
+
+  + label {
+    &::before {
+      margin-top: 0;
+    }
+    &::after {
+      left: 17px;
+      top: 40%;
+    }
+  }
+}
+
 .inline-radio {
   margin-bottom: 0;
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR adds hitbox on radio component for mobile devices.

**Related github/jira issue (required)**:

Closes #7659

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/radios/example-hitbox
- Radio button and labels should have 44px height (much bigger compare to the default radio button size)

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
