### PR TITLE
8472 - Fix text moves upward when focused

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - `[Checkboxes]` Fixed RTL alignment for dirty tracker and required label. ([#8308](https://github.com/infor-design/enterprise/issues/8308))
 - `[Datagrid]` Fixed a bug in datagrid cell where readonly background color was not recognizable. ([#8459](https://github.com/infor-design/enterprise/issues/8459))
+- `[Datagrid]` Fixed a bug where the text moves upward when the cell is focused. ([#8472](https://github.com/infor-design/enterprise/issues/8472))
 - `[Datagrid]` Fixed cell editable not getting focused on click. ([#8408](https://github.com/infor-design/enterprise/issues/8408))
 - `[Datagrid]` Fixed wrong cell focus on blur in tree grid. ([NG#1616](https://github.com/infor-design/enterprise-ng/issues/1616))
 - `[Datagrid]` Fixed cell editable not getting focused on click. ([#8408](https://github.com/infor-design/enterprise/issues/8408))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -2739,7 +2739,6 @@ $datagrid-small-row-height: 25px;
         span.trigger {
           overflow: hidden;
           text-overflow: ellipsis;
-          vertical-align: top;
           white-space: nowrap;
         }
       }
@@ -4348,6 +4347,12 @@ td .btn-actions {
 .datagrid-trigger-cell {
   &:not(.is-readonly) {
     cursor: pointer;
+  }
+
+  &:focus {
+    .datagrid-cell-wrapper span {
+      vertical-align: middle;
+    }
   }
 
   &.text-ellipsis {

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -1678,7 +1678,6 @@ $datagrid-small-row-height: 25px;
 
           .dropdown-trigger {
             margin-left: 2px;
-            margin-top: 1px;
 
             + .icon {
               left: -3px;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the text moves upward when the cell is focused.

**Related github/jira issue (required)**:

Closes #8472 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/example-books.html?theme=new&mode=light&colors=default
- Click any cell from `Book Currency` to `Deprecation History`
- Text should not move

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
