### PR TITLE
8260 - Fix required icon color

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[Datagrid]` Fixed extra space increase on editable fields when clicking in and out of it. ([#8155](https://github.com/infor-design/enterprise/issues/8155))
 - `[Datagrid]` Fixed tab key navigation when using actionable mode when having editor. ([#8141](https://github.com/infor-design/enterprise/issues/8141))
 - `[Datagrid]` Fixed tab key navigation when using actionable mode when having formatter. ([#8245](https://github.com/infor-design/enterprise/issues/8245))
+- `[Datagrid]` Fixed invisible color on required icon in datagrid. ([#8260](https://github.com/infor-design/enterprise/issues/8260))
 - `[Dropdown]` Fixed a bug where list is broken when empty icon is in the first option. ([#8105](https://github.com/infor-design/enterprise/issues/8105))
 - `[Pager]` Fixed double call on update pager when using keydown. ([#8156](https://github.com/infor-design/enterprise/issues/8156))
 - `[Personalization]` Removed box shadow on selected tabs. ([#8086](https://github.com/infor-design/enterprise/issues/8086))

--- a/src/themes/theme-new-contrast.scss
+++ b/src/themes/theme-new-contrast.scss
@@ -645,7 +645,7 @@ $datagrid-list-alt-sorted-icon-color: $ids-color-palette-slate-50;
 $datagrid-list-draggable-sorted-icon-color: $ids-color-palette-slate-50;
 $datagrid-sort-icon-color: $ids-color-palette-slate-60;
 $datagrid-sort-icon-sorted-color: $ids-color-palette-slate-100;
-$datagrid-required-icon-color: $ids-color-palette-white;
+$datagrid-required-icon-color: $ids-color-palette-slate-100;
 
 $datagrid-filter-border-color: $ids-color-palette-slate-100;
 $datagrid-filter-hover-border-color: $ids-color-palette-slate-90;

--- a/src/themes/theme-new-dark.scss
+++ b/src/themes/theme-new-dark.scss
@@ -705,7 +705,7 @@ $datagrid-header-active-color: $ids-color-palette-slate-80;
 $datagrid-header-checkbox-border-color: $ids-color-palette-slate-30;
 $datagrid-sort-icon-color: $ids-color-palette-slate-30;
 $datagrid-sort-icon-sorted-color: $ids-color-palette-slate-10;
-$datagrid-required-icon-color: $ids-color-palette-slate-100;
+$datagrid-required-icon-color: $ids-color-palette-white;
 
 $datagrid-cell-color: $ids-color-palette-slate-10;
 $datagrid-cell-bg-color: $ids-color-palette-slate-90;

--- a/src/themes/theme-new-light.scss
+++ b/src/themes/theme-new-light.scss
@@ -112,6 +112,7 @@ $datagrid-nested-header-border-color: $ids-color-palette-slate-30;
 $datagrid-header-border-color: $ids-color-palette-slate-30;
 $datagrid-header-checkbox-border-color: $ids-color-palette-slate-80;
 $datagrid-header-active-color: $ids-color-palette-slate-20;
+$datagrid-required-icon-color: $ids-color-palette-slate-100;
 
 $datagrid-list-header-color: $ids-color-font-base;
 $datagrid-list-header-bg-color: $ids-color-palette-slate-10;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes the wrong colored icon in datagrid for required columns.

**Related github/jira issue (required)**:
Fixes #8260 

**Steps necessary to review your pull request (required)**:
- test page http://localhost:4000/components/datagrid/example-editable.html and make sure the icon is visible
- try all 6 theme/modes

**Included in this Pull Request**:
- [x] A note to the change log.
