### PR TITLE
#8365 - RegExp instanceof check in Mask component unreliable

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@
 - `[Link]` Changed selected border color for link card. ([#8225](https://github.com/infor-design/enterprise/issues/8225))
 - `[Locale]` Changed all `zh` locales time format as suggested by native speakers. ([#8313](https://github.com/infor-design/enterprise/issues/8313))
 - `[Lookup]` Fixed clear button in keyword search not updating search results on click. ([#8258](https://github.com/infor-design/enterprise/issues/8258))
+- `[Mask]` Alternative approach for checking instanceof RegExp if `instanceof RegExp` returns false. ([8365](https://github.com/infor-design/enterprise/issues/8365))
 - `[Modal]` Fixed a bug where the modal would shift up when toggling a switch inside of it. ([#8018](https://github.com/infor-design/enterprise/issues/8018))
 - `[Modal]` Fixed a bug where textarea field is bigger than other fields on screen widths less that 400px. ([#8125](https://github.com/infor-design/enterprise/issues/8125))
 - `[Process Indicator]` Adjusted alignment of icon in compact process indicator. ([#8241](https://github.com/infor-design/enterprise/issues/8241))

--- a/src/components/mask/mask-api.js
+++ b/src/components/mask/mask-api.js
@@ -497,7 +497,7 @@ MaskAPI.prototype = {
         `The mask that was received is: ${JSON.stringify(mask)}`);
     }
 
-    const ret = mask.map(char => ((char instanceof RegExp) ?
+    const ret = mask.map(char => ((char instanceof RegExp || Object.prototype.toString.call(char) === '[object RegExp]') ?
       placeholderChar : char)).join(masks.EMPTY_STRING);
 
     return ret;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Included an additional check when `instanceof RegExp` fails that leverages `Object.prototype.toString` as an extended `typeof` and an alternative for `instanceof` (see https://javascript.info/instanceof#bonus-object-prototype-tostring-for-the-type).

This resolves an issue that is deemed to be occurring when creating a RegExp object in an older version of ECMA Script, GWT does not compile against ECMA Script 6, and passing to the IDS JavaScript which is using the new modern standard.

**Related github/jira issue (required)**:
Fixes https://github.com/infor-design/enterprise/issues/8365

**Steps necessary to review your pull request (required)**:
Difficult to test unless using GWT and calling into creating a Mask, however existing examples at http://localhost:4000/components/mask should still work.

- go to http://localhost:4000/components/mask
- test mask examples

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
