### PR TITLE
8372 - Add data automation id in grid tooltip

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v4.93.0
 
+## v4.93.0 Features
+
+- `[Datagrid]` Added data automation id of the column's filter operator. ([#8372](https://github.com/infor-design/enterprise/issues/8372))
+
 ## v4.93.0 Fixes
 
 - `[Datagrid]` Fixed cell editable not getting focused on click. ([8408](https://github.com/infor-design/enterprise/issues/8408))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -13080,6 +13080,7 @@ Datagrid.prototype = {
       const isHeaderFilter = DOM.hasClass(elem.parentNode, 'datagrid-filter-wrapper');
       const cell = elem.getAttribute('aria-colindex') - 1;
       const col = this.columnSettings(cell);
+      const gridTooltip = $('.grid-tooltip');
       let title;
 
       tooltip = { content: '', wrapper: elem.querySelector('.datagrid-cell-wrapper') };
@@ -13219,6 +13220,12 @@ Datagrid.prototype = {
 
         if (isTh) {
           tooltip.textwidth = stringUtils.textWidth(tooltip.content);
+        }
+
+        if (gridTooltip) {
+          const gridTooltipId = gridTooltip.attr('id');
+          gridTooltip.attr('data-automation-id', `${gridTooltipId}-grid-tooltip`);
+          $(this.tooltip).find('.tooltip-content').attr('data-automation-id', `${gridTooltipId}-content`);
         }
 
         tooltip.content = contentTooltip ? tooltip.content : `<p>${tooltip.content}</p>`;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR adds a data automation ID to the grid tooltip, which is based on it's ID. It is added to both the grid tooltip and the tooltip content.

FYI: This applies not only to the filter button but also to all tooltips in the grid.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise/issues/8372

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-filter-with-tooltip.html
- Hover on button filter
- Open the dev tools and check the tooltip element
- There should be `data-automation-id` in the grid tooltip
- There should also be a `data-automation-id` in the tooltip content

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
