### PR TITLE
8047 - Fix zoom issue on windows

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -73,6 +73,7 @@
 - `[Searchfield]` Fix ability to select and delete text in firefox. Adjusted custom button positioning. ([#7962](https://github.com/infor-design/enterprise/issues/7962))
 - `[Searchfield]` Fixed on go button misalignment. ([#7910](https://github.com/infor-design/enterprise/issues/7910))
 - `[Tabs]` Fixed the focus alignment in tabs for RTL. ([#7772](https://github.com/infor-design/enterprise/issues/7772))
+- `[Tabs]` Added fixes for zoom issue on vertical tabs. ([#8046](https://github.com/infor-design/enterprise/issues/8046))
 - `[Toolbar]` Added additional selectors and colors for dark theme dropdown label. ([#7897](https://github.com/infor-design/enterprise/issues/7897))
 - `[Tree]` Fixed Cross-Site Scripting (XSS) when setting up tree node. ([#7631](https://github.com/infor-design/enterprise/issues/7631))
 - `[Weekview]` Adjusted the positioning of text within the footer cell to keep it centered. Adjusted calendar icon position to be better aligned. ([#7926](https://github.com/infor-design/enterprise/issues/7926))

--- a/src/components/tabs-vertical/_tabs-vertical-new.scss
+++ b/src/components/tabs-vertical/_tabs-vertical-new.scss
@@ -1,14 +1,14 @@
 
 .tab-container.vertical {
   background-color: $vertical-tab-background-color;
-  border-right: 1px solid $vertical-tab-border-color;
 
   > .tab-list-container {
     background-color: $vertical-tab-background-color;
+    border-right: 1px solid $vertical-tab-border-color;
 
     > .tab-list {
       > .tab {
-        max-width: 250px;
+        width: 250px;
         max-height: 40px;
 
         a {

--- a/src/components/tabs-vertical/_tabs-vertical.scss
+++ b/src/components/tabs-vertical/_tabs-vertical.scss
@@ -222,7 +222,6 @@
   min-height: 200px;
   min-width: 250px;
   position: relative;
-  border-right: 1px solid transparent;
 
   > .tab-list,
   > .tab-list-container {
@@ -275,7 +274,7 @@
     display: inline-block;
     margin: 0;
     vertical-align: top;
-    width: calc(100% - 251px);
+    width: calc(100% - 250px);
 
     &.scrollable,
     &.scrollable-x,


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes an irregular size (250 and 100% - 251) that caused tab panes to overflow on zoom. And removed a "double" border.

**Related github/jira issue (required)**:
Fixes #8046 

**Steps necessary to review your pull request (required)**:
- Go to http://localhost:4000/components/tabs-vertical/example-index.html
- Zoom in (50%) on my monitor (try lots of zoom levels 40-50% min)
- Notice content will not disappear
- Test classic/other themes that the right border is still ok

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
