### PR TITLE
7887 - Fix timepicker enable function and click to close

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Masthead]` Set height of masthead to 40px. ([#7857](https://github.com/infor-design/enterprise/issues/7857))
 - `[Popover]` Improved popover title style and position, excluding the 'alternate' class. ([#7676](https://github.com/infor-design/enterprise/issues/7676))
 - `[Radios]` Added hitbox feature for mobile devices. ([#7659](https://github.com/infor-design/enterprise/issues/7659))
+- `[Timepicker]` Fix issue with `enable` function. ([#7887](https://github.com/infor-design/enterprise/issues/7887))
 - `[Typography]` Added `text-wrap` class. ([#7497](https://github.com/infor-design/enterprise/issues/7497))
 
 ## v4.87.0 Fixes

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -49,6 +49,8 @@ $.fn.enable = function () {
   this.removeAttr('disabled readonly')
     .closest('.field')
     .removeClass('is-disabled');
+
+  this.closest('.field').find('button.trigger').enable();
   return this;
 };
 

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -821,6 +821,23 @@ Tooltip.prototype = {
               self.element.prev().is('.datepicker')) {
             self.hide();
           }
+
+          let didHide = false;
+          if (target.closest('.popover').length === 0 &&
+            target.closest('.dropdown-list').length === 0) {
+            if (!(target.is('button') &&
+              (target.siblings().hasClass('datepicker') || target.siblings().hasClass('timepicker')) &&
+              self.element.get(0) === target.get(0))) {
+              if (!(self.element.get(0) === target.get(0) && target.is('button') && !target.is('button.trigger'))) {
+                self.hide();
+                didHide = true;
+              }
+            }
+          }
+
+          if (target.closest('.popover').length === 0 && target.is('.field') && !didHide) {
+            self.hide();
+          }
         })
         .on(`keydown.${COMPONENT_NAME}-${self.uniqueId}`, (e) => {
           if (e.which === 27 || self.settings.isError) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes two bugs

a) the `enable` function left the timepicker disabled
b) clicking out didnt close the popup (i regressed it on https://github.com/infor-design/enterprise/pull/7876/files)

**Related github/jira issue (required)**:
Fixes #7887 
Relates to https://github.com/infor-design/enterprise/pull/787

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/timepicker/example-index.html
- type this in the console

```js
$('#timepicker-id-1').disable()
$('#timepicker-id-1').enable()
```

- make sire you can now open the picker with the timepicker button
- also when the picker is open, click the button again and make sure it closes
- try opening the picker and then clicking the page to close (should work again it was broke)
- go to http://localhost:4000/components/popover/example-index.html and click the button to open the popup
- click again on the button should close it

**Included in this Pull Request**:
- [x ] A note to the change log.
