### PR TITLE
NG1614 - Tooltip Special Characters

### DIFF
--- a/app/views/components/tooltip/test-tooltip-number-sign.html
+++ b/app/views/components/tooltip/test-tooltip-number-sign.html
@@ -1,0 +1,15 @@
+<div class="row">
+  <div class="six columns">
+    <h2>Tooltip Example: Standard Text Tooltip</h2>
+  </div>
+</div>
+
+<div class="row top-padding">
+  <div class="twelve columns">
+
+    <button id="tooltip-btn" class="btn-secondary" type="button" title="#10 - 24# WHITE MOVE" data-options="{ 'attributes': [ { 'name': 'data-automation-id', 'value': 'test-tooltip' } ]}">
+      Normal Tooltip
+    </button>
+
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `[Masthead]` Fixed incorrectly visible `audible` spans. ([8422](https://github.com/infor-design/enterprise/issues/8422))
 - `[TabsHeader]` Added fixes for the focus state and minor layout issue in left and right to left. ([#8405](https://github.com/infor-design/enterprise/issues/8405))
 - `[TabsModule]` Added setting `maxWidth` for tabs for long titles. ([#8017](https://github.com/infor-design/enterprise/issues/8017))
+- `[Tooltip]` Allowed tooltip to be shown by fixing expression error when having special characters. ([#8017](https://github.com/infor-design/enterprise/issues/8017))
 
 ## v4.92.2
 

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -498,12 +498,17 @@ Tooltip.prototype = {
       // and store the reference only.
       // Adding a condition if it's really uses the ID attribute.
       if (content.indexOf('#') === 0 && content.indexOf('/') < 0) { // Needs to check / before puting it in a content check because it breaks the string and makes jQuery think that it is an expression
-        const contentCheck = $(`${content}`);
-        if (contentCheck.length) {
-          this.content = contentCheck;
-          doRender();
-          return true;
+        try {
+          const contentCheck = $(`${content}`);
+          if (contentCheck.length) {
+            this.content = contentCheck;
+            doRender();
+            return true;
+          }
+        } catch (err) {
+          this.content = xssUtils.sanitizeHTML(content);
         }
+
         this.content = content;
         doRender();
         return true;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix wrong cell focus on blur in tree grid.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1614

**Steps necessary to review your pull request (required)**:
- Pull this git repository, build, and run the app
- Go to http://localhost:4000/components/tooltip/test-tooltip-number-sign.html
- Hover to the button
- Tooltip should be shown `#10 - 24# WHITE`

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

