### PR TITLE
7849 - Space between text in rows are not trimmed as default

### DIFF
--- a/app/data/datagrid-sample-data.json
+++ b/app/data/datagrid-sample-data.json
@@ -95,5 +95,19 @@
      "phone": "(888) 888-8888",
      "orderDate": "2018-08-08T06:00:00.000Z",
      "action": "On Hold"
-  }
+  },
+  {
+      "id": "7",
+      "productId": "SPC     2642206",
+      "sku": "#9000001-231",
+      "productName": "  Some    Space       Compressor",
+      "activity": "inspect and Repair",
+      "quantity": 41,
+      "price": 123.99,
+      "percent": 0.10,
+      "status": "OK",
+      "phone": "(888) 888-8888",
+      "orderDate": "2018-08-08T06:00:00.000Z",
+      "action": "On Hold"
+   }
 ]

--- a/app/views/components/datagrid/example-index.html
+++ b/app/views/components/datagrid/example-index.html
@@ -27,6 +27,7 @@
           columns: columns,
           dataset: res,
           saveColumns: false,
+          showSpace: true,
           attributes: [{ name: 'id', value: 'custom-id' }, { name: 'data-automation-id', value: 'custom-automation-id' } ],
           toolbar: {title: 'Compressors', results: true, actions: true, rowHeight: true, personalize: true}
         });

--- a/app/views/components/datagrid/example-index.html
+++ b/app/views/components/datagrid/example-index.html
@@ -13,8 +13,8 @@
       $.getJSON('{{basepath}}api/datagrid-sample-data', function(res) {
 
         // Define Columns for the Grid.
-        columns.push({ id: 'productId', hideable: false, name: 'Id', field: 'productId', formatter: Soho.Formatters.Text });
-        columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Soho.Formatters.Hyperlink, click: function(e) { console.log('Click Fired') } });
+        columns.push({ id: 'productId', hideable: false, name: 'Id', field: 'productId', formatter: Soho.Formatters.Text, whiteSpace: 'pre-wrap' });
+        columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Soho.Formatters.Hyperlink, click: function(e) { console.log('Click Fired') }, whiteSpace: 'pre-wrap' });
         columns.push({ id: 'activity', name: 'Activity', field: 'activity'});
         columns.push({ id: 'hidden', hidden: true, name: 'Hidden', field: 'hidden'});
         columns.push({ id: 'price', align: 'right', name: 'Actual Price', field: 'price', formatter: Soho.Formatters.Decimal, numberFormat: {minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'currency', currencySign: '$'}});
@@ -27,7 +27,6 @@
           columns: columns,
           dataset: res,
           saveColumns: false,
