### PR TITLE
8056 - Fix quad widget width

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - `[Checkbox]` Changed color of checkbox in dark mode. ([#7991](https://github.com/infor-design/enterprise/issues/7991))
 - `[Form/Label]` Implemented a form layout designed to facilitate an inline design within a responsive-form container. ([#7764](https://github.com/infor-design/enterprise/issues/7764))
+- `[Homepages]` Changed incorrect width on quad widgets. ([#8056](https://github.com/infor-design/enterprise/issues/8056))
 - `[Module Nav]` Added usage guidance to docs. ([#7869](https://github.com/infor-design/enterprise/issues/7869))
 - `[Module Nav]` Added mobile behaviors. ([#7804](https://github.com/infor-design/enterprise/issues/7804))
 - `[Module Nav]` Fixed an alignment issue. ([#7934](https://github.com/infor-design/enterprise/issues/7934))

--- a/src/components/homepage/_homepage.scss
+++ b/src/components/homepage/_homepage.scss
@@ -221,7 +221,7 @@
 .widget.quintuple-width.to-single,
 .card.sextuple-width.to-single,
 .widget.sextuple-width.to-single {
-  width: 360px; // 320 (single)
+  width: 360px; // 360 (single)
 }
 
 .small-widget.double-width.to-single,
@@ -229,7 +229,7 @@
 .small-widget.quad-width.to-single,
 .small-widget.quintuple-width.to-single,
 .small-widget.sextuple-width.to-single {
-  width: 260px; // 320 (single)
+  width: 260px; // 260 (single)
 }
 
 .card.double-width,
@@ -242,7 +242,7 @@
 .widget.quintuple-width.to-double,
 .card.sextuple-width.to-double,
 .widget.sextuple-width.to-double {
-  width: 736px; // 660 (double: 380 + single)
+  width: 736px; // (360 * 2) + 16
 }
 
 .small-widget.double-width,
@@ -261,7 +261,7 @@
 .widget.quintuple-width.to-triple,
 .card.sextuple-width.to-triple,
 .widget.sextuple-width.to-triple {
-  width: 1112px; //1000 (triple: 380 + double)
+  width: 1112px; // (360 * 3) + (16 * 2)
 }
 
 .small-widget.triple-width,
@@ -277,7 +277,7 @@
 .widget.quintuple-width.to-quad,
 .card.sextuple-width.to-quad,
 .widget.sextuple-width.to-quad {
-  width: 1500px; //1340 (quad: 380 + triple)
+  width: 1488px; // (360 * 4)+(16 * 3)
 }
 
 .small-widget.quad-width,
@@ -290,7 +290,7 @@
 .widget.quintuple-width,
 .card.sextuple-width.to-quintuple,
 .widget.sextuple-width.to-quintuple {
-  width: 1880px; //1680 (quintuple: 380 + quad)
+  width: 1864; // (360 * 5)+(16 * 4)
 }
 
 .small-widget.quintuple-width,
@@ -300,7 +300,7 @@
 
 .card.sextuple-width,
 .widget.sextuple-width {
-  width: 2260px;
+  width: 2240; // (360 * 6)+(16 * 5)
 }
 
 .small-widget.sextuple-width {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes an incorrect calc on quad width widgets. (not added patch already to 4.88)

**Related github/jira issue (required)**:
Fixes #8056 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/homepage/example-scenario-i.html
- also test http://localhost:4000/components/homepage/example-scenario-i.html
- in all cases widgets should line up in width
- for good measure test all scenarios http://localhost:4000/components/homepage/ (for QA)

**Included in this Pull Request**:
- [x] A note to the change log.
