### PR TITLE
8025 - Datagrid: Toolbar issue when toolbar has settings title

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Datagrid]` Fixed an issue where the new row did not display an error tooltip on the first cell. ([#8071](https://github.com/infor-design/enterprise/issues/8071))
 - `[Fileupload]` Added condition to not allow for input clearing for readonly and disabled. ([#8024](https://github.com/infor-design/enterprise/issues/8024))
 - `[Modal]` Adjusted modal title spacing to avoid icon from cropping. ([#8031](https://github.com/infor-design/enterprise/issues/8031))
+- `[Modal]` Fixed the searchfield size when settings has title in toolbar. ([#8025](https://github.com/infor-design/enterprise/issues/8025))
 - `[Timepicker]` Remove `disabled` prop in trigger button on enable call. ([NG#1567](https://github.com/infor-design/enterprise-ng/issues/1567))
 
 ## v4.89.0

--- a/src/components/lookup/_lookup-new.scss
+++ b/src/components/lookup/_lookup-new.scss
@@ -24,6 +24,10 @@
   .searchfield-wrapper.non-collapsible.is-open > .icon:not(.close):not(.icon-error) {
     left: 9px;
   }
+
+  .datagrid-result-count {
+    top: -2px;
+  }
 }
 
 .lookup-wrapper {

--- a/src/components/lookup/_lookup.scss
+++ b/src/components/lookup/_lookup.scss
@@ -184,7 +184,7 @@
 
   .datagrid-result-count {
     margin-inline-start: 4px;
-    top: -2px;
+    top: 6px;
     vertical-align: middle;
   }
 

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -123,8 +123,9 @@ Toolbar.prototype = {
     // Check for a "title" element.  This element is optional.
     // If a title element exists, a tooltip will be created for when it's not
     // possible to show the entire title text on screen.
+    this.isModalToolbar = this.element.parent().is('.modal-body');
     this.title = this.element.children('.title');
-    if (this.title.length) {
+    if (this.title.length && !this.isModalToolbar) {
       this.element[0].classList.add('has-title');
 
       this.cutoffTitle = false;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix the searchfield size when settings has title in toolbar.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/8025

**Steps necessary to review your pull request (required)**:
- Pull this git repository, build, and run the app
- Go to http://localhost:4000/components/lookup/example-index.html
- Refresh the browser
- Open the lookup
- See the searchfield do not fit in the lookup

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

