### PR TITLE
8088 - Page patterns: Fix hovered selected tab background

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Datagrid]` Fixed an issue where the new row did not display an error tooltip on the first cell. ([#8071](https://github.com/infor-design/enterprise/issues/8071))
 - `[Fileupload]` Added condition to not allow for input clearing for readonly and disabled. ([#8024](https://github.com/infor-design/enterprise/issues/8024))
 - `[Modal]` Adjusted modal title spacing to avoid icon from cropping. ([#8031](https://github.com/infor-design/enterprise/issues/8031))
+- `[Page-Patterns]` Fixed background on hovered selected tab. ([#8088](https://github.com/infor-design/enterprise/issues/8088))
 - `[Timepicker]` Remove `disabled` prop in trigger button on enable call. ([NG#1567](https://github.com/infor-design/enterprise-ng/issues/1567))
 
 ## v4.89.0

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -496,6 +496,7 @@ html.theme-classic-dark .header.is-personalizable .buttonset .searchfield-wrappe
 .personalize-header.tab-container.header-tabs:not(.alternate) > .tab-list-container .tab.is-selected:not(.is-disabled) {
   color: ${colors.headerTabsSelectedTextColor} !important;
   opacity: 1;
+  background-color: transparent;
 }
 
 .header.is-personalizable .flex-toolbar .has-collapse-button .collapse-button {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Removed background for hovered selected tab

**Related github/jira issue (required)**:
Fixes #8088 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4000/components/page-patterns/example-search-form.html?theme=classic&mode=contrast&colors=ffffff
- Click on 'Recent'
- Hover over it
- See there is no background

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
