### PR TITLE
8198 - Datagrid Frozen Column Prevent Reorder

### DIFF
--- a/app/views/components/datagrid/test-frozen-columns.html
+++ b/app/views/components/datagrid/test-frozen-columns.html
@@ -1,0 +1,48 @@
+<div class="full-height full-width">
+  <div id="datagrid" class="datagrid">
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+      var grid,
+        columns = [],
+        data = [];
+
+      var url = '{{basepath}}api/compressors?pageNum=1&pageSize=100';
+      $.getJSON(url, function(res) {
+        data = res.data;
+
+        // Define Columns for the Grid.
+        columns.push({ id: 'productId', reorderable: false, name: 'Product Id', field: 'productId', formatter: Soho.Formatters.Text});
+        // columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Soho.Formatters.Hyperlink, href: 'http://www.google.com', target: '_blank'});
+        columns.push({ id: 'activity', name: 'Activity', field: 'activity'});
+        columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity'});
+        // columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Soho.Formatters.Date, dateFormat: 'M/d/yyyy'});
+        // columns.push({ id: 'price', align: 'right', name: 'Actual Price', field: 'price', formatter: Soho.Formatters.Decimal, numberFormat: {minimumFractionDigits: 0, maximumFractionDigits: 0, style: 'currency', currencySign: '$'}});
+        // columns.push({ id: 'status', name: 'Status', field: 'status', formatter: Soho.Formatters.Text});
+        // columns.push({ id: 'pumpLife', name: 'Pump Life', field: 'pumpLife'});
+        // columns.push({ id: 'ratedTemp', name: 'Temp. Rating', field: 'ratedTemp'});
+        // columns.push({ id: 'productSku', name: 'Sku', field: 'productSku'});
+        // columns.push({ id: 'action', name: 'Action', field: 'action'});
+        // columns.push({ id: 'rpm', name: 'Motor Rpm', field: 'rpm'});
+        // columns.push({ id: 'maxPressure', name: 'Max Pressure', field: 'maxPressure'});
+        // columns.push({ id: 'weight', name: 'Weight', field: 'weight'});
+        // columns.push({ id: 'actionButton', name: 'Button', field: '', text: 'Buy Now', align: 'center', sortable: false, formatter: Soho.Formatters.Button, click: function (e, args) {console.log('Button was clicked', args);}, width: 160, exportable: false});
+
+        // Init and get the api for the grid
+        $('#datagrid').datagrid({
+          columns: columns,
+          columnReorder: true,
+          dataset: data,
+          paging: true,
+          pagesize: 50,
+          frozenColumns: {
+            left: ['productId'],
+            // right: ['actionButton']
+          },
+          toolbar: {title: 'Compressors', actions: true, rowHeight: true, results: true, personalize: true, exportToExcel: true }
+        });
+      });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[Cards]` Fixed widget header alignment with the parent. ([#8351](https://github.com/infor-design/enterprise/issues/8351))
 - `[Cards]` Fixed title alignment for bordered and borderless. ([#8212](https://github.com/infor-design/enterprise/issues/8212))
 - `[Contextual Action Panel]` Fixed alignments of searchfield icons in RTL. ([#8208](https://github.com/infor-design/enterprise/issues/8208))
+- `[Datagrid]` Fixed frozen columns getting out of sync when columnReorder is set to true. ([#8198](https://github.com/infor-design/enterprise/issues/8198))
 - `[Datagrid]` Replaced the toolbar with a flex toolbar for the editable example. ([#8093](https://github.com/infor-design/enterprise/issues/8093))
 - `[Datagrid]` Fixed Hyperlink Formatter `cssClass` string resolution. ([#8340](https://github.com/infor-design/enterprise/issues/8340))
 - `[Dropdown]` Fixed handling for null, undefined objects passed to updateItemIcon method. ([#8353](https://github.com/infor-design/enterprise/issues/8353))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3519,14 +3519,12 @@ Datagrid.prototype = {
     }
 
     for (let i = 0; i < frozenColArr.length; i++) {
-      let filteredKey = targetArr.filter(col => col.id === frozenColArr[i]);
+      const filteredKey = targetArr.filter(col => col.id === frozenColArr[i]);
       
       isFrozenColumn = filteredKey.length > 0;
-      break;
-    }
-
-    if (isFrozenColumn) {
-      return;
+      if (isFrozenColumn) {
+        return;
+      }
     }
 
     arr.splice(to, 0, arr.splice(from, 1)[0]);

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3290,8 +3290,15 @@ Datagrid.prototype = {
                     target = self.draggableColumnTargets[n];
                   }
 
-                  target.el.addClass('is-over');
-                  showTarget.addClass('is-over');
+                  const columnName = target.el.siblings('.datagrid-column-wrapper').find('.datagrid-header-text').text();
+                  const frozenColDtls = self.getFrozenColumnDetails();
+                  const isFrozenColumn = frozenColDtls.filter(col => col.name === columnName).length > 0;
+
+                  if (!isFrozenColumn) {
+                    target.el.addClass('is-over');
+                    showTarget.addClass('is-over');
+                  }
+
                   rect = target.el[0].getBoundingClientRect();
                   showTarget[0].style.left = `${parseInt(rect.left + (Locale.isRTL() ? 2 : 1), 10)}px`;
                   let lastAdjustment = 0;
@@ -3423,6 +3430,30 @@ Datagrid.prototype = {
     });
   },
 
+  getFrozenColumnDetails() {
+    const frozenCols = this.settings.frozenColumns;
+    let frozenColArr = [];
+    let frozenColDtls = [];
+
+    if (frozenCols.left.length > 0) {
+      frozenColArr = $.merge(frozenColArr, frozenCols.left);
+    }
+
+    if (frozenCols.right.length > 0) {
+      frozenColArr = $.merge(frozenColArr, frozenCols.right);
+    }
+
+    for (let i = 0; i < frozenColArr.length; i++) {
+      const filteredCol = this.settings.columns.filter(col => col.id === frozenColArr[i]);
+
+      if (filteredCol.length > 0) {
+        frozenColDtls.push(filteredCol[0]);
+      }
+    }
+
+    return frozenColDtls;
+  },
+
   /**
   * Set draggable columns target elements
   * @private
@@ -3505,23 +3536,14 @@ Datagrid.prototype = {
    * @returns {void}
    */
   arrayIndexMove(arr, from, to) {
-    const frozenCols = this.settings.frozenColumns;
     const targetArr = [arr[from], arr[to]];
-    let frozenColArr = [];
+    const frozenColDtls = this.getFrozenColumnDetails();
     let isFrozenColumn = false;
 
-    if (frozenCols.left.length > 0) {
-      frozenColArr = $.merge(frozenColArr, frozenCols.left);
-    }
-
-    if (frozenCols.right.length > 0) {
-      frozenColArr = $.merge(frozenColArr, frozenCols.right);
-    }
-
-    for (let i = 0; i < frozenColArr.length; i++) {
-      const filteredKey = targetArr.filter(col => col.id === frozenColArr[i]);
+    for (let i = 0; i < frozenColDtls.length; i++) {
+      const filteredCol = targetArr.filter(col => col.id === frozenColDtls[i].id);
       
-      isFrozenColumn = filteredKey.length > 0;
+      isFrozenColumn = filteredCol .length > 0;
       if (isFrozenColumn) {
         return;
       }

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3433,7 +3433,7 @@ Datagrid.prototype = {
   getFrozenColumnDetails() {
     const frozenCols = this.settings.frozenColumns;
     let frozenColArr = [];
-    let frozenColDtls = [];
+    const frozenColDtls = [];
 
     if (frozenCols.left.length > 0) {
       frozenColArr = $.merge(frozenColArr, frozenCols.left);
@@ -3543,7 +3543,7 @@ Datagrid.prototype = {
     for (let i = 0; i < frozenColDtls.length; i++) {
       const filteredCol = targetArr.filter(col => col.id === frozenColDtls[i].id);
       
-      isFrozenColumn = filteredCol .length > 0;
+      isFrozenColumn = filteredCol.length > 0;
       if (isFrozenColumn) {
         return;
       }

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3505,6 +3505,30 @@ Datagrid.prototype = {
    * @returns {void}
    */
   arrayIndexMove(arr, from, to) {
+    const frozenCols = this.settings.frozenColumns;
+    const targetArr = [arr[from], arr[to]];
+    let frozenColArr = [];
+    let isFrozenColumn = false;
+
+    if (frozenCols.left.length > 0) {
+      frozenColArr = $.merge(frozenColArr, frozenCols.left);
+    }
+
+    if (frozenCols.right.length > 0) {
+      frozenColArr = $.merge(frozenColArr, frozenCols.right);
+    }
+
+    for (let i = 0; i < frozenColArr.length; i++) {
+      let filteredKey = targetArr.filter(col => col.id === frozenColArr[i]);
+      
+      isFrozenColumn = filteredKey.length > 0;
+      break;
+    }
+
+    if (isFrozenColumn) {
+      return;
+    }
+
     arr.splice(to, 0, arr.splice(from, 1)[0]);
   },
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix frozen columns getting out of sync when columnReorder is set to true.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/8198

**Steps necessary to review your pull request (required)**:
- Pull this git repository, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-frozen-columns.html
- Open `...` on the header of the datagrid
- Click `Personalize Columns`
- See the order and click `Close`
- Try dragging `Product Id` column, it shouldn't be allowed
- Try dragging `Quantity` column to `Product Id` column, nothing happens
- Open `...` on the header of the datagrid
- Click `Personalize Columns`
- The order should be the same

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

