### PR TITLE
7889 - Fix chart title's width for column charts

### DIFF
--- a/app/views/components/column-grouped/example-axis-labels.html
+++ b/app/views/components/column-grouped/example-axis-labels.html
@@ -3,7 +3,7 @@
   <div class="two-thirds column">
       <div class="widget">
         <div class="widget-header">
-          <h2 class="widget-title">Grouped Column Chart - Axis Labels</h2>
+          <h2 class="widget-title">Grouped Column Chart</h2>
         </div>
         <div class="widget-content">
           <div id="column-grouped-example" class="chart-container">

--- a/app/views/components/column/example-rotate.html
+++ b/app/views/components/column/example-rotate.html
@@ -3,7 +3,7 @@
   <div class="two-thirds column">
       <div class="widget">
         <div class="widget-header">
-          <h2 class="widget-title">Column Chart Example - xAxis Rotated</h2>
+          <h2 class="widget-title">Column Chart</h2>
         </div>
         <div class="widget-content">
           <div id="column-bar-example" class="chart-container">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## v4.88.0 Fixes
 
 - `[Tabs]` Fixed the focus alignment in tabs for RTL. ([#7772](https://github.com/infor-design/enterprise/issues/7772))
+- `[Charts]` Fixed the size of the chart titles in columns. ([#7889](https://github.com/infor-design/enterprise/issues/7889))
 
 ## v4.87.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ## v4.88.0 Fixes
 
+- `[Column]` Fixed the size of the chart titles in columns. ([#7889](https://github.com/infor-design/enterprise/issues/7889))
 - `[Tabs]` Fixed the focus alignment in tabs for RTL. ([#7772](https://github.com/infor-design/enterprise/issues/7772))
-- `[Charts]` Fixed the size of the chart titles in columns. ([#7889](https://github.com/infor-design/enterprise/issues/7889))
 
 ## v4.87.0
 

--- a/src/components/cards/_cards.scss
+++ b/src/components/cards/_cards.scss
@@ -800,7 +800,6 @@ html[dir='rtl'] {
 
   .widget-title {
     margin: 0;
-    width: 230px;
   }
 
   .widget-title:has(+ .badge) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Adjusted width for widget title to allow for full text chart title.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise/issues/7889

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build, and run the app.
- Go to: 
  - http://localhost:4000/components/column/example-rotate.html
  - http://localhost:4000/components/column-grouped/example-axis-labels.html
  - http://localhost:4000/components/column-grouped/example-column-grouped-with-line-combined-hide-dots.html
  - http://localhost:4000/components/column-grouped/example-column-grouped-with-line-combined.html
- Chart titles should not overflow.

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
