### PR TITLE
8270 - Add attributes setting for automation id in module nav switcher

### DIFF
--- a/app/views/components/module-nav/example-index.html
+++ b/app/views/components/module-nav/example-index.html
@@ -68,7 +68,7 @@
           <div class="module-nav-switcher">
             <div class="module-nav-section role-dropdown">
               <label for="module-nav-role-switcher" class="label audible">Roles</label>
-              <select id="module-nav-role-switcher" name="module-nav-role-switcher" class="dropdown" data-automation-id="custom-automation-dropdown-id">
+              <select id="module-nav-role-switcher" name="module-nav-role-switcher" class="dropdown" data-options="{attributes: [{ name: 'id', value: 'switcher-id-1' }, { name: 'data-automation-id', value: 'switcher-automation-id' }]}" data-automation-id="custom-automation-dropdown-id">
                 <option value="admin" data-icon="{icon: 'app-ac'}">Admin Console</option>
                 <option value="job-console" data-icon="{icon: 'app-jo'}">Job Console</option>
                 <option value="landing-page-designer" data-icon="{icon: 'app-lmd'}">Landing Page Designer</option>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## v4.90.1 Features
 
 - `[ModuleNav]` Added a new "guest" section and some new settings to toggle the search and module switcher section. ([#8232](https://github.com/infor-design/enterprise/issues/8232))
+- `[ModuleNav]` Added `attributes` setting (for automation id) in the module nav switcher. ([#8270](https://github.com/infor-design/enterprise/issues/8270))
 
 ## v4.90.1 Fixes
 

--- a/src/components/module-nav/module-nav.switcher.js
+++ b/src/components/module-nav/module-nav.switcher.js
@@ -28,6 +28,7 @@ const MODULE_NAV_SWITCHER_DEFAULTS = {
   changeIconOnSelect: true,
   moduleButtonText: 'Standard Module',
   roleDropdownLabel: 'Roles',
+  attributes: null,
   roles: []
 };
 
@@ -191,7 +192,8 @@ ModuleNavSwitcher.prototype = {
       extraListWrapper: true,
       width: 'parent',
       widthTarget: '.module-nav-switcher',
-      noSearch: this.settings.noSearch
+      noSearch: this.settings.noSearch,
+      attributes: this.settings.attributes,
     }).off('change.module-nav').on('change.module-nav', (e) => {
       if (!this.settings.changeIconOnSelect) return;
       this.selectRole(e.currentTarget.value);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR adds `attributes` setting to add automation id in the module nav switcher only.

**Related github/jira issue (required)**:

Closes #8270

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/module-nav/example-index.html?colors=fff
- Click the hamburger menu to open the nav switcher
- Click the nav switcher
- Inspect the list
- It should have automation-id and id attributes e.g., `data-automation-id="switcher-automation-id-option-x"`

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
