### PR TITLE
8201 - Improve hover animation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Datagrid]` Fixed misalignment on date cells when selected. ([#8021](https://github.com/infor-design/enterprise/issues/8021))
 - `[Datagrid]` Fixed an issue where the new row did not display an error tooltip on the first cell. ([#8071](https://github.com/infor-design/enterprise/issues/8071))
 - `[Datagrid]` Fixed an issue where dirty tracker will appear even no change was made from the cell. ([#8020](https://github.com/infor-design/enterprise/issues/8020))
+- `[Homepage]` Improve hover animation after resize. ([#8201](https://github.com/infor-design/enterprise/issues/8201))
 - `[Fileupload]` Added condition to not allow for input clearing for readonly and disabled. ([#8024](https://github.com/infor-design/enterprise/issues/8024))
 - `[Modal]` Adjusted modal title spacing to avoid icon from cropping. ([#8031](https://github.com/infor-design/enterprise/issues/8031))
 - `[Modal]` Fixed the searchfield size when settings has title in toolbar. ([#8025](https://github.com/infor-design/enterprise/issues/8025))

--- a/src/components/cards/_cards-new.scss
+++ b/src/components/cards/_cards-new.scss
@@ -13,7 +13,7 @@
     &:hover {
       outline: 1px solid $card-border-color-hover;
       box-shadow: 0 2px 4px 1px $cardlist-box-shadow-color-hover;
-      transition: box-shadow 0.3s cubic-bezier(.17, .04, .03, .94);
+      transition: box-shadow 0.3s cubic-bezier(.17, .04, .03, .94) !important;
     }
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

After resizing the home page the animation is applied for the widgets to "shuffle". This animation animates more than the box-shadow and causes a subtle issue on hover. In order to fix it need to add !important to the hover animation so both animations can still work ok.

**Related github/jira issue (required)**:
Fixes #8201 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/cards/example-workspace-widgets.html
- hover the borderless cards and note the subtle border change animation 
- resize the page so the widgets "shuffle"
- retry to hover the borderless cards and note the subtle border change animation -> should look same as before resize

**Included in this Pull Request**:
- [x] A note to the change log.
