### PR TITLE
NG1578 - Tabs Vetoable

### DIFF
--- a/app/views/components/tabs/example-activated-event.html
+++ b/app/views/components/tabs/example-activated-event.html
@@ -1,11 +1,11 @@
 <div class="row">
-  <div class="six columns">
+  <div class="twelve columns">
 
-    <h2>Tabs Example:  "activated" Event</h2>
+    <h2 class="fieldset-title">Tabs Example: "beforeactivated, activated and afteractivated" Event</h2>
 
-    <p>Provides a visual example of the Tabs "activated" event and its firing timing.</p>
+    <p>Provides a visual example of the Tabs "beforeactivated, activated and afteractivated" event and its firing timing.</p>
 
-    <p></p>
+    <p><strong>Vetoed Tabs: Opportunities and Notes</strong></p>
 
   </div>
 </div>
@@ -22,18 +22,23 @@
         <li class="tab"><a href="#tabs-normal-notes">Notes</a></li>
       </ul>
       <div id="tabs-normal-contracts" class="tab-panel">
+        <p>Contracts</p>
         <p>Facilitate cultivate monetize, seize e-services peer-to-peer content integrateAJAX-enabled user-centric strategize. Mindshare; repurpose integrate global addelivery leading-edge frictionless, harness real-time plug-and-play standards-compliant 24/7 enterprise strategize robust infomediaries: functionalities back-end. Killer disintermediate web-enabled ubiquitous empower relationships, solutions, metrics architectures.</p>
       </div>
       <div id="tabs-normal-opportunities" class="tab-panel">
+        <p>Opportunities</p>
         <p>Bricks-and-clicks? Evolve ubiquitous matrix B2B 24/365 vertical 24/365 platforms standards-compliant global leverage dynamic 24/365 intuitive ROI seamless rss-capable. Cutting-edge grow morph web services leverage; ROI, unleash reinvent innovative podcasts citizen-media networking. Frictionless webservices, killer open-source innovate, best-of-breed.</p>
       </div>
       <div id="tabs-normal-attachments" class="tab-panel">
+        <p>Attachments</p>
         <p>Frictionless webservices, killer open-source innovate, best-of-breed, whiteboard interactive back-end optimize capture dynamic front-end. Initiatives ubiquitous 24/7 enhance channels B2B drive frictionless web-readiness generate recontextualize widgets applications. Sexy sticky matrix, user-centred, rich user-centric: peer-to-peer podcasting networking addelivery optimize streamline integrated proactive: granular morph.</p>
       </div>
       <div id="tabs-normal-contacts" class="tab-panel">
+        <p>Contacts</p>
         <p>Exploit niches; enable A-list web-enabled holistic end-to-end. Exploit experiences value-added tagclouds, open-source cross-platform e-tailers, user-contributed, implement! Convergence, solutions front-end, "synergize markets initiatives integrateAJAX-enabled platforms; wireless, supply-chains reinvent, mindshare, synergies implement, drive evolve!" Post incentivize; rich-clientAPIs customized revolutionize 24/365 killer incentivize integrate intuitive utilize!</p>
       </div>
       <div id="tabs-normal-notes" class="tab-panel">
+        <p>Notes</p>
         <p> Post incentivize; rich-clientAPIs customized revolutionize 24/365 killer incentivize integrate intuitive utilize!</p>
       </div>
     </div>
@@ -63,10 +68,30 @@
     });
   }
 
+  function onBeforeActivationEvent(e, anchor) {
+    var type = e.type;
+    var color = '#aa1111';
+    var anchorName = anchorName = anchor.text().trim();
+    var anchorId = anchorId = anchor.attr('href');
+
+    if (anchorName === 'Opportunities' || anchorName === 'Notes') {
+      $('body').toast({
+        title: 'tab <span style="color: '+ color +'; font-weight: bold;">' + anchorId + '</span> ['+ type +'] blocked!',
+        message: 'The "<b>'+ anchorName +'</b>" tab was blocked!'
+      });
+      return false;
+    }
+
+    $('body').toast({
+      title: 'tab <span style="color: '+ color +'; font-weight: bold;">' + anchorId + '</span> ['+ type +'] triggered!',
+      message: 'The "<b>'+ anchorName +'</b>" tab was clicked or triggered!'
+    });
+  }
+
   $('body').on('initialized', function() {
     $('#tabs')
       .on('activated.test', onActivationEvent)
-      .on('beforeactivated.test', onActivationEvent)
+      .on('beforeactivated.test', onBeforeActivationEvent)
       .on('afteractivated.test', onActivationEvent);
   });
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `[Calendar]` Fixed event icon not properly rendered across week view mode. ([#8456](https://github.com/infor-design/enterprise/issues/8456))
 - `[Radio]` Fixed alignment in short form of radio button. ([#8193](https://github.com/infor-design/enterprise/issues/8193))
 - `[Tabs]` Added guards on possible undefined objects. ([#8419](https://github.com/infor-design/enterprise/issues/8419))
+- `[Tabs]` Fixed beforeactivated event not cancelling activation of tabs properly. ([NG#1578](https://github.com/infor-design/enterprise-ng/issues/1578))
 - `[Textarea]` Fixed the character count message in textarea.([#8449](https://github.com/infor-design/enterprise/issues/8449))
 - `[Toolbar]` Fixed button shapes in toolbar. ([#8523](https://github.com/infor-design/enterprise/issues/8523))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,7 +18,7 @@
 - `[Calendar]` Fixed event icon not properly rendered across week view mode. ([#8456](https://github.com/infor-design/enterprise/issues/8456))
 - `[Radio]` Fixed alignment in short form of radio button. ([#8193](https://github.com/infor-design/enterprise/issues/8193))
 - `[Tabs]` Added guards on possible undefined objects. ([#8419](https://github.com/infor-design/enterprise/issues/8419))
-- `[Tabs]` Fixed beforeactivated event not cancelling activation of tabs properly. ([NG#1578](https://github.com/infor-design/enterprise-ng/issues/1578))
+- `[Tabs]` Fixed `beforeactivated` event not cancelling activation of tabs properly. ([NG#1578](https://github.com/infor-design/enterprise-ng/issues/1578))
 - `[Textarea]` Fixed the character count message in textarea.([#8449](https://github.com/infor-design/enterprise/issues/8449))
 - `[Toolbar]` Fixed button shapes in toolbar. ([#8523](https://github.com/infor-design/enterprise/issues/8523))
 

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -2204,15 +2204,15 @@ Tabs.prototype = {
     // NOTE: Breaking Change as of 4.3.3 - `beforeactivate` to `beforeactivated`
     // See SOHO-5994 for more details
     /**
-     * Fires when an attempt at activating a tab is started
+     * Fires when an attempt at activating a tab is started. Returning false from the request function will cancel tab activation.
      *
      * @event beforeactivated
      * @memberof Tabs
      * @param {jQuery.Event} e event object
      * @param {jQuery} a the tab anchor attempting to activate
      */
-    const isCancelled = self.element.trigger('beforeactivated', [a]);
-    if (!isCancelled) {
+    const canActivate = self.element.triggerHandler('beforeactivated', [a]);
+    if (canActivate === false) {
       return false;
     }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix `beforeactivated` event not cancelling activation of tabs properly.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1578

**Steps necessary to review your pull request (required)**:
- Pull this git repository, build, and run the app
- Go to http://localhost:4000/components/tabs/example-activated-event.html
- The vetoable tabs are `Opportunities` and `Notes`
- Try to click these two, it should block tab activation

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

