### PR TITLE
8397 - Fix slider ticks visibility inside of a modal

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[Masthead]` Fixed incorrect color on hover. ([8391](https://github.com/infor-design/enterprise/issues/8391))
 - `[Multiselect]` Fixed misaligned `x` buttons. ([8421](https://github.com/infor-design/enterprise/issues/8421))
 - `[Masthead]` Fixed incorrectly visible `audible` spans. ([8422](https://github.com/infor-design/enterprise/issues/8422))
+- `[Slider]` Fixed visiblity of slider ticks inside of a modal.([#8397](https://github.com/infor-design/enterprise/issues/8397))
 - `[TabsHeader]` Added fixes for the focus state and minor layout issue in left and right to left. ([#8405](https://github.com/infor-design/enterprise/issues/8405))
 - `[TabsModule]` Added setting `maxWidth` for tabs for long titles. ([#8017](https://github.com/infor-design/enterprise/issues/8017))
 

--- a/src/themes/theme-new-dark.scss
+++ b/src/themes/theme-new-dark.scss
@@ -535,7 +535,7 @@ $pager-hover-color: $font-color-extrahighcontrast;
 $pager-disabled-color: $ids-color-palette-slate-60;
 
 // Slider
-$slider-bg-color: $ids-color-palette-slate-80;
+$slider-bg-color: $ids-color-palette-slate-50;
 $slider-active-bg-color: $ids-color-brand-primary-base;
 $slider-labels-color: $ids-color-palette-slate-30;
 $slider-disabled-color: $ids-color-palette-slate-60;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes slider ticks visibility inside of a modal in dark mode.

**Related github/jira issue (required)**:

Closes #8397

**Steps necessary to review your pull request (required)**:
- Go to http://localhost:4000/components/modal/example-slider.html?theme=new&mode=dark&colors=default
- Open the modal
- Slider ticks should be more visible in dark mode

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
