### PR TITLE
8422 - Fix audible spans in masthead

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `[Datagrid]` Fixed cell editable not getting focused on click. ([8408](https://github.com/infor-design/enterprise/issues/8408))
 - `[Masthead]` Fixed incorrect color on hover. ([8391](https://github.com/infor-design/enterprise/issues/8391))
+- `[Masthead]` Fixed incorrectly visible `audible` spans. ([8422](https://github.com/infor-design/enterprise/issues/8422))
 - `[TabsHeader]` Added fixes for the focus state and minor layout issue in left and right to left. ([#8405](https://github.com/infor-design/enterprise/issues/8405))
 
 ## v4.92.2

--- a/src/components/masthead/_masthead.scss
+++ b/src/components/masthead/_masthead.scss
@@ -174,7 +174,7 @@
         border-color: transparent;
       }
 
-      span {
+      span:not(.audible) {
         color: inherit;
         position: relative;
         top: -1px;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes a bug where audible spans became visible.

**Related github/jira issue (required)**:
Fixes #8422 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/masthead/example-index.html
- audible spans should be invisible like before https://4910-enterprise.demo.design.infor.com/components/masthead/example-index.html and not https://main-enterprise.demo.design.infor.com/components/masthead/example-index.html which was incorrect

**Included in this Pull Request**:
- [x] A note to the change log.
