### PR TITLE
8167 - Breadcrumb Fix misaligned item in RTL in Safari browser

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## v4.90.0 Fixes
 
 - `[Badges]` Adjusted color and positioning of dismissible button in multiselect dropdown tags. ([#8036](https://github.com/infor-design/enterprise/issues/8036))
+- `[Breadcrumb]` Fixed misaligned item in RTL in Safari browser. ([#8167](https://github.com/infor-design/enterprise/issues/8167))
 - `[Button]` Adjusted personalize button hover colors. ([#8035](https://github.com/infor-design/enterprise/issues/8035))
 - `[Calendar]` Added additional check on triggering `eventclick` to avoid executing twice. ([#8051](https://github.com/infor-design/enterprise/issues/8051))
 - `[Colorpicker]` Updated color palette for colorpicker. ([#8165](https://github.com/infor-design/enterprise/issues/8165))

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -629,6 +629,7 @@ html[dir='rtl'] {
 
     &:last-child::after {
       content: '';
+      display: inline-block;
     }
 
     &:first-child {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added `display` CSS property to breadcrumb's pseudo-element 

**Related github/jira issue (required)**:
Closes #8167 

**Steps necessary to review your pull request (required)**:
- pull and build
- **use Safari browser**
- go to http://localhost:4000/components/breadcrumb/example-index.html?locale=ar-SA
- see the `Fourth Item` is aligned with the rest

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