-          showSpace: true,
           attributes: [{ name: 'id', value: 'custom-id' }, { name: 'data-automation-id', value: 'custom-automation-id' } ],
           toolbar: {title: 'Compressors', results: true, actions: true, rowHeight: true, personalize: true}
         });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Accordion]` Adjusted rules of accordion top border to be consistent whether open or closed. ([#7978](https://github.com/infor-design/enterprise/issues/7978))
 - `[Button]` Adjusted rule for primary button styling when hovered in new version. ([#7977](https://github.com/infor-design/enterprise/issues/7977))
 - `[Datagrid]` Fixed the position of empty message without icon in the datagrid. ([#7854](https://github.com/infor-design/enterprise/issues/7854))
+- `[Datagrid]` Space between text in rows are not trimmed as default. ([#7849](https://github.com/infor-design/enterprise/issues/7849))
 - `[Module Nav]` Fixed a bug where the settings was behind the main module nav element. ([#8063](https://github.com/infor-design/enterprise/issues/8063))
 - `[Module Nav]` Fixed a bug where the accordion in the page container inherited module nav accordion styles. ([#8040](https://github.com/infor-design/enterprise/issues/7884))
 - `[Searchfield]` Adjusted width on mobile. ([#6831](https://github.com/infor-design/enterprise/issues/6831))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -2699,7 +2699,7 @@ $datagrid-small-row-height: 25px;
     overflow: hidden;
     text-overflow: ellipsis;
     -webkit-text-size-adjust: none; //Prevent huge text on IOS
-    white-space: nowrap;
+    white-space: pre-wrap;
 
     &:focus,
     &.is-focused {
@@ -3411,6 +3411,10 @@ $datagrid-small-row-height: 25px;
         display: none;
       }
     }
+  }
+
+  &.trim-space td {
+    white-space: nowrap;
   }
 
   // Nested Grids

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -337,6 +337,11 @@ $datagrid-small-row-height: 25px;
     height: calc(100% - 40px);
   }
 
+
+  &.show-space td {
+    white-space: pre-wrap;
+  }
+
   // Hide last bottom border
   tr:last-child td {
     border-bottom: 0;
@@ -2699,7 +2704,7 @@ $datagrid-small-row-height: 25px;
     overflow: hidden;
     text-overflow: ellipsis;
     -webkit-text-size-adjust: none; //Prevent huge text on IOS
-    white-space: pre-wrap;
+    white-space: nowrap;
 
     &:focus,
     &.is-focused {
@@ -3411,10 +3416,6 @@ $datagrid-small-row-height: 25px;
         display: none;
       }
     }
-  }
-
-  &.trim-space td {
-    white-space: nowrap;
   }
 
   // Nested Grids

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -115,7 +115,6 @@ const COMPONENT_NAME = 'datagrid';
  * @param {boolean}  [settings.disableRowDeactivation=false] if a row is activated the user will not be able to deactivate it by clicking on the activated row
  * @param {boolean}  [settings.disableRowDeselection=false] if a row is selected the user will not be able to deselect it by clicking on the selected row again
  * @param {boolean}  [settings.sizeColumnsEqually=false] If true make all the columns equal width
- * @param {boolean}  [settings.showSpace=false] If true all text space will be shown, if false, extra space will be trimmed
  * @param {boolean}  [settings.expandableRow=false] If true we append an expandable row area without the rowTemplate feature being needed.
  * @param {boolean}  [settings.exportConvertNegative=false] If set to true export data with trailing negative signs moved in front.
  * @param {array}    [settings.columnGroups=null] An array of columns to use for grouped column headers.
@@ -493,10 +492,6 @@ Datagrid.prototype = {
     if (this.settings.emptyMessage) {
       self.setEmptyMessage(this.settings.emptyMessage);
       self.checkEmptyMessage();
-    }
-
-    if (this.settings.showSpace) {
-      this.element.addClass('show-space');
     }
 
     self.buttonSelector = '.btn, .btn-secondary, .btn-primary, .btn-modal-primary, .btn-tertiary, .btn-icon, .btn-actions, .btn-menu, .btn-split';
@@ -5033,7 +5028,8 @@ Datagrid.prototype = {
         }${colspan ? ` colspan="${colspan}"` : ''
         }${col.tooltip && typeof col.tooltip === 'string' ? ` title="${col.tooltip.replace('{{value}}', cellValue)}"` : ''
         }${self.settings.columnGroups ? `headers = "${self.uniqueId(`-header-${j}`)} ${self.getColumnGroup(j)}"` : ''
-        }${rowspan || ''}>${rowStatus.svg}<div class="datagrid-cell-wrapper">`;
+        }${rowspan || ''}>${rowStatus.svg}<div class="datagrid-cell-wrapper"
+        ${col.whiteSpace ? `style="white-space: ${col.whiteSpace}"` : ''}>`;
 
       if (col.contentVisible) {
         const canShow = col.contentVisible(dataRowIdx + 1, j, cellValue, col, rowData);

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -494,8 +494,8 @@ Datagrid.prototype = {
       self.checkEmptyMessage();
     }
 
-    if (this.settings.trimSpaces) {
-      this.element.addClass('trim-space');
+    if (this.settings.showSpace) {
+      this.element.addClass('show-space');
     }
 
     self.buttonSelector = '.btn, .btn-secondary, .btn-primary, .btn-modal-primary, .btn-tertiary, .btn-icon, .btn-actions, .btn-menu, .btn-split';

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -115,6 +115,7 @@ const COMPONENT_NAME = 'datagrid';
  * @param {boolean}  [settings.disableRowDeactivation=false] if a row is activated the user will not be able to deactivate it by clicking on the activated row
  * @param {boolean}  [settings.disableRowDeselection=false] if a row is selected the user will not be able to deselect it by clicking on the selected row again
  * @param {boolean}  [settings.sizeColumnsEqually=false] If true make all the columns equal width
+ * @param {boolean}  [settings.showSpace=false] If true all text space will be shown, if false, extra space will be trimmed
  * @param {boolean}  [settings.expandableRow=false] If true we append an expandable row area without the rowTemplate feature being needed.
  * @param {boolean}  [settings.exportConvertNegative=false] If set to true export data with trailing negative signs moved in front.
  * @param {array}    [settings.columnGroups=null] An array of columns to use for grouped column headers.

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -494,6 +494,10 @@ Datagrid.prototype = {
       self.checkEmptyMessage();
     }
 
+    if (this.settings.trimSpaces) {
+      this.element.addClass('trim-space');
+    }
+
     self.buttonSelector = '.btn, .btn-secondary, .btn-primary, .btn-modal-primary, .btn-tertiary, .btn-icon, .btn-actions, .btn-menu, .btn-split';
     $(self.buttonSelector, self.table).button();
 

--- a/test/components/datagrid/datagrid-filtering-func-test.js
+++ b/test/components/datagrid/datagrid-filtering-func-test.js
@@ -98,13 +98,13 @@ describe('Datagrid Filter API', () => {
     filter = [{ columnId: 'price', operator: 'greater-than', value: 121 }];
     datagridObj.applyFilter(filter);
 
-    expect(document.body.querySelectorAll('tbody tr').length).toEqual(5);
+    expect(document.body.querySelectorAll('tbody tr').length).toEqual(6);
 
     // Date Type
     filter = [{ columnId: 'orderDate', operator: 'greater-than', value: '07/09/2014', format: 'MM/dd/yyyy' }];
     datagridObj.applyFilter(filter);
 
-    expect(document.body.querySelectorAll('tbody tr').length).toEqual(7);
+    expect(document.body.querySelectorAll('tbody tr').length).toEqual(8);
 
     // Checkbox Type
     filter = [{ columnId: 'inStock', operator: 'selected' }];

--- a/test/components/datagrid/datagrid-filtering-func-test.js
+++ b/test/components/datagrid/datagrid-filtering-func-test.js
@@ -92,7 +92,7 @@ describe('Datagrid Filter API', () => {
       { columnId: 'phone', operator: 'equals', value: '(888) 888-8888' }];
     datagridObj.applyFilter(filter);
 
-    expect(document.body.querySelectorAll('tbody tr').length).toEqual(3);
+    expect(document.body.querySelectorAll('tbody tr').length).toEqual(4);
 
     // Integer Type
     filter = [{ columnId: 'price', operator: 'greater-than', value: 121 }];
@@ -147,7 +147,7 @@ describe('Datagrid Filter API', () => {
 
     datagridObj.clearFilter();
 
-    expect(document.body.querySelectorAll('tbody tr').length).toEqual(7);
+    expect(document.body.querySelectorAll('tbody tr').length).toEqual(8);
   });
 
   it.skip('should be able to set filter UI only', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Space between text in rows are not trimmed as default

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #7849 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datagrid/example-index.html
- Check last row, spaces should be shown in ID and Product Name 

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
