### PR TITLE
8154 - Breadcrumb Fix overflow menu items don't fire a callback function

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## v4.91.0 Fixes
 
 - `[Accordion]` Fixed a bug where focus border was not fully shown in subheader. ([#8109](https://github.com/infor-design/enterprise/issues/8109))
+- `[Breadcrumb]` Fixed a bug where overflow menu items don't fire a callback function. ([#8154](https://github.com/infor-design/enterprise/issues/8154))
 - `[Cards/Widget]` Fixed vertical alignment of detail title in cards/widget. ([#8235](https://github.com/infor-design/enterprise/issues/8235))
 - `[Charts]` Improved the positioning of chart legend color. ([#8159](https://github.com/infor-design/enterprise/issues/8159))
 - `[Bar Chart]` Displayed the x-axis ticks for the bar grouped when single group. ([#7976](https://github.com/infor-design/enterprise/issues/7976))

--- a/src/components/breadcrumb/breadcrumb.js
+++ b/src/components/breadcrumb/breadcrumb.js
@@ -463,7 +463,7 @@ Breadcrumb.prototype = {
         }
 
         const menuItemHTML = `<li class="${liDisabled}">
-          <a href="#" data-breadcrumb-index="${i}"${aDisabled}>${breadcrumb.settings.content || ''}</a>
+          <a href="${breadcrumb.settings.href || '#'}" data-breadcrumb-index="${i}"${aDisabled}>${breadcrumb.settings.content || ''}</a>
         </li>`;
         menuHTML += menuItemHTML;
       });
@@ -726,7 +726,7 @@ Breadcrumb.prototype = {
         const liItem = args[0];
         const index = liItem[0].getAttribute('data-breadcrumb-index');
         const breadcrumbAPI = this.overflowed[Number(index)];
-        $(breadcrumbAPI.a).trigger('click');
+        $(breadcrumbAPI.element).trigger('click');
       });
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Trigger click on `li` element instead of `a` when overflowed menu `selected` event fires. Added `href` to overflowed menu items `a` so it's linkable

**Related github/jira issue (required)**:
#8154 

**Steps necessary to review your pull request (required)**:
- pull and build
- go to http://localhost:4000/components/breadcrumb/example-add-remove.html
- click on the Add button to create enough crumbs that there is an overflow
- open the overflow and click one
- notice when clicking an overflow item that the callback is executed (text in Last-Clicked Breadcrumb Contents and toast message)

**Included in this Pull Request**:
- [x] A note to the change log.