### PR TITLE
8265 - Tabs Header Contrast Classic

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - `[Modal]` Fixed a bug where the modal would shift up when toggling a switch inside of it. ([#8018](https://github.com/infor-design/enterprise/issues/8018))
 - `[Tabs]` Fixed size in close button of tab list. ([#8274](https://github.com/infor-design/enterprise/issues/8274))
+- `[TabsHeader]` Fixed focus border not visible in classic contrast alabaster. ([#8265](https://github.com/infor-design/enterprise/issues/8265))
 
 ## v4.91.0
 

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -692,6 +692,10 @@ html[class*='classic-'] .is-personalizable .tab-container.header-tabs.alternate 
   border-color: ${colors.contrast};
 }
 
+html[class*='classic-contrast'] .is-personalizable .tab-container.header-tabs.alternate > .tab-list-container .tab.is-selected:not(.is-disabled) {
+  border-color: ${colors.light};
+}
+
 .tab-container.header-tabs.alternate > .tab-list-container .tab.is-disabled {
   color: ${colors.contrast};
   opacity: 0.6;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix focus border not visible in classic contrast alabaster.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/8265

**Steps necessary to review your pull request (required)**:
- Pull this git repository, build, and run the app
- Go to http://localhost:4000/components/tabs-header/example-alternate.html?theme=classic&mode=contrast&colors=ffffff
- Click one of the tabs header
- Active Tab should be visible

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

