### PR TITLE
NG1616 - Selection Focus Tree Grid after Change/Blur

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## v4.93.0 Fixes
 
 - `[Datagrid]` Fixed cell editable not getting focused on click. ([#8408](https://github.com/infor-design/enterprise/issues/8408))
+- `[Datagrid]` Fixed wrong cell focus on blur in tree grid. ([NG#1616](https://github.com/infor-design/enterprise-ng/issues/1616))
 - `[Docs]` Changed `attributes` property type to array/object. ([#8228](https://github.com/infor-design/enterprise/issues/8228))
 - `[Lookup]` Fixed unexpected multiselect selecting lookup when entering manual input. ([NG#1635](https://github.com/infor-design/enterprise-ng/issues/1635))
 - `[Masthead]` Fixed incorrect color on hover. ([8391](https://github.com/infor-design/enterprise/issues/8391))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -11985,7 +11985,7 @@ Datagrid.prototype = {
 
     if (typeof row === 'number') {
       rowNum = row;
-      rowElem = this.tableBody.find('tr:visible').eq(row);
+      rowElem = this.settings.treeGrid ? this.actualRowNode(row) : this.tableBody.find('tr:visible').eq(row);
       rowIndex = this.actualRowIndex(rowElem);
       dataRowNum = this.dataRowIndex(rowElem);
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix wrong cell focus on blur in tree grid.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1616

**Steps necessary to review your pull request (required)**:
- Pull this git repository, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-tree-editable.html
- Navigate to "Description" column of Row with Id=5
- Change the text to some random and press Enter
- Notice the location of the focus cell should be the same

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

