### PR TITLE
8155 - Fixed extra space increase on editable fields when clicking in and out of it

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # What's New with Enterprise
 
+## v4.91.0
+
+## v4.91.0 Features
+
+## v4.91.0 Fixes
+
+- `[Datagrid]` Fixed extra space increase on editable fields when clicking in and out of it. ([#8155](https://github.com/infor-design/enterprise/issues/8155))
+
 ## v4.90.0
 
 ## v4.90.0 Features

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10360,7 +10360,7 @@ Datagrid.prototype = {
 
     const isEditor = $('.is-editor', cellParent).length > 0;
     const isPlaceholder = $('.is-placeholder', cellNode).length > 0;
-    let cellValue = (cellNode.text() ?
+    let cellValue = (cellNode.text() && cellNode.text().trim().length > 0 ?
       cellNode.text() : this.fieldValue(rowData, col.field));
 
     if (isEditor || isPlaceholder) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Added additional check when assigning the cell value.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #8155 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datagrid/example-editable.html
- Click on the blank cell in Row 2, under Product Name
- Type a space
- Click in and out of the cell multiple times
- Value should be the same

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
