### PR TITLE
8303 - Fix close icon lookup modal in RTL

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[Datagrid]` Fixed cell value replacing special characters on cell change. ([8285](https://github.com/infor-design/enterprise/issues/8285))
 - `[Docs]` Changed `attributes` property type to array/object. ([#8228](https://github.com/infor-design/enterprise/issues/8228))
 - `[Lookup]` Fixed unexpected multiselect selecting lookup when entering manual input. ([NG#1635](https://github.com/infor-design/enterprise-ng/issues/1635))
+- `[Lookup]` Fixed close button icon in lookup modal RTL. ([#8303](https://github.com/infor-design/enterprise/issues/8303))
 - `[Masthead]` Fixed incorrect color on hover. ([8391](https://github.com/infor-design/enterprise/issues/8391))
 - `[Multiselect]` Fixed misaligned `x` buttons. ([8421](https://github.com/infor-design/enterprise/issues/8421))
 - `[Masthead]` Fixed incorrectly visible `audible` spans. ([8422](https://github.com/infor-design/enterprise/issues/8422))

--- a/src/components/lookup/_lookup-new.scss
+++ b/src/components/lookup/_lookup-new.scss
@@ -159,9 +159,10 @@ html[dir='rtl'] {
 }
 
 html[dir='rtl'] .modal-content .toolbar .buttonset .searchfield-wrapper .btn-icon.close {
-  top: 4px;
+  top: 50%;
 
   svg.icon.close {
-    left: -4px;
+    position: relative;
+    top: 1px;
   }
 }

--- a/src/components/lookup/_lookup.scss
+++ b/src/components/lookup/_lookup.scss
@@ -417,6 +417,7 @@ html:not([dir='rtl'])[class*='theme-classic-'] .modal-content .toolbar .buttonse
 html[dir='rtl'] .modal-content .toolbar .buttonset .searchfield-wrapper .btn-icon.close {
   left: 7px;
   right: unset;
+  top: 50%;
 }
 
 html[class*='theme-classic-'] .modal-content .toolbar .buttonset .searchfield-wrapper .btn-icon.close {
@@ -432,6 +433,6 @@ html[dir='rtl'][class*='theme-classic-'] .modal-content .toolbar .buttonset .sea
     left: 2px;
     position: absolute;
     right: unset;
-    top: 4px;
+    top: 3px;
   }
 }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the close icon button in lookup modal in RTL.

**Related github/jira issue (required)**:

Closes #8303 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/lookup/example-index.html?theme=new&mode=light&colors=default&locale=ar-SA
- Open lookup in `Products`
- Type anything in search bar
- Close icon should be aligned correctly

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
