### PR TITLE
NG1639 - Fixed a bug where parent modal closes instead of currently active modal when pressing the escape key

### DIFF
--- a/app/views/components/modal/test-nested.html
+++ b/app/views/components/modal/test-nested.html
@@ -18,6 +18,9 @@
       <div class="field">
           <button id="open-message" class="btn-secondary" type="button" >Show Message</button>
       </div>
+      <div class="field">
+        <button id="open-tab" class="btn-secondary" type="button">Show Tabs</button>
+      </div>
       <div class="modal-buttonset">
         <button type="button" class="btn-default btn-close">Close</button>
       </div>
@@ -56,6 +59,29 @@
   </div>
 </div>
 
+<div class="modal" id="modal-5" style="height: calc(100% - 40px); margin-bottom: calc(50px - 65%);">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h1 class="modal-title">Test Tab</h1>
+    </div>
+
+    <div class="modal-body">
+      <div id="tabs-normal" class="tab-container">
+        <ul class="tab-list">
+          <li class="tab">
+            <a id="tabs-a" data-automation-id="tabs-a-contracts" href="#tabs-normal-contracts">Tab A</a>
+          </li>
+        </ul>
+      </div>
+      <div class="tab-panel-container">
+        <div id="tabs-normal-contracts" data-automation-id="tabs-panel-contracts" class="tab-panel">
+          <p>Hello</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
 <script>
   $('#open-message').on('click', function() {
     $('body').message({
@@ -72,5 +98,22 @@
           isDefault: true
       }]
     });
+  });
+
+  $('#open-tab').on('click', () => {
+    $('body').modal({
+      content: $('#modal-5'),
+			buttons: [{
+				text: 'Cancel',
+				click: function(e, modal) {
+					modal.close();
+				}
+			}, {
+				text: 'Save',
+				click: function(e, modal) {
+					modal.close();
+				}
+			}]
+		})
   });
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@
 - `[Masthead]` Fixed incorrectly visible `audible` spans. ([#8422](https://github.com/infor-design/enterprise/issues/8422))
 - `[Modal]` Fixed a bug where hitting the escape button in a modal with subcomponents popover caused a crash. ([#8344](https://github.com/infor-design/enterprise/issues/8344))
 - `[Modal]` Fixed a bug where the colorpicker did not close when hitting the escape key in the modal datagrid. ([#8411](https://github.com/infor-design/enterprise/issues/8411))
+- `[Modal]` Fixed a bug where parent modal closes instead of currently active modal when pressing the escape key. ([NG#1639](https://github.com/infor-design/enterprise/issues/1639))
 - `[Multiselect]` Fixed misaligned `x` buttons. ([8421](https://github.com/infor-design/enterprise/issues/8421))
 - `[Pie]` Fixed an error encountered when having many records inside the graph. ([#8422](https://github.com/infor-design/enterprise/issues/8422))
 - `[Popupmenu]` Fixed a bug where single select check items were getting deselected. ([8422](https://github.com/infor-design/enterprise/issues/8422))

--- a/src/components/modal/modal.manager.js
+++ b/src/components/modal/modal.manager.js
@@ -335,7 +335,7 @@ ModalManager.prototype = {
 
     // Setup a global keydown event that can handle the closing of modals in the proper order.
     $(document).on(`keydown.${EVENT_NAMESPACE}`, (e) => {
-      const modalTargetElem = $(e.target).parents('.modal');
+      const modalTargetElem = $(e.target).parents('.modal.is-active');
       const keyCode = e.which || e.keyCode;
 
       switch (keyCode) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Should only check active modals when close api is called

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise-ng/issues/1639

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/modal/test-nested.html
- Open modal 
- Open Tabs modal
- Press escape key
- Only Tabs modal should close

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
