### PR TITLE
8515 - Fixed search icon misalignment in dropdown cells

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise
 
+## v4.95.0
+
+## v4.95.0 Fixes
+
+- `[Datagrid]` Fixed search icon misalignment in dropwdown cells. ([#8515](https://github.com/infor-design/enterprise/issues/8515))
+
 ## v4.94.0
 
 ## v4.94.0 Features

--- a/src/components/datagrid/_datagrid-new.scss
+++ b/src/components/datagrid/_datagrid-new.scss
@@ -803,7 +803,11 @@
 
 .datagrid-dropdown-list.extra-small-rowheight .trigger .icon {
   left: 4px !important;
-  top: 6px;
+  top: 8px;
+
+  &.search {
+    top: 3px;
+  }
 }
 
 .datagrid-dropdown-list.small-rowheight .trigger .icon {

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -4989,7 +4989,7 @@ td .btn-actions {
     }
 
     &.dropdown-list .trigger .icon {
-      margin-top: 3.5px;
+      margin-top: 2px;
     }
   }
 
@@ -4997,7 +4997,7 @@ td .btn-actions {
   .icon {
     color: $ids-color-font-base;
     left: 0 !important;
-    margin-top: 7px;
+    margin-top: 6px;
 
     &.search {
       margin-top: 7px;

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -4970,7 +4970,7 @@ td .btn-actions {
       &.search {
         height: 13px;
         left: 4px !important;
-        top: 0;
+        top: 1px;
       }
     }
   }
@@ -4993,13 +4993,14 @@ td .btn-actions {
     }
   }
 
+  > .trigger .icon,
   .icon {
     color: $ids-color-font-base;
     left: 0 !important;
     margin-top: 7px;
 
     &.search {
-      margin-top: 7px !important;
+      margin-top: 7px;
     }
   }
 }

--- a/src/components/dropdown/_dropdown-new.scss
+++ b/src/components/dropdown/_dropdown-new.scss
@@ -63,7 +63,7 @@ div.multiselect {
 .dropdown-list {
   &.small-rowheight {
     &.datagrid-dropdown-list .trigger .icon {
-    top: 7px;
+    top: 1px;
     margin-left: 2px;
     }
   }

--- a/src/components/dropdown/_dropdown-new.scss
+++ b/src/components/dropdown/_dropdown-new.scss
@@ -423,6 +423,10 @@ html.is-firefox:not([dir='rtl']) {
       &.datagrid-dropdown-list .trigger .icon {
         top: 7.5px;
         margin-left: 0.5px;
+
+        &.search {
+          top: 1px;
+        }
       }
     }
 
@@ -430,6 +434,10 @@ html.is-firefox:not([dir='rtl']) {
       &.datagrid-dropdown-list .trigger .icon {
         top: 7px;
         margin-left: 0;
+
+        &.search {
+          top: 2px;
+        }
       }
     }
 

--- a/src/components/dropdown/_dropdown-new.scss
+++ b/src/components/dropdown/_dropdown-new.scss
@@ -63,8 +63,11 @@ div.multiselect {
 .dropdown-list {
   &.small-rowheight {
     &.datagrid-dropdown-list .trigger .icon {
-    top: 1px;
-    margin-left: 2px;
+      margin-left: 2px;
+
+      &.search {
+        top: 1px;
+      }
     }
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fixed search icon misalignment in dropdown cells

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #8515 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datagrid/example-editable.html
- Check dropdown cell (Action) in all sizes. Type on cell to show search icon

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
