### PR TITLE
8539 - Make avatar not round

### DIFF
--- a/app/views/components/images/example-avatar.html
+++ b/app/views/components/images/example-avatar.html
@@ -6,11 +6,11 @@
       <div class="avatar">AC</div>&nbsp;&nbsp;&nbsp;&nbsp;
       <div class="avatar large">Ac</div>&nbsp;&nbsp;&nbsp;&nbsp;
       <br /><br />
-      <div class="avatar azure05">AC</div>&nbsp;&nbsp;&nbsp;&nbsp;
-      <div class="avatar large azure05">Ac</div>
+      <div class="avatar azure05 square">AC</div>&nbsp;&nbsp;&nbsp;&nbsp;
+      <div class="avatar large azure05 square">Ac</div>
       <br /><br />
-      <div class="avatar three-char">mon</div>&nbsp;&nbsp;&nbsp;&nbsp;
-      <div class="avatar large three-char">mon</div>
+      <div class="avatar three-char square">mon</div>&nbsp;&nbsp;&nbsp;&nbsp;
+      <div class="avatar large three-char square">mon</div>
       <br /><br />
       <img class="image-round" src="{{basepath}}/images/10.jpg" alt="Photo of Evyn" tabindex="0"/>
       <br/><br/>

--- a/app/views/components/module-nav/example-icon.html
+++ b/app/views/components/module-nav/example-icon.html
@@ -6,7 +6,7 @@
     justify-content: center;
     background-color: #0072EC;
     color: white;
-    border-radius: 4px;
+    border-radius: 8px;
     overflow: hidden;
     height: 100%;
   }

--- a/app/views/components/module-nav/example-set-role-from-data.html
+++ b/app/views/components/module-nav/example-set-role-from-data.html
@@ -6,7 +6,7 @@
     justify-content: center;
     background-color: #0072EC;
     color: white;
-    border-radius: 4px;
+    border-radius: 8px;
     overflow: hidden;
     height: 100%;
   }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## v4.94.0 Fixes
 
+- `[Avatar]` Is no longer round by default. To use it in module nav add the new `square` class. ([#8539](https://github.com/infor-design/enterprise/issues/8539))
 - `[Calendar]` Fixed inconsistencies in border colors of events in calendar. ([#8452](https://github.com/infor-design/enterprise/issues/8452))
 - `[Datagrid]` Fixed datagrid unable to have resize handle when using different column structure such as single lines. ([#8417](https://github.com/infor-design/enterprise/issues/8417))
 - `[Datagrid]` Removed escaping HTML for cell nodes. ([#8516](https://github.com/infor-design/enterprise/issues/8516))

--- a/src/components/images/_images.scss
+++ b/src/components/images/_images.scss
@@ -101,17 +101,21 @@ $images-size: (
 .avatar {
   background: $ids-color-palette-emerald-50;
   border: 1px solid transparent; // to prevent jump on focus
-  border-radius: 8px;
   color: $ids-color-palette-white;
+  border-radius: 50%;
   display: inline-block;
   font-size: 14px;
   font-weight: 600;
+  min-height: 32px;
   height: 32px;
+  max-height: 32px;
   line-height: 30px;
   text-align: center;
   text-transform: uppercase;
   vertical-align: middle;
+  min-width: 32px;
   width: 32px;
+  max-width: 32px;
   user-select: none;
 
   &.three-char {
@@ -119,14 +123,22 @@ $images-size: (
   }
 
   &.large {
+    min-height: 48px;
     height: 48px;
+    max-height: 48px;
     font-size: 20px;
     line-height: 48px;
+    min-width: 48px;
     width: 48px;
+    max-width: 48px;
   }
 
   &.round {
     border-radius: 50%;
+  }
+
+  &.square {
+    border-radius: 8px;
   }
 
   &:focus {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Previously when adding new avatar css we accidentally made the default not round. Reverted this and will patch to 4.92.0

**Related github/jira issue (required)**:
Fixes #8539 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/images/example-avatar
- the first two should not be round

**Included in this Pull Request**:
- [x] A note to the change log.
