### PR TITLE
1620 - Fix popup selection bug 

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,7 +17,6 @@
 - `[Multiselect]` Fixed misaligned `x` buttons. ([8421](https://github.com/infor-design/enterprise/issues/8421))
 - `[Masthead]` Fixed incorrectly visible `audible` spans. ([8422](https://github.com/infor-design/enterprise/issues/8422))
 - `[Popupmenu]` Fixed a bug where single select check items were getting deselected. ([8422](https://github.com/infor-design/enterprise/issues/8422))
-https://github.com/infor-design/enterprise-ng/issues/1620
 - `[TabsHeader]` Added fixes for the focus state and minor layout issue in left and right to left. ([#8405](https://github.com/infor-design/enterprise/issues/8405))
 - `[TabsModule]` Added setting `maxWidth` for tabs for long titles. ([#8017](https://github.com/infor-design/enterprise/issues/8017))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,8 @@
 - `[Masthead]` Fixed incorrect color on hover. ([8391](https://github.com/infor-design/enterprise/issues/8391))
 - `[Multiselect]` Fixed misaligned `x` buttons. ([8421](https://github.com/infor-design/enterprise/issues/8421))
 - `[Masthead]` Fixed incorrectly visible `audible` spans. ([8422](https://github.com/infor-design/enterprise/issues/8422))
+- `[Popupmenu]` Fixed a bug where single select check items were getting deselected. ([8422](https://github.com/infor-design/enterprise/issues/8422))
+https://github.com/infor-design/enterprise-ng/issues/1620
 - `[TabsHeader]` Added fixes for the focus state and minor layout issue in left and right to left. ([#8405](https://github.com/infor-design/enterprise/issues/8405))
 - `[TabsModule]` Added setting `maxWidth` for tabs for long titles. ([#8017](https://github.com/infor-design/enterprise/issues/8017))
 

--- a/src/components/charts/_charts.scss
+++ b/src/components/charts/_charts.scss
@@ -67,7 +67,7 @@
       }
 
       .chart-legend-item.is-one-line {
-        margin: 15px auto !important;
+        margin: 22px auto !important;
       }
     }
 
@@ -148,7 +148,7 @@
   .list-button {
     float: right;
     margin-right: 17px;
-    margin-top: 1px;
+    margin-top: -4px;
     margin-bottom: 1px;
   }
 
@@ -294,6 +294,7 @@
         align-items: center;
         display: flex !important;
         font-size: 0;
+        padding: 0 4px 2px;
 
         &.is-two-column {
           padding: 2px 5px 4px 2px;
@@ -321,7 +322,7 @@
     float: left;
     margin: 7px 10px 7px 0;
     outline: none;
-    padding: 0 7px 0 3px;
+    padding: 3px 4px 0 !important;
 
     &[tabindex='-1'] {
       cursor: inherit;
@@ -390,7 +391,7 @@
   .chart-popup-menu-color {
     height: 15px;
     width: 15px;
-    margin: 8% 5px;
+    margin: 12px 8px 0 0;
   }
 
   .chart-popup-menu-text {

--- a/src/components/charts/charts.js
+++ b/src/components/charts/charts.js
@@ -454,7 +454,7 @@ charts.addLegend = function (series, chartType, settings, container) {
         float: 'none',
         display: 'block',
         margin: '0 auto',
-        width: `${width}px`,
+        width: `${width + 15}px`,
       });
     }
 
@@ -651,7 +651,7 @@ charts.handleElementClick = function (idx, line, series, settings, container) {
 
     chartLegendItem.empty();
     chartLegendItem.append(color, `<span class="audible">${Locale.translate('Highlight')}</span>`, textBlock);
-
+    chartLegendItem.attr('index-id', `chart-legend-${idx}`);
     container.find('.list-button').data('popupmenu').menu.children().removeClass('is-hidden');
     $(container.find('.list-button').data('popupmenu').menu.children().get(idx)).addClass('is-hidden');
   }

--- a/src/components/pie/pie.js
+++ b/src/components/pie/pie.js
@@ -308,8 +308,6 @@ Pie.prototype = {
 
       s.svg = self.svg;
       charts.addLegend(series, 'pie', s, this.element);
-      const setClass = heightAdjusted > 0 ? 'addClass' : 'removeClass';
-      this.element.find('.chart-legend')[setClass]('adjusted-height');
     }
 
     this.setInitialSelected();

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -2256,6 +2256,11 @@ PopupMenu.prototype = {
     }
 
     if (parent.hasClass('is-multiselectable') || multipleMenu || multipleSection) {
+      if (parent.hasClass('is-checked')) {
+        parent.removeClass('is-checked');
+        returnObj.push('deselected');
+        return returnObj;
+      }
       parent.addClass('is-checked');
       returnObj.push('selected');
       return returnObj;

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -2249,11 +2249,6 @@ PopupMenu.prototype = {
 
     // If the entire menu is "selectable", place the checkmark where it's supposed to go.
     if ((parent.hasClass('is-selectable') && !anchor.find('.icon').length) || singleMenu || singleSection) {
-      if (parent.hasClass('is-checked')) {
-        parent.removeClass('is-checked');
-        returnObj.push('deselected');
-        return returnObj;
-      }
       parent.prevUntil('.heading, .separator').add(parent.nextUntil('.heading, .separator')).removeClass('is-checked');
       parent.addClass('is-checked');
       returnObj.push('selected');
@@ -2261,11 +2256,6 @@ PopupMenu.prototype = {
     }
 
     if (parent.hasClass('is-multiselectable') || multipleMenu || multipleSection) {
-      if (parent.hasClass('is-checked')) {
-        parent.removeClass('is-checked');
-        returnObj.push('deselected');
-        return returnObj;
-      }
       parent.addClass('is-checked');
       returnObj.push('selected');
       return returnObj;

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -3278,7 +3278,7 @@ Tabs.prototype = {
     sizeableTabs.removeAttr('style');
 
     this.setMaxWidth();
-    
+
     sizeableTabs.each(function () {
       const t = $(this);
       if (self.isTabOverflowed(t)) {
@@ -3868,8 +3868,8 @@ Tabs.prototype = {
     const isCounts = parentContainer.hasClass('has-counts');
     const isAddTabButton = target.is('.add-tab-button');
     const isSelected = target.is('.is-selected');
-    const tabListScrollHeight = scrollingTablist.prop('scrollHeight');
-    const tabListClientHeight = scrollingTablist.prop('clientHeight');
+    const tabListScrollHeight = scrollingTablist?.prop('scrollHeight');
+    const tabListClientHeight = scrollingTablist?.prop('clientHeight');
 
     function adjustForParentContainer(targetRectObj, parentElement, tablistContainer, transformPercentage) {
       const parentRect = parentElement[0].getBoundingClientRect();

--- a/src/components/tooltip/_tooltip.scss
+++ b/src/components/tooltip/_tooltip.scss
@@ -23,6 +23,10 @@
   z-index: 5010;
 }
 
+html[class*='theme-classic-'] .tooltip.is-pie {
+  min-height: 32px;
+}
+
 .tooltip {
   @include word-wrap();
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes a regression in popupmenu where some items that should be checked are not checked.
This was caused be https://github.com/infor-design/enterprise/pull/8124
@tjamesallen15 can you test this PR since i see you added those lines?

**Related github/jira issue (required)**:
Fixes https://github.com/infor-design/enterprise-ng/issues/1620

**Steps necessary to review your pull request (required)**:
- get the latest  https://github.com/infor-design/enterprise-ng as an example was added
- `npm run build` then copy to  https://github.com/infor-design/enterprise-ng and run 
- run http://localhost:4200/ids-enterprise-ng-demo/popupmenu
- open the "Menu For Loop" example and try and toggle between the selected items
- reopen and it should show the right one as selected
- on this repo run this branch
- test http://localhost:4000/components/donut/example-legend-bottom-popup.html -> when you select the menu items it should toggle the selected item in the chart
- check the "selection/selected" examples on http://localhost:4000/components/popupmenu

**Included in this Pull Request**:
- [x] A note to the change log.