### PR TITLE
Added trigger for column reorder.

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3402,6 +3402,21 @@ Datagrid.prototype = {
                 self.updateGroupHeadersAfterColumnReorder(indexFrom, indexTo);
                 self.arrayIndexMove(self.settings.columns, indexFrom, indexTo);
                 self.updateColumns(self.settings.columns);
+				
+				/**
+				* Fires after a column is moved to target.
+				* @event columnreorder
+				* @memberof Datagrid
+				* @property {object} event The jquery event object
+				* @property {number} indexTo The ending column index
+				* @property {number} indexFrom The starting column index
+				*/
+				self.element.trigger('columnreorder', [{
+					  indexFrom: indexFrom,
+					  indexTo: indexTo,
+					  columns: self.settings.columns,
+				  }]);
+				  
               }
             }
           });

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3402,21 +3402,20 @@ Datagrid.prototype = {
                 self.updateGroupHeadersAfterColumnReorder(indexFrom, indexTo);
                 self.arrayIndexMove(self.settings.columns, indexFrom, indexTo);
                 self.updateColumns(self.settings.columns);
-				
-				/**
-				* Fires after a column is moved to target.
-				* @event columnreorder
-				* @memberof Datagrid
-				* @property {object} event The jquery event object
-				* @property {number} indexTo The ending column index
-				* @property {number} indexFrom The starting column index
-				*/
-				self.element.trigger('columnreorder', [{
-					  indexFrom: indexFrom,
-					  indexTo: indexTo,
-					  columns: self.settings.columns,
-				  }]);
-				  
+
+                /**
+                * Fires after a column is moved to target.
+                * @event columnreorder
+                * @memberof Datagrid
+                * @property {object} event The jquery event object
+                * @property {number} indexTo The ending column index
+                * @property {number} indexFrom The starting column index
+                */
+                self.element.trigger('columnreorder', [{
+                  indexFrom,
+                  indexTo,
+                  columns: self.settings.columns,
+                }]);
               }
             }
           });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When is reorder columns in the grid does not have trigger with indexfrom and indexTo.
For requirement I need these information to reorder my internal model to be synchronized with IDS model.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->

**Steps necessary to review your pull request (required)**:
1- Move column index 0 to index 3.
2- Result : Give me indexFrom =0 and indexTo =3.
Added columns also just for test purpose to verify.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [ ] A note to the change log. - Add triiger for column reorder.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
