### PR TITLE
518 - Change color of empty message

### DIFF
--- a/src/components/emptymessage/_emptymessage-new.scss
+++ b/src/components/emptymessage/_emptymessage-new.scss
@@ -45,7 +45,7 @@
 .card-empty-info,
 .widget-empty-info,
 .empty-info {
-  color: $font-color-muted;
+  color: $emptymessage-text-color;
   font-size: 1.6rem;
   padding: 0 20px 20px;
 }
@@ -63,7 +63,7 @@
 
 .empty-title,
 .card-empty-title {
-  color: $font-color-muted;
+  color: $emptymessage-title-color;
 }
 
 .empty-icon,

--- a/src/components/emptymessage/_emptymessage.scss
+++ b/src/components/emptymessage/_emptymessage.scss
@@ -29,9 +29,9 @@
 }
 
 .icon-empty-state {
-  color: $ids-color-brand-primary-base;
+  color: $emptymessage-icon-color;
   display: inline-block;
-  fill: $ids-color-brand-primary-base;
+  fill: $emptymessage-icon-color;
   height: 65px;
   position: relative;
   width: 65px;

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -544,6 +544,11 @@ $spinbox-hover-color: $ids-color-font-base;
 $spinbox-disabled-icon-color: $input-disabled-color;
 $spinbox-readonly-icon-color: $ids-color-palette-graphite-40;
 
+// Empty Message
+$emptymessage-text-color: $ids-color-palette-slate-60;
+$emptymessage-title-color: $ids-color-palette-slate-70;
+$emptymessage-icon-color: $ids-color-brand-primary-base;
+
 // Error Page
 $error-page-bg-color: $ids-color-palette-graphite-30;
 $error-page-content-bg-color: $ids-color-palette-white;

--- a/src/themes/theme-classic-dark.scss
+++ b/src/themes/theme-classic-dark.scss
@@ -406,6 +406,9 @@ $fieldset-border-top-color: $ids-color-palette-slate-60;
 $fieldset-border-bottom-color: transparent;
 $fieldset-title-color: $font-color-highcontrast;
 
+// Empty Message
+$emptymessage-icon-color: $ids-color-palette-slate-20;
+
 // Expandable Area
 $expandable-area-border-color: $ids-color-palette-slate-50;
 $expandable-area-title-color: $ids-color-palette-white;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Following up on a PR / comments from QA. Darkened the empty message color.

**Related github/jira issue (required)**:
Follow up to https://github.com/infor-design/design-system/issues/518

**Steps necessary to review your pull request (required)**:
- try http://localhost:4000/components/icons/example-empty-widgets.html?theme=new&mode=contrast&colors=default in all six themes and make sure the text doesnt look dim
