### PR TITLE
8081 - Fix cards menu button positioning for no header.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Accordion]` Adjusted rules of accordion top border to be consistent whether open or closed. ([#7978](https://github.com/infor-design/enterprise/issues/7978))
 - `[Button]` Adjusted rule for primary button styling when hovered in new version. ([#7977](https://github.com/infor-design/enterprise/issues/7977))
 - `[Button]` Adjusted rule for button styling on contextual action toolbars. ([#8084](https://github.com/infor-design/enterprise/issues/8084))
+- `[Cards]` Adjusted menu button positioning for no header. ([#8081](https://github.com/infor-design/enterprise/issues/8081))
 - `[Datagrid]` Fixed the position of empty message without icon in the datagrid. ([#7854](https://github.com/infor-design/enterprise/issues/7854))
 - `[Datagrid]` Space between text in rows are not trimmed as default. ([#7849](https://github.com/infor-design/enterprise/issues/7849))
 - `[Datagrid]` Added option to use for flex toolbar. ([#7928](https://github.com/infor-design/enterprise/issues/7928))

--- a/src/components/cards/_cards-new.scss
+++ b/src/components/cards/_cards-new.scss
@@ -75,21 +75,6 @@
     }
   }
 
-  &.no-header {
-    .card-content {
-      border-top-left-radius: 8px;
-      border-top-right-radius: 8px;
-
-      .btn-actions-wrapper {
-        min-width: 35px;
-        padding: 1px;
-        position: absolute;
-        right: 8px;
-        top: 8px;
-      }
-    }
-  }
-
   &:not(.show-buttons) button.btn-actions:not(.list-button) {
     opacity: 0;
   }

--- a/src/components/cards/_cards.scss
+++ b/src/components/cards/_cards.scss
@@ -101,6 +101,23 @@ $card-header-section: '.card-header-section', '.widget-header-section';
   position: relative;
   width: 100%;
 
+  &.no-header {
+    .card-content {
+      border-top-left-radius: 8px;
+      border-top-right-radius: 8px;
+
+      .btn-actions-wrapper {
+        min-width: 38px;
+        min-height: 38px;
+        padding: 2px;
+        margin: 1px;
+        position: absolute;
+        right: 8px;
+        top: 8px;
+      }
+    }
+  }
+
   &.border-less {
     background: none;
     border-color: transparent;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Adjusted positioning of card menu button for no header to be at the upper left of the card.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
CLoses https://github.com/infor-design/enterprise/issues/8081

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build, and run the app.
- Go to http://localhost:4000/components/cards/example-no-header.html?theme=classic&mode=light&colors=default
- Menu button should be at the upper left of the card.

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
