### PR TITLE
8172 - PopupMenu Fix submenu icon is overlapped with the item label in RTL

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `[Page-Patterns]` Fixed background on hovered selected tab. ([#8088](https://github.com/infor-design/enterprise/issues/8088))
 - `[ProcessIndicator]` Fixed icon alignment in RTL. ([#8168](https://github.com/infor-design/enterprise/issues/8168))
 - `[Popupmenu]` Added fix for icon size in new. ([#8175](https://github.com/infor-design/enterprise/issues/8175))
+- `[Popupmenu]` Fixed submenu icon is overlapped with the item label in RTL. ([#8172](https://github.com/infor-design/enterprise/issues/8172))
 - `[Searchfield]` Fixed animation of collapsible searchfield. ([#8076](https://github.com/infor-design/enterprise/issues/8076))
 - `[Searchfield]` Adjusted height so that focus is fully seen. ([#8085](https://github.com/infor-design/enterprise/issues/8085))
 - `[Tabs Header]` Fixed gradient color for personalizable overflowing header tabs. ([#8110](https://github.com/infor-design/enterprise/issues/8110))

--- a/src/components/popupmenu/_popupmenu.scss
+++ b/src/components/popupmenu/_popupmenu.scss
@@ -717,7 +717,6 @@ html[dir='rtl'] {
       > .icon.icon-dropdown {
         left: 5px;
         right: auto;
-        top: 5px;
         transform: rotate(90deg);
       }
     }
@@ -734,7 +733,7 @@ html[dir='rtl'] {
       &.is-selectable,
       &.is-multiselectable {
         > a {
-          padding-left: 10px;
+          padding-left: 45px;
           padding-right: 35px;
         }
       }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Fix submenu icon is overlapped with the item label in RTL

**Related github/jira issue (required)**:
Closes #8172 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4000/components/popupmenu/test-multiselect-singleselect.html?locale=ar-SA
- see the submenu icon is not overlapped with the item label in RTL

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
