### PR TITLE
8438 - Added copy to clipboard button to about page

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # What's New with Enterprise
 
+## v4.95.0
+
+## v4.95.0 Features
+
+- `[About]` Added copy to clipboard button. ([#8438](https://github.com/infor-design/enterprise/issues/8438))
+
 ## v4.94.0
 
 ## v4.94.0 Features

--- a/src/components/about/_about.scss
+++ b/src/components/about/_about.scss
@@ -121,6 +121,6 @@ html[dir='rtl'] {
 
 #copy-to-clipboard {
   top: 375px;
-  right: 30px;
+  right: 12px;
   position: absolute;
 }

--- a/src/components/about/_about.scss
+++ b/src/components/about/_about.scss
@@ -121,6 +121,6 @@ html[dir='rtl'] {
 
 #copy-to-clipboard {
   top: 375px;
-  right: 12px;
+  right: 20px;
   position: absolute;
 }

--- a/src/components/about/_about.scss
+++ b/src/components/about/_about.scss
@@ -118,3 +118,9 @@ html[dir='rtl'] {
     }
   }
 }
+
+#copy-to-clipboard {
+  top: 375px;
+  right: 30px;
+  position: absolute;
+}

--- a/src/components/about/about.js
+++ b/src/components/about/about.js
@@ -19,6 +19,7 @@ const COMPONENT_NAME = 'about';
  * @param {boolean} [settings.useDefaultCopyright=true] Add the Legal Approved Infor Copyright Text.
  * @param {string} [settings.version] Semantic Version Number for example (4.0.0).
  * @param {array|object} [settings.attributes=null] Add extra attributes like id's to the toast element. For example `attributes: { name: 'id', value: 'my-unique-id' }`
+ * @param {array|object} [settings.showCopyButton=true] Show copy to clipboard button
 */
 const ABOUT_DEFAULTS = {
   appName: 'Infor Application Name',
@@ -28,6 +29,7 @@ const ABOUT_DEFAULTS = {
   productName: undefined,
   useDefaultCopyright: true,
   version: undefined,
+  showCopyButton: true
 };
 
 function About(element, settings) {
@@ -143,16 +145,46 @@ About.prototype = {
     $('.modal-body', this.modal)[0].tabIndex = 0;
 
     this.modal.appendTo('body');
+
     this.modal.modal({
       trigger: this.isBody ? 'immediate' : 'click',
       attributes: this.settings.attributes
     });
+
+    if (this.settings.showCopyButton) {
+      $(`<button type="button" class="btn-icon" id="copy-to-clipboard" title="${Locale.translate('CopyToClipboard')}">
+          <span>${Locale.translate('CopyToClipboard')}</span>
+          <svg role="presentation" aria-hidden="true" focusable="false" class="icon">
+            <use href="#icon-copy"></use>
+          </svg>
+        </button>`).prependTo(this.modal.find('.modal-body-wrapper')).on('click', () => {
+        this.copyToClipBoard();
+      }).tooltip();
+    }
 
     // Link the About API to the Modal API
     const modalAPI = this.modal.data('modal');
     modalAPI.aboutAPI = this;
 
     return this;
+  },
+
+  /**
+   * Copy inner text to clipboard
+   */
+  copyToClipBoard() {
+    const container = document.createElement('div');
+    container.innerHTML = this.modal.find('.modal-body').html();
+    container.style.position = 'fixed';
+    container.style.pointerEvents = 'none';
+    container.style.opacity = 0;
+    document.body.appendChild(container);
+    window.getSelection().removeAllRanges();
+    const range = document.createRange();
+    range.selectNode(container);
+    window.getSelection().addRange(range);
+    document.execCommand('copy');
+    document.body.removeChild(container);
   },
 
   /**

--- a/src/components/locale/cultures/en-US.js
+++ b/src/components/locale/cultures/en-US.js
@@ -147,6 +147,7 @@ Soho.Locale.addCulture('en-US', {
     Contrast: { id: 'Contrast', value: 'Contrast', comment: 'Name of the high contrast theme' },
     CookiesEnabled: { id: 'CookiesEnabled', value: 'Cookies enabled', comment: 'Returns if browser cookies are enabled or not.' },
     Copy: { id: 'Copy', value: 'Copy', comment: 'Copy tooltip' },
+    CopyToClipboard: { id: 'CopyToClipboard', value: 'Copy to clipboard', comment: 'Copy to clipboard' },
     Croatian: { id: 'Croatian', value: 'Croatian', comment: 'Croatian (Croatia) language' },
     CssClass: { id: 'CssClass', value: 'Css class', comment: 'Label for entering a Css Class name' },
     Cut: { id: 'Cut', value: 'Cut', comment: 'Cut tooltip' },

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -413,7 +413,6 @@ $.copyToClipboard = function (text) { // eslint-disable-line
     try {
       return document.execCommand('copy'); // Security exception may be thrown by some browsers.
     } catch (ex) {
-      // console.warn('Copy to clipboard failed.', ex);
       return false;
     } finally {
       document.body.removeChild(textarea);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adds a copy button to the about page.

**Related github/jira issue (required)**:
Fixes #8438 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/about/example-index.html
- click the button to open the moda
- click the button at the bottom to copy to clipboard
- paste the output in a file to check it

**Included in this Pull Request**:
- [x] A note to the change log.
