### PR TITLE
8220 - Fixed wrong hover color on button

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[Charts]` Improved the positioning of chart legend color. ([#8159](https://github.com/infor-design/enterprise/issues/8159))
 - `[Circlepager]` Fixed the positioning of the next and previous buttons. ([#8266](https://github.com/infor-design/enterprise/issues/8266))
 - `[Bar Chart]` Displayed the x-axis ticks for the bar grouped when single group. ([#7976](https://github.com/infor-design/enterprise/issues/7976))
+- `[Button]` Fixed wrong hover color on button. ([#8220](https://github.com/infor-design/enterprise/issues/8220))
 - `[Datagrid]` Fixed a bug where dropdown remains open when scrolling and modal is closed. ([#8127](https://github.com/infor-design/enterprise/issues/8127))
 - `[Datagrid]` Fixed extra space increase on editable fields when clicking in and out of it. ([#8155](https://github.com/infor-design/enterprise/issues/8155))
 - `[Datagrid]` Added `contentWidth` column setting to set width in formatters. ([#8132](https://github.com/infor-design/enterprise/issues/8132))

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -596,8 +596,7 @@ a.btn-close {
 
   &:hover:not(:disabled) {
     color: $button-color-tertiary-hover-font;
-    background-color: $button-color-tertiary-hover-background;
-    
+
     .icon {
       color: $button-color-tertiary-hover-font;
     }

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -594,7 +594,7 @@ a.btn-close {
   color: $button-color-tertiary-initial-font;
   overflow: hidden;
 
-  &:hover:not(:disabled) {
+  &:hover {
     color: $button-color-tertiary-hover-font;
 
     .icon {

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -4591,6 +4591,8 @@ td .btn-actions {
   }
 
   &:hover:not([disabled]) {
+    background-color: $button-color-tertiary-hover-background;
+
     .icon.plus-minus::before,
     .icon.plus-minus::after {
       background-color: $button-color-tertiary-hover-font;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Moved hover color to datagrid expand button as it seems to be for that only.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #8220 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/button/example-100-percent.html
- Hover on buttons
- Hover color should be correct

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
