### PR TITLE
8611 - Add fix for error with no widgets

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,8 @@
 # What's New with Enterprise
 
-## v4.95.0
+## v4.96.0
 
-## v4.95.0 Fixes
+## v4.96.0 Fixes
 
 - `[Homepage]` Fixed bug that caused errors on resize when no widgets. ([#8611](https://github.com/infor-design/enterprise/issues/8611))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## v4.95.0
 
+## v4.95.0 Fixes
+
+- `[Homepage]` Fixed bug that caused errors on resize when no widgets. ([#8611](https://github.com/infor-design/enterprise/issues/8611))
+
+## v4.95.0
+
 ## v4.95.0 Features
 
 - `[About]` Added copy to clipboard button. ([#8438](https://github.com/infor-design/enterprise/issues/8438))
@@ -12,7 +18,7 @@
 - `[Cards]` Fixed title and button regression and position. ([#8602](https://github.com/infor-design/enterprise/issues/8602))
 - `[Contextual Action Panel]` Fixed added padding on contextual action panel. ([#8553](https://github.com/infor-design/enterprise/issues/8553))
 - `[Forms]` Fixed fileupload layout in compact form. ([#8537](https://github.com/infor-design/enterprise/issues/8537))
-- `[Datagrid]` Fixed search icon misalignment in dropwdown cells. ([#8515](https://github.com/infor-design/enterprise/issues/8515))
+- `[Datagrid]` Fixed search icon misalignment in dropdown cells. ([#8515](https://github.com/infor-design/enterprise/issues/8515))
 - `[Datagrid]` Fixed an error editing on non first page in server side paging datagrid. ([#8537](https://github.com/infor-design/enterprise-ng/issues/1672))
 - `[Cards]` Fixed title and button regression and position. ([#8602](https://github.com/infor-design/enterprise/issues/8602))
 - `[Forms]` Fixed fileupload layout in compact form. ([#8537](https://github.com/infor-design/enterprise/issues/8537))

--- a/src/components/homepage/homepage.js
+++ b/src/components/homepage/homepage.js
@@ -741,9 +741,10 @@ Homepage.prototype = {
       let rowsUsed = 0;
       let abort = false;
       let calcHeight = card.outerHeight();
-      if (!card[0]) return;
-      calcHeight += parseInt(window.getComputedStyle(card[0]).getPropertyValue('margin-top'), 10);
-      calcHeight += parseInt(window.getComputedStyle(card[0]).getPropertyValue('margin-bottom'), 10);
+      if (card[0]) {
+        calcHeight += parseInt(window.getComputedStyle(card[0]).getPropertyValue('margin-top'), 10);
+        calcHeight += parseInt(window.getComputedStyle(card[0]).getPropertyValue('margin-bottom'), 10);
+      }
 
       for (let rows = 0; rows < this.rowsAndCols.length && !abort; rows++) {
         rowsUsed++;

--- a/src/components/homepage/homepage.js
+++ b/src/components/homepage/homepage.js
@@ -741,6 +741,7 @@ Homepage.prototype = {
       let rowsUsed = 0;
       let abort = false;
       let calcHeight = card.outerHeight();
+      if (!card[0]) return;
       calcHeight += parseInt(window.getComputedStyle(card[0]).getPropertyValue('margin-top'), 10);
       calcHeight += parseInt(window.getComputedStyle(card[0]).getPropertyValue('margin-bottom'), 10);
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When home page has no widgets and you resize an error occured. This is a fix for this.

cc @anhallbe (does this need a patch on 4.94?)

**Related github/jira issue (required)**:
Fixes #8611 

**Steps necessary to review your pull request (required)**:
- retest https://github.com/infor-design/enterprise/pull/8544
- go to http://localhost:4000/components/homepage/test-add-remove-widget.html
- remove all widgets with the remove button
- check the console
- resize the page
- should be no errors with or without widgets

**Included in this Pull Request**:
- [x] A note to the change log.