### PR TITLE
NG1552 - Fix on shared menu not closing and opening correctly

### DIFF
--- a/app/views/components/popupmenu/test-share-popup.html
+++ b/app/views/components/popupmenu/test-share-popup.html
@@ -1,0 +1,44 @@
+<div class="row">
+  <div class="twelve columns">
+
+    <div class="field">
+      <button id="popupmenu-trigger" class="btn-menu" data-init="false">
+        <span>Normal Menu</span>
+        <svg role="presentation" aria-hidden="true" focusable="false" class="icon icon-dropdown">
+          <use href="#icon-dropdown"></use>
+        </svg>
+      </button>
+      <button id="popupmenu-trigger-2" class="btn-menu" data-init="false">
+        <span>Normal Menu 2</span>
+        <svg role="presentation" aria-hidden="true" focusable="false" class="icon icon-dropdown">
+          <use href="#icon-dropdown"></use>
+        </svg>
+      </button>
+      <ul id="popup-menu" class="popupmenu" data-init="false">
+      </ul>
+    </div>
+
+  </div>
+</div>
+
+<script id="test-script">
+  const beforeOpen = (response, options) =>  {
+    response(`<li><a href="#" id="test1">Menu Option #1</a></li>
+        <li><a href="#" id="test2">Menu Option #2</a></li>
+        <li><a href="#" id="test3">Menu Option #3</a></li>`);
+  }
+
+  const beforeOpen2 = (response, options) =>  {
+    response(`<li><a href="#" id="test1">Menu Option #4</a></li>
+        <li><a href="#" id="test2">Menu Option #5</a></li>
+        <li><a href="#" id="test3">Menu Option #6</a></li>`);
+  }
+  $('#popupmenu-trigger').popupmenu({
+    beforeOpen: beforeOpen,
+    menu: 'popup-menu'
+  });
+  $('#popupmenu-trigger-2').popupmenu({
+    beforeOpen: beforeOpen2,
+    menu: 'popup-menu'
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Accordion]` Adjusted rules of accordion top border to be consistent whether open or closed. ([#7978](https://github.com/infor-design/enterprise/issues/7978))
 - `[Datagrid]` Fixed the position of empty message without icon in the datagrid. ([#7854](https://github.com/infor-design/enterprise/issues/7854))
 - `[Module Nav]` Fixed a bug where the accordion in the page container inherited module nav accordion styles. ([#8040](https://github.com/infor-design/enterprise/issues/7884))
+- `[Popupmenu]` Fix on shared menu not closing and opening correctly. ([NG#1552](https://github.com/infor-design/enterprise-ng/issues/1552))
 - `[Spinbox]` Adjusted spinbox wrapper sizing to stop increment button from overflowing in classic. ([#7988](https://github.com/infor-design/enterprise/issues/7988))
 - `[Tabs]` Adjusted placement of icons in tab list spillover. ([#7970](https://github.com/infor-design/enterprise/issues/7970))
 - `[Weekview]` Added overnight event view when end time goes to next day. ([#7840](https://github.com/infor-design/enterprise/issues/7840))

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -974,6 +974,10 @@ PopupMenu.prototype = {
         self.holdingDownClick = true;
       }
 
+      if (self.menu.hasClass('is-open')) {
+        self.close();
+      }
+
       doOpen(e);
     }
 
@@ -2408,7 +2412,7 @@ PopupMenu.prototype = {
       isCancelled = false;
     }
 
-    if (!this.menu || !this.isOpen) {
+    if (!(this.menu || this.isOpen)) {
       return;
     }
 
@@ -2621,7 +2625,6 @@ PopupMenu.prototype = {
       .removeAttr('aria-controls')
       .removeAttr('aria-haspopup')
       .off('touchend.popupmenu touchcancel.popupmenu click.popupmenu keydown.popupmenu keypress.popupmenu contextmenu.popupmenu updated.popupmenu');
-
     return this;
   },
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fix on shared menu not closing and opening correctly

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise-ng/issues/1552

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/popupmenu/test-share-popup.html
- Click on menu 1 button
- Click on menu 2 button
- Menu should close and open to next button with different options

**Included in this Pull Request**:\
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
