### PR TITLE
8232 - Add External settings and hide show sections to module nav

### DIFF
--- a/app/views/components/module-nav/example-hide-show-sections.html
+++ b/app/views/components/module-nav/example-hide-show-sections.html
@@ -54,12 +54,19 @@
           <path d="M3.6772 20V11.2727H5.25817V18.6747H9.10192V20H3.6772ZM10.4741 11.2727H12.4087L14.9996 17.5966H15.1019L17.6928 11.2727H19.6275V20H18.1104V14.0043H18.0295L15.6175 19.9744H14.484L12.0721 13.9915H11.9911V20H10.4741V11.2727ZM24.3065 20H21.3491V11.2727H24.3661C25.2326 11.2727 25.9769 11.4474 26.5991 11.7969C27.2241 12.1435 27.7042 12.642 28.0394 13.2926C28.3746 13.9432 28.5423 14.7216 28.5423 15.6278C28.5423 16.5369 28.3732 17.3182 28.0352 17.9716C27.6999 18.625 27.2156 19.1264 26.582 19.4759C25.9513 19.8253 25.1928 20 24.3065 20ZM22.93 18.6321H24.2298C24.8377 18.6321 25.3448 18.5213 25.7511 18.2997C26.1573 18.0753 26.4627 17.7415 26.6673 17.2983C26.8718 16.8523 26.9741 16.2955 26.9741 15.6278C26.9741 14.9602 26.8718 14.4062 26.6673 13.9659C26.4627 13.5227 26.1602 13.1918 25.7596 12.973C25.3619 12.7514 24.8675 12.6406 24.2766 12.6406H22.93V18.6321Z" fill="white"/>
         </symbol>
 
+        <svg id="icon-app-guest" width="32" height="32" viewBox="0 0 32 32" fill="none">
+          <circle cx="16" cy="16" r="15.36" fill="#39A9AA" />
+          <path
+            d="M12.5028 20.9443C11.6221 20.9443 10.8388 20.7395 10.1527 20.3299C9.46662 19.9101 8.92902 19.311 8.5399 18.5328C8.15078 17.7546 7.95622 16.8176 7.95622 15.7219C7.95622 14.6365 8.1559 13.7046 8.55526 12.9264C8.95462 12.1482 9.50246 11.5491 10.1988 11.1293C10.8951 10.7094 11.6887 10.4995 12.5796 10.4995C13.2759 10.4995 13.8596 10.6326 14.3306 10.8989C14.8119 11.1549 15.1959 11.4365 15.4826 11.7437L14.7761 12.5731C14.5201 12.3069 14.2231 12.0816 13.8852 11.8973C13.5473 11.713 13.1223 11.6208 12.6103 11.6208C11.9345 11.6208 11.3457 11.7898 10.8439 12.1277C10.3421 12.4554 9.95302 12.9213 9.67654 13.5254C9.4103 14.1296 9.27718 14.8515 9.27718 15.6912C9.27718 16.961 9.5639 17.9696 10.1373 18.7171C10.721 19.4544 11.5505 19.823 12.6257 19.823C12.9841 19.823 13.3271 19.7718 13.6548 19.6694C13.9825 19.5568 14.2436 19.4083 14.4381 19.224V16.5974H12.3031V15.5376H15.6055V19.777C15.2881 20.1149 14.858 20.3965 14.3153 20.6218C13.7828 20.8368 13.1786 20.9443 12.5028 20.9443ZM20.8154 20.9443C20.1089 20.9443 19.4535 20.8112 18.8493 20.545C18.2452 20.2685 17.7229 19.905 17.2826 19.4544L18.0506 18.5635C18.409 18.9424 18.8289 19.2496 19.3101 19.4851C19.8017 19.7104 20.3085 19.823 20.8308 19.823C21.4964 19.823 22.0135 19.6746 22.3821 19.3776C22.7508 19.0704 22.9351 18.671 22.9351 18.1795C22.9351 17.8314 22.8583 17.5549 22.7047 17.3501C22.5613 17.1453 22.3617 16.9712 22.1057 16.8278C21.8599 16.6845 21.5783 16.5411 21.2609 16.3978L19.817 15.768C19.4996 15.6349 19.1821 15.4608 18.8647 15.2458C18.5575 15.0307 18.2964 14.7542 18.0813 14.4163C17.8765 14.0784 17.7741 13.6637 17.7741 13.1722C17.7741 12.6602 17.9073 12.2045 18.1735 11.8051C18.45 11.3955 18.8289 11.0781 19.3101 10.8528C19.7914 10.6173 20.3341 10.4995 20.9383 10.4995C21.5425 10.4995 22.1005 10.6173 22.6125 10.8528C23.1245 11.0781 23.5597 11.375 23.9181 11.7437L23.2269 12.5731C22.9197 12.2762 22.5767 12.0458 22.1978 11.8819C21.8292 11.7078 21.4093 11.6208 20.9383 11.6208C20.3751 11.6208 19.9194 11.7539 19.5713 12.0202C19.2333 12.2864 19.0644 12.6448 19.0644 13.0954C19.0644 13.4128 19.1463 13.679 19.3101 13.8941C19.4842 14.0989 19.6993 14.2678 19.9553 14.401C20.2113 14.5341 20.4724 14.657 20.7386 14.7696L22.1671 15.384C22.5562 15.5478 22.9044 15.7475 23.2116 15.983C23.529 16.2083 23.7799 16.4899 23.9642 16.8278C24.1485 17.1555 24.2407 17.5702 24.2407 18.072C24.2407 18.6045 24.1025 19.0909 23.826 19.5312C23.5495 19.9613 23.1553 20.3043 22.6433 20.5603C22.1313 20.8163 21.522 20.9443 20.8154 20.9443Z"
+            fill="white" />
+        </svg>
+
        </svg>
     </div>
 </div>
 
