### PR TITLE
NG1567 - Remove disabled prop in trigger button on enable call

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## v4.90.0 Fixes
 
 - `[Modal]` Adjusted modal title spacing to avoid icon from cropping. ([#8031](https://github.com/infor-design/enterprise/issues/8031))
+- `[Timepicker]` Remove `disabled` prop in trigger button on enable call. ([NG#1567](https://github.com/infor-design/enterprise-ng/issues/1567))
 
 ## v4.89.0
 

--- a/src/components/timepicker/timepicker.js
+++ b/src/components/timepicker/timepicker.js
@@ -1211,6 +1211,7 @@ TimePicker.prototype = {
    */
   enable() {
     this.element.removeAttr('disabled readonly').closest('.field').removeClass('is-disabled');
+    this.trigger.removeAttr('disabled');
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Remove disabled prop in trigger button on enable call

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise-ng/issues/1567

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/timepicker/test-states.html
- Click Disable
- Timepicker should be disabled
- Click Enable
- Timepicker should be enabled

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
