### PR TITLE
7852 - Included a prepend whitespace when adding a cssClass property.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Accordion]` Updated selected header text color. ([#7769](https://github.com/infor-design/enterprise/issues/7769))
 - `[Breadcrumb]` Updated hover color for breadcrumb in header. ([#7801](https://github.com/infor-design/enterprise/issues/7801))
 - `[Button]` Updated hover color for header and CAP. ([#7944/7943](https://github.com/infor-design/enterprise/issues/7944))
+- `[Button]` Formatted the appending of a cssClass property to include a prefix whitespace. ([#7852](https://github.com/infor-design/enterprise/issues/7852))
 - `[Card/Widget]` Fix inconsistency in widget size. ([#7896](https://github.com/infor-design/enterprise/issues/7896))
 - `[Chart]` Fix on focus border being off in chart legend items. ([#7850](https://github.com/infor-design/enterprise/issues/7850))
 - `[Chart]` Fixed on focus border being off in chart legend items. ([#7850](https://github.com/infor-design/enterprise/issues/7850))

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -298,7 +298,7 @@ Button.prototype = {
 
     // Add extra, user-defined CSS classes, if applicable
     if (typeof this.settings.cssClass === 'string') {
-      this.element[0].className += xssUtils.stripHTML(this.settings.cssClass);
+      this.element[0].className += xssUtils.stripHTML(` ${this.settings.cssClass}`);
     }
 
     // Add hitbox area element.


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
When adding buttons to a modal, there is an option to add a cssClass property to the button's class list. This pull request solves how classes are appended to have a prefix whitespace so that they are added properly to the button's class list.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise/issues/7852

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build, and run the app.
- Open the example-index.html file under the modal component.
- Add a cssClass property in the "Cancel" button and set it to "test".
<img width="226" alt="image" src="https://github.com/infor-design/enterprise/assets/75935158/f0643476-fe1a-43af-a2a2-96c200790f8c">

- Go to: http://localhost:4000/components/modal/example-index.html
- Press the "Show Modal" button.
- Inspect the "Cancel" button.
- Classes for the "Cancel" button should include the properly added "test" class.

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