-<section class="module-nav-container mode-collapsed">
-  <aside id="nav" class="module-nav" data-options="{ 'filterable': true }">
+<section class="module-nav-container">
+  <aside id="nav" class="module-nav" data-options="{ 'pinSections': true, 'filterable': true, 'showModuleSwitcher': false, 'showSearchBar': false, 'showGuestSection': true }">
     <div class="module-nav-bar">
       <!-- Module Nav's top-level navigation items are inside the accordion -->
       <div class="module-nav-accordion accordion panel" data-options="{'allowOnePane': false}">
@@ -68,7 +75,7 @@
           <div class="module-nav-switcher">
             <div class="module-nav-section role-dropdown">
               <label for="module-nav-role-switcher" class="label audible">Roles</label>
-              <select id="module-nav-role-switcher" name="module-nav-role-switcher" data-options="{'noSearch': true}" class="dropdown" data-automation-id="custom-automation-dropdown-id">
+              <select id="module-nav-role-switcher" name="module-nav-role-switcher" class="dropdown" data-automation-id="custom-automation-dropdown-id">
                 <option value="admin" data-icon="{icon: 'app-ac'}">Admin Console</option>
                 <option value="job-console" data-icon="{icon: 'app-jo'}">Job Console</option>
                 <option value="landing-page-designer" data-icon="{icon: 'app-lmd'}">Landing Page Designer</option>
@@ -80,7 +87,6 @@
             </div>
           </div>
         </div>
-
         <div class="module-nav-search-container accordion-section">
           <label class="audible" for="module-nav-searchfield">Search</label>
           <input id="module-nav-searchfield" data-init="false" class="searchfield module-nav-search" placeholder="Search" />
@@ -92,7 +98,7 @@
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
               <use href="#icon-male"></use>
             </svg>
-            <a href="#" id="item-config" data-automation-id="module-nav-item-config"><span>Configuration and Personalization</span></a>
+            <a href="#" id="item-config" data-automation-id="module-nav-item-config"><span>Job Search</span></a>
           </div>
           <div class="accordion-pane">
             <div class="accordion-header">
@@ -112,7 +118,7 @@
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
               <use href="#icon-database"></use>
             </svg>
-            <a href="#" id="item-database" data-automation-id="module-nav-item-databasde"><span>Database</span></a>
+            <a href="#" id="item-database" data-automation-id="module-nav-item-databasde"><span>Profile</span></a>
           </div>
           <div class="accordion-pane">
             <div class="accordion-header">
@@ -132,7 +138,7 @@
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
               <use href="#icon-translate"></use>
             </svg>
-            <a href="#" id="item-translation" data-automation-id="module-nav-item-translation"><span>Data Translation</span></a>
+            <a href="#" id="item-translation" data-automation-id="module-nav-item-translation"><span>Applications</span></a>
           </div>
           <div class="accordion-pane">
             <div class="accordion-header">
@@ -152,7 +158,7 @@
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
               <use href="#icon-security-on"></use>
             </svg>
-            <a href="#" id="item-security" data-automation-id="module-nav-item-security"><span>Security</span></a>
+            <a href="#" id="item-security" data-automation-id="module-nav-item-security"><span>Saved Jobs & Alerts</span></a>
           </div>
           <div class="accordion-pane">
             <div class="accordion-header">
@@ -166,33 +172,6 @@
             <div class="accordion-header">
               <a href="#"><span>Label</span></a>
             </div>
-          </div>
-
-          <div class="accordion-header">
-            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-              <use href="#icon-line-bar-chart"></use>
-            </svg>
-            <a href="#" id="item-analytics" data-automation-id="module-nav-item-analytics"><span>Analytics</span></a>
-          </div>
-          <div class="accordion-pane">
-            <div class="accordion-header">
-              <a href="#"><span>Label</span></a>
-            </div>
-
-            <div class="accordion-header">
-              <a href="#"><span>Label</span></a>
-            </div>
-
-            <div class="accordion-header">
-              <a href="#"><span>Label</span></a>
-            </div>
-          </div>
-
-          <div class="accordion-header">
-            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-              <use href="#icon-import-spreadsheet"></use>
-            </svg>
-            <a href="#" id="item-audit" data-automation-id="module-nav-item-audit"><span>Audit and Monitoring</span></a>
           </div>
         </div>
 
@@ -202,23 +181,16 @@
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
               <use href="#icon-document"></use>
             </svg>
-            <a href="#" id="module-nav-item-documents" data-automation-id="module-nav-documents"><span>Documents</span></a>
+            <a href="#" id="module-nav-item-signin" data-automation-id="module-nav-signin"><span>Sign In</span></a>
           </div>
 
           <div class="accordion-header is-selected">
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
               <use href="#icon-report"></use>
             </svg>
