### PR TITLE
8071 - Fix on new row not showing error tooltip on first cell

### DIFF
--- a/app/views/components/datagrid/test-newrow-error.html
+++ b/app/views/components/datagrid/test-newrow-error.html
@@ -1,0 +1,52 @@
+<div class="row">
+  <div class="twelve columns">
+    <div role="toolbar" class="toolbar">
+      <div class="buttonset">
+        <button type="button" id="add-row-button" class="btn">
+          <span>Add Row</span>
+        </button>
+        <button type="button" id="add-error-button" class="btn">
+          <span>Add Error</span>
+        </button>
+      </div>
+    </div>
+    <div id="datagrid" class="datagrid">
+    </div>
+  </div>
+</div>
+
+<script id="datagrid-script">
+  $('body').one('initialized', function () {
+
+      let columns = [];
+      let gridApi;
+
+      $.getJSON('{{basepath}}api/datagrid-sample-data', function(res) {
+        columns.push({ id: 'productId', hideable: false, name: 'Id', field: 'productId', formatter: Soho.Formatters.Text, whiteSpace: 'pre-wrap' });
+        columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Soho.Formatters.Hyperlink, click: function(e) { console.log('Click Fired') }, whiteSpace: 'pre-wrap' });
+        columns.push({ id: 'activity', name: 'Activity', field: 'activity'});
+        columns.push({ id: 'hidden', hidden: true, name: 'Hidden', field: 'hidden'});
+        columns.push({ id: 'price', align: 'right', name: 'Actual Price', field: 'price', formatter: Soho.Formatters.Decimal, numberFormat: {minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'currency', currencySign: '$'}});
+        columns.push({ id: 'percent', align: 'right', name: 'Actual %', field: 'percent', formatter: Soho.Formatters.Decimal, numberFormat: {minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'percent'}});
+        columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Soho.Formatters.Date, dateFormat: 'M/d/yyyy'});
+        columns.push({ id: 'phone', name: 'Phone', field: 'phone', formatter: Soho.Formatters.Text});
+
+        gridApi = $('#datagrid').datagrid({
+          columns: columns,
+          dataset: res,
+          saveColumns: false,
+          attributes: [{ name: 'id', value: 'custom-id' }, { name: 'data-automation-id', value: 'custom-automation-id' } ],
+          toolbar: {title: 'Compressors', results: true, actions: true, rowHeight: true, personalize: true}
+        }).data('datagrid');
+
+        $('#add-row-button').on('click', function (e) {
+          gridApi.addRow({}, 0);
+        });
+
+        $('#add-error-button').on('click', function (e) {
+          gridApi.showCellError(0, 0, "TOOLTIP ERROR MESSAGE 0", "error");
+          gridApi.showCellError(0, 1, "TOOLTIP ERROR MESSAGE 1", "error");
+        });
+      });
+ });
+</script>

--- a/app/views/components/datagrid/test-newrow-error.html
+++ b/app/views/components/datagrid/test-newrow-error.html
@@ -44,8 +44,8 @@
         });
 
         $('#add-error-button').on('click', function (e) {
-          gridApi.showCellError(0, 0, "TOOLTIP ERROR MESSAGE 0", "error");
-          gridApi.showCellError(0, 1, "TOOLTIP ERROR MESSAGE 1", "error");
+          gridApi.showCellError(0, 0, "Tooltip Error Message 0", "error");
+          gridApi.showCellError(0, 1, "Tooltip Error Message 1", "error");
         });
       });
  });

