### PR TITLE
8127 - Datagrid Fix dropdown remains open when scrolling in modal

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[Charts]` Improved the positioning of chart legend color. ([#8159](https://github.com/infor-design/enterprise/issues/8159))
 - `[Bar Chart]` Displayed the x-axis ticks for the bar grouped when single group. ([#7976](https://github.com/infor-design/enterprise/issues/7976))
+- `[Datagrid]` Fixed a bug where dropdown remains open when scrolling and modal is closed. ([#8127](https://github.com/infor-design/enterprise/issues/8127))
 - `[Dropdown]` Fixed a bug where list is broken when empty icon is in the first option. ([#8105](https://github.com/infor-design/enterprise/issues/8105))
 
 ## v4.90.0

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -2365,7 +2365,10 @@ Dropdown.prototype = {
     let parentScrollableArea = $('.modal.is-visible .modal-body-wrapper');
     const subScrollableSection = self.element.parents('.scrollable, .scrollable-x, .scrollable-y, .card-content');
     if (subScrollableSection.length) {
-      parentScrollableArea = subScrollableSection;
+      const hasScrollbar = subScrollableSection.get(0).scrollHeight > subScrollableSection.get(0).clientHeight;
+      if (hasScrollbar) {
+        parentScrollableArea = subScrollableSection;
+      }
     }
     if (parentScrollableArea.length) {
       this.parentScrollableArea = parentScrollableArea;

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -333,7 +333,9 @@ Modal.prototype = {
       }
 
       this.element.find('.modal-content').append(closeBtn);
-      closeBtn.on(`click.${this.namespace}`, () => this.close()).tooltip();
+      closeBtn.on(`click.${this.namespace}`, () => {
+        this.close();
+      }).tooltip();
 
       if (this.settings.closeBtnOptions.attributes) {
         utils.addAttributes(closeBtn, this, this.settings.closeBtnOptions.attributes, '', true);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Added a check to ensure that the sub scrollable section in the datagrid is scrollable before attaching a scroll event to it

**Related github/jira issue (required)**:
Closes #8127

**Steps necessary to review your pull request (required)**:
- pull and build 
- go to http://localhost:4000/components/datagrid/test-dropdown-scroll.html
- open the modal and open any of action dropdowns
- scroll outside the dropdown options within the table
- see the dropdown has been closed
- open any of action dropdowns again and click on close (x) button
- see the dropdown has been closed

**Included in this Pull Request**:
- [x] A note to the change log.