### PR TITLE
8120 - ContextualActionPanel Remove 'Run' button from vertical examples

### DIFF
--- a/app/views/components/contextualactionpanel/example-cap-tabs-vertical-scroll.html
+++ b/app/views/components/contextualactionpanel/example-cap-tabs-vertical-scroll.html
@@ -83,12 +83,6 @@
             </li>
           </ul>
 
-          <div class="tab-list-info">
-            <button type="button" id="action-run" data-automation-id="tabs-action-run-btn" class="btn-primary">
-              <span>Run</span>
-            </button>
-          </div>
-
         </div><!-- .tab-list-container -->
       </div><!-- .vertical.tab-container -->
 

--- a/app/views/components/contextualactionpanel/example-cap-tabs-vertical.html
+++ b/app/views/components/contextualactionpanel/example-cap-tabs-vertical.html
@@ -69,12 +69,6 @@
             </li>
           </ul>
 
-          <div class="tab-list-info">
-            <button type="button" id="action-run" data-automation-id="tabs-action-run-btn" class="btn-primary">
-              <span>Run</span>
-            </button>
-          </div>
-
         </div><!-- .tab-list-container -->
       </div><!-- .vertical.tab-container -->
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Calendar]` Added additional check on triggering `eventclick` to avoid executing twice. ([#8051](https://github.com/infor-design/enterprise/issues/8051))
 - `[Colorpicker]` Updated color palette for colorpicker. ([#8165](https://github.com/infor-design/enterprise/issues/8165))
 - `[ContextualActionPanel]` Fixed close button layout for RTL. ([#8166](https://github.com/infor-design/enterprise/issues/8166))
+- `[ContextualActionPanel]` Removed 'Run' button from vertical examples. ([#8120](https://github.com/infor-design/enterprise/issues/8120))
 - `[Datagrid]` Adjusted hover styling for search and expand buttons. ([#8078](https://github.com/infor-design/enterprise/issues/8078))
 - `[Datagrid]` Fixed misalignment on date cells when selected. ([#8021](https://github.com/infor-design/enterprise/issues/8021))
 - `[Datagrid]` Fixed an issue where the new row did not display an error tooltip on the first cell. ([#8071](https://github.com/infor-design/enterprise/issues/8071))


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Removed 'Run' button from vertical examples for contextual action panel

**Related github/jira issue (required)**:
Closes #8120 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4000/components/contextualactionpanel/example-cap-tabs-vertical-scroll.html and http://localhost:4000/components/contextualactionpanel/example-cap-tabs-vertical.html
- open the modal and see that there is no 'Run' button below the menu

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
