### PR TITLE
8103 - Fix searchfield icon alignments in RTL

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `[Personalization]` Removed box shadow on selected tabs. ([#8086](https://github.com/infor-design/enterprise/issues/8086))
 - `[Popupmenu]` Fixed a bug where menu buttons did not close when toggled. ([#8232](https://github.com/infor-design/enterprise/issues/8232))
 - `[Searchfield]` Fixed styling issues in RTL. ([#6982](https://github.com/infor-design/enterprise/issues/6982))
+- `[Searchfield]` Fixed searchfield stylings in RTL and in mobile viewport. ([#8103](https://github.com/infor-design/enterprise/issues/8103))
 
 ## v4.90.0
 

--- a/src/components/searchfield/_searchfield-toolbar.scss
+++ b/src/components/searchfield/_searchfield-toolbar.scss
@@ -1087,7 +1087,7 @@ html[dir='rtl'] {
       &.active {
         .btn,
         .collapse-button {
-          border-bottom-color: rgba($searchfield-border-color, 1);
+          border-color: transparent;
         }
       }
     }
@@ -1297,6 +1297,10 @@ html[dir='rtl'] {
     @media (min-width: $breakpoint-phone-to-tablet) {
       right: 193px;
     }
+  }
+
+  .flex-toolbar .toolbar-section .searchfield-wrapper.toolbar-searchfield-wrapper.has-close-icon-button.active:not(.is-open) .custom-button {
+    right: calc(100% - 30px);
   }
 
   .flex-toolbar .toolbar-section .searchfield-wrapper.toolbar-searchfield-wrapper.has-close-icon-button.has-text.active.has-close-icon-button .custom-button {

--- a/src/components/toolbar-flex/_toolbar-flex-searchfield-new.scss
+++ b/src/components/toolbar-flex/_toolbar-flex-searchfield-new.scss
@@ -124,18 +124,6 @@ html[dir='rtl'] {
   }
 }
 
-html[dir='rtl'] {
-  &.is-firefox {
-    .toolbar-section.search {
-      .toolbar-searchfield-wrapper {
-        .icon:not(.close) {
-          top: 10px;
-        }
-      }
-    }
-  }
-}
-
 .flex-toolbar .toolbar-searchfield-wrapper > svg.icon {
   top: 10px;
   width: 20px;

--- a/src/components/toolbar-flex/_toolbar-flex-searchfield.scss
+++ b/src/components/toolbar-flex/_toolbar-flex-searchfield.scss
@@ -172,8 +172,6 @@ html[dir='rtl'] {
       .searchfield-wrapper,
       .toolbar-searchfield-wrapper {
         &.is-open.has-collapse-button {
-          width: calc(98% + 35px);
-
           &.has-go-button {
             width: calc(94% + 35px);
 

--- a/src/components/toolbar-flex/_toolbar-flex.scss
+++ b/src/components/toolbar-flex/_toolbar-flex.scss
@@ -417,6 +417,13 @@
 
 // RTL Styles
 html[dir='rtl'] {
+  .flex-toolbar {
+    .toolbar-section.search .toolbar-searchfield-wrapper.has-custom-button.has-close-icon-button.is-open {
+      .btn-icon.close {
+        right: calc(100% - 70px);
+      }
+    }
+  }
   .toolbar-section {
     &.title + .toolbar-section.buttonset {
       text-align: left;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the alignment issues of searchfield icons in RTL and within the mobile viewport.

**Related github/jira issue (required)**:

Closes #8103

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/searchfield/example-buttons.html?theme=new&mode=light&colors=default&locale=ar-SA
- Check all icons in the searchfield component including on mobile viewport (`custom icon`, `close`, `search`)
- Icons should be positioned correctly

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
