### PR TITLE
Adjusted the resets for spans

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Accordion]` Adjusted rules of accordion top border to be consistent whether open or closed. ([#7978](https://github.com/infor-design/enterprise/issues/7978))
 - `[Button]` Adjusted rule for primary button styling when hovered in new version. ([#7977](https://github.com/infor-design/enterprise/issues/7977))
 - `[Datagrid]` Fixed the position of empty message without icon in the datagrid. ([#7854](https://github.com/infor-design/enterprise/issues/7854))
+- `[General]` Adjusted the reset for spans. ([#1513](https://github.com/infor-design/enterprise/issues/7854))
 - `[Module Nav]` Fixed a bug where the settings was behind the main module nav element. ([#8063](https://github.com/infor-design/enterprise/issues/8063))
 - `[Module Nav]` Fixed a bug where the accordion in the page container inherited module nav accordion styles. ([#8040](https://github.com/infor-design/enterprise/issues/7884))
 - `[Popupmenu]` Fixed shared menu not closing and opening correctly. ([NG#1552](https://github.com/infor-design/enterprise-ng/issues/1552))

--- a/src/components/typography/_typography.scss
+++ b/src/components/typography/_typography.scss
@@ -59,7 +59,7 @@ h4,
 label,
 p,
 small,
-span,
+span.label,
 ul,
 ol {
   @include antialiased();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Moved spans out of the reset for font-weight

**Related github/jira issue (required)**:
Fixes https://github.com/infor-design/enterprise-wc/issues/1513

**Steps necessary to review your pull request (required)**:
- smoke test kitchen sink http://localhost:4000/ and http://localhost:4000/components/typography/example-index.html

**Included in this Pull Request**:
- [x] A note to the change log.