### PR TITLE
8373 - Add `dateTimestamp` date format

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## v4.93.0 Features
 
 - `[Datagrid]` Added data automation id of the column's filter operator. ([#8372](https://github.com/infor-design/enterprise/issues/8372))
+- `[Locale]` Added `dateTimestamp` date format. ([#8373](https://github.com/infor-design/enterprise/issues/8373))
 
 ## v4.93.0 Fixes
 

--- a/src/components/locale/cultures/af-ZA.js
+++ b/src/components/locale/cultures/af-ZA.js
@@ -24,6 +24,7 @@ Soho.Locale.addCulture('af-ZA', {
       timestampMillis: 'HH:mm:ss.SSS',
       hour: 'HH:mm',
       datetime: 'yyyy-MM-dd HH:mm',
+      dateTimestamp: 'yyyy-MM-dd HH:mm:ss',
       datetimeMillis: 'yyyy-MM-dd HH:mm:ss.SSS',
       timezone: 'yyyy-MM-dd HH:mm zz',
       timezoneLong: 'yyyy-MM-dd HH:mm zzzz'

--- a/src/components/locale/cultures/ar-EG.js
+++ b/src/components/locale/cultures/ar-EG.js
@@ -27,6 +27,7 @@ Soho.Locale.addCulture('ar-EG', {
         timestampMillis: 'h:mm:ss.SSS a',
         hour: 'h:mm a',
         datetime: 'yyyy/MM/dd h:mm a',
+        dateTimestamp: 'yyyy-MM-dd HH:mm:ss',
         datetimeMillis: 'yyyy/MM/dd h:mm:ss.SSS a',
         timezone: 'yyyy/MM/dd h:mm a zz',
         timezoneLong: 'yyyy-MM-dd h:mm a zzzz'

--- a/src/components/locale/cultures/ar-SA.js
+++ b/src/components/locale/cultures/ar-SA.js
@@ -25,6 +25,7 @@ Soho.Locale.addCulture('ar-SA', {
         timestampMillis: 'h:mm:ss.SSS a',
         hour: 'h:mm a',
         datetime: 'yyyy/MM/dd h:mm a',
+        dateTimestamp: 'yyyy-MM-dd HH:mm:ss',
         datetimeMillis: 'yyyy/MM/dd h:mm:ss.SSS a',
         timezone: 'yyyy/MM/dd h:mm a zz',
         timezoneLong: 'yyyy/MM/dd h:mm a zzzz'

--- a/src/components/locale/cultures/bg-BG.js
+++ b/src/components/locale/cultures/bg-BG.js
@@ -22,6 +22,7 @@ Soho.Locale.addCulture('bg-BG', {
       year: 'MMMM yyyy г.',
       dayOfWeek: 'EEE d',
       timestamp: 'H:mm:ss',
+      dateTimestamp: 'yyyy-MM-dd HH:mm:ss',
       timestampMillis: 'H:mm:ss.SSS',
       hour: 'H:mm',
       datetime: 'd.MM.yyyy H:mm',

--- a/src/components/locale/cultures/cs-CZ.js
+++ b/src/components/locale/cultures/cs-CZ.js
@@ -21,6 +21,7 @@ Soho.Locale.addCulture('cs-CZ', {
       year: 'MMMM yyyy',
       dayOfWeek: 'EEE d',
       timestamp: 'H:mm:ss',
+      dateTimestamp: 'yyyy-MM-dd HH:mm:ss',
       timestampMillis: 'H:mm:ss.sss',
       hour: 'H:mm',
       datetime: 'dd.MM.yyyy H:mm',

--- a/src/components/locale/cultures/da-DK.js
+++ b/src/components/locale/cultures/da-DK.js
@@ -21,6 +21,7 @@ Soho.Locale.addCulture('da-DK', {
       year: 'MMMM yyyy',
       dayOfWeek: 'EEE d',
       timestamp: 'HH.mm.ss',
+      dateTimestamp: 'yyyy-MM-dd HH:mm:ss',
       timestampMillis: 'HH.mm.ss.SSS',
       hour: 'HH.mm',
       datetime: 'dd-MM-yyyy HH.mm',

--- a/src/components/locale/cultures/de-DE.js
+++ b/src/components/locale/cultures/de-DE.js
@@ -21,6 +21,7 @@ Soho.Locale.addCulture('de-DE', {
       year: 'MMMM yyyy',
       dayOfWeek: 'EEE d',
       timestamp: 'HH:mm:ss',
+      dateTimestamp: 'yyyy-MM-dd HH:mm:ss',
       timestampMillis: 'HH:mm:ss.SSS',
       hour: 'HH:mm',
       datetime: 'dd.MM.yyyy HH:mm',

--- a/src/components/locale/cultures/el-GR.js
+++ b/src/components/locale/cultures/el-GR.js
@@ -21,6 +21,7 @@ Soho.Locale.addCulture('el-GR', {
       year: 'MMMM yyyy',
       dayOfWeek: 'EEE d',
       timestamp: 'h:mm:ss a',
+      dateTimestamp: 'yyyy-MM-dd HH:mm:ss',
       timestampMillis: 'h:mm:ss.SSS a',
       hour: 'h:mm a',
       datetime: 'd/M/yyyy h:mm a',

--- a/src/components/locale/cultures/en-AU.js
+++ b/src/components/locale/cultures/en-AU.js
@@ -21,6 +21,7 @@ Soho.Locale.addCulture('en-AU', {
       year: 'MMMM yyyy',
       dayOfWeek: 'EEE d',
       timestamp: 'h:mm:ss a',
+      dateTimestamp: 'yyyy-MM-dd HH:mm:ss',
       timestampMillis: 'h:mm:ss.SSS a',
       hour: 'h:mm a',
       datetime: 'd/MM/yyyy h:mm a',

--- a/src/components/locale/cultures/en-GB.js
+++ b/src/components/locale/cultures/en-GB.js
@@ -21,6 +21,7 @@ Soho.Locale.addCulture('en-GB', {
       year: 'MMMM yyyy',
       dayOfWeek: 'EEE d',
       timestamp: 'HH:mm:ss',
+      dateTimestamp: 'yyyy-MM-dd HH:mm:ss',
       timestampMillis: 'HH:mm:ss.SSS',
       hour: 'HH:mm',
       datetime: 'dd/MM/yyyy HH:mm',

--- a/src/components/locale/cultures/en-IN.js
+++ b/src/components/locale/cultures/en-IN.js
@@ -21,6 +21,7 @@ Soho.Locale.addCulture('en-IN', {
       year: 'MMMM, yyyy',
       dayOfWeek: 'EEE d',
       timestamp: 'h:mm:ss a',
+      dateTimestamp: 'yyyy-MM-dd HH:mm:ss',
       timestampMillis: 'h:mm:ss.SSS a',
       hour: 'h:mm a',
       datetime: 'dd-MM-yyyy h:mm a',

--- a/src/components/locale/cultures/en-NZ.js
+++ b/src/components/locale/cultures/en-NZ.js
@@ -21,6 +21,7 @@ Soho.Locale.addCulture('en-NZ', {
       year: 'MMMM yyyy',
       dayOfWeek: 'EEE d',
       timestamp: 'h:mm:ss a',
+      dateTimestamp: 'yyyy-MM-dd HH:mm:ss',
       timestampMillis: 'h:mm:ss.SSS a',
       hour: 'h:mm a',
       datetime: 'd/MM/yyyy h:mm a',

--- a/src/components/locale/cultures/en-US.js
+++ b/src/components/locale/cultures/en-US.js
@@ -21,6 +21,7 @@ Soho.Locale.addCulture('en-US', {
       year: 'MMMM yyyy',
       dayOfWeek: 'd EEE',
       timestamp: 'h:mm:ss a',
+      dateTimestamp: 'yyyy-MM-dd HH:mm:ss',
       timestampMillis: 'h:mm:ss:SSS a',
       hour: 'h:mm a',
       datetime: 'M/d/yyyy h:mm a',

--- a/src/components/locale/cultures/en-ZA.js
+++ b/src/components/locale/cultures/en-ZA.js
@@ -24,6 +24,7 @@ Soho.Locale.addCulture('en-ZA', {
       timestampMillis: 'HH:mm:ss.SSS',
       hour: 'HH:mm',
       datetime: 'yyyy/MM/dd HH:mm',
+      dateTimestamp: 'yyyy-MM-dd HH:mm:ss',
       datetimeMillis: 'yyyy/MM/dd HH:mm:ss.SSS',
       timezone: 'yyyy/MM/dd HH:mm zz',
       timezoneLong: 'yyyy/MM/dd HH:mm zzzz'

--- a/src/components/locale/cultures/es-419.js
+++ b/src/components/locale/cultures/es-419.js
@@ -24,6 +24,7 @@ Soho.Locale.addCulture('es-419', {
       timestampMillis: 'HH:mm:ss.SSS',
       hour: 'HH:mm',
       datetime: 'd/M/yyyy HH:mm',
+      dateTimestamp: 'yyyy-MM-dd HH:mm:ss',
       datetimeMillis: 'd/M/yyyy HH:mm:ss.SSS',
       timezone: 'd/M/yyyy HH:mm zz',
       timezoneLong: 'd/M/yyyy HH:mm zzzz'

--- a/src/components/locale/cultures/es-AR.js
+++ b/src/components/locale/cultures/es-AR.js
@@ -24,6 +24,7 @@ Soho.Locale.addCulture('es-AR', {
       timestampMillis: 'HH:mm:ss.SSS',
       hour: 'HH:mm',
       datetime: 'd/M/yyyy HH:mm',
+      dateTimestamp: 'yyyy-MM-dd HH:mm:ss',
       datetimeMillis: 'd/M/yyyy HH:mm:ss.SSS',
       timezone: 'd/M/yyyy HH:mm zz',
       timezoneLong: 'd/M/yyyy HH:mm zzzz'

--- a/src/components/locale/cultures/es-ES.js
+++ b/src/components/locale/cultures/es-ES.js
@@ -24,6 +24,7 @@ Soho.Locale.addCulture('es-ES', {
       timestampMillis: 'H:mm:ss.SSS',
       hour: 'HH:mm',
       datetime: 'd/M/yyyy H:mm',
+      dateTimestamp: 'yyyy-MM-dd HH:mm:ss',
       datetimeMillis: 'd/M/yyyy H:mm:ss.SSS',
       timezone: 'd/M/yyyy H:mm zz',
       timezoneLong: 'd/M/yyyy H:mm zzzz'

--- a/src/components/locale/cultures/fr-CA.js
+++ b/src/components/locale/cultures/fr-CA.js
@@ -24,6 +24,7 @@ Soho.Locale.addCulture('fr-CA', {
       timestampMillis: 'HH:mm:ss.SSS',
       hour: 'HH:mm',
       datetime: 'yyyy-MM-dd HH:mm',
+      dateTimestamp: 'yyyy-MM-dd HH:mm:ss',
       datetimeMillis: 'yyyy-MM-dd HH:mm:ss.SSS',
       timezone: 'yyyy-MM-dd HH:mm zz',
       timezoneLong: 'yyyy-MM-dd HH:mm zzzz'

--- a/src/components/locale/cultures/lt-LT.js
+++ b/src/components/locale/cultures/lt-LT.js
@@ -24,6 +24,7 @@ Soho.Locale.addCulture('lt-LT', {
       timestampMillis: 'HH:mm:ss.SSS',
       hour: 'HH:mm',
       datetime: 'yyyy-MM-dd HH:mm',
+      dateTimestamp: 'yyyy-MM-dd HH:mm:ss',
       datetimeMillis: 'yyyy-MM-dd HH:mm:ss.SSS',
       timezone: 'yyyy-MM-dd HH:mm zz',
       timezoneLong: 'yyyy-MM-dd HH:mm zzzz'

--- a/src/components/locale/cultures/sv-SE.js
+++ b/src/components/locale/cultures/sv-SE.js
@@ -24,6 +24,7 @@ Soho.Locale.addCulture('sv-SE', {
       timestampMillis: 'HH:mm:ss.SSS',
       hour: 'HH:mm',
       datetime: 'yyyy-MM-dd HH:mm',
+      dateTimestamp: 'yyyy-MM-dd HH:mm:ss',
       datetimeMillis: 'yyyy-MM-dd HH:mm:ss.SSS',
       timezone: 'yyyy-MM-dd HH:mm zz',
       timezoneLong: 'yyyy-MM-dd HH:mm zzzz'

--- a/src/components/locale/locale.js
+++ b/src/components/locale/locale.js
@@ -1791,7 +1791,8 @@ const Locale = {  // eslint-disable-line
           month: 'MMMM d',
           year: 'MMMM yyyy',
           timestamp: 'h:mm:ss a',
-          datetime: 'M/d/yyyy h:mm a'
+          datetime: 'M/d/yyyy h:mm a',
+          dateTimestamp: 'yyyy-MM-dd HH:mm:ss'
         },
         timeFormat: 'HH:mm:ss',
         dayPeriods: ['AM', 'PM']


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR adds `dateTimestamp` date format.

**Related github/jira issue (required)**:

Closes #8373

**Steps necessary to review your pull request (required)**:
- Go to http://localhost:4000/components/datepicker/example-index.html
- Open developer tool console and run this code `Soho.Locale.formatDate(new Date(2000, 10, 8, 13, 40, 30, 999), { date: 'dateTimestamp' })`
- Output should be `'2000-11-08 13:40:30'`

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
