### PR TITLE
7782 - Fix appmenu switcher button hover background color

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## v4.88.0 Fixes
 
 - `[Accordion]` Updated selected header text color. ([#7769](https://github.com/infor-design/enterprise/issues/7769))
+- `[ApplicationMenu]` Fixed an issue where the hover button color was incorrect. ([#7933](https://github.com/infor-design/enterprise/issues/7782))
 - `[Bar]` Fixed overlapping and cropped axis labels (left & right) when horizontal bar label is lengthy. ([#7614](https://github.com/infor-design/enterprise/issues/7614))
 - `[Build]` Fixed wrong filename in build download. ([#7992](https://github.com/infor-design/enterprise/issues/7992))
 - `[Breadcrumb]` Updated hover color for breadcrumb in header. ([#7801](https://github.com/infor-design/enterprise/issues/7801))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@
 ## v4.88.0 Fixes
 
 - `[Accordion]` Updated selected header text color. ([#7769](https://github.com/infor-design/enterprise/issues/7769))
-- `[ApplicationMenu]` Fixed an issue where the hover button color was incorrect. ([#7933](https://github.com/infor-design/enterprise/issues/7782))
+- `[ApplicationMenu]` Fixed an issue where the hover button background color was incorrect. ([#7933](https://github.com/infor-design/enterprise/issues/7782))
 - `[Bar]` Fixed overlapping and cropped axis labels (left & right) when horizontal bar label is lengthy. ([#7614](https://github.com/infor-design/enterprise/issues/7614))
 - `[Build]` Fixed wrong filename in build download. ([#7992](https://github.com/infor-design/enterprise/issues/7992))
 - `[Breadcrumb]` Updated hover color for breadcrumb in header. ([#7801](https://github.com/infor-design/enterprise/issues/7801))

--- a/src/components/applicationmenu/_applicationmenu-new.scss
+++ b/src/components/applicationmenu/_applicationmenu-new.scss
@@ -69,7 +69,7 @@
       }
 
       &:hover {
-        background-color: $new-appmenu-hover-bg-color;
+        background-color: $new-appmenu-hover-bg-color !important;
       }
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the issue where the hover button background color was incorrect. 

It's weird that the button's CSS takes precedence over the appmenu's CSS.

**Related github/jira issue (required)**:

Closes #7782 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to
    - http://localhost:4000/components/applicationmenu/example-menu-notification.html
    - http://localhost:4000/components/applicationmenu/example-personalized-role-switcher.html
    - http://localhost:4000/components/applicationmenu/example-resizable-menu.html
- Hover over on `Employee` dropdown menu button
- Hover button background color shouldn't be lighter

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
