### PR TITLE
7897 - Fix standalone toolbar dropdown label visibility for dark mode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Popover]` Added scrollable class for popover. ([#7678](https://github.com/infor-design/enterprise/issues/7678))
 - `[Listview]` Adjusted searchfield in listview when inside modal to fix alignment. ([NG#1547](https://github.com/infor-design/enterprise-ng/issues/1547))
 - `[Tabs]` Fixed the focus alignment in tabs for RTL. ([#7772](https://github.com/infor-design/enterprise/issues/7772))
+- `[Toolbar]` Added additional selectors and colors for dark theme dropdown label. ([#7897](https://github.com/infor-design/enterprise/issues/7897))
 - `[Tree]` Fixed Cross-Site Scripting (XSS) when setting up tree node. ([#7631](https://github.com/infor-design/enterprise/issues/7631))
 
 ## v4.87.0

--- a/src/components/toolbar/_toolbar.scss
+++ b/src/components/toolbar/_toolbar.scss
@@ -264,6 +264,18 @@ $toolbar-buttonset-height: 40px;
   }
 }
 
+// For Standalone popup menu label
+.btn-menu,
+.btn-actions {
+  &.is-open {
+    color: $toolbar-standalone-popup-label-color;
+
+    .icon {
+      color: $toolbar-standalone-popup-label-color;
+    }
+  }
+}
+
 // Used in Editor, some card menus, etc.
 .popupmenu.toolbar-options {
   li {

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -434,6 +434,7 @@ $toolbar-separator-color: $ids-color-palette-graphite-30;
 $toolbar-btn-actions-hover-bg-color: $button-color-tertiary-hover-background-new;
 $toolbar-contextual-button-hover-bg-color: rgba(0, 0, 0, .3);
 $toolbar-contextual-button-color: $ids-color-palette-white;
+$toolbar-standalone-popup-label-color: $ids-color-brand-primary-base;
 
 // Field Filter
 $fieldfilter-border-side-color: transparent;

--- a/src/themes/theme-classic-dark.scss
+++ b/src/themes/theme-classic-dark.scss
@@ -298,6 +298,7 @@ $toolbar-standalone-border-color: $ids-color-palette-slate-50;
 $toolbar-standalone-disabled-color: $ids-color-palette-slate-50;
 $toolbar-separator-color: $ids-color-palette-slate-50;
 $toolbar-btn-actions-hover-bg-color: transparent;
+$toolbar-standalone-popup-label-color: $ids-color-palette-white;
 
 // Formatter Toolbar
 $formatter-toolbar-separator-color: $ids-color-palette-slate-40;

--- a/src/themes/theme-new-dark.scss
+++ b/src/themes/theme-new-dark.scss
@@ -339,6 +339,7 @@ $toolbar-standalone-border-color: $ids-color-palette-slate-50;
 $toolbar-standalone-disabled-color: $ids-color-palette-slate-40;
 $toolbar-separator-color: $ids-color-palette-slate-50;
 $toolbar-btn-actions-hover-bg-color: $button-color-tertiary-hover-background-new;
+$toolbar-standalone-popup-label-color: $ids-color-palette-white;
 
 // Color Palette Background
 $color-border-color: rgba(255, 255, 255, 0.2);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Added additional selectors and colors for the dropdown labels in the standalone toolbar to ensure visibility in dark mode.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #7897 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build, and run the app.
- Go to: http://localhost:4000/components/toolbar/example-standalone-style.html?theme=new&mode=dark&colors=default
- Make sure dark mode is active
- Click a drop down
- Lose focus or move the cursor anywhere on the page
- Label should remain visible

**Included in this Pull Request**:
- [X] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
