### PR TITLE
8216 - Fixed dropdown icon misalignment in extra small rowheight

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[Datagrid]` Fixed tab key navigation when using actionable mode when having formatter. ([#8245](https://github.com/infor-design/enterprise/issues/8245))
 - `[Datagrid]` Fixed invisible color on required icon in datagrid. ([#8260](https://github.com/infor-design/enterprise/issues/8260))
 - `[Datagrid]` Fixed disabled color for colorpicker. ([#8218](https://github.com/infor-design/enterprise/issues/8218))
+- `[Datagrid]` Fixed dropdown icon misalignment in extra small rowheight. ([#8216](https://github.com/infor-design/enterprise/issues/8216))
 - `[Dropdown]` Fixed a bug where list is broken when empty icon is in the first option. ([#8105](https://github.com/infor-design/enterprise/issues/8105))
 - `[Message]` Fixed success icon alignment in message header. ([#8240](https://github.com/infor-design/enterprise/issues/8240))
 - `[ModuleNav]` Removed usage guidance from readme.md to support updated doc site structure. ([#8282](https://github.com/infor-design/enterprise/issues/8282))

--- a/src/components/datagrid/_datagrid-new.scss
+++ b/src/components/datagrid/_datagrid-new.scss
@@ -1125,6 +1125,13 @@ html[dir='rtl'] {
         top: 11px;
       }
     }
+
+    .datagrid-cell-wrapper {
+      .dropdown-trigger:not(.colorpicker-container) + .icon {
+        top: 2px !important;
+        left: -4px !important;
+      }
+    }
   }
 
   .datagrid.small-rowheight {

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1199,7 +1199,7 @@ $datagrid-small-row-height: 25px;
 
           .dropdown-trigger {
             margin-left: -1px;
-            margin-top: -1px;
+            margin-top: 5px;
 
             + .icon {
               top: 0;
@@ -5012,18 +5012,24 @@ html[dir='rtl'] {
   }
 
   .datagrid.small-rowheight {
-    .datagrid-trigger-cell.has-editor {
-      &:not(.is-readonly) {
-        &:hover,
-        &:focus {
-          svg.icon + .icon-error,
-          svg.icon + .icon-info,
-          svg.icon + .icon-alert {
-            &:not(.datagrid-alert-icon) {
-              margin-left: 26px !important;
+    .datagrid-trigger-cell {
+      &.has-editor {
+        &:not(.is-readonly) {
+          &:hover,
+          &:focus {
+            svg.icon + .icon-error,
+            svg.icon + .icon-info,
+            svg.icon + .icon-alert {
+              &:not(.datagrid-alert-icon) {
+                margin-left: 26px !important;
+              }
             }
           }
         }
+      }
+
+      .dropdown-trigger:not(.colorpicker-container) + .icon {
+        left: 5px;
       }
     }
   }
@@ -5084,17 +5090,23 @@ html[dir='rtl'] {
   }
 
   .datagrid.extra-small-rowheight {
-    .datagrid-trigger-cell.has-editor {
-      .icon-error {
-        left: 0 !important;
+    .datagrid-trigger-cell {
+      &.has-editor {
+        .icon-error {
+          left: 0 !important;
+        }
+
+        &.is-editing {
+          .trigger {
+            left: -6px;
+            margin-right: 0;
+            top: 0;
+          }
+        }
       }
 
-      &.is-editing {
-        .trigger {
-          left: -6px;
-          margin-right: 0;
-          top: 0;
-        }
+      .dropdown-trigger:not(.colorpicker-container) + .icon {
+        left: 7px !important;
       }
     }
   }
@@ -5970,7 +5982,7 @@ html[dir='rtl'] {
           &:hover {
             color: $contextual-toolbar-button-hover-color;
             background-color: rgba(0, 0, 0, .3) !important;
-    
+
             .icon {
               color: $contextual-toolbar-button-hover-color !important;
             }

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -5682,7 +5682,7 @@ html[dir='rtl'] {
       content: '';
     }
 
-    .required::before {
+    .required::after {
       @include required-indicator();
 
       color: $datagrid-required-icon-color;
@@ -5690,7 +5690,7 @@ html[dir='rtl'] {
       top: 0;
     }
 
-    th .datagrid-header-text.required::before {
+    th .datagrid-header-text.required::after {
       font-size: 1.8rem;
     }
 

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -5690,6 +5690,10 @@ html[dir='rtl'] {
       top: 0;
     }
 
+    th .datagrid-header-text.required::before {
+      font-size: 1.8rem;
+    }
+
     &.left {
       th:last-child {
         border-right: 0;

--- a/src/components/dropdown/_dropdown-new.scss
+++ b/src/components/dropdown/_dropdown-new.scss
@@ -524,7 +524,15 @@ html[dir='rtl'] {
 
     > .trigger {
       .icon {
-        margin-right: -24px;
+        margin-right: -16px;
+      }
+    }
+  }
+
+  .datagrid-dropdown-list {
+    &.extra-small-rowheight {
+      input {
+        padding-right: 5px;
       }
     }
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fixed dropdown icon misalignment in extra small rowheight

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #8216 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datagrid/example-editable.html?theme=new&mode=light&colors=default&locale=ar-SA
- Hover over dropdown cells
- Arrow icon should be seen

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
