### PR TITLE
8141 - Datagrid Actional Mode Navigation

### DIFF
--- a/app/views/components/datagrid/test-datagrid-tab-navigation.html
+++ b/app/views/components/datagrid/test-datagrid-tab-navigation.html
@@ -1,0 +1,109 @@
+<div class="row">
+  <div class="twelve columns">
+    <h2 class="fieldset-title">Soho Data Grid - Tab Navigation</h2>
+    <!-- <p>
+      This demo illustrates the use of a summary row.
+    </p> -->
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+    <div role="toolbar" class="toolbar">
+
+      <div class="title">
+        Partner Map Line
+       </div>
+
+      <div class="buttonset">
+        <button type="button" id="add-row-button" class="btn">
+          <span>Add Row</span>
+        </button>
+      </div>
+    </div>
+    <div id="datagrid" class="datagrid">
+    </div>
+  </div>
+</div>
+
+<script id="datagrid-script">
+  $('body').one('initialized', function () {
+
+      var columns = [], grid;
+      var businessKeysList = [{ label: 'BUYER', value: 'BUYER' }, { label: 'SELLER', value: 'SELLER' }, {label: '', value: '' }];
+      var accountingEntityList = [{ label: 'AE1', value: 'AE1' }, {value: 'AE2', label: 'AE2'}, {value: 'AE3', label: 'AE3'}];
+      var locationList = [{ label: 'AE1', value: 'AE1' }, {value: 'AE2', label: 'AE2'}, {value: 'AE3', label: 'AE3'}];
+
+      $.getJSON('{{basepath}}api/datagrid-sample-data', function(res) {
+
+        // Define Columns for the Grid.
+
+        columns.push({
+          id: 'selectionCheckbox',
+          name: '',
+          field: '',
+          sortable: false,
+          formatter: Soho.Formatters.SelectionCheckbox,
+          align: 'center'
+        });
+        columns.push({
+          id: 'externalValue',
+          name: 'Source Value',
+          field: 'externalValue',
+          formatter: Soho.Formatters.Text,
+          editor: Soho.Editors.Input
+        });
+        columns.push({
+          id: 'internalValue',
+          name: 'Target Value',
+          field: 'internalValue',
+          formatter: Soho.Formatters.Text,
+          editor: Soho.Editors.Input
+        });
+        columns.push({
+          id: 'businessKey',
+          name: 'Assignment Type',
+          field: 'businessKey',
+          formatter: Soho.Formatters.Dropdown,
+          options: businessKeysList,
+          editor: Soho.Editors.Dropdown
+        });
+        columns.push({
+          id: 'accountingEntityId',
+          name: 'Accounting Entity',
+          field: 'accountingEntityId',
+          formatter: Soho.Formatters.Dropdown,
+          options: accountingEntityList,
+          editor: Soho.Editors.Dropdown
+        });
+        columns.push({
+          id: 'locationId',
+          name: 'Location',
+          field: 'locationId',
+          formatter: Soho.Formatters.Dropdown,
+          options: locationList,
+          editor: Soho.Editors.Dropdown
+        });
+
+        // Init and get the api for the grid
+        grid = $('#datagrid').datagrid({
+          columns: columns,
+          saveColumns: false,
+          actionableMode: true,
+          rowNavigation: true,
+          showNewRowIndicator: true,
+          editable: true,
+          attributes: [{ name: 'id', value: 'custom-id' }, { name: 'data-automation-id', value: 'custom-automation-id' } ],
+          toolbar: {title: 'Compressors', results: true, actions: true, rowHeight: true, personalize: true}
+        });
+
+        var gridApi = grid.data('datagrid');
+
+        $('#add-row-button').on('click', function (e) {
+          gridApi.addRow({ externalValue: '', internalValue: '', businessKey: '', accountingEntityID: '', locationId: '' }, 0);
+        });
+      });
+
+      
+ });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,8 +9,8 @@
 - `[Bar Chart]` Displayed the x-axis ticks for the bar grouped when single group. ([#7976](https://github.com/infor-design/enterprise/issues/7976))
 - `[Datagrid]` Fixed a bug where dropdown remains open when scrolling and modal is closed. ([#8127](https://github.com/infor-design/enterprise/issues/8127))
 - `[Datagrid]` Fixed extra space increase on editable fields when clicking in and out of it. ([#8155](https://github.com/infor-design/enterprise/issues/8155))
-- `[Datagrid]` Fixed tab key navigation when using actional mode when having editor. ([#8141](https://github.com/infor-design/enterprise/issues/8141))
-- `[Datagrid]` Fixed tab key navigation when using actional mode when having formatter. ([#8245](https://github.com/infor-design/enterprise/issues/8245))
+- `[Datagrid]` Fixed tab key navigation when using actionable mode when having editor. ([#8141](https://github.com/infor-design/enterprise/issues/8141))
+- `[Datagrid]` Fixed tab key navigation when using actionable mode when having formatter. ([#8245](https://github.com/infor-design/enterprise/issues/8245))
 - `[Dropdown]` Fixed a bug where list is broken when empty icon is in the first option. ([#8105](https://github.com/infor-design/enterprise/issues/8105))
 - `[Personalization]` Removed box shadow on selected tabs. ([#8086](https://github.com/infor-design/enterprise/issues/8086))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@
 - `[Bar Chart]` Displayed the x-axis ticks for the bar grouped when single group. ([#7976](https://github.com/infor-design/enterprise/issues/7976))
 - `[Datagrid]` Fixed a bug where dropdown remains open when scrolling and modal is closed. ([#8127](https://github.com/infor-design/enterprise/issues/8127))
 - `[Datagrid]` Fixed extra space increase on editable fields when clicking in and out of it. ([#8155](https://github.com/infor-design/enterprise/issues/8155))
+- `[Datagrid]` Fixed tab key navigation when using actional mode when having editor. ([#8141](https://github.com/infor-design/enterprise/issues/8141))
+- `[Datagrid]` Fixed tab key navigation when using actional mode when having formatter. ([#8245](https://github.com/infor-design/enterprise/issues/8245))
 - `[Dropdown]` Fixed a bug where list is broken when empty icon is in the first option. ([#8105](https://github.com/infor-design/enterprise/issues/8105))
 - `[Personalization]` Removed box shadow on selected tabs. ([#8086](https://github.com/infor-design/enterprise/issues/8086))
 

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -2526,6 +2526,20 @@ $datagrid-small-row-height: 25px;
       overflow: hidden;
       padding: 4px 16px 0;
 
+      &.is-dropdown-wrapper {
+        .dropdown-wrapper {
+          margin-top: 2px;
+          .dropdown {
+            padding: 0 8px 10px 4px;
+          }
+
+          .icon {
+            top: 4px;
+            right: -8px;
+          }
+        }
+      }
+
       .colorpicker-container {
         background-color: transparent;
         border: 0;

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -2529,6 +2529,7 @@ $datagrid-small-row-height: 25px;
       &.is-dropdown-wrapper {
         .dropdown-wrapper {
           margin-top: 2px;
+
           .dropdown {
             padding: 0 8px 10px 4px;
           }

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10418,6 +10418,10 @@ Datagrid.prototype = {
     }
 
     this.editor =  new col.editor(idx, cell, cellValue, cellNode, col, event, this, rowData); // eslint-disable-line
+
+    if (this.editor.input.is('.dropdown') && this.editor.input.parent().is('.datagrid-cell-wrapper')) {
+      this.editor.input.parent().addClass('is-dropdown-wrapper');
+    }
     this.editor.row = idx;
     this.editor.cell = cell;
 
@@ -11534,7 +11538,7 @@ Datagrid.prototype = {
       args.rowData = isTreeGrid && this.settings.treeDepth[row] ?
         this.settings.treeDepth[row].node : rowData;
 
-      if (!this.isCellDirty(row, cell)) {
+      if (!this.isCellDirty(row, cell) && !this.settings.actionableMode) {
         this.setActiveCell(row, cell);
       }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix tab key navigation when using actionable mode when having editor and formatter.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/8141
Closes https://github.com/infor-design/enterprise/issues/8245

**Steps necessary to review your pull request (required)**:
- Pull this git repository, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-datagrid-tab-navigation.html
- Click `Add Row`
- Click on the cell under column `Source Value`
- Press `1` and then press `Tab`
- it should go to the next column.
- Press `2` and then press `Tab`
- It should go to the next column.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

