### PR TITLE
8044 - Fix accordion button on mobile

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## v4.90.0 Fixes
 
+- `[Accordion]` Fixed a bug where the plus-minus icon shows ellipsis on mobile viewport. ([#8044](https://github.com/infor-design/enterprise/issues/8044))
 - `[Badges]` Adjusted color and positioning of dismissible button in multiselect dropdown tags. ([#8036](https://github.com/infor-design/enterprise/issues/8036))
 - `[Button]` Adjusted personalize button hover colors. ([#8035](https://github.com/infor-design/enterprise/issues/8035))
 - `[Calendar]` Added additional check on triggering `eventclick` to avoid executing twice. ([#8051](https://github.com/infor-design/enterprise/issues/8051))

--- a/src/components/button/_button-chevron.scss
+++ b/src/components/button/_button-chevron.scss
@@ -30,6 +30,7 @@
 
     &.plus-minus {
       position: static;
+      width: auto;
 
       &::before,
       &::after {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes accordion button `plus-minus` on mobile viewport.

**Related github/jira issue (required)**:

Closes #8044 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/accordion/test-all-plus-minus and use mobile viewport via device toolbar in Chrome
- Button `plus-minus` should not have ellipsis
- Compare it to main https://main-enterprise.demo.design.infor.com/components/accordion/test-all-plus-minus.html (this is the issue)

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
