### PR TITLE
8043 - Popupmenu Submenu Not Closing in some scenarios

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `[Page-Patterns]` Fixed background on hovered selected tab. ([#8088](https://github.com/infor-design/enterprise/issues/8088))
 - `[ProcessIndicator]` Fixed icon alignment in RTL. ([#8168](https://github.com/infor-design/enterprise/issues/8168))
 - `[Popupmenu]` Added fix for icon size in new. ([#8175](https://github.com/infor-design/enterprise/issues/8175))
+- `[Popupmenu]` Fixed popupmenu submenu not closing in some scenarios. ([#8043](https://github.com/infor-design/enterprise/issues/8043))
 - `[Searchfield]` Fixed animation of collapsible searchfield. ([#8076](https://github.com/infor-design/enterprise/issues/8076))
 - `[Tabs Header]` Fixed gradient color for personalizable overflowing header tabs. ([#8110](https://github.com/infor-design/enterprise/issues/8110))
 - `[Tabs-Module]` Removed padding in embedded mode. ([#8060](https://github.com/infor-design/enterprise/issues/8060))

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -2001,13 +2001,14 @@ PopupMenu.prototype = {
 
       const hasWrapper = menuToClose.parent('.wrapper').length > 0;
       const isLeft = (hasWrapper ? parseInt(menuToClose.parent('.wrapper')[0].style.left, 10) : 0) < 0;
+      const isSubMenu = menuToClose.parents('.submenu').length > 0;
       let canClose = (tracker - startY) < 3.5;
 
       if (isLeft) {
         canClose = (tracker - startY) >= 0;
       }
 
-      if (canClose) { // We are moving slopie to the menu
+      if (canClose || isSubMenu) { // We are moving slopie to the menu
         menuToClose.removeClass('is-open').removeAttr('style');
         menuToClose.parent('.wrapper').removeAttr('style');
         menuToClose.parent().parent().removeClass('is-submenu-open');


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix popupmenu submenu not closing in some scenarios.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/8043

**Steps necessary to review your pull request (required)**:
- Pull this git repository, build, and run the app
- Go to http://localhost:4000/components/popupmenu/example-mixing-selectables.html
- Open `Partially Selectable Menu`
- Go to `Non-selectable Item #5`
- After the submenu opens, slowly move the mouse above `Non-selectable Item #4`
- Submenu should be closed

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