-            <a href="#" id="module-nav-item-reports" data-automation-id="module-nav-reports"><span>Reports</span></a>
+            <a href="#" id="module-nav-item-register" data-automation-id="module-nav-register"><span>Register</span></a>
           </div>
 
-          <div class="accordion-header">
-            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
-              <use href="#icon-notification"></use>
-            </svg>
-            <a href="#" id="module-nav-item-notifications"
-              data-automation-id="module-nav-notifications"><span>Notification</span></a>
-          </div>
         </div>
 
         <!-- Settings area is also separate and permanently "pinned" to the bottom -->
@@ -313,17 +285,33 @@
             </li>
           </ul>
         </div>
+
+        <!-- Guest area is also separate and permanently "pinned" to the bottom -->
+        <div class="module-nav-guest accordion-section">
+          <a href="#" class="module-nav-guest-link">
+            <svg class="icon-guest" focusable="false" aria-hidden="true" width="32" height="32" viewBox="0 0 32 32" fill="none">
+              <circle cx="16" cy="16" r="15.36" fill="#39A9AA" />
+              <path
+                d="M12.5028 20.9443C11.6221 20.9443 10.8388 20.7395 10.1527 20.3299C9.46662 19.9101 8.92902 19.311 8.5399 18.5328C8.15078 17.7546 7.95622 16.8176 7.95622 15.7219C7.95622 14.6365 8.1559 13.7046 8.55526 12.9264C8.95462 12.1482 9.50246 11.5491 10.1988 11.1293C10.8951 10.7094 11.6887 10.4995 12.5796 10.4995C13.2759 10.4995 13.8596 10.6326 14.3306 10.8989C14.8119 11.1549 15.1959 11.4365 15.4826 11.7437L14.7761 12.5731C14.5201 12.3069 14.2231 12.0816 13.8852 11.8973C13.5473 11.713 13.1223 11.6208 12.6103 11.6208C11.9345 11.6208 11.3457 11.7898 10.8439 12.1277C10.3421 12.4554 9.95302 12.9213 9.67654 13.5254C9.4103 14.1296 9.27718 14.8515 9.27718 15.6912C9.27718 16.961 9.5639 17.9696 10.1373 18.7171C10.721 19.4544 11.5505 19.823 12.6257 19.823C12.9841 19.823 13.3271 19.7718 13.6548 19.6694C13.9825 19.5568 14.2436 19.4083 14.4381 19.224V16.5974H12.3031V15.5376H15.6055V19.777C15.2881 20.1149 14.858 20.3965 14.3153 20.6218C13.7828 20.8368 13.1786 20.9443 12.5028 20.9443ZM20.8154 20.9443C20.1089 20.9443 19.4535 20.8112 18.8493 20.545C18.2452 20.2685 17.7229 19.905 17.2826 19.4544L18.0506 18.5635C18.409 18.9424 18.8289 19.2496 19.3101 19.4851C19.8017 19.7104 20.3085 19.823 20.8308 19.823C21.4964 19.823 22.0135 19.6746 22.3821 19.3776C22.7508 19.0704 22.9351 18.671 22.9351 18.1795C22.9351 17.8314 22.8583 17.5549 22.7047 17.3501C22.5613 17.1453 22.3617 16.9712 22.1057 16.8278C21.8599 16.6845 21.5783 16.5411 21.2609 16.3978L19.817 15.768C19.4996 15.6349 19.1821 15.4608 18.8647 15.2458C18.5575 15.0307 18.2964 14.7542 18.0813 14.4163C17.8765 14.0784 17.7741 13.6637 17.7741 13.1722C17.7741 12.6602 17.9073 12.2045 18.1735 11.8051C18.45 11.3955 18.8289 11.0781 19.3101 10.8528C19.7914 10.6173 20.3341 10.4995 20.9383 10.4995C21.5425 10.4995 22.1005 10.6173 22.6125 10.8528C23.1245 11.0781 23.5597 11.375 23.9181 11.7437L23.2269 12.5731C22.9197 12.2762 22.5767 12.0458 22.1978 11.8819C21.8292 11.7078 21.4093 11.6208 20.9383 11.6208C20.3751 11.6208 19.9194 11.7539 19.5713 12.0202C19.2333 12.2864 19.0644 12.6448 19.0644 13.0954C19.0644 13.4128 19.1463 13.679 19.3101 13.8941C19.4842 14.0989 19.6993 14.2678 19.9553 14.401C20.2113 14.5341 20.4724 14.657 20.7386 14.7696L22.1671 15.384C22.5562 15.5478 22.9044 15.7475 23.2116 15.983C23.529 16.2083 23.7799 16.4899 23.9642 16.8278C24.1485 17.1555 24.2407 17.5702 24.2407 18.072C24.2407 18.6045 24.1025 19.0909 23.826 19.5312C23.5495 19.9613 23.1553 20.3043 22.6433 20.5603C22.1313 20.8163 21.522 20.9443 20.8154 20.9443Z"
+                fill="white" />
+            </svg>
+            <div class="module-nav-guest-text">
+              <span class="module-nav-guest-title">Guest</span>
+              <span class="module-nav-guest-subtext">Create an account to save your settings.</span>
+            </div>
+          </a>
+        </div>
       </div>
     </div>
 
     <!-- Detail area is optional and can have additional context -->
     <div class="module-nav-detail">&nbsp;</div>
   </aside>
