### PR TITLE
8110 - Header Tabs Fix personalizable overflowing gradient color

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[ProcessIndicator]` Fixed icon alignment in RTL. ([#8168](https://github.com/infor-design/enterprise/issues/8168))
 - `[Popupmenu]` Added fix for icon size in new. ([#8175](https://github.com/infor-design/enterprise/issues/8175))
 - `[Searchfield]` Fixed animation of collapsible searchfield. ([#8076](https://github.com/infor-design/enterprise/issues/8076))
+- `[Tabs Header]` Fixed gradient color for personalizable overflowing header tabs. ([#8110](https://github.com/infor-design/enterprise/issues/8110))
 - `[Tabs-Module]` Removed padding in embedded mode. ([#8060](https://github.com/infor-design/enterprise/issues/8060))
 - `[Timepicker]` Removed `disabled` prop in trigger button on enable call. ([NG#1567](https://github.com/infor-design/enterprise-ng/issues/1567))
 

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -873,22 +873,22 @@ html[dir='rtl'] .scrollable-flex-header.is-personalizable .breadcrumb.truncated:
 
 .is-personalizable .tab-container.header-tabs:not(.alternate)::before,
 .is-personalizable.tab-container.header-tabs:not(.alternate)::before {
-  background-image: linear-gradient(to right, ${colors.base} , ${colorUtils.hexToRgba(colors.base, 0)}) !important;
+  background-image: linear-gradient(to right, ${colors.tabHeaderColor} , ${colorUtils.hexToRgba(colors.base, 0)}) !important;
 }
 
 html[dir='rtl'] .is-personalizable .tab-container.header-tabs:not(.alternate)::before,
 html[dir='rtl'] .is-personalizable.tab-container.header-tabs:not(.alternate)::before {
-  background-image: linear-gradient(to left, ${colors.base}, ${colorUtils.hexToRgba(colors.base, 0)}) !important;
+  background-image: linear-gradient(to left, ${colors.tabHeaderColor}, ${colorUtils.hexToRgba(colors.base, 0)}) !important;
 }
 
 .is-personalizable .tab-container.header-tabs:not(.alternate)::after,
 .is-personalizable.tab-container.header-tabs:not(.alternate)::after {
-  background-image: linear-gradient(to right, ${colorUtils.hexToRgba(colors.base, 0)}, ${colors.base}) !important;
+  background-image: linear-gradient(to right, ${colorUtils.hexToRgba(colors.base, 0)}, ${colors.tabHeaderColor}) !important;
 }
 
 html[dir='rtl'] .is-personalizable .tab-container.header-tabs:not(.alternate)::after,
 html[dir='rtl'] .is-personalizable.tab-container.header-tabs:not(.alternate)::after {
-  background-image: linear-gradient(to left, ${colorUtils.hexToRgba(colors.base, 0)}, ${colors.base}) !important;
+  background-image: linear-gradient(to left, ${colorUtils.hexToRgba(colors.base, 0)}, ${colors.tabHeaderColor}) !important;
 }
 
 .is-personalizable.header .section-title {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Changed color variable for the gradient to be the same as the header tabs background

**Related github/jira issue (required)**:
Closes #8110 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4000/components/tabs-header/example-index.html?theme=new&mode=dark&colors=ffffff
- resize the browser so the tabs overflow, click on a tab so tabs overflow on both sides
- see the color of the gradient is the same as bg color of the tabs
- check RTL mode http://localhost:4000/components/tabs-header/example-index.html?theme=new&mode=dark&colors=ffffff&locale=ar-SA

**Included in this Pull Request**:
~- [ ] An e2e or functional test for the bug or feature.~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
