### PR TITLE
7677 - Change popover to allow components with event handlers

### DIFF
--- a/app/views/components/popover/test-nested.html
+++ b/app/views/components/popover/test-nested.html
@@ -39,9 +39,7 @@
 
 <script>
   $('body').one('initialized', function () {
-    let grid,
-      textArea,
-      columns = [],
+    let columns = [],
       data = [];
 
     // Some Sample Data
@@ -77,12 +75,7 @@
         y: 10
       },
       title: 'Text Area',
-      trigger: 'click',
-      onHidden: () => {
-        if (textArea) {
-          textArea.destroy();
-        }
-      }
+      trigger: 'click'
     };
 
     const POPOVER_OPTIONS_2 = {
@@ -90,30 +83,18 @@
       content: $('#popover-contents-2'),
       popover: true,
       title: 'Datagrid',
-      trigger: 'click',
-      onHidden: () => {
-        if (grid) {
-          grid.destroy();
-        }
-      }
+      trigger: 'click'
     };
 
-    $('#popover-trigger').popover(POPOVER_OPTIONS).on('beforeshow', () => {
-      textArea = $('#text-area').data('textarea');
-      if (!textArea) {
-        textArea = $('#text-area').textarea().data('textarea');
-      }
-    });
-    $('#popover-trigger-2').popover(POPOVER_OPTIONS_2).on('beforeshow', () => {
-      grid = $('#datagrid').data('datagrid');
-      if (!grid) {
-        grid = $('#datagrid').datagrid({
+    $('#text-area').textarea().data('textarea');
+    $('#datagrid').datagrid({
           columns: columns,
           dataset: data,
           rowTemplate: rowTemplate
         }).data('datagrid');
-      }
-    })
+
+    $('#popover-trigger').popover(POPOVER_OPTIONS);
+    $('#popover-trigger-2').popover(POPOVER_OPTIONS_2);
   });
 
 </script>

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -609,7 +609,7 @@ Tooltip.prototype = {
 
     if (typeof content === 'string') {
       content = $(content);
-      contentArea.html(content);
+      DOM.replaceHtml(contentArea, content);
       contentArea.find('.hidden').removeClass('hidden');
     } else if (useHtml) {
       const clone = content[0].cloneNode(true);
@@ -617,9 +617,9 @@ Tooltip.prototype = {
       if (id) {
         clone.id = `${id}-${this.uniqueId}`;
       }
-      contentArea.html(clone.outerHTML);
+      DOM.replaceHtml(contentArea, clone.outerHTML);
     } else {
-      contentArea.html(content);
+      DOM.replaceHtml(contentArea, content);
     }
 
     const popoverWidth = contentArea.width();

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -273,6 +273,29 @@ DOM.html = function html(el, contents, stripTags) {
 };
 
 /**
+ * Replace content of a DOM element
+ * @param {HTMLElement|SVGElement|jQuery[]} el The element to append to
+ * @param {string|jQuery} contents The html string or jQuery object.
+ * @param {string} stripTags A list of tags to strip to prevent xss, or * for sanitizing and allowing all tags.
+ */
+DOM.replaceHtml = function replaceHtml(el, contents, stripTags) {
+  let domEl = el;
+  let domContents = contents;
+
+  if (el instanceof $ && el.length) {
+    domEl = domEl[0];
+  }
+
+  if (contents instanceof $ && el.length) {
+    domContents = contents[0];
+  }
+
+  if (domEl instanceof HTMLElement || domEl instanceof SVGElement) {
+    domEl.replaceChildren(this.xssClean(domContents, stripTags));
+  }
+};
+
+/**
  * Recursively checks parent nodes for a matching CSS selector
  * @param {HTMLElement/SVGElement} el the lower-level element being checked
  * @param {string} selector a valid CSS selector


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
This pull request provides alternative solution for the #7677 issue. It allows to use other components with event handlers, without the need to destroy them, when popover is hidden and recreate them before popover is shown.

**Related github/jira issue (required)**:
Closes #7677 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/popover/test-nested
- Click buttons to check popover
- Try typing in the text area (check the counter) or try to expand datagrid row
- Close and open again
- Try typing in the text area (check the counter) or try to expand datagrid row
- smoke test tooltip and popover components

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
