### PR TITLE
8063 - Add fixes to keep settings menu visible

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Accordion]` Adjusted rules of accordion top border to be consistent whether open or closed. ([#7978](https://github.com/infor-design/enterprise/issues/7978))
 - `[Button]` Adjusted rule for primary button styling when hovered in new version. ([#7977](https://github.com/infor-design/enterprise/issues/7977))
 - `[Datagrid]` Fixed the position of empty message without icon in the datagrid. ([#7854](https://github.com/infor-design/enterprise/issues/7854))
+- `[Module Nav]` Fixed a bug where the settings was behind the main module nav element. ([#8063](https://github.com/infor-design/enterprise/issues/8063))
 - `[Module Nav]` Fixed a bug where the accordion in the page container inherited module nav accordion styles. ([#8040](https://github.com/infor-design/enterprise/issues/7884))
 - `[Spinbox]` Adjusted spinbox wrapper sizing to stop increment button from overflowing in classic. ([#7988](https://github.com/infor-design/enterprise/issues/7988))
 - `[Tabs]` Adjusted placement of icons in tab list spillover. ([#7970](https://github.com/infor-design/enterprise/issues/7970))

--- a/src/components/module-nav/module-nav.js
+++ b/src/components/module-nav/module-nav.js
@@ -206,10 +206,12 @@ ModuleNav.prototype = {
       $(this.accordionEl).on(`aftercollapse.${COMPONENT_NAME}`, () => {
         this.setScrollable();
       });
-      $(this.accordionEl).on(`selected.${COMPONENT_NAME}`, () => {
+      $(this.accordionEl).on(`selected.${COMPONENT_NAME}`, (e, header) => {
+        if ($(header).is('#module-nav-settings-btn')) return;
         this.handleAutoCollapseOnMobile();
       });
-      $(this.accordionEl).on(`followlink.${COMPONENT_NAME}`, () => {
+      $(this.accordionEl).on(`followlink.${COMPONENT_NAME}`, (e, header) => {
+        if ($(header).is('#module-nav-settings-btn')) return;
         this.handleAutoCollapseOnMobile();
       });
     }

--- a/src/components/module-nav/module-nav.settings.scss
+++ b/src/components/module-nav/module-nav.settings.scss
@@ -7,6 +7,10 @@
   padding-inline: 0;
 }
 
+.popupmenu-wrapper.module-nav-settings-menu {
+  z-index: 8500;
+}
+
 .popupmenu.module-nav-settings-menu {
   @include settings-menu-box-shadow;
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes a bug reported by @krishollenbeck where the settings menu is hidden. Will patch to 4.84 and 4.88 when tested.

**Related github/jira issue (required)**:
Fixes #8063 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/module-nav/example-index.html?colors=fff
- on desktop size:
- open the menu
- click the settings menu -> settings menu should now be visible and actionable
- on mobile size:
- open the menu
- click the settings menu -> settings menu should now be visible and actionable and the menu should be on top
- should still be able to select an item in the settings menu, when it closes select a nav item and it should shut the menu on mobile

**Included in this Pull Request**:
- [x] A note to the change log.
