### PR TITLE
8516 - Removed escaping HTML for cell nodes

### DIFF
--- a/app/views/components/datagrid/example-editable.html
+++ b/app/views/components/datagrid/example-editable.html
@@ -176,7 +176,7 @@
       columnReorder: true,
       showDirty: true
     }).on('cellchange', function (e, args) {
-      console.log('cellchange', args);
+      console.log('cellchange', `value (${typeof args.value}): ${args.value}`, args);
     }).on('rowadd', function (e, args) {
       console.log(e, args);
     }).on('rowremove', function (e, args) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## v4.94.0 Fixes
 
 - `[Datagrid/Card]` When in a card/widget the size of the datagrid would be incorrect and the pager would be moved to the wrong place. Now on default widget size the widget will contain the pager correctly. You may need css for custom sized widgets or non default widget sizes ([#8496](https://github.com/infor-design/enterprise/issues/8372))
+- `[Datagrid]` Removed escaping HTML for cell nodes. ([#8516](https://github.com/infor-design/enterprise/issues/8516))
 
 ## v4.93.0
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -3887,9 +3887,10 @@ Datagrid.prototype = {
   * @private
   * @param {object} obj The object to use
   * @param {string} field The field as a string fx 'field' or 'obj.field.id'
+  * @param {boolean} escapeHtml Should the value have html characters escaped or not
   * @returns {any} The current value in the field.
   */
-  fieldValue(obj, field) {
+  fieldValue(obj, field, escapeHtml = true) {
     if (!field || !obj) {
       return '';
     }
@@ -3902,7 +3903,11 @@ Datagrid.prototype = {
     }
 
     let value = (rawValue || rawValue === 0 || rawValue === false ? rawValue : '');
-    value = xssUtils.escapeHTML(value);
+
+    if (escapeHtml) {
+      value = xssUtils.escapeHTML(value);
+    }
+
     return value;
   },
 
@@ -11455,20 +11460,9 @@ Datagrid.prototype = {
       rowNodes = this.visualRowNode(row);
       cellNode = rowNodes.find('td').eq(cell);
     }
-    let oldVal = this.fieldValue(rowData, col.field);
+    const oldVal = this.fieldValue(rowData, col.field, false);
 
-    // Coerce/Serialize value if from cell edit
-    if (!fromApiCall && oldVal !== value) {
-      coercedVal = this.coerceValue(value, oldVal, col, row, cell);
-
-      // coerced value may be coerced to empty string, null, or 0
-      if (coercedVal === undefined) {
-        coercedVal = value;
-      }
-    } else {
-      coercedVal = value;
-    }
-
+    coercedVal = value;
     // Remove rowStatus icon
     if (rowNodes.length && rowData && !rowData.rowStatus) {
       const rowstatusIcon = rowNodes.find('svg.icon-rowstatus');
@@ -11613,10 +11607,6 @@ Datagrid.prototype = {
     if (this.settings.summaryRow && !this.settings.groupable) {
       this.updateSummaryRow(col, cell);
     }
-
-    // Sanitize console methods
-    oldVal = xssUtils.sanitizeConsoleMethods(oldVal);
-    coercedVal = xssUtils.sanitizeConsoleMethods(coercedVal);
 
     let isCellChange;
     if (typeof oldVal === 'string' && typeof coercedVal === 'string') {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Removed escaping HTML for cell nodes. Any special character and tag will be accepted as is.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #8516 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datagrid/example-editable.html
- Update a cell with `related[BALMAS1("TX60:\{IndexList_Items.TX60}")]`
- Should accept it as is
- Check console logs
- Object printed should have the same values

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
