### PR TITLE
7896 - Fix widget sizes

### DIFF
--- a/app/views/components/cards/example-expandable.html
+++ b/app/views/components/cards/example-expandable.html
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="six columns">
 
-    <h2>Card Example: Expandable</h2>
+    <h2>Card Example: Expandable</h2><br>
   </div>
 </div>
 
@@ -142,7 +142,7 @@ var LISTVIEW_DATASET = [{
 <script>
   $('#product-list').listview({
     dataset: LISTVIEW_DATASET,
-    selectable: false,
+    selectable: true,
     template: $('#product-list-tmpl')
   });
 </script>

--- a/app/views/components/cards/test-datagrid.html
+++ b/app/views/components/cards/test-datagrid.html
@@ -1,8 +1,7 @@
+
 <div class="row">
   <div class="six columns">
-
     <h2>Card Test: Datagrid</h2>
-
   </div>
 </div>
 

--- a/app/views/components/cards/test-full-width.html
+++ b/app/views/components/cards/test-full-width.html
@@ -13,27 +13,7 @@
           <li><a href="#" id="action-2">Action Two</a></li>
         </ul>
     </div>
-    <div class="card-content" style="height: 400px">
-    </div>
-  </div>
-</div>
-
-<div class="full-width no-padding">
-  <div class="card auto-height">
-    <div class="card-header">
-        <h2 class="widget-title">Chart Title</h2>
-        <button class="btn-actions" type="button" id="btn-2">
-          <span class="audible">Actions</span>
-          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-            <use href="#icon-vertical-ellipsis"></use>
-          </svg>
-        </button>
-        <ul class="popupmenu actions top">
-          <li><a href="#" id="action-3">Action One</a></li>
-          <li><a href="#" id="action-4">Action Two</a></li>
-        </ul>
-    </div>
-    <div class="card-content" style="height: 400px">
+    <div class="card-content" style="height: 200px">
     </div>
   </div>
 </div>

--- a/app/views/components/cards/test-paging-datagrid.html
+++ b/app/views/components/cards/test-paging-datagrid.html
@@ -1,5 +1,14 @@
+<style>
+  .datagrid-container.paginated {
+    height: calc(100% - 8px) !important
+  }
+  .card-footer {
+    padding: 0px 20px;
+  }
+</style>
 <div class="row">
   <div class="six columns">
+    <br>
     <h2>Card Test: Paging Datagrid</h2>
   </div>
 </div>

--- a/app/views/components/cards/test-tabs-card.html
+++ b/app/views/components/cards/test-tabs-card.html
@@ -1,3 +1,8 @@
+<style>
+  .tab-panel {
+    margin: 12px;
+  }
+</style>
 <div class="two-thirds column row">
     <div class="card">
       <div class="card-header">

--- a/app/views/components/homepage/example-add-widget.html
+++ b/app/views/components/homepage/example-add-widget.html
@@ -1,3 +1,8 @@
+<style>
+  #bar-stacked-example {
+    height: 310px;
+  }
+</style>
 <div id="maincontent" class="homepage page-container scrollable" data-columns="3" role="main">
   <button type="button" class="btn-secondary" id="toggleBusinessInsight" style="margin: 0 0 15px 20px;">Append Business Insight</button>
 
@@ -79,28 +84,30 @@
   $('body').on('initialized', function () {
     var barData = [{
       data: [{
-        name: '2008',
-        value: 123
+          name: 'Category A',
+          value: 373,
+          url: 'test',
+          tooltip: 'Tooltip by Data <br> Component A <br> Information',
+          attributes: [
+           { name: 'id', value: 'bar-a' },
+           { name: 'data-automation-id', value: 'automation-id-bar-a' }
+         ]
       }, {
-        name: '2009',
-        value: 234
+          name: 'Category B',
+          value: 372,
+          attributes: [
+           { name: 'id', value: 'bar-b' },
+           { name: 'data-automation-id', value: 'automation-id-bar-b' }
+         ]
       }, {
-        name: '2010',
-        value: 345
+          name: 'Category C',
+          value: 236.35,
+          attributes: [
+           { name: 'id', value: 'bar-c' },
+           { name: 'data-automation-id', value: 'automation-id-bar-c' }
+         ]
       }],
-      name: 'Series 1'
-    }, {
-      data: [{
-        name: '2008',
-        value: 235
-      }, {
-        name: '2009',
-        value: 267
-      }, {
-        name: '2010',
-        value: 573
-      }],
-      name: 'Series 2'
+      name: 'Categories'  //Can be optionally passed in makes less sense with one: Group 1
     }];
 
     var pieData = [{

--- a/app/views/components/homepage/example-filled.html
+++ b/app/views/components/homepage/example-filled.html
@@ -105,18 +105,6 @@
         value: 345
       }],
       name: 'Series 1'
-    }, {
-      data: [{
-        name: '2008',
-        value: 235
-      }, {
-        name: '2009',
-        value: 267
-      }, {
-        name: '2010',
-        value: 573
-      }],
-      name: 'Series 2'
     }];
 
     var pieData = [{

--- a/app/views/components/homepage/example-monthviews.html
+++ b/app/views/components/homepage/example-monthviews.html
@@ -16,7 +16,7 @@
         </ul>
       </div>
 
-      <div class="widget-content">
+      <div class="widget-content no-scroll">
         <div id="monthview-one" class="monthview" data-init="false">
         </div>
       </div>
@@ -37,7 +37,7 @@
         </ul>
       </div>
 
-      <div class="widget-content">
+      <div class="widget-content no-scroll">
         <div id="monthview-two" class="monthview" data-init="false">
         </div>
       </div>
@@ -58,7 +58,7 @@
         </ul>
       </div>
 
-      <div class="widget-content">
+      <div class="widget-content no-scroll">
         <div id="monthview-three" class="monthview" data-init="false">
         </div>
       </div>

--- a/app/views/components/homepage/example-scenario-h.html
+++ b/app/views/components/homepage/example-scenario-h.html
@@ -12,6 +12,8 @@
         <div class="widget-header">
           <h2 tabindex="0" class="widget-title">Widget 1x2 (Dom Order 2) - B</h2>
         </div>
+        <div class="widget-content">
+        </div>
       </div>
 
       <div class="widget double-width">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise
 
+## v4.88.0
+
+## v4.88.0 Fixes
+
+- `[Card/Widget]` Fix inconsistency in widget size. ([#7896](https://github.com/infor-design/enterprise/issues/7896))
+
 ## v4.87.0
 
 ## v4.87.0 Features

--- a/src/components/calendar/_calendar-toolbar.scss
+++ b/src/components/calendar/_calendar-toolbar.scss
@@ -150,7 +150,7 @@
       margin-right: 0;
 
       &.active:not([disabled]) .icon {
-        color: $datepicker-selected-bg-color;
+        color: $button-color-tertiary-initial-font;
       }
     }
 
@@ -166,7 +166,7 @@
 
     .btn-cal-month-year {
       &.active:not([disabled]) .icon {
-        color: $datepicker-selected-bg-color;
+        color: $button-color-tertiary-initial-font;
       }
 
       .icon {

--- a/src/components/cards/_cards-new.scss
+++ b/src/components/cards/_cards-new.scss
@@ -5,6 +5,7 @@
   box-shadow: 0 0 4px $cardlist-box-shadow-color-hover;
   height: 368px;
   min-height: 368px;
+  overflow: hidden;
 
   &.bordered {
     border: none;
@@ -280,8 +281,6 @@
   }
 
   .listview {
-    border-bottom-left-radius: 8px;
-    border-bottom-right-radius: 8px;
     overflow: hidden;
     height: auto;
 

--- a/src/components/cards/_cards-new.scss
+++ b/src/components/cards/_cards-new.scss
@@ -3,8 +3,8 @@
 .widget {
   border-radius: 8px;
   box-shadow: 0 0 4px $cardlist-box-shadow-color-hover;
-  height: 373px;
-  min-height: 373px;
+  height: 368px;
+  min-height: 368px;
 
   &.bordered {
     border: none;

--- a/src/components/cards/_cards.scss
+++ b/src/components/cards/_cards.scss
@@ -269,7 +269,7 @@ $card-header-section: '.card-header-section', '.widget-header-section';
 
     .expandable-header {
       &:first-child {
-        padding-top: 13px;
+        padding-top: 0;
       }
 
       .icon {
@@ -280,7 +280,7 @@ $card-header-section: '.card-header-section', '.widget-header-section';
 
     .btn-expander {
       border: 1px solid transparent;
-      border-radius: 2px;
+      border-radius: 8px;
       display: inline-block;
 
       &:focus:not(.hide-focus) {
@@ -525,7 +525,7 @@ $card-header-section: '.card-header-section', '.widget-header-section';
 
       .icon {
         left: 11px;
-        top: 11px;
+        top: 9px;
       }
     }
 

--- a/src/components/cards/_cards.scss
+++ b/src/components/cards/_cards.scss
@@ -542,8 +542,8 @@ $card-header-section: '.card-header-section', '.widget-header-section';
 .widget-content,
 .card-content {
   flex-direction: column;
-  height: 318px;
-  min-height: 318px;
+  height: 320px;
+  min-height: 320px;
   overflow: auto;
   width: 100%;
 

--- a/src/components/homepage/_homepage.scss
+++ b/src/components/homepage/_homepage.scss
@@ -169,8 +169,8 @@
   .card-header {
     + .widget-content,
     + .card-content {
-      height: 708px;
-      min-height: 708px;
+      height: 704px;
+      min-height: 704px;
     }
   }
 }

--- a/src/components/homepage/_homepage.scss
+++ b/src/components/homepage/_homepage.scss
@@ -337,6 +337,11 @@
   text-align: center;
 }
 
+.widget-content.no-scroll,
+.card-content.no-scroll {
+  overflow: hidden;
+}
+
 // Hero widget
 .hero-widget {
   background-color: $header-hero-widget-bg-color;

--- a/src/components/homepage/homepage.js
+++ b/src/components/homepage/homepage.js
@@ -387,7 +387,7 @@ Homepage.prototype = {
           }
         });
     } else {
-      cards.attr('draggable', false);
+      cards.removeAttr('draggable');
       cards.children('.card-remove').remove();
       cards.off('mouseenter.card mouseleave.card dragstart.card dragenter.card dragend.card');
       cards.not('.card-list .card').css('cursor', 'auto');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixed as noted that the widget height is a bit inconsistent. Sizes should be

- Widget Total 368
- Header 48
- Body 320 

cc @talkaboutdesign

**Related github/jira issue (required)**:
Fixes #7896

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/cards/example-workspace-widgets.html and confirm
- test all widget and card examples http://localhost:4000/components/cards http://localhost:4000/components/widgets and http://localhost:4000/components/homepage
- looking for unneeded scrollbars or similar issue
- also check the double height widget on http://localhost:4000/components/homepage/example-scenario-h.html (widget 752, header 48, content 704)

**Included in this Pull Request**:
- [x] A note to the change log.

**Screen Shots**

![Screenshot 2023-09-06 at 1 14 12 PM](https://github.com/infor-design/enterprise/assets/814283/45534d16-7fbe-452f-be9e-f19e92225de0)
![Screenshot 2023-09-06 at 1 14 02 PM](https://github.com/infor-design/enterprise/assets/814283/f31573c5-1726-4756-aa18-7c92f337a19f)
![Screenshot 2023-09-06 at 1 13 55 PM](https://github.com/infor-design/enterprise/assets/814283/c2091e4e-70f0-4733-8da2-1e9f4cabe9ea)