-  <div class="page-container scrollable has-module-nav-offset">
+  <div class="page-container scrollable">
     <header class="header is-personalizable">
       <div class="flex-toolbar">
         <div class="toolbar-section">
-          <button id="header-hamburger" class="btn-icon application-menu-trigger personalize-actionable" type="button">
+          <button id="header-hamburger" class="btn-icon application-menu-trigger personalize-actionable" type="button" title="Toggle Module Nav">
             <span class="audible" data-translate="text">AppMenuTriggerTextAlt</span>
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
               <use href="#icon-menu"></use>
@@ -344,27 +332,28 @@
       <div class="four columns">&nbsp;</div>
       <div class="four columns">
         <div class="field">
-          <label for="display-mode-dropdown" class="label">Display mode</label>
-          <select id="display-mode-dropdown" class="dropdown">
-            <option value="collapsed" selected>Collapsed</option>
-            <option value="expanded">Expanded</option>
-            <option value="">Hidden</option>
-          </select>
+          <input type="checkbox" class="checkbox" name="pin-sections" id="pin-sections" checked />
+          <label for="pin-sections" class="checkbox-label">Unpin pinned section</label>
         </div>
 
         <div class="field">
-          <input type="checkbox" class="checkbox" name="pin-sections" id="pin-sections" />
-          <label for="pin-sections" class="checkbox-label">Show 'pinSections' setting</label>
+          <input type="checkbox" class="checkbox" name="hide-completely" id="hide-completely" />
+          <label for="hide-completely" class="checkbox-label">Hide completely</label>
         </div>
 
         <div class="field">
-          <input type="checkbox" class="checkbox" name="display-detail-check" id="display-detail-check" />
-          <label for="display-detail-check" class="checkbox-label">Show 'showDetailView' setting</label>
+          <input type="checkbox" class="checkbox" name="show-switcher" id="show-switcher" />
+          <label for="show-switcher" class="checkbox-label">Show switcher section</label>
         </div>
-        <legend>Mobile options</legend>
+
         <div class="field">
-          <input type="checkbox" checked="true" class="checkbox" name="offset-check" id="offset-check" />
-          <label for="offset-check" class="checkbox-label">Expanded menu offsets page, showing all content</label>
+          <input type="checkbox" class="checkbox" name="show-search" id="show-search" />
+          <label for="show-search" class="checkbox-label">Show search section</label>
+        </div>
+
+        <div class="field">
+          <input type="checkbox" class="checkbox" name="show-search" id="show-guest" />
+          <label for="show-guest" class="checkbox-label">Hide guest section</label>
         </div>
       </div>
     </div>
@@ -383,44 +372,43 @@
     $('html').personalize({ colors: '#fff' });
     $('[data-theme-name="theme-classic"]').parent().addClass('is-disabled');
 
-    const navAPI = $('#nav').data('modulenav');
+    const navEl = $('#nav');
+    const navAPI = navEl.data('modulenav');
     const containerEl = $('.module-nav-container');
-    const dropdownEl = $('#display-mode-dropdown')
-    const dropdownAPI = $('#display-mode-dropdown').data('dropdown');
-    const displayCheckEl = $('#display-detail-check');
-    const offsetCheckEl = $('#offset-check');
+    const hideCompletelyEl = $('#hide-completely');
     const hamburgerBtnEl = $('#header-hamburger');
     const pinSectionsCheckEl = $('#pin-sections');
-
-    // Connect form control event handling
-    dropdownAPI.element.on('change.test', (e) => {
-      let val = dropdownAPI.value;
-      if (val === 'Hidden') val = false;
-      navAPI.updated({ displayMode: val });
-    });
-
-    displayCheckEl.on('change.test', (e) => {
-      navAPI.updated({ showDetailView: displayCheckEl[0].checked });
-    });
-
-    offsetCheckEl.on('change.test', (e) => {
-      const pageContainer = containerEl.find('.page-container');
-      pageContainer[0].classList[ offsetCheckEl[0].checked ? 'add' : 'remove' ]('has-module-nav-offset');
-    });
+    const showSwitcherCheckEl = $('#show-switcher');
+    const showSearchBarCheckEl = $('#show-search');
+    const showGuestSectionCheckEl = $('#show-guest');
+    const guestSectionLink = $('a.module-nav-guest-link');
 
     pinSectionsCheckEl.on('change.test', (e) => {
       navAPI.updated({ pinSections: pinSectionsCheckEl[0].checked });
     });
 
