### PR TITLE
8012 - Fix datagrid's drag handle position in firefox

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Calendar]` Added additional check on triggering `eventclick` to avoid executing twice. ([#8051](https://github.com/infor-design/enterprise/issues/8051))
 - `[Colorpicker]` Updated color palette for colorpicker. ([#8165](https://github.com/infor-design/enterprise/issues/8165))
 - `[ContextualActionPanel]` Fixed close button layout for RTL. ([#8166](https://github.com/infor-design/enterprise/issues/8166))
+- `[Datagrid]` Fixed a bug where the drag handle was overlapping the header text in firefox. ([#8012](https://github.com/infor-design/enterprise/issues/8012))
 - `[Datagrid]` Adjusted hover styling for search and expand buttons. ([#8078](https://github.com/infor-design/enterprise/issues/8078))
 - `[Datagrid]` Fixed misalignment on date cells when selected. ([#8021](https://github.com/infor-design/enterprise/issues/8021))
 - `[Datagrid]` Fixed an issue where the new row did not display an error tooltip on the first cell. ([#8071](https://github.com/infor-design/enterprise/issues/8071))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -5822,12 +5822,6 @@ html[dir='rtl'] {
 // Firefox on Mac only
 .is-mac.is-firefox {
   .has-draggable-columns {
-    th {
-      .handle {
-        padding: 4px 0 0 5px;
-      }
-    }
-
     &.small-rowheight,
     &.extra-small-rowheight {
       th {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the issue of the (Datagrid) drag handle's position overlapping the header text in the Firefox.

**Related github/jira issue (required)**:

Closes #8012

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Open firefox browser and go to http://localhost:4000/components/datagrid/test-filter-custom-date.html
- Hover over any column (left-aligned text)
- Drag handle should not overlapping the header text

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
