### PR TITLE
8351 - [Preview] Cards Widget Header

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## v4.92.0 Fixes
 
+- `[Cards]` Fixed widget header alignment with the parent. ([#8351](https://github.com/infor-design/enterprise/issues/8351))
 - `[Cards]` Fixed title alignment for bordered and borderless. ([#8212](https://github.com/infor-design/enterprise/issues/8212))
 - `[Contextual Action Panel]` Fixed alignments of searchfield icons in RTL. ([#8208](https://github.com/infor-design/enterprise/issues/8208))
 - `[Datagrid]` Replaced the toolbar with a flex toolbar for the editable example. ([#8093](https://github.com/infor-design/enterprise/issues/8093))

--- a/src/components/cards/_cards-new.scss
+++ b/src/components/cards/_cards-new.scss
@@ -293,7 +293,7 @@
     padding-left: 16px;
     padding-right: 8px;
     padding-top: 0;
-    width: 360px;
+    width: inherit;
   }
 
   > button.btn-actions:not(.has-toolbar) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix widget header alignment with the parent.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/8351
Relates https://github.com/infor-design/enterprise/issues/8212

**Steps necessary to review your pull request (required)**:
- Pull this git repository, build, and run the app
- Go to http://localhost:4000/components/homepage/example-index.html
- Check widget header are align to the width of the paren
- Go to http://localhost:4000/components/cards/example-workspace-widgets.html
- Open `Developer Console`
- Try to highlight the widget header for both bordered and borderless
- It should 360px both

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

