### PR TITLE
evaluate column cssClass and use it properly on the hyperlink formatter string template

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[Tabs]` Fixed size in close button of tab list. ([#8274](https://github.com/infor-design/enterprise/issues/8274))
 - `[Tabs Header]` Fixed focus border not visible in classic contrast alabaster. ([#8265](https://github.com/infor-design/enterprise/issues/8265))
 - `[Tabs Module]` Fixed more button not visible in alabaster. ([#8271](https://github.com/infor-design/enterprise/issues/8271))
+- `[Datagrid]` Fixed Hyperlink Formatter cssClass string resolution. ([#8340](https://github.com/infor-design/enterprise/issues/8340))
 
 ## v4.91.0
 

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -296,12 +296,14 @@ const formatters = {
       return '';
     }
 
+    const columnCssClass = col.cssClass(row, cell, value, col, item) || '';
+
     return col.icon ?
-      (`<a href="${colHref}"${disableAttr} class="btn-icon row-btn ${(col.cssClass || '')}" ${(!api.settings.rowNavigation ? '' : 'tabindex="-1"')}${(col.hyperlinkTooltip ? ` title="${col.hyperlinkTooltip}"` : '')}>
+      (`<a href="${colHref}"${disableAttr} class="btn-icon row-btn ${columnCssClass}" ${(!api.settings.rowNavigation ? '' : 'tabindex="-1"')}${(col.hyperlinkTooltip ? ` title="${col.hyperlinkTooltip}"` : '')}>
           ${$.createIcon({ icon: col.icon, file: col.iconFile })}
           <span class="audible">${textValue}</span>
         </a>`) :
-      (`<a href="${colHref}"${disableAttr} ${(!api.settings.rowNavigation ? '' : 'tabindex="-1"')} class="hyperlink ${(col.cssClass || '')}"${(col.target ? ` target="${col.target}"` : '')}${(col.hyperlinkTooltip ? ` title="${col.hyperlinkTooltip}"` : '')}>${textValue}</a>`);
+      (`<a href="${colHref}"${disableAttr} ${(!api.settings.rowNavigation ? '' : 'tabindex="-1"')} class="hyperlink ${columnCssClass}"${(col.target ? ` target="${col.target}"` : '')}${(col.hyperlinkTooltip ? ` title="${col.hyperlinkTooltip}"` : '')}>${textValue}</a>`);
   },
 
   Template(row, cell, value, col, item) {

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -296,7 +296,14 @@ const formatters = {
       return '';
     }
 
-    const columnCssClass = col.cssClass(row, cell, value, col, item) || '';
+    let columnCssClass = '';
+    if (typeof col.cssClass === 'string') {
+      columnCssClass = col.cssClass;
+    }
+
+    if (typeof col.cssClass === 'function') {
+      columnCssClass = col.cssClass(row, cell, value, col, item) || '';
+    }
 
     return col.icon ?
       (`<a href="${colHref}"${disableAttr} class="btn-icon row-btn ${columnCssClass}" ${(!api.settings.rowNavigation ? '' : 'tabindex="-1"')}${(col.hyperlinkTooltip ? ` title="${col.hyperlinkTooltip}"` : '')}>


### PR DESCRIPTION
This PR evaluates the column cssClass callback for usage in the hyperlink class, previously it is just using the callback as is in a text format to the class

**Steps necessary to review your pull request (required)**:
Provide a cssClass callback that returns a string on a SohoDatagridColumn, and use a Soho.Formatters.Hyperlink on the formatter definition

This PR solves:
Fixes https://github.com/infor-design/enterprise/issues/8340

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
