### PR TITLE
7955 - Tabs Radios Overflow

### DIFF
--- a/app/views/components/tabs/example-enable-disable-individual-tabs.html
+++ b/app/views/components/tabs/example-enable-disable-individual-tabs.html
@@ -107,15 +107,18 @@
         </fieldset>
 
         <fieldset class="radio-group">
-          <legend>Radio Buttons</legend>
-          <input type="radio" class="radio" name="radio" id="radio1" value="1" />
-          <label for="radio1" class="radio-label">Radio 1</label>
-          <br>
-          <input type="radio" class="radio" name="radio" id="radio2" value="2" />
-          <label for="radio2" class="radio-label">Radio 2</label>
-          <br>
-          <input type="radio" class="radio" name="radio" id="radio3" value="3" />
-          <label for="radio3" class="radio-label">Radio 3</label>
+          <div class="field">
+            <legend>Radio Buttons</legend>
+            <input type="radio" class="radio" name="radio" id="radio1" value="1" />
+            <label for="radio1" class="radio-label">Radio 1</label>
+            <br>
+            <input type="radio" class="radio" name="radio" id="radio2" value="2" />
+            <label for="radio2" class="radio-label">Radio 2</label>
+            <br>
+            <input type="radio" class="radio" name="radio" id="radio3" value="3" />
+            <label for="radio3" class="radio-label">Radio 3</label>
+          </div>
+          
         </fieldset>
       </div>
       <div id="programmatic-tabs-disabled" class="tab-panel">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[ProcessIndicator]` Adjusted icon sizing to remove gaps between separators. ([#7982](https://github.com/infor-design/enterprise/issues/7982))
 - `[Spinbox]` Adjusted spinbox wrapper sizing to stop increment button from overflowing in classic. ([#7988](https://github.com/infor-design/enterprise/issues/7988))
 - `[Tabs]` Adjusted placement of icons in tab list spillover. ([#7970](https://github.com/infor-design/enterprise/issues/7970))
+- `[Tabs]` Fixed the focus state of radio button not fully shown in tabs. ([#7955](https://github.com/infor-design/enterprise/issues/7955))
 - `[Weekview]` Added overnight event view when end time goes to next day. ([#7840](https://github.com/infor-design/enterprise/issues/7840))
 - `[Weekview]` Fixed an issue with the week change when clicking the `Today` button. ([#7792](https://github.com/infor-design/enterprise/issues/7792))
 - `[Validation]` Fixed the position of exclamation points of validation in non english localization. ([#5119](https://github.com/infor-design/enterprise/issues/5119))

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -352,7 +352,7 @@ html[dir='rtl'] {
   .inline .radio ~ .label-text::after,
   .radio + label::after {
     left: auto;
-    right: 4px;
+    right: 0;
   }
 
   // Adjust the label padding for RTL in short mode

--- a/src/components/tabs-header/_tabs-header-new.scss
+++ b/src/components/tabs-header/_tabs-header-new.scss
@@ -282,7 +282,7 @@
   .tab-panel {
     overflow-y: auto;
     margin-top: -5px;
-    padding-inline-start: 2px;
+    padding-inline-start: 4px;
   }
 }
 

--- a/src/components/tabs-header/_tabs-header-new.scss
+++ b/src/components/tabs-header/_tabs-header-new.scss
@@ -282,6 +282,7 @@
   .tab-panel {
     overflow-y: auto;
     margin-top: -5px;
+    padding-inline-start: 2px;
   }
 }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix the focus state of radio button not fully shown in tabs.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/7955

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/tabs/example-enable-disable-individual-tabs.html
- Click one radio button
- Press arrow down or up (depending on what you radio button clicked)
- See the focus

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

