### PR TITLE
8421 - Fix tags close button alignment

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `[Datagrid]` Fixed cell editable not getting focused on click. ([8408](https://github.com/infor-design/enterprise/issues/8408))
 - `[Masthead]` Fixed incorrect color on hover. ([8391](https://github.com/infor-design/enterprise/issues/8391))
+- `[Multiselect]` Fixed misaligned `x` buttons. ([8421](https://github.com/infor-design/enterprise/issues/8421))
 - `[TabsHeader]` Added fixes for the focus state and minor layout issue in left and right to left. ([#8405](https://github.com/infor-design/enterprise/issues/8405))
 
 ## v4.92.2

--- a/src/components/badges/_badges-new.scss
+++ b/src/components/badges/_badges-new.scss
@@ -38,7 +38,7 @@
   }
 
   .tag.is-dismissible .btn-dismissible .icon {
-    top: -2px;
+    top: -1px;
     vertical-align: middle;
   }
 }

--- a/src/components/badges/_badges.scss
+++ b/src/components/badges/_badges.scss
@@ -132,10 +132,12 @@
       vertical-align: top;
 
       .icon {
-        height: 10px;
+        height: 12px;
         margin: 0;
+        margin-inline-end: -2px;
         vertical-align: unset;
-        width: 10px;
+        top: 1px;
+        width: 12px;
       }
     }
   }
@@ -355,7 +357,7 @@
     .tag-list .tag.is-dismissible {
       .btn-dismissible {
         .icon {
-          top: -1px;
+          top: -.5px;
           vertical-align: middle;
         }
       }

--- a/src/components/badges/_badges.scss
+++ b/src/components/badges/_badges.scss
@@ -517,7 +517,7 @@ html.theme-new-contrast {
       .tag-list .tag.is-dismissible {
         .btn-dismissible {
           .icon {
-            top: -2px;
+            top: 4px;
             vertical-align: middle;
           }
         }

--- a/src/components/button/_button-new.scss
+++ b/src/components/button/_button-new.scss
@@ -299,7 +299,7 @@
 }
 
 .field-short [class^='btn']:not(.btn-editor):not(.btn-icon),
-.form-layout-compact .field [class^='btn']:not(.btn-editor):not(.btn-icon) {
+.form-layout-compact .field [class^='btn']:not(.btn-editor):not(.btn-icon):not(.btn-dismissible) {
   min-height: $button-size-compact-height;
 
   > .icon + span:not(.audible):not(:empty) {

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -1164,7 +1164,7 @@ a.btn-close {
 // Short field buttons
 .field-short,
 .form-layout-compact .field {
-  [class^='btn']:not(.btn-editor):not(.btn-icon) {
+  [class^='btn']:not(.btn-editor):not(.btn-icon):not(.btn-dismissible) {
     height: $button-size-compact-height;
     margin-bottom: 10px;
     min-height: $button-size-compact-height;

--- a/src/components/dropdown/_dropdown-new.scss
+++ b/src/components/dropdown/_dropdown-new.scss
@@ -413,7 +413,7 @@ html.is-firefox:not([dir='rtl']) {
 
     &.datagrid-dropdown-list.is-editing .trigger .icon {
       top: 8.5px;
-      margin-left: -0.5px;
+      margin-left: 1px;
     }
 
     &.small-rowheight {
@@ -627,7 +627,11 @@ html[dir='rtl'] {
         padding: 2px 5px 2px 16px;
 
         + .icon {
-          top: -2px;
+          top: 3px;
+        }
+
+        &.has-tags +.icon {
+          top: 6px;
         }
       }
     }

--- a/src/components/dropdown/_dropdown-new.scss
+++ b/src/components/dropdown/_dropdown-new.scss
@@ -549,11 +549,18 @@ html[dir='rtl'] {
 
       + .icon {
         left: 5px;
-        top: 0;
+        top: 2px;
       }
 
       .listoption-icon {
         top: 5px;
+      }
+    }
+
+    div.has-tags {
+      +.icon {
+        left: 5px;
+        top: 10px;
       }
     }
   }

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -1377,10 +1377,10 @@ html[dir='rtl'] {
     }
 
     .tag-list {
-      padding: 2px 10px 3px 30px;
+      padding: 2px 5px 2px 30px !important;
 
       &.empty {
-        padding: 16px 10px 15px 30px;
+        padding: 16px 10px 15px 30px !important;
       }
     }
 
@@ -1571,6 +1571,10 @@ html[dir='rtl'] {
         }
       }
     }
+  }
+
+  .form-layout-compact .field div.dropdown.has-tags .tag-list {
+    padding:4px 1px 4px 30px !important;
   }
 
   .dropdown-list:not(.dropdown-short) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes tags close button alignment

**Related github/jira issue (required)**:
Fixes #8421 

**Steps necessary to review your pull request (required)**:
- review the x on http://localhost:4000/components/multiselect/example-compact.html it should be aligned in classic and new theme
- review the x on http://localhost:4000/components/tag/example-index.html it should be aligned in classic and new theme

**Included in this Pull Request**:
- [x] A note to the change log.
