### PR TITLE
8212 - Cards Title Widget Alignment

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## v4.92.0 Fixes
 
+- `[Cards]` Fixed title alignment for bordered and borderless. ([#8212](https://github.com/infor-design/enterprise/issues/8212))
 - `[Locale]` Changed all `zh` locales time format as suggested by native speakers. ([#8313](https://github.com/infor-design/enterprise/issues/8313))
 - `[Modal]` Fixed a bug where the modal would shift up when toggling a switch inside of it. ([#8018](https://github.com/infor-design/enterprise/issues/8018))
 - `[Process Indicator]` Adjusted alignment of icon in compact process indicator. ([#8241](https://github.com/infor-design/enterprise/issues/8241))

--- a/src/components/cards/_cards-new.scss
+++ b/src/components/cards/_cards-new.scss
@@ -293,6 +293,7 @@
     padding-left: 16px;
     padding-right: 8px;
     padding-top: 0;
+    width: 360px;
   }
 
   > button.btn-actions:not(.has-toolbar) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix title alignment for bordered and borderless

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/8212

**Steps necessary to review your pull request (required)**:
- Pull this git repository, build, and run the app
- Go to http://localhost:4000/components/cards/example-workspace-widgets.html
- Open `Developer Console`
- Try to highlight the widget header for both bordered and borderless
- It should 360px both

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

