### PR TITLE
8175 - Fix Icon size

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@
 - `[Datagrid]` Fixed an issue where the new row did not display an error tooltip on the first cell. ([#8071](https://github.com/infor-design/enterprise/issues/8071))
 - `[Fileupload]` Added condition to not allow for input clearing for readonly and disabled. ([#8024](https://github.com/infor-design/enterprise/issues/8024))
 - `[Modal]` Adjusted modal title spacing to avoid icon from cropping. ([#8031](https://github.com/infor-design/enterprise/issues/8031))
-- `[Popupmenu]` Added fix for icon size in new theme. ([#1626](https://github.com/infor-design/enterprise/issues/1626))
+- `[Popupmenu]` Added fix for icon size in new. ([#8175](https://github.com/infor-design/enterprise/issues/8175))
 - `[Timepicker]` Remove `disabled` prop in trigger button on enable call. ([NG#1567](https://github.com/infor-design/enterprise-ng/issues/1567))
 
 ## v4.89.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Datagrid]` Fixed an issue where the new row did not display an error tooltip on the first cell. ([#8071](https://github.com/infor-design/enterprise/issues/8071))
 - `[Fileupload]` Added condition to not allow for input clearing for readonly and disabled. ([#8024](https://github.com/infor-design/enterprise/issues/8024))
 - `[Modal]` Adjusted modal title spacing to avoid icon from cropping. ([#8031](https://github.com/infor-design/enterprise/issues/8031))
+- `[Popupmenu]` Added fix for icon size in new theme. ([#1626](https://github.com/infor-design/enterprise/issues/1626))
 - `[Timepicker]` Remove `disabled` prop in trigger button on enable call. ([NG#1567](https://github.com/infor-design/enterprise-ng/issues/1567))
 
 ## v4.89.0

--- a/src/components/popupmenu/_popupmenu-new.scss
+++ b/src/components/popupmenu/_popupmenu-new.scss
@@ -6,3 +6,8 @@
     line-height: normal;
   }
 }
+
+.popupmenu.has-icons .icon:not(.arrow) {
+  height: 18px;
+  margin-top: 7px;
+}


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Icons in new theme were wrong size. Should be 18 not 14

**Related github/jira issue (required)**:
Fixes #8175 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/popupmenu/example-icons.html?theme=new&mode=light&colors=default
- open menus and see icon size is 18px and centers
- try also http://localhost:4000/components/popupmenu/example-icons.html?theme=classic where they are still 14

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
