### PR TITLE
8061 - Add setting for two digit year cutover

### DIFF
--- a/app/views/components/datepicker/test-two-digit-year.html
+++ b/app/views/components/datepicker/test-two-digit-year.html
@@ -1,0 +1,32 @@
+
+<div class="row">
+  <div class="four columns">
+    <div class="field">
+      <label for="date-field-a" class="label">Date Field</label>
+      <input id="date-field-a" class="datepicker" name="date-field" type="text" data-init="false" value="74-12-11" />
+    </div>
+
+    <div class="field">
+      <label for="date-field-b" class="label">Date Field</label>
+      <input id="date-field-b" class="datepicker" name="date-field" type="text" data-init="false" value="06/12/77"/>
+    </div>
+
+  </div>
+
+</div>
+
+<script>
+  $('body').on('initialized', function() {
+    Soho.Locale.twoDigitYearCutoff = 75;
+
+    $('#date-field-a').datepicker({
+      dateFormat: 'yy-MM-dd'
+    });
+
+    $('#date-field-b')
+      .datepicker({ dateFormat: 'dd/MM/yy' })
+      .on('change', function () {
+        console.log('Change Event Fired')
+      });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## v4.90.1 Features
 
+- `[Dates]` Added a new `twoDigitYear` setting to set the switch over for two digit years. ([#8061](https://github.com/infor-design/enterprise/issues/8061))
 - `[ModuleNav]` Added a new "guest" section and some new settings to toggle the search and module switcher section. ([#8232](https://github.com/infor-design/enterprise/issues/8232))
 
 ## v4.90.1 Fixes

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -38,6 +38,7 @@ const Locale = {  // eslint-disable-line
   cultures: {},
   languages: {},
   dff: [],
+  twoDigitYearCutoff: 39,
   culturesPath: existingCulturePath,
   defaultLocales: [
     { lang: 'af', default: 'af-ZA' },
@@ -1407,7 +1408,8 @@ const Locale = {  // eslint-disable-line
    * @returns {number} Converted 3 digit year.
    */
   twoToFourDigitYear(twoDigitYear) {
-    return parseInt((twoDigitYear > 39 ? '19' : '20') + twoDigitYear, 10);
+    // eslint-disable-next-line no-undef
+    return parseInt((twoDigitYear > this.twoDigitYearCutoff ? '19' : '20') + twoDigitYear, 10);
   },
 
   /**

--- a/src/components/locale/readme.md
+++ b/src/components/locale/readme.md
@@ -38,6 +38,16 @@ By default, it will fetch the JS files on your server from the `cultures/` folde
 SohoConfig.culturesPath = 'myserver/path/cultures/';
 ```
 
+## Code Example - Two Digit Year
+
+Two digit years are confusing to users and should be avoided at all costs. If for legacy reasons you need to support two digit years you can use `yy` in a date format and most behavior will work. Two digit years work on a cut over. By default this is `39` this means > 38 will produce `2038` and < 39 will produce `1938`. You can configure this globally with the setting `Locale.twoDigitYearCutoff`
+
+```javascript
+Locale.twoDigitYearCutoff = 75;
+Locale.twoToFourDigitYear(74) // 2074
+Locale.twoToFourDigitYear(77) // 1977
+```
+
 ## Code Example - Using minified files
 
 IDS ships with a minified set of Culture files.  To configure the Locale system to pull in these files instead of the uncompressed ones, you can use SohoConfig:

--- a/test/components/locale/locale-func-test.js
+++ b/test/components/locale/locale-func-test.js
@@ -2200,20 +2200,15 @@ describe('Locale API', () => {
     expect(Locale.translate('AddComments')).toEqual('Ajouter commentaires');
   });
 
-  it('should be able to determine if we are using the islamic calendar', () => {
+  it('should be able to switch two digit year', () => {
     Locale.set('en-US');
+    expect(Locale.twoDigitYearCutoff).toBe(39);
+    expect(Locale.twoToFourDigitYear(38)).toEqual(2038);
+    expect(Locale.twoToFourDigitYear(41)).toEqual(1941);
 
-    expect(Locale.isIslamic()).toEqual(false);
-
-    Locale.set('ar-SA');
-
-    expect(Locale.isIslamic()).toEqual(true);
-
-    Locale.set('es-ES');
-
-    expect(Locale.isIslamic()).toEqual(false);
-    expect(Locale.isIslamic('ar-SA')).toEqual(true);
-    expect(Locale.isIslamic('xx-XX')).toEqual(false);
+    Locale.twoDigitYearCutoff = 75;
+    expect(Locale.twoToFourDigitYear(74)).toEqual(2074);
+    expect(Locale.twoToFourDigitYear(77)).toEqual(1977);
   });
 
   it.skip('should correct placeholder missing translations', () => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR lets you configure the two digit year switchover to a different year than the default which is `39`

**Related github/jira issue (required)**:
Fixes #8061 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datepicker/test-two-digit-year.html
- note the switcher is changed to 75 (2075)
- open the first picker and it should show 1977 as the year
- try selecting and opening for different years close anove and below 2075

**Included in this Pull Request**:
- [x] An e2e or functional test for the bug or feature.
- [x] A note to the change log.