### PR TITLE
7970 - Fix alignment of icons in tabs dropdown menu.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - `[Module Nav]` Fixed a bug where the accordion in the page container inherited module nav accordion styles. ([#8040](https://github.com/infor-design/enterprise/issues/7884))
 - `[Spinbox]` Adjusted spinbox wrapper sizing to stop increment button from overflowing in classic. ([#7988](https://github.com/infor-design/enterprise/issues/7988))
+- `[Tabs]` Adjusted placement of icons in tab list spillover. ([#7970](https://github.com/infor-design/enterprise/issues/7970))
 
 ## v4.88.0
 

--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -116,8 +116,6 @@
               padding-right: 6px;
               position: absolute;
               right: 1px;
-              top: 1px;
-              transform: translateY(50%);
             }
           }
         }
@@ -291,7 +289,7 @@
         padding-left: 57px;
       }
 
-      .icon:not(.arrow) {
+      .icon:not(.arrow):not(.close) {
         left: 58px;
       }
     }
@@ -300,7 +298,7 @@
       &:not(.arrow) {
         height: 14px;
         margin-left: -28px;
-        margin-top: 10px;
+        margin-top: 0;
         pointer-events: none;
         position: absolute;
       }

--- a/src/components/tabs/_tabs-new.scss
+++ b/src/components/tabs/_tabs-new.scss
@@ -97,7 +97,7 @@
     &.icon-error,
     &.icon-info,
     &.icon-alert {
-      top: 10px;
+      top: 9px;
     }
   }
 }

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -741,7 +741,8 @@ html.theme-classic-contrast .tab-container.alternate.header-tabs > .tab-list-con
         height: 14px;
         position: absolute;
         right: 5px;
-        top: 9px;
+        top: 1px;
+        transform: translateY(50%);
       }
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Adjusted placement of error and dismissible icons in tabs spillover/dropdown menu.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise/issues/7970

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build, and run the app.
- Go to http://localhost:4000/components/tabs/example-enable-disable.html
- Open the "Can Have Error Icon" tab.
- Type anything in any of the required fields.
- Delete all text from required fields to trigger the error icon.
- Shrink window size/switch to responsive view until the tabs spillover/dropdown menu is shown.
- Open the dropdown menu.
- "Error" icon should be aligned.

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
