### PR TITLE
8400 - Fix datepicker popover footer button position in RTL mode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[Datagrid]` Fixed wrong cell focus on blur in tree grid. ([NG#1616](https://github.com/infor-design/enterprise-ng/issues/1616))
 - `[Datagrid]` Fixed cell editable not getting focused on click. ([8408](https://github.com/infor-design/enterprise/issues/8408))
 - `[Datagrid]` Fixed cell value replacing special characters on cell change. ([8285](https://github.com/infor-design/enterprise/issues/8285))
+- `[Datepicker]` Fixed datepicker popover footer button position in RTL. ([#8400](https://github.com/infor-design/enterprise/issues/8400))
 - `[Docs]` Changed `attributes` property type to array/object. ([#8228](https://github.com/infor-design/enterprise/issues/8228))
 - `[Lookup]` Fixed unexpected multiselect selecting lookup when entering manual input. ([NG#1635](https://github.com/infor-design/enterprise-ng/issues/1635))
 - `[Masthead]` Fixed incorrect color on hover. ([8391](https://github.com/infor-design/enterprise/issues/8391))

--- a/src/components/datepicker/_datepicker.scss
+++ b/src/components/datepicker/_datepicker.scss
@@ -256,6 +256,16 @@ html[dir='rtl'] {
       left: 0;
     }
   }
+
+  .monthview-popup.popover .popup-footer {
+    button {
+      margin-left: 0;
+
+      &:first-child:hover {
+        border-left: none;
+      }
+    }
+  }
 }
 
 // TODO


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR Fixes datepicker's popover footer button position in RTL mode.

**Related github/jira issue (required)**:

Closes #8400
Closes #8304

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datepicker/example-index.html?locale=ar-SA
- Open a datepicker
- Check the footer button
- It should align correctly

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
