### PR TITLE
Remove usage from Module Nav readme

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## v4.90.1 Fixes
 
+- `[ModuleNav]` Removed usage guidance from readme.md to support updated doc site structure. ([#8282](https://github.com/infor-design/enterprise/issues/8282))
 - `[Popupmenu]` Fixed a bug where menu buttons did not close when toggled. ([#8232](https://github.com/infor-design/enterprise/issues/8232))
 
 ## v4.91.0

--- a/src/components/module-nav/readme.md
+++ b/src/components/module-nav/readme.md
@@ -1,6 +1,6 @@
 ---
 title: Module Nav
-description: null
+description:
 demo:
   embedded:
   - name: Example

--- a/src/components/module-nav/readme.md
+++ b/src/components/module-nav/readme.md
@@ -1,61 +1,13 @@
 ---
 title: Module Nav
-description: Helps users navigate within an application.
+description: null
 demo:
   embedded:
   - name: Example
     slug: example-index
 ---
-
-## Basics
-
-### Anatomy
-
-- Header
-    - Module switcher
-    - Dropdown
-    - Searchfield
-- Accordion
-- Footer
-
-### Options
-
-Modes
-
-- Default: Collapsed menu shows icons on hover.
-- Expanded: Menu opens to show icon labels, dropdown, an optional searchfield, and expandable accordions.
-- Hidden
-
-## Guidelines
-
-### When to use
-
-- Use to help people navigate within different areas and change their application settings.
-
-### Usability guidance
-
-- Combine with the [header](./header) to provide the ability for users to expand and collapse the menu.
-- Display only the most important navigation within the menu.
-- Avoid nesting several items within the menu, as only the top-level items are available from the collapsed menu.
-    - If use cases warrant a more complex menu hierarchy, an optional searchfield can help users reveal nested links.
-- When applicable, pin the menu header and footer to keep them visible in the menu.
-- On mobile, tapping on page content collapses an expanded menu.
-
-### UX writing
-
-- Keep navigation labels concise, aiming for a max of 30 characters to avoid truncation.
-- Consider how translations may increase string length.
-
-### Related
-
-- [App menu](./applicationmenu)
-- [Header](./header)
-- [Accordion](./accordion)
-- [Searchfield](./searchfield)
-
-## Code
   
-### Settings
+## Settings
 
 | Name | Description |
 | ----------- | ----------- |
@@ -64,9 +16,9 @@ Modes
 | `pinSections` | Pins the header and footer areas, allowing only the navigation items to scroll. |
 | `showDetailView` | Enables a secondary pane for more content, if needed. |
 
-### Implementation
+## Implementation
 
-The layout system is created with a `.module-nav-container` CSS class. This structure provides full functionality:
+The layout system is created with a `.module-nav-container` CSS class, which provides full functionality:
 
 ```html
 <section class="module-nav-container">


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Removed usage guidance from Module Nav readme. Usage will display in separate tab within component page on design.infor.com.

**Related github/jira issue (required)**:
- Closes #8282 
- Closes [Jira IDS-1804](https://jira.infor.com/browse/IDS-1804)

**Steps necessary to review your pull request (required)**:
- View `src/components/module-nav/readme.md`

**Included in this Pull Request**:
- [ ] A note to the change log.


