### PR TITLE
8208 - Fixed alignments of searchfield icons in RTL

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## v4.92.0 Fixes
 
+- `[Contextual Action Panel]` Fixed alignments of searchfield icons in RTL. ([#8208](https://github.com/infor-design/enterprise/issues/8208))
 - `[Tabs]` Fixed size in close button of tab list. ([#8274](https://github.com/infor-design/enterprise/issues/8274))
 
 ## v4.91.0

--- a/src/components/toolbar/_toolbar-new.scss
+++ b/src/components/toolbar/_toolbar-new.scss
@@ -123,3 +123,27 @@
     }
   }
 }
+
+html[dir='rtl'] {
+  .toolbar {
+    &:not(.standalone) .searchfield-wrapper.toolbar-searchfield-wrapper:not(.has-categories):not(.is-open) {
+      input {
+        padding-left: 31px;
+      }
+
+      .icon:not(.icon-dropdown) {
+        right: 9px;
+      }
+
+      &.has-text {
+        input {
+          padding-left: 18px;
+        }
+
+        .icon:not(.icon-dropdown) {
+          right: 74px;
+        }
+      }
+    }
+  }
+}

--- a/src/components/toolbar/_toolbar-new.scss
+++ b/src/components/toolbar/_toolbar-new.scss
@@ -123,27 +123,3 @@
     }
   }
 }
-
-html[dir='rtl'] {
-  .toolbar {
-    &:not(.standalone) .searchfield-wrapper.toolbar-searchfield-wrapper:not(.has-categories):not(.is-open) {
-      input {
-        padding-left: 31px;
-      }
-
-      .icon:not(.icon-dropdown) {
-        right: 9px;
-      }
-
-      &.has-text {
-        input {
-          padding-left: 18px;
-        }
-
-        .icon:not(.icon-dropdown) {
-          right: 74px;
-        }
-      }
-    }
-  }
-}

--- a/src/components/toolbar/_toolbar.scss
+++ b/src/components/toolbar/_toolbar.scss
@@ -493,6 +493,26 @@ html[dir='rtl'] {
         }
       }
     }
+
+    &:not(.standalone) .searchfield-wrapper.toolbar-searchfield-wrapper:not(.has-categories):not(.is-open) {
+      input {
+        padding-left: 31px;
+      }
+
+      .icon:not(.icon-dropdown) {
+        right: 9px;
+      }
+
+      &.has-text {
+        input {
+          padding-left: 19px;
+        }
+
+        .icon:not(.icon-dropdown) {
+          right: 71px;
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fixed alignments of searchfield icons in RTL

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #8208 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/toolbarsearchfield/example-inside-contextual-panel.html?locale=ar-SA
- Open Contextual Action Panel
- Searchfield icon placeholder text should not be shown
- Type in searchfield and unfocus
- Text and icon should be aligned

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