+    showSwitcherCheckEl.on('change.test', (e) => {
+      navAPI.updated({ showModuleSwitcher: showSwitcherCheckEl[0].checked });
+    });
+
+    showSearchBarCheckEl.on('change.test', (e) => {
+      navAPI.updated({ showSearchBar: showSearchBarCheckEl[0].checked });
+    });
+
+    showGuestSectionCheckEl.on('change.test', (e) => {
+      navAPI.updated({ showGuestSection: !showGuestSectionCheckEl[0].checked });
+    });
+
+    guestSectionLink.on('click.test', (e) => {
+      $('body').toast({
+        'title': 'Guest link clicked',
+        'message': 'Following the guest link'
+      });
+    });
+
     if (hamburgerBtnEl.length) {
       hamburgerBtnEl.on('click.test', (e) => {
-        if (dropdownAPI.value === 'collapsed') {
-          dropdownAPI.selectValue('expanded')
-          dropdownEl.trigger('change');
-        } else {
-          dropdownAPI.selectValue('collapsed')
-          dropdownEl.trigger('change');
-        }
+        navAPI.handleHamburgerClick();
       });
     }
 
@@ -438,7 +426,27 @@
       console.info('Module Button Click');
     })
 
+    hideCompletelyEl.on('change.test', (e) => {
+      console.log(hideCompletelyEl[0].checked)
+
+      if (hideCompletelyEl[0].checked) {
+        navAPI.updated({ displayMode: false });
+        hamburgerBtnEl.attr('disabled', 'true');
+      }
+      else {
+       navAPI.updated({ displayMode: navAPI.isLargerThanBreakpoint() ? 'collapsed' : 'expanded' });
+       hamburgerBtnEl.removeAttr('disabled');
+      }
+    });
+
     // Customizations to the component after init
-    navAPI.updated({ displayMode: 'collapsed' });
+    navAPI.updated({ displayMode: 'expanded' });
+
+    $('.module-nav-switcher').on('listcontextmenu', function (e, delegate) {
+      console.log('Context Menu Event Fired')
+      const url = $(delegate.target).text().replace(/^\s+|\s+$/g, '').replace(' ', '').toLocaleLowerCase();
+      $(delegate.target)
+        .attr('href', `https://example.com/${url}`);
+    });
   });
 </script>

--- a/app/views/components/module-nav/example-index.html
+++ b/app/views/components/module-nav/example-index.html
@@ -345,11 +345,11 @@
       <div class="four columns">
         <div class="field">
           <input type="checkbox" class="checkbox" name="pin-sections" id="pin-sections" />
-          <label for="pin-sections" class="checkbox-label">Preview 'pinSections' setting</label>
+          <label for="pin-sections" class="checkbox-label">Show 'pinSections' setting</label>
         </div>
         <div class="field">
           <input type="checkbox" class="checkbox" name="display-detail-check" id="display-detail-check" />
-          <label for="display-detail-check" class="checkbox-label">Preview 'showDetailView' setting</label>
+          <label for="display-detail-check" class="checkbox-label">Show 'showDetailView' setting</label>
         </div>
         <div class="field">
           <input type="checkbox" class="checkbox" name="hide-completely" id="hide-completely" />

--- a/app/views/components/module-nav/example-one-pane.html
+++ b/app/views/components/module-nav/example-one-pane.html
@@ -331,7 +331,7 @@
         <p></p>
         <div class="field">
           <input type="checkbox" class="checkbox" name="pin-sections" id="pin-sections" />
-          <label for="pin-sections" class="checkbox-label">Preview 'pinSections' setting</label>
+          <label for="pin-sections" class="checkbox-label">Show 'pinSections' setting</label>
         </div>
       </div>
     </div>

--- a/app/views/components/module-nav/example-with-accordion-in-page-container.html
+++ b/app/views/components/module-nav/example-with-accordion-in-page-container.html
@@ -358,7 +358,7 @@
               </p>
             </div>
           </div>
-    
+
           <div id="header-two" class="accordion-header">
             <a href="#" id="sort-by" data-automation-id="accordion-a-sort-by"><span>Sort By</span></a>
             <button id="sort-by-expander" data-automation-id="accordion-btn-sort-by" class="btn" tabindex="-1">
@@ -389,7 +389,7 @@
               </div>
             </div>
           </div>
-    
+
           <div id="header-three" class="accordion-header">
             <a id="brand-name" data-automation-id="accordion-a-brand-name" href="#"><span>Brand Name</span></a>
             <button id="brand-name-expander" data-automation-id="accordion-btn-brand-name" class="btn" tabindex="-1">
@@ -406,7 +406,7 @@
                 </p>
             </div>
           </div>
-    
+
           <div id="header-four" class="accordion-header">
             <a id="material" data-automation-id="accordion-a-material" href="#"><span>Material</span></a>
             <button id="material-expander" data-automation-id="accordion-btn-material" class="btn" tabindex="-1">
@@ -437,11 +437,11 @@
 
         <div class="field">
           <input type="checkbox" class="checkbox" name="pin-sections" id="pin-sections" />
-          <label for="pin-sections" class="checkbox-label">Preview 'pinSections' setting</label>
+          <label for="pin-sections" class="checkbox-label">Show 'pinSections' setting</label>
         </div>
         <div class="field">
           <input type="checkbox" class="checkbox" name="display-detail-check" id="display-detail-check" />
