### PR TITLE
8457 - Datagrid Editable Left Right Transfer Cells

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## v4.93.0 Fixes
 
 - `[Checkboxes]` Fixed RTL alignment for dirty tracker and required label. ([#8308](https://github.com/infor-design/enterprise/issues/8308))
+- `[Datagrid]` Fixed a bug unable to use the left/right arrow keys on the text in an editable cell. ([#8457](https://github.com/infor-design/enterprise/issues/8457))
 - `[Datagrid]` Fixed a bug in datagrid cell where readonly background color was not recognizable. ([#8459](https://github.com/infor-design/enterprise/issues/8459))
 - `[Datagrid]` Fixed cell editable not getting focused on click. ([#8408](https://github.com/infor-design/enterprise/issues/8408))
 - `[Datagrid]` Fixed wrong cell focus on blur in tree grid. ([NG#1616](https://github.com/infor-design/enterprise-ng/issues/1616))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10220,7 +10220,7 @@ Datagrid.prototype = {
           self.setNextActiveCell(e);
         } else {
           self.makeCellEditable(self.activeCell.rowIndex, cell, e);
-          if (self.containsTextField(node) && self.containsTriggerField(node)) {
+          if (self.containsTextField(node) && self.containsTriggerField(node) && self.settings?.actionableMode) {
             self.quickEditMode = true;
           }
         }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will a bug unable to use the left/right arrow keys on the text in an editable cell.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/8457

**Steps necessary to review your pull request (required)**:
- Pull this git repository, build, and run the app
- Go to http://localhost:4000/components/datagrid/example-editable?theme=uplift&variant=light&layout=embedded
- Click on an editable cell (e.g. Assemble Paint)
- Set the cursor at letter "m" in the word "Assemble" and press the left arrow key.
- Verify it sets focus on the left cell beside the editable cell.
- Press the right arrow key to go back to the editable cell.
- Press Enter key. Take note that the word is highlighted.
- Set the cursor after letter "m" and press the left/right arrow keys.
- Should transfer to another cell

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

