### PR TITLE
1672 - Fix errors editing on second page

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## v4.95.0 Fixes
 
+- `[Datagrid]` Fixed an error editing on non first page in server side paging datagrid. ([#8537](https://github.com/infor-design/enterprise-ng/issues/1672))
 - `[Forms]` Fixed fileupload layout in compact form. ([#8537](https://github.com/infor-design/enterprise/issues/8537))
 
 ## v4.94.0

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -11468,7 +11468,7 @@ Datagrid.prototype = {
       dataRowIndex = row;
     }
 
-    if (!isTreeGrid && this.settings.paging && this.pagerAPI.activePage > 1) {
+    if (!isTreeGrid && this.settings.paging && this.pagerAPI.activePage > 1 && !this.settings.source) {
       if (dataRowIndex < (this.pagerAPI.activePage - 1) * this.settings.pagesize) {
         dataRowIndex += (this.pagerAPI.activePage - 1) * this.settings.pagesize;
       }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixed a bug editing on the second page in server side paging. This was caused by https://github.com/infor-design/enterprise/pull/7577

**Related github/jira issue (required)**:
Fixes https://github.com/infor-design/enterprise-ng/issues/1672

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-expandable-paging-server-side.html
- go to page two
- edit the editable cells (productName)
- check console and should be no error
- retest https://github.com/infor-design/enterprise/pull/7577 should still work

**Included in this Pull Request**:
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