-          <label for="display-detail-check" class="checkbox-label">Preview 'showDetailView' setting</label>
+          <label for="display-detail-check" class="checkbox-label">Apply 'showDetailView' setting</label>
         </div>
       </div>
     </div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## v4.90.1 Fixes
 
 - `[Popupmenu]` Fixed a bug where menu buttons did not close when toggled. ([#8232](https://github.com/infor-design/enterprise/issues/8232))
+
 ## v4.91.0
 
 ## v4.91.0 Fixes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # What's New with Enterprise
 
+## v4.90.1
+
+## v4.90.1 Features
+
+- `[ModuleNav]` Added a new "guest" section and some new settings to toggle the search and module switcher section. ([#8232](https://github.com/infor-design/enterprise/issues/8232))
+
+## v4.90.1 Fixes
+
+- `[Popupmenu]` Fixed a bug where menu buttons did not close when toggled. ([#8232](https://github.com/infor-design/enterprise/issues/8232))
+
 ## v4.90.0
 
 ## v4.90.0 Features

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -521,6 +521,7 @@
     width: calc(100% - 1px);
 
     > span {
+      margin-top: -1px;
       display: inline-block; // to allow offsetWidth
       overflow: hidden;
       text-overflow: ellipsis;

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -1445,7 +1445,6 @@ html[dir='rtl'] {
       .listoption-icon {
         left: auto;
         margin-left: 7px;
-        margin-right: inherit;
         right: 0;
       }
 

--- a/src/components/module-nav/module-nav.accordion.scss
+++ b/src/components/module-nav/module-nav.accordion.scss
@@ -119,7 +119,7 @@
 
       [class^='btn'] {
         &:focus:not(.hide-focus) {
-          border-color: transparent;
+          border-color: transparent !important;
         }
 
         .icon {

--- a/src/components/module-nav/module-nav.dropdown.scss
+++ b/src/components/module-nav/module-nav.dropdown.scss
@@ -74,6 +74,7 @@ $module-nav-container-size: $module-nav-switcher-button-size + $module-nav-switc
 
       + span {
         padding-inline-start: 0;
+        padding-inline-end: 1px;
       }
     }
   }
@@ -138,7 +139,7 @@ $module-nav-container-size: $module-nav-switcher-button-size + $module-nav-switc
     a {
       color: $module-nav-switcher-dropdown-item-text-color;
       padding-inline-start: 44px;
-      padding-block-start: $module-nav-switcher-button-gutter-size - 1px;
+      padding-block-start: $module-nav-switcher-button-gutter-size + 1;
     }
 
     .listoption-icon {
@@ -199,6 +200,20 @@ $module-nav-container-size: $module-nav-switcher-button-size + $module-nav-switc
     }
   }
 }
+
+html[dir='rtl'] .dropdown-list.role-dropdown > .trigger .icon {
+  margin-right: 10px;
+}
+
+html[dir='rtl'] .dropdown-list.role-dropdown.has-icons .dropdown-search {
+  width: calc(100% - 55px);
+}
+
+html[dir='rtl'] .module-nav-search-container .searchfield-wrapper.has-close-icon-button.has-text .btn-icon.close {
+  top: 9px;
+  right: calc(300px - 20px);
+}
+
 
 // =====================================================
 // Scrollable, non-pinned (changes some component sizes)

--- a/src/components/module-nav/module-nav.guest.scss
+++ b/src/components/module-nav/module-nav.guest.scss
@@ -1,0 +1,57 @@
+@import './module-nav.common.scss';
+
+// Module Nav Guest Section
+//================================================== //
+.module-nav-guest {
+  border-top: 1px solid $module-nav-separator-color;
+
+  &.hidden,
+  [hidden] {
+    display: none;
+  }
+}
+
+// Link Styles
+.module-nav-guest a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: $module-nav-item-padding-size 0;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.mode-expanded .module-nav-guest a {
+  justify-content: flex-start;
+
+  svg {
+    margin-inline-start: 4px;
+  }
+}
+
+// Text Styles
+.module-nav-guest-text {
+  display: flex;
+  flex-direction: column;
+  margin-inline-start: 13px;
+  max-width: 257px;
+}
+
+.module-nav-guest-title,
+.module-nav-guest-subtext {
+  color: $module-nav-item-text-color;
+  font-size: 16px;
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.module-nav-guest-subtext {
+  color: $module-nav-item-light-text-color;
+  font-size: 14px;
+}
+
+.mode-collapsed .module-nav-guest-text {
+  display: none;
+}

--- a/src/components/module-nav/module-nav.js
+++ b/src/components/module-nav/module-nav.js
@@ -36,6 +36,9 @@ const MODULE_NAV_DEFAULTS = {
   mobileBehavior: true,
   breakpoint: 'phone-to-tablet', // Can be 'tablet' or 'phone-to-tablet'(+ 767), 'phablet (+610)', 'desktop' + (1024) or 'tablet-to-desktop'(+1280).Default is 'phone-to-tablet'(767)
   showOverlay: true,
+  showModuleSwitcher: true,
+  showGuestSection: false,
+  showSearchBar: true,
   enableOutsideClick: false,
   autoCollapseOnMobile: true
 };
@@ -85,10 +88,31 @@ ModuleNav.prototype = {
   },
 
   /**
- * @returns {HTMLElement | undefined} container element for Module Nav component and page content
- */
+   * @returns {HTMLElement | undefined} container element for Module Nav component and page content
+   */
   get pageContainerEl() {
     return this.element.next('.page-container');
+  },
+
+  /**
+   * @returns {HTMLElement | undefined} container element for module nav switcher area
+   */
+  get moduleSwitcherEl() {
+    return this.element.find('.module-nav-header')[0];
+  },
+
+  /**
+   * @returns {HTMLElement | undefined} container element for module nav search
+   */
+  get moduleSearchEl() {
+    return this.element.find('.module-nav-search-container')[0];
+  },
+
+  /**
+   * @returns {HTMLElement | undefined} container element for module nav guest section
+   */
+  get moduleGuestSectionEl() {
+    return this.element.find('.module-nav-guest')[0];
   },
 
   /**
@@ -137,6 +161,9 @@ ModuleNav.prototype = {
     this.setPinSections(this.settings.pinSections);
     this.setScrollable();
     this.setShowDetailView(this.settings.showDetailView);
+    this.setShowModuleSwitcher(this.settings.showModuleSwitcher);
+    this.setShowModuleSearch(this.settings.showSearchBar);
+    this.setShowGuestSection(this.settings.showGuestSection);
     this.configureResize();
     return this;
   },
@@ -506,6 +533,33 @@ ModuleNav.prototype = {
   },
 
   /**
+   * Configures display of the Module Nav's module switcher section
+   * @param {boolean} val true if the module switcher section should be shown
+   * @returns {void}
+   */
+  setShowModuleSwitcher(val) {
+    this.moduleSwitcherEl?.classList[!val ? 'add' : 'remove']('hidden');
+  },
+
+  /**
+   * Configures display of the Module Nav's module search section
+   * @param {boolean} val true if the module search section should be shown
+   * @returns {void}
+   */
+  setShowModuleSearch(val) {
+    this.moduleSearchEl?.classList[!val ? 'add' : 'remove']('hidden');
+  },
+
+  /**
+   * Configures display of the Module Nav's module guest section
+   * @param {boolean} val true if the module guest section should be shown
+   * @returns {void}
+   */
+  setShowGuestSection(val) {
+    this.moduleGuestSectionEl?.classList[val ? 'remove' : 'add']('hidden');
+  },
+
+  /**
    * Checks the window size against the defined breakpoint.
    * @private
    * @returns {boolean} whether or not the window size is larger than the settings-defined breakpoint
@@ -538,7 +592,7 @@ ModuleNav.prototype = {
    */
   updated(settings) {
     if (settings) {
-      this.settings = utils.mergeSettings(this.element[0], settings, this.settings);
+      this.settings = utils.deepMergeObject(this.settings, settings);
       if (this.switcherAPI) this.switcherAPI.settings.displayMode = this.settings.displayMode;
       if (this.settingsAPI) this.settingsAPI.settings.displayMode = this.settings.displayMode;
     }

--- a/src/components/module-nav/module-nav.searchfield.scss
+++ b/src/components/module-nav/module-nav.searchfield.scss
@@ -17,7 +17,7 @@
       border: $module-nav-input-border-width solid transparent;
       color: inherit;
       padding-inline-start: $module-nav-search-input-text-y-offset;
-      padding-inline-end: 10px;
+      padding-inline-end: 35px;
       height: $module-nav-search-input-height;
       width: 100%;
 

--- a/src/components/module-nav/module-nav.searchfield.scss
+++ b/src/components/module-nav/module-nav.searchfield.scss
@@ -98,6 +98,13 @@
   }
 }
 
+.module-nav-search-container {
+  &.hidden,
+  [hidden] {
+    display: none;
+  }
+}
+
 // =====================================================
 // Display Mode: Collapsed
 

--- a/src/components/module-nav/module-nav.switcher.scss
+++ b/src/components/module-nav/module-nav.switcher.scss
@@ -2,6 +2,12 @@
 
 // Module Nav Switcher Component
 //================================================== //
+.module-nav-header {
+  &.hidden,
+  [hidden] {
+    display: none;
+  }
+}
 
 .module-nav-switcher {
   @include nav-item-style;

--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -434,7 +434,7 @@ Personalize.prototype = {
         colors.headerTextColor = themeColors.palette.slate[10].value;
         colors.headerTabsTextColor = themeColors.palette.slate[10].value;
 
-        colors.headerTabBorder = themeColors.palette.slate[60].value;
+        colors.headerTabBorder = themeColors.palette.slate[70].value;
         colors.verticalTabBorder = themeColors.palette.slate[60].value;
         colors.tabFocusIndicator = themeColors.palette.white.value;
         colors.tabSelectedColor = themeColors.palette.slate[90].value;

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -974,7 +974,10 @@ PopupMenu.prototype = {
         self.holdingDownClick = true;
       }
 
-      self.close();
+      if (self.isOpen) {
+        self.close();
+        return;
+      }
       doOpen(e);
     }
 

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -782,6 +782,7 @@ $module-nav-item-collapsed-size: 40px;
 $module-nav-item-collapsed-general-spacing-size: 4px;
 $module-nav-item-collapsed-first-last-spacing-size: 4px;
 $module-nav-item-text-color: $ids-color-palette-slate-100;
+$module-nav-item-light-text-color: $ids-color-palette-slate-60;
 $module-nav-item-hover-bg-color: $ids-color-palette-slate-20;
 $module-nav-item-hover-text-color: $ids-color-palette-slate-100;
 $module-nav-item-selected-bg-color: $ids-color-palette-azure-10;

--- a/src/core/_controls-new.scss
+++ b/src/core/_controls-new.scss
@@ -89,6 +89,7 @@
 @import '../components/module-nav/module-nav.dropdown';
 @import '../components/module-nav/module-nav.searchfield';
 @import '../components/module-nav/module-nav.settings';
+@import '../components/module-nav/module-nav.guest';
 @import '../components/module-nav/module-nav.switcher';
 @import '../components/pager/pager';
 @import '../components/pager/pager-new';

--- a/src/core/_controls.scss
+++ b/src/core/_controls.scss
@@ -55,6 +55,7 @@
 @import '../components/module-nav/module-nav.dropdown';
 @import '../components/module-nav/module-nav.searchfield';
 @import '../components/module-nav/module-nav.settings';
+@import '../components/module-nav/module-nav.guest';
 @import '../components/module-nav/module-nav.switcher';
 @import '../components/pager/pager';
 @import '../components/popdown/popdown';

--- a/src/themes/theme-new-contrast.scss
+++ b/src/themes/theme-new-contrast.scss
@@ -560,6 +560,7 @@ $module-nav-input-text-color: $ids-color-palette-slate-70;
 
 // Module Nav Item (Accordion Header/Menu Button)
 $module-nav-item-text-color: $ids-color-palette-slate-100;
+$module-nav-item-light-text-color: $ids-color-palette-slate-70;
 $module-nav-item-hover-bg-color: $ids-color-palette-slate-30;
 $module-nav-item-hover-text-color: $ids-color-palette-slate-100;
 $module-nav-item-selected-bg-color: $ids-color-palette-azure-20;

--- a/src/themes/theme-new-dark.scss
+++ b/src/themes/theme-new-dark.scss
@@ -612,6 +612,7 @@ $module-nav-input-text-color: $ids-color-palette-slate-10;
 
 // Module Nav Item (Accordion Header/Menu Button)
 $module-nav-item-text-color: $ids-color-palette-slate-10;
+$module-nav-item-light-text-color: $ids-color-palette-slate-40;
 $module-nav-item-hover-bg-color: $ids-color-palette-slate-80;
 $module-nav-item-hover-text-color: $ids-color-palette-slate-10;
 $module-nav-item-selected-bg-color: $ids-color-palette-azure-60;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -677,7 +677,7 @@ utils.isPlainObject = function isPlainObject(obj) {
 };
 
 /**
- * Merge an array be each index position
+ * Merge an array by each index position
  * @param  {array} arr1 The first array
  * @param  {array} arr2  The second array
  * @returns {array} The merged array
@@ -1395,6 +1395,33 @@ utils.waitForTransitionEnd = function (el, property) {
     };
     el.addEventListener('transitionend', transitionEnded);
   });
+};
+
+/**
+ * Simple deep merge function for nested objects
+ * @param {object} targetObject the target object
+ * @param {object} sourceObject the object to merge on
+ * @returns {object} the merged object
+ */
+utils.deepMergeObject = function (targetObject = {}, sourceObject = {}) {
+  // clone the source and target objects to avoid the mutation
+  const copyTargetObject = JSON.parse(JSON.stringify(targetObject));
+  const copySourceObject = JSON.parse(JSON.stringify(sourceObject));
+  // Iterating through all the keys of source object
+  Object.keys(copySourceObject).forEach((key) => {
+    if (typeof copySourceObject[key] === 'object' && !Array.isArray(copySourceObject[key])) {
+      // If property has nested object, call the function recursively
+      copyTargetObject[key] = utils.deepMergeObject(
+        copyTargetObject[key],
+        copySourceObject[key]
+      );
+    } else {
+      // else merge the object source to target
+      copyTargetObject[key] = copySourceObject[key];
+    }
+  });
+
+  return copyTargetObject;
 };
 
 export { utils, math };


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adds two new features to module nav. One is a guest section at the bottom, and the second is the ability to hide and show the search and switcher section. Additionally fixed a couple bugs.

- the utils.mergesettings worked odd and didnt properly merger. made a new function in utils
- fixed the dark mode header border it was too light
- fixed a bug in menu button that clicking when open did not toggle the menu button

**Design Review Questions**

See: https://8232-external-settings-enterprise.demo.design.infor.com/components/module-nav/example-hide-show-sections.html?colors=fff

- is guest section optionally clickable
- i made guest section a bit more compact

@krishollenbeck -> can you see if this looks good or needs anything from your end (I will add types to the wrapper when reviewed)
@talkaboutdesign -> please have a look
@EdwardCoyle -> notice change to updated a different merge function, i think this is why we have wierd workaround and settings needed in NG wrapper (just a note) but do review please

**Related github/jira issue (required)**:
Fixes #8232 

**Steps necessary to review your pull request (required)**:
- http://localhost:4000/components/module-nav/example-hide-show-sections.html?colors=fff
- click the buttons on the side when expanded and collapsed to hide/show each section
- try RTL
- try themes (in dark mode notice the bottom border)
- go to http://localhost:4000/components/popupmenu/example-menubutton.html and click to open then click again and it should now show

**Included in this Pull Request**:
- [x] A note to the change log.