--- a/app/views/components/datagrid/test-newrow-error.html
+++ b/app/views/components/datagrid/test-newrow-error.html
@@ -44,8 +44,8 @@
         });
 
         $('#add-error-button').on('click', function (e) {
-          gridApi.showCellError(0, 0, "Tooltip Error Message 0", "error");
-          gridApi.showCellError(0, 1, "Tooltip Error Message 1", "error");
+          gridApi.showCellError(0, 0, "Test tooltip 0", "error");
+          gridApi.showCellError(0, 1, "Test tooltip 1", "error");
         });
       });
  });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `[Datagrid]` Whitespace should be shown on cell when expanded. ([#7848](https://github.com/infor-design/enterprise/issues/7848))
 - `[Datagrid]` Additional check for modal width. ([#7923](https://github.com/infor-design/enterprise/issues/7923))
 - `[Datagrid]` Additional check for select row when datagrid has grouping and filter. ([NG#1549](https://github.com/infor-design/enterprise-ng/issues/1549))
+- `[Datagrid]` Fix on new row not showing error tooltip on first cell. ([#8071](https://github.com/infor-design/enterprise/issues/8071))
 - `[Datepicker]` Adjusted sizing of monthview popup to better accommodate smaller dimensions. ([#7974](https://github.com/infor-design/enterprise/issues/7974))
 - `[Datepicker]` Fixed datepicker prematurely closing after selecting a date when having a time format. ([#7916](https://github.com/infor-design/enterprise/issues/7916))
 - `[General]` Adjusted the reset for spans. ([#1513](https://github.com/infor-design/enterprise/issues/7854))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## v4.90.0 Fixes
 
+- `[Datagrid]` Fix on new row not showing error tooltip on first cell. ([#8071](https://github.com/infor-design/enterprise/issues/8071))
 - `[Modal]` Adjusted modal title spacing to avoid icon from cropping. ([#8031](https://github.com/infor-design/enterprise/issues/8031))
 
 ## v4.89.0
@@ -28,7 +29,6 @@
 - `[Datagrid]` Whitespace should be shown on cell when expanded. ([#7848](https://github.com/infor-design/enterprise/issues/7848))
 - `[Datagrid]` Additional check for modal width. ([#7923](https://github.com/infor-design/enterprise/issues/7923))
 - `[Datagrid]` Additional check for select row when datagrid has grouping and filter. ([NG#1549](https://github.com/infor-design/enterprise-ng/issues/1549))
-- `[Datagrid]` Fix on new row not showing error tooltip on first cell. ([#8071](https://github.com/infor-design/enterprise/issues/8071))
 - `[Datepicker]` Adjusted sizing of monthview popup to better accommodate smaller dimensions. ([#7974](https://github.com/infor-design/enterprise/issues/7974))
 - `[Datepicker]` Fixed datepicker prematurely closing after selecting a date when having a time format. ([#7916](https://github.com/infor-design/enterprise/issues/7916))
 - `[Dropdown]` Fixed a bug where the text and dropdown icon were overlapping on smaller viewports. ([#8000](https://github.com/infor-design/enterprise/issues/8000))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## v4.90.0 Fixes
 
-- `[Datagrid]` Fix on new row not showing error tooltip on first cell. ([#8071](https://github.com/infor-design/enterprise/issues/8071))
+- `[Datagrid]` Fixed an issue where the new row did not display an error tooltip on the first cell. ([#8071](https://github.com/infor-design/enterprise/issues/8071))
 - `[Fileupload]` Added condition to not allow for input clearing for readonly and disabled. ([#8024](https://github.com/infor-design/enterprise/issues/8024))
 - `[Modal]` Adjusted modal title spacing to avoid icon from cropping. ([#8031](https://github.com/infor-design/enterprise/issues/8031))
 

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -3411,7 +3411,7 @@ $datagrid-small-row-height: 25px;
     }
 
     &.is-dirty-cell,
-    &.error {
+    &.has-editor.error {
       .icon-rowstatus {
         display: none;
       }

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10766,7 +10766,8 @@ Datagrid.prototype = {
         placement: 'bottom',
         content: message,
         isError: type === 'error' || type === 'dirtyerror',
-        wrapper: icon
+        wrapper: icon,
+        y: 5
       };
       this.cacheTooltip(icon, tooltip);
       this.setupTooltips(false, true);

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5703,7 +5703,7 @@ Datagrid.prototype = {
     // Set selector
     const selector = {
       th: '.datagrid-header th',
-      td: '.datagrid-wrapper tbody tr.datagrid-row td[role="gridcell"]:not(.rowstatus-cell)',
+      td: '.datagrid-wrapper tbody tr.datagrid-row td[role="gridcell"]',
       rowstatus: '.datagrid-wrapper tbody tr.datagrid-row td[role="gridcell"] .icon-rowstatus',
       headerIcon: '.datagrid-header th .datagrid-header-icon'
     };

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -379,7 +379,7 @@
 }
 
 .tooltip-content {
-  padding: 6px 10px 3px;
+  padding: 10px 10px 3px;
   word-break: normal;
 
   &.header-icon {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fix on new row not showing error tooltip on first cell. 

Note: Made test page based on the instructions given on the issue. Should also be able to replicate it via console to be sure as no stackblitz example was given.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #8071 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datagrid/test-newrow-error.html
- Click on Add Row
- Click on Add Error
- Hover over the error icons
- Tooltip should appear

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
