### PR TITLE
8086 - Personalization Remove box shadow on selected tabs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Bar Chart]` Displayed the x-axis ticks for the bar grouped when single group. ([#7976](https://github.com/infor-design/enterprise/issues/7976))
 - `[Dropdown]` Fixed a bug where list is broken when empty icon is in the first option. ([#8105](https://github.com/infor-design/enterprise/issues/8105))
+- `[Personalization]` Removed box shadow on selected tabs. ([#8086](https://github.com/infor-design/enterprise/issues/8086))
 
 ## v4.90.0
 

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -291,9 +291,14 @@ a.is-personalizable svg.ripple-effect {
 .tab-container.personalize-header.header-tabs:not(.alternate) > .tab-list-container .tab:not(.is-disabled).is-selected,
 .header.is-personalizable .tab-container.header-tabs:not(.alternate) .tab-focus-indicator.is-visible,
 .header.is-personalizable .tab-container.header-tabs:not(.alternate) > .tab-list-container .tab.is-selected,
-.personalize-header.tab-container.header-tabs:not(.alternate) > .tab-list-container .tab.is-selected:not(.is-disabled),
-.personalize-header.tab-container.header-tabs:not(.alternate) .tab-focus-indicator.is-visible {
+.personalize-header.tab-container.header-tabs:not(.alternate) > .tab-list-container .tab.is-selected:not(.is-disabled) {
   border-color: ${colors.headerTabsSelectedTextColor} !important;
+}
+
+.tab-container.is-personalizable.header-tabs:not(.alternate) .tab-focus-indicator.is-visible,
+.tab-container.personalize-header.header-tabs:not(.alternate) .tab-focus-indicator.is-visible,
+.header.is-personalizable .tab-container.header-tabs:not(.alternate) .tab-focus-indicator.is-visible,
+.personalize-header.tab-container.header-tabs:not(.alternate) .tab-focus-indicator.is-visible {
   box-shadow: ${colors.tabFocusBoxShadow} !important;
 }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Removed box shadow on selected tabs so only focus indicator has it

**Related github/jira issue (required)**:
Closes #8086

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4000/components/personalize/example-form-landmark2-horizontal.html?theme=new&mode=contrast&colors=ffffff
- click on a tab
- see there is no box shadow
- focus a tab
- see the box shadow

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
