### PR TITLE
8078 - Fix hover state styling for Datagrid search and expand buttons.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## v4.90.0 Fixes
 
+- `[Datagrid]` Adjusted hover styling for search and expand buttons. ([#8078](https://github.com/infor-design/enterprise/issues/8078))
 - `[Fileupload]` Added condition to not allow for input clearing for readonly and disabled. ([#8024](https://github.com/infor-design/enterprise/issues/8024))
 - `[Modal]` Adjusted modal title spacing to avoid icon from cropping. ([#8031](https://github.com/infor-design/enterprise/issues/8031))
 

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -4648,7 +4648,7 @@ td .btn-actions {
   }
 
   .datagrid-expand-btn {
-    line-height: 27px !important;
+    line-height: 19px !important;
   }
 
   .datagrid-filter-wrapper .dropdown {

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -16,7 +16,7 @@ $toolbarsearchfield-category-empty-width: 51px;
   text-align: left;
   white-space: nowrap;
   width: $toolbarsearchfield-empty-width;
-  min-height: 38px;
+  min-height: 34px;
 
   @media only screen and (max-width: $breakpoint-phone-to-tablet) {
     overflow: auto;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Hover states for search and expand buttons were not centered. Adjusted hover styling to fix this.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise/issues/8078

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build, and run the app.
- Go to http://localhost:4000/components/datagrid/test-expandable-row-editable-with-summary.html?theme=new&mode=contrast&colors=default
- Hover over search and expandable(+/-) icons.
- Hover indicator should be centered.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
