### PR TITLE
8065 - Make slate color darker

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - `[Accordion]` Adjusted rules of accordion top border to be consistent whether open or closed. ([#7978](https://github.com/infor-design/enterprise/issues/7978))
 - `[Button]` Adjusted rule for primary button styling when hovered in new version. ([#7977](https://github.com/infor-design/enterprise/issues/7977))
+- `[Colors]` Made slate 01 darker based on feedback. ([#8065](https://github.com/infor-design/enterprise/issues/8065))
 - `[Datagrid]` Fixed the position of empty message without icon in the datagrid. ([#7854](https://github.com/infor-design/enterprise/issues/7854))
 - `[Module Nav]` Fixed a bug where the accordion in the page container inherited module nav accordion styles. ([#8040](https://github.com/infor-design/enterprise/issues/7884))
 - `[Spinbox]` Adjusted spinbox wrapper sizing to stop increment button from overflowing in classic. ([#7988](https://github.com/infor-design/enterprise/issues/7988))

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -1,6 +1,9 @@
 // Variables
 //================================================== //
 
+// Color Override
+$ids-color-palette-slate-10: #f5f5f5;
+
 // Form Background Color
 $header-bg-color: $ids-color-palette-azure-60;
 $subhead-bg-color: $ids-color-palette-azure-70;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

For initial testing. I will make this change to the ids-identity repo for the real fix.

**Related github/jira issue (required)**:
Fixes #8065 

**Steps necessary to review your pull request (required)**:
**List Of Areas with  (possibly) Slate 01**
Check things look ok in all themes (easies on kitchen sink http://localhost:4000/). Some call outs:

- http://localhost:4000/components/applicationmenu/test-six-levels.html -> h1-h5 content
- http://localhost:4000/components/masthead/example-index.html -> masthead title text
- http://localhost:4000/components/datagrid/example-index.html -> header color
- http://localhost:4000/components/popupmenu/example-index.html?theme=new&mode=dark&colors=default -> menu items
- http://localhost:4000/components/module-nav/example-index.html?colors=fff -> module nav bg color
- http://localhost:4000/components/tabs-vertical/example-index.html -> background color (looks good)
- http://localhost:4000/components/header/example-breadcrumbs.html -> header breadcrumb color
- http://localhost:4000/?theme=new&mode=contrast&colors=default -> lots in contrast mode
- http://localhost:4000/?theme=new&mode=dark&colors=default -> lots in dark mode

** Design QA Links**
- https://8065-slate01-enterprise.demo.design.infor.com/components/applicationmenu/test-six-levels.html -> h1-h5 content
- https://8065-slate01-enterprise.demo.design.infor.com/components/masthead/example-index.html -> masthead title text
- https://8065-slate01-enterprise.demo.design.infor.com/components/datagrid/example-index.html -> header color
- https://8065-slate01-enterprise.demo.design.infor.com/components/popupmenu/example-index.html?theme=new&mode=dark&colors=default -> menu items
- https://8065-slate01-enterprise.demo.design.infor.com/components/module-nav/example-index.html?colors=fff -> module nav bg color
- https://8065-slate01-enterprise.demo.design.infor.com/components/tabs-vertical/example-index.html -> background color (looks good)
- https://8065-slate01-enterprise.demo.design.infor.com/components/header/example-breadcrumbs.html -> header breadcrumb color
- https://8065-slate01-enterprise.demo.design.infor.com/?theme=new&mode=contrast&colors=default -> lots in contrast mode
- https://8065-slate01-enterprise.demo.design.infor.com/?theme=new&mode=dark&colors=default -> lots in dark mode

**Included in this Pull Request**:
- [x] A note to the change log.
