### PR TITLE
7680 - Added expanded default for expandable formatter

### DIFF
--- a/app/views/components/datagrid/example-expandable-row.html
+++ b/app/views/components/datagrid/example-expandable-row.html
@@ -15,7 +15,7 @@
         data = [];
 
       // Some Sample Data
-      data.push({ id: 1, productId: 2142201, sku: 'SKU #9000001-237', productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+      data.push({ id: 1, productId: 2142201, sku: 'SKU #9000001-237', productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action', expanded: true});
       data.push({ id: 2, productId: 2241202, sku: 'SKU #9000001-236', productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
       data.push({ id: 3, productId: 2342203, sku: 'SKU #9000001-235', productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
       data.push({ id: 4, productId: 2445204, sku: 'SKU #9000001-234', productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `[Dropdown]` Adjusted dropdown text in Firefox. ([#7763](https://github.com/infor-design/enterprise/issues/7763))
 - `[Datagrid]` Fixed bug where default filter wasn't honored for date or time columns. ([#7766](https://github.com/infor-design/enterprise/issues/7766))
 - `[Datagrid]` Fixed datagrid column filter not open after a series of simultaneous clicking of column filters. ([#7750](https://github.com/infor-design/enterprise/issues/7750))
+- `[Datagrid]` Added expanded default for expandable formatter. ([#7680](https://github.com/infor-design/enterprise/issues/7680))
 - `[Datepicker]` Fixed bug where date range selected is not properly rendered in some scenarios. ([#7528](https://github.com/infor-design/enterprise/issues/7528))
 - `[Datepicker]` Added a new `listcontextmenu` event that fires on right click of menu items. ([#7822](https://github.com/infor-design/enterprise/issues/7822))
 - `[Editor]` Added swatch bar on colorpicker button. ([#7571](https://github.com/infor-design/enterprise/issues/7571))

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -412,8 +412,8 @@ const formatters = {
   // Expand / Collapse Button
   Expander(row, cell, value, col, item, api) {
     const attrs = utils.stringAttributes(api, api.settings.attributes, `btn-expand-row-${row}`);
-    const button = `<button ${attrs} type="button" aria-label="${Locale.translate('ExpandCollapse')}" class="btn-icon datagrid-expand-btn" tabindex="-1">
-      <span class="icon plus-minus"></span>
+    const button = `<button ${attrs} type="button" aria-label="${Locale.translate('ExpandCollapse')}" class="btn-icon datagrid-expand-btn ${item.expanded ? 'is-expanded' : ''}" tabindex="-1">
+      <span class="icon plus-minus ${item.expanded ? 'active' : ''}"></span>
       </button>${(value ? `<span> ${value}</span>` : '')}`;
 
     return button;

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5078,7 +5078,7 @@ Datagrid.prototype = {
       }
 
       containerHtml.center += `<tr class="datagrid-expandable-row ${item.expanded ? ' is-expanded' : ''}"><td colspan="${visibleColumnsCenter + (this.settings.spacerColumn ? 1 : 0)}">
-        <div class="datagrid-row-detail hewwo" ${item.expanded ? ' style="height: auto"' : ''}><div class="datagrid-row-detail-padding">${renderedTmpl}</div></div>
+        <div class="datagrid-row-detail" ${item.expanded ? ' style="height: auto"' : ''}><div class="datagrid-row-detail-padding">${renderedTmpl}</div></div>
         </td></tr>`;
       if (this.hasRightPane) {
         containerHtml.right += `<tr class="datagrid-expandable-row no-border"><td colspan="${visibleColumnsRight}">

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4194,6 +4194,7 @@ Datagrid.prototype = {
 
       self.runningCount++;
       const rowHtml = self.rowHtml(s.dataset[i], currentCount, i);
+
       if (self.hasLeftPane && rowHtml.left) {
         tableHtmlLeft += rowHtml.left;
       }
@@ -4754,9 +4755,8 @@ Datagrid.prototype = {
 
     isEven = (this.recordCount % 2 === 0);
     const isSelected = this.isRowSelected(rowData);
-    const isActivated = rowData._rowactivated;
+    const isActivated = rowData._rowactivated || rowData.expanded;
     const rowStatus = { class: '', svg: '' };
-
     if (rowData && rowData.rowStatus && (rowData.rowStatus.icon === 'new' ? self.settings.showNewRowIndicator : true)) {
       rowStatus.show = true;
       rowStatus.class = ` rowstatus-row-${rowData.rowStatus.icon}`;
@@ -4823,7 +4823,7 @@ Datagrid.prototype = {
         self,
         formatLocale
       );
-
+      // ELEPHANT
       if (formatted.indexOf('<span class="is-readonly">') === 0) {
         col.readonly = true;
       }
@@ -5076,8 +5076,9 @@ Datagrid.prototype = {
           <div class="datagrid-row-detail"><div style="height: ${height}px"></div></div>
           </td></tr>`;
       }
-      containerHtml.center += `<tr class="datagrid-expandable-row"><td colspan="${visibleColumnsCenter + (this.settings.spacerColumn ? 1 : 0)}">
-        <div class="datagrid-row-detail"><div class="datagrid-row-detail-padding">${renderedTmpl}</div></div>
+
+      containerHtml.center += `<tr class="datagrid-expandable-row ${item.expanded ? ' is-expanded' : ''}"><td colspan="${visibleColumnsCenter + (this.settings.spacerColumn ? 1 : 0)}">
+        <div class="datagrid-row-detail hewwo" ${item.expanded ? ' style="height: auto"' : ''}><div class="datagrid-row-detail-padding">${renderedTmpl}</div></div>
         </td></tr>`;
       if (this.hasRightPane) {
         containerHtml.right += `<tr class="datagrid-expandable-row no-border"><td colspan="${visibleColumnsRight}">

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -4823,7 +4823,7 @@ Datagrid.prototype = {
         self,
         formatLocale
       );
-      // ELEPHANT
+
       if (formatted.indexOf('<span class="is-readonly">') === 0) {
         col.readonly = true;
       }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
A row will be expanded if there's an `expanded: true` in the dataset item.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #7680 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datagrid/example-expandable-row.html
- First row should be expanded

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
