### PR TITLE
8327 - Added example with back button

### DIFF
--- a/app/views/components/header/example-hamburger-back.html
+++ b/app/views/components/header/example-hamburger-back.html
@@ -1,0 +1,27 @@
+<header class="header is-personalizable">
+  <div class="flex-toolbar">
+    <div class="toolbar-section">
+      {{> includes/header-appmenu-back}}
+    </div>
+    <div class="toolbar-section title">
+      <h1>Page Title</h1>
+    </div>
+
+    <div class="toolbar-section search">
+      <label for="header-searchfield" class="audible">Search</label>
+      <input id="header-searchfield" class="searchfield" name="header-searchfield" data-options="{'collapsible': true, 'clearable': true}" />
+    </div>
+
+    {{> includes/header-actionbutton}}
+
+  </div>
+</header>
+
+<script>
+  $("#back-button").on('click', () => {
+    $('body').toast({
+      title: 'Go back',
+      message: 'The back button was clicked.'
+    });
+  });
+</script>

--- a/app/views/includes/header-appmenu-back.html
+++ b/app/views/includes/header-appmenu-back.html
@@ -1,0 +1,12 @@
+<button id="header-hamburger" class="btn-icon application-menu-trigger personalize-actionable" type="button" id="hamburger-button">
+  <span class="audible" data-translate="text">AppMenuTriggerTextAlt</span>
+  <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+    <use href="#icon-menu"></use>
+  </svg>
+</button>
+<button class="btn-icon personalize-actionable" type="button" id="back-button">
+  <span class="audible">Drill Down</span>
+  <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+    <use href="#icon-arrow-left"></use>
+  </svg>
+</button>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## v4.92.0 Features
 
+- `[Header]` Added an example configuration with both a hamburger and a back button. ([#8327](https://github.com/infor-design/enterprise/issues/8327))
+
 ## v4.92.0 Fixes
 
 - `[Locale]` Changed all `zh` locales time format as suggested by native speakers. ([#8313](https://github.com/infor-design/enterprise/issues/8313))


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Added a new example showing both a back and hamburger button. This was sort of already possible so just added a new example.

**Related github/jira issue (required)**:

Fixes #8327 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/header/example-hamburger-back.html?colors=ffffff
- clicking the burger icon will operate the menu
- clicking the back will show a toast for example purposes

**Included in this Pull Request**:
- [x] A note to the change log.
