### PR TITLE
8541 - Fix uneeded timeouts on gen-ai

### DIFF
--- a/app/views/components/button/example-index.html
+++ b/app/views/components/button/example-index.html
@@ -202,6 +202,7 @@
     e.preventDefault();
     var $btn = $(this);
     var btnApi = $btn.data('button');
-    btnApi.performAnimation(10000);
+    btnApi.startAnimation();
+    // btnApi.stopAnimation(); // later
   });
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## v4.95.0 Fixes
 
+- `[Button]` Fixed unneeded timeout in performAnimation. ([#8541](https://github.com/infor-design/enterprise/issues/8541))
 - `[Cards]` Fixed title and button regression and position. ([#8602](https://github.com/infor-design/enterprise/issues/8602))
 - `[Cards]` Fixed title and button regression and position. ([#8602](https://github.com/infor-design/enterprise/issues/8602))
 - `[Contextual Action Panel]` Fixed added padding on contextual action panel. ([#8553](https://github.com/infor-design/enterprise/issues/8553))

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -605,7 +605,6 @@ Button.prototype = {
   /**
    * Performs a generative action by replacing the content of a button with a loading indicator,
    * then replacing it with generated AI content after a specified delay.
-   *
    * @param {number} delay - The delay (in milliseconds) before replacing the loading indicator.
    * @returns {void}
    */
@@ -621,7 +620,6 @@ Button.prototype = {
 
   /**
    * Starts a generative action.
-   *
    * @returns {void}
    */
   startAnimation() {
@@ -630,14 +628,9 @@ Button.prototype = {
 
   /**
    * Stops a generative action.
-   *
    * @returns {void}
    */
   stopAnimation() {
-    if (isNaN(this.generativeAnimation)) {
-      return;
-    }
-
     clearTimeout(this.generativeAnimation);
     this.generativeAnimation = undefined;
     this.removeGenerativeStyles();

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -609,16 +609,19 @@ Button.prototype = {
    * @param {number} delay - The delay (in milliseconds) before replacing the loading indicator.
    * @returns {void}
    */
-  performAnimation(delay = 5000) {
+  performAnimation(delay = 0) {
     this.renderGenerativeStyles();
-    this.generativeAnimation = setTimeout(() => {
-      this.removeGenerativeStyles();      
-    }, delay);
+
+    if (delay) {
+      this.generativeAnimation = setTimeout(() => {
+        this.removeGenerativeStyles();
+      }, delay);
+    }
   },
 
   /**
    * Starts a generative action.
-   * 
+   *
    * @returns {void}
    */
   startAnimation() {
@@ -627,7 +630,7 @@ Button.prototype = {
 
   /**
    * Stops a generative action.
-   * 
+   *
    * @returns {void}
    */
   stopAnimation() {
@@ -642,7 +645,7 @@ Button.prototype = {
 
   /**
    * Renders a generative action by replacing the content of a button with a loading indicator.
-   * 
+   *
    * @returns {void}
    */
   renderGenerativeStyles() {
@@ -678,7 +681,7 @@ Button.prototype = {
 
   /**
    * Removes a generative action by replacing it with generated AI content.
-   * 
+   *
    * @returns {void}
    */
   removeGenerativeStyles() {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes a bug that `startAnimation` times out after 5 seconds.

**Related github/jira issue (required)**:
Fixes #8541 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/button/example-index.html
- click the gen AI button
- animation should start and never stop in the example (unless you call the following function)
- call `$('#btn-generate-ai-1').data('button').stopAnimation()` in the console to stop it

**Included in this Pull Request**:
- [x] A note to the change log.
