### PR TITLE
8132 - Added contentWidth column setting to set width in formatters

### DIFF
--- a/app/views/components/datagrid/test-contentwidth.html
+++ b/app/views/components/datagrid/test-contentwidth.html
@@ -21,7 +21,7 @@
       data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '100.99', status: 'OK', orderDate: new Date(2014, 6, 9, 12, 12, 12), action: 'On Hold', ordered: 0});
 
 
-      columns.push({ width: 70, contentWidth: '100%', id: 'action', name: 'Active', field: 'action', text: 'Action', sortable: false, align: 'center',formatter: Soho.Formatters.Button, click: function (e, args) {$('body').toast({ title: 'Click Fired', message: 'Id : ' + args[0].item.id + ' was clicked.' })}
+      columns.push({ width: 90, contentWidth: '100%', id: 'action', name: 'Active', field: 'action', text: 'Action', sortable: false, align: 'center',formatter: Soho.Formatters.Button, click: function (e, args) {$('body').toast({ title: 'Click Fired', message: 'Id : ' + args[0].item.id + ' was clicked.' })}
       , contentVisible: function (row, cell, data, col, item) { return (item.status === 'OK');} });
       columns.push({ id: 'activity', name: 'Activity', field: 'activity'});
       columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity'});

--- a/app/views/components/datagrid/test-contentwidth.html
+++ b/app/views/components/datagrid/test-contentwidth.html
@@ -23,6 +23,8 @@
 
       columns.push({ width: 70, contentWidth: '100%', id: 'action', name: 'Active', field: 'action', text: 'Action', sortable: false, align: 'center',formatter: Soho.Formatters.Button, click: function (e, args) {$('body').toast({ title: 'Click Fired', message: 'Id : ' + args[0].item.id + ' was clicked.' })}
       , contentVisible: function (row, cell, data, col, item) { return (item.status === 'OK');} });
+      columns.push({ id: 'activity', name: 'Activity', field: 'activity'});
+      columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity'});
       columns.push({ id: 'productId', hidden: true, name: 'Product Id', field: 'productId', formatter: Soho.Formatters.Readonly });
       columns.push({ id: 'productDesc', name: 'Product Desc', field: 'productName', formatter: Soho.Formatters.Hyperlink});
       columns.push({ id: 'actionLink', name: 'As Link', field: 'action', sortable: false, align: 'center', formatter: Soho.Formatters.Hyperlink, icon: 'reset'});

--- a/app/views/components/datagrid/test-contentwidth.html
+++ b/app/views/components/datagrid/test-contentwidth.html
@@ -1,15 +1,5 @@
 <div class="row">
   <div class="twelve columns">
-    <br />
-    <h3>Grid Example: Customization</h3>
-    <p>
-    Shows how to create an form button column. Also using the contentVisible function on the column you can customize on which rows it should be visible.
-    </p><br />
-  </div>
-</div>
-
-<div class="row">
-  <div class="twelve columns">
     <div id="datagrid">
     </div>
   </div>
@@ -17,12 +7,10 @@
 
 <script>
     $('body').on('initialized', function () {
-     //Locale.set('en-US').done(function () {
-      var grid,
+      let grid,
         columns = [],
         data = [];
 
-      // Some Sample Data
       data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action', ordered: 1, setting: {optionOne: 'One', optionTwo: 'One'}});
       data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold', ordered: true, setting: {optionOne: 'One', optionTwo: 'One'}});
       data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action', ordered: true, comment: 'Dynamic harness out-of-the-box /n syndicate models deliver. Disintermediate, technologies /n scale deploy social streamline, methodologies, killer podcasts innovate. Platforms A-list disintermediate, value visualize dot-com /n tagclouds platforms incentivize interactive vortals disintermediate networking, webservices envisioneer; tag share value-added, disintermediate, revolutionary.'});
@@ -32,14 +20,11 @@
       data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', ordered: 0});
       data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '100.99', status: 'OK', orderDate: new Date(2014, 6, 9, 12, 12, 12), action: 'On Hold', ordered: 0});
 
-      //Define Columns for the Grid.
 
-      columns.push({ width: 100, contentWidth: '100%', id: 'action', name: 'Active', field: 'action', text: 'Action', sortable: false, align: 'center',formatter: Soho.Formatters.Button, click: function (e, args) {$('body').toast({ title: 'Click Fired', message: 'Id : ' + args[0].item.id + ' was clicked.' })}
+      columns.push({ width: 70, contentWidth: '100%', id: 'action', name: 'Active', field: 'action', text: 'Action', sortable: false, align: 'center',formatter: Soho.Formatters.Button, click: function (e, args) {$('body').toast({ title: 'Click Fired', message: 'Id : ' + args[0].item.id + ' was clicked.' })}
       , contentVisible: function (row, cell, data, col, item) { return (item.status === 'OK');} });
       columns.push({ id: 'productId', hidden: true, name: 'Product Id', field: 'productId', formatter: Soho.Formatters.Readonly });
       columns.push({ id: 'productDesc', name: 'Product Desc', field: 'productName', formatter: Soho.Formatters.Hyperlink});
-      columns.push({ id: 'activity', name: 'Activity', field: 'activity'});
-      columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity'});
       columns.push({ id: 'actionLink', name: 'As Link', field: 'action', sortable: false, align: 'center', formatter: Soho.Formatters.Hyperlink, icon: 'reset'});
 
       //Init and get the api for the grid

--- a/app/views/components/datagrid/test-form-buttons.html
+++ b/app/views/components/datagrid/test-form-buttons.html
@@ -34,13 +34,13 @@
 
       //Define Columns for the Grid.
 
-      columns.push({ width: 100, contentWidth: '100%', id: 'action', name: 'Active', field: 'action', text: 'Action', sortable: false, align: 'center',formatter: Soho.Formatters.Button, click: function (e, args) {$('body').toast({ title: 'Click Fired', message: 'Id : ' + args[0].item.id + ' was clicked.' })}
-      , contentVisible: function (row, cell, data, col, item) { return (item.status === 'OK');} });
       columns.push({ id: 'productId', hidden: true, name: 'Product Id', field: 'productId', formatter: Soho.Formatters.Readonly });
       columns.push({ id: 'productDesc', name: 'Product Desc', field: 'productName', formatter: Soho.Formatters.Hyperlink});
       columns.push({ id: 'activity', name: 'Activity', field: 'activity'});
       columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity'});
       columns.push({ id: 'actionLink', name: 'As Link', field: 'action', sortable: false, align: 'center', formatter: Soho.Formatters.Hyperlink, icon: 'reset'});
+      columns.push({ id: 'action', name: 'Active', field: 'action', text: 'Action', sortable: false, align: 'center',formatter: Soho.Formatters.Button, click: function (e, args) {$('body').toast({ title: 'Click Fired', message: 'Id : ' + args[0].item.id + ' was clicked.' })}
+      , contentVisible: function (row, cell, data, col, item) { return (item.status === 'OK');} });
 
       //Init and get the api for the grid
       grid = $('#datagrid').datagrid({

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Bar Chart]` Displayed the x-axis ticks for the bar grouped when single group. ([#7976](https://github.com/infor-design/enterprise/issues/7976))
 - `[Datagrid]` Fixed a bug where dropdown remains open when scrolling and modal is closed. ([#8127](https://github.com/infor-design/enterprise/issues/8127))
 - `[Datagrid]` Fixed extra space increase on editable fields when clicking in and out of it. ([#8155](https://github.com/infor-design/enterprise/issues/8155))
+- `[Datagrid]` Added `contentWidth` column setting to set width in formatters. ([#8132](https://github.com/infor-design/enterprise/issues/8132))
 - `[Dropdown]` Fixed a bug where list is broken when empty icon is in the first option. ([#8105](https://github.com/infor-design/enterprise/issues/8105))
 - `[Pager]` Fixed double call on update pager when using keydown. ([#8156](https://github.com/infor-design/enterprise/issues/8156))
 - `[Personalization]` Removed box shadow on selected tabs. ([#8086](https://github.com/infor-design/enterprise/issues/8086))

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -625,18 +625,19 @@ const formatters = {
   Button(row, cell, value, col, item, api) {
     let text;
     const disableAttr = isColumnDisabled(row, cell, value, col, item) ? ' disabled' : '';
+    const contentWidth = col.contentWidth ? ` style="width: ${col.contentWidth}"` : '';
+
     if (col.text) {
       text = col.text;
     } else {
       text = (value === null || value === undefined || value === '') ? '' : value.toString();
     }
-    let markup = `<button type="button"${disableAttr} class="${(col.icon ? 'btn-icon' : 'btn-secondary')} row-btn ${(col.cssClass ? col.cssClass : '')}"${(!api.settings.rowNavigation ? '' : ' tabindex="-1"')} >`;
+    let markup = `<button type="button"${disableAttr}${contentWidth} class="${(col.icon ? 'btn-icon' : 'btn-secondary')} row-btn ${(col.cssClass ? col.cssClass : '')}"${(!api.settings.rowNavigation ? '' : ' tabindex="-1"')} >`;
 
     if (col.icon) {
       markup += $.createIcon({ icon: col.icon, file: col.iconFile });
     }
     markup += `<span>${text}</span></button>`;
-
     return markup;
   },
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -6715,7 +6715,8 @@ Datagrid.prototype = {
         const diff = currentColWidth - (left - leftOffset);
 
         // Enforce Column or Default min and max widths
-        widthToSet = cssWidth - diff;
+        const newWidthToSet = cssWidth - diff;
+        widthToSet = widthToSet && Math.abs(newWidthToSet - widthToSet) <= 3 ? widthToSet : newWidthToSet;
 
         if (widthToSet < minWidth || widthToSet > maxWidth) {
           self.resizeHandle.css('cursor', 'inherit');
@@ -6725,6 +6726,7 @@ Datagrid.prototype = {
         if (widthToSet === cssWidth) {
           return;
         }
+
         currentCol.style.width = (`${widthToSet}px`);
 
         const inRange = (idx === this.settings.frozenColumns.left.length - 1) ||


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Added contentWidth column setting to set width in formatters. Currently only used in button formatter

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #8132 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datagrid/test-contentwidth
- Adjust column width of button column
- Should stay in 100% and adjust accordingly

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
