### PR TITLE
8037 - Fix env for safari

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,10 +32,11 @@
 - `[Chart]` Fixed on focus border being off in chart legend items. ([#7850](https://github.com/infor-design/enterprise/issues/7850))
 - `[Column]` Fixed the size of the chart titles in columns. ([#7889](https://github.com/infor-design/enterprise/issues/7889))
 - `[Column]` Fixed an error loading on windows and a warning. ([#7941](https://github.com/infor-design/enterprise/issues/7941))
+- `[Contextmenu]` Changed color of checkbox in dark mode. ([#7991](https://github.com/infor-design/enterprise/issues/7991))
 - `[Datagrid]` Fixed a bug where the validation icon position was not correct in RTL (Right-to-Left) mode. ([#7768](https://github.com/infor-design/enterprise/issues/7768))
 - `[Datagrid]` Added undefined check for column settings to avoid errors in spacer. ([#7807](https://github.com/infor-design/enterprise/issues/7807))
 - `[Datagrid]` Added Placeholder for Datagrid Date Field. ([NG#1531](https://github.com/infor-design/enterprise-ng/issues/1531))
-- `[Datagrid]` Adjusted positioning of drilldown button. ([#7014](https://github.com/infor-design/enterprise/issues/7014))
+- `[Datagrid]` Adjusted positioning of `drilldown` button. ([#7014](https://github.com/infor-design/enterprise/issues/7014))
 - `[Datagrid]` Added a test page for column filter locale settings. ([#7554](https://github.com/infor-design/enterprise/issues/7554)
 - `[Datagrid]` Adjusted positioning of `drilldown` button. ([#7014](https://github.com/infor-design/enterprise/issues/7014))
 - `[Datagrid]` Fixed a bug where expanded rows showed as activated. ([#7979](https://github.com/infor-design/enterprise/issues/7979))
@@ -66,7 +67,7 @@
 - `[Toolbar]` Added additional selectors and colors for dark theme dropdown label. ([#7897](https://github.com/infor-design/enterprise/issues/7897))
 - `[Tree]` Fixed Cross-Site Scripting (XSS) when setting up tree node. ([#7631](https://github.com/infor-design/enterprise/issues/7631))
 - `[Weekview]` Adjusted the positioning of text within the footer cell to keep it centered. Adjusted calendar icon position to be better aligned. ([#7926](https://github.com/infor-design/enterprise/issues/7926))
-- `[Weekview]` Added event modal on doubleclick. ([#7824](https://github.com/infor-design/enterprise/issues/7824))
+- `[Weekview]` Added event modal on `doubleclick`. ([#7824](https://github.com/infor-design/enterprise/issues/7824))
 
 ## v4.87.0
 

--- a/src/components/place/place.js
+++ b/src/components/place/place.js
@@ -553,7 +553,7 @@ Place.prototype = {
   /**
    * Checks if the parent element is in viewport
    * @param {Object} parentElement element to be checked
-   * @returns {boolean}
+   * @returns {boolean} whether or not the element is in the viewport
    */
   isParentElementinViewport(parentElement) {
     if (typeof jQuery === 'function' && parentElement instanceof jQuery) {
@@ -839,7 +839,6 @@ Place.prototype = {
     const windowH = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
     const windowW = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
 
-    console.log('shrink');
     // Figure out the viewport boundaries
     const leftViewportEdge = (accountForScrolling ? scrollX : 0) +
       (containerBleed ? 0 : containerRect.left) + placementObj.containerOffsetX;

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -989,8 +989,7 @@ PopupMenu.prototype = {
       if (!leftClick) {
         this.menu.parent().on('contextmenu.popupmenu', disableBrowserContextMenu);
 
-        const disallowedOS = ['android', 'ios'];
-        if (disallowedOS.indexOf(env.os.name) === -1) {
+        if (!env.features.touch) {
           // Normal desktop operation
           this.element
             .on('contextmenu.popupmenu', (e) => {

--- a/src/utils/environment.js
+++ b/src/utils/environment.js
@@ -138,6 +138,7 @@ const Environment = {
 
     const macosPlatforms = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'];
     if (macosPlatforms.indexOf(platform) > -1 && !/Linux/.test(platform)) {
+      cssClasses = cssClasses.replace('ios ', '');
       cssClasses += 'is-mac ';
       this.os.name = 'mac';
     }

--- a/src/utils/environment.js
+++ b/src/utils/environment.js
@@ -87,12 +87,6 @@ const Environment = {
       this.browser.name = 'chrome';
     }
 
-    const macosPlatforms = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'];
-    if (macosPlatforms.indexOf(platform) > -1 && !/Linux/.test(platform)) {
-      cssClasses += 'is-mac ';
-      this.os.name = 'mac';
-    }
-
     if (ua.indexOf('Firefox') > 0) {
       cssClasses += 'is-firefox ';
       this.browser.name = 'firefox';
@@ -140,6 +134,12 @@ const Environment = {
           this.device = iDevices[i];
         }
       }
+    }
+
+    const macosPlatforms = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'];
+    if (macosPlatforms.indexOf(platform) > -1 && !/Linux/.test(platform)) {
+      cssClasses += 'is-mac ';
+      this.os.name = 'mac';
     }
 
     if ((/Android/.test(ua))) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes an issue where context menu right clicking stopped working in safari. This may be due to some changes in the safari user agent.

To Fix:

- made isMac override is IOS
- changed to use touch (feature detection)

**Related github/jira issue (required)**:
Fixes #8037 

**Steps necessary to review your pull request (required)**:
- test http://localhost:4000/components/contextmenu/example-index.html
- need to test on every browser and devices
- on touch devices like IOS and android a longpress will open on the input will open the menu
- on mac/windows -> safari and chrome a right click will open the menu 
- run page http://localhost:4000/components/environment/example-browser-specs.html on the same devices and check `Soho.env.devicespecs.os`

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
