### PR TITLE
7796 - editor header firefox change

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Chart]` Fixed on focus border being off in chart legend items. ([#7850](https://github.com/infor-design/enterprise/issues/7850))
 - `[Column]` Fixed the size of the chart titles in columns. ([#7889](https://github.com/infor-design/enterprise/issues/7889))
 - `[Editor]` Fixed editor text not changing to other font headers after changing colors. ([#7793](https://github.com/infor-design/enterprise/issues/7793))
+- `[Editor]` Fixed editor text not changing to other font headers in some scenarios after changing colors in Firefox. ([#7796](https://github.com/infor-design/enterprise/issues/7796))
 - `[Lookup]` Fixed count text positioning. ([#7905](https://github.com/infor-design/enterprise/issues/7905))
 - `[Popover]` Added scrollable class for popover. ([#7678](https://github.com/infor-design/enterprise/issues/7678))
 - `[Listview]` Adjusted searchfield in listview when inside modal to fix alignment. ([NG#1547](https://github.com/infor-design/enterprise-ng/issues/1547))

--- a/src/components/editor/_editor.scss
+++ b/src/components/editor/_editor.scss
@@ -797,6 +797,10 @@ html.is-firefox {
   .flex-toolbar.formatter-toolbar .fontpicker {
     span {
       padding-top: 3px !important;
+
+      &.audible + span:not([class]) {
+        padding-top: unset !important;
+      }
     }
   }
 }

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -2783,8 +2783,8 @@ Editor.prototype = {
     }
 
     // Check if selected text is in current editor
-    const selectedElement = $(this.selection.anchorNode.parentNode).is('font') ? $(this.selection.anchorNode.parentNode.parentNode) : $(this.selection.anchorNode.parentNode); 
-    if (this.element.get(0) !== selectedElement.parent().get(0)) {
+    const selectedElement = $(this.selection.anchorNode).is('div.editor') ? $(this.selection.anchorNode).get(0) : $(this.selection.anchorNode).parents('div.editor').get(0);
+    if (selectedElement === undefined || this.element.get(0) !== selectedElement) {
       return;
     }
 

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -2782,8 +2782,10 @@ Editor.prototype = {
       return;
     }
 
+    const selectedElement = $(this.selection.anchorNode).is('div.editor') ? $(this.selection.anchorNode).get(0) : $(this.selection.anchorNode).parents('div.editor').get(0);
+
     // Check if selected text is in current editor
-    if (this.element.get(0) !== $(this.selection.anchorNode.parentNode).parent().get(0)) {
+    if (selectedElement === undefined || this.element.get(0) !== selectedElement) {
       return;
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix editor text not changing to other font headers in some scenarios after changing colors in Firefox.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/7796

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Open in `Firefox`
- Go to http://localhost:4000/components/editor/example-index.html
- Select all the text inside the editor
- Change to `Header 1`
- Change the color of the text
- Change to `Normal Text`

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

