### PR TITLE
2178 - Add support for ids-breadcrumb

### DIFF
--- a/app/views/components/header/example-wc-breadcrumb.html
+++ b/app/views/components/header/example-wc-breadcrumb.html
@@ -1,5 +1,5 @@
 
-<link rel="stylesheet" href="https://unpkg.com/ids-enterprise-wc@1.0.0/themes/ids-theme-default-light.css" type="text/css">
+<link id="ids-stylesheet" rel="stylesheet" href="https://unpkg.com/ids-enterprise-wc@1.0.0/themes/ids-theme-default-light.css" type="text/css">
 <script defer type="module" src="https://unpkg.com/ids-enterprise-wc@1.0.0/components/ids-breadcrumb/ids-breadcrumb.js"></script>
 
 <div class="header is-personalizable">
@@ -21,3 +21,4 @@
     $('[data-theme-name="theme-classic"]').parent().addClass('is-disabled');
   });
 </script>
+

--- a/app/views/components/header/example-wc-breadcrumb.html
+++ b/app/views/components/header/example-wc-breadcrumb.html
@@ -1,0 +1,23 @@
+
+<link rel="stylesheet" href="https://unpkg.com/ids-enterprise-wc@1.0.0/themes/ids-theme-default-light.css" type="text/css">
+<script defer type="module" src="https://unpkg.com/ids-enterprise-wc@1.0.0/components/ids-breadcrumb/ids-breadcrumb.js"></script>
+
+<div class="header is-personalizable">
+  <ids-breadcrumb truncate="true">
+    <ids-hyperlink font-size="14" text-decoration="hover" href="#">First Item</ids-hyperlink>
+    <ids-hyperlink font-size="14" text-decoration="hover" href="#">Second Item</ids-hyperlink>
+    <ids-hyperlink font-size="14" text-decoration="hover" href="#">Third Item</ids-hyperlink>
+    <ids-hyperlink font-size="14" text-decoration="hover" href="#">Fourth Item</ids-hyperlink>
+    <ids-hyperlink font-size="14" text-decoration="hover" href="#">Fifth Item</ids-hyperlink>
+    <ids-hyperlink font-size="14" text-decoration="hover" href="#">Sixth Item</ids-hyperlink>
+    <ids-hyperlink font-size="14" text-decoration="hover" href="#">Seventh Item</ids-hyperlink>
+    <ids-hyperlink font-size="14" text-decoration="hover" disabled>Disabled Item</ids-hyperlink>
+    <ids-hyperlink font-size="14">Current Item</ids-hyperlink>
+  </ids-breadcrumb>
+</div>
+
+<script>
+  $('body').on('initialized', () => {
+    $('[data-theme-name="theme-classic"]').parent().addClass('is-disabled');
+  });
+</script>

--- a/app/views/components/header/test-no-personalize.html
+++ b/app/views/components/header/test-no-personalize.html
@@ -1,0 +1,24 @@
+<header class="header">
+  <div class="flex-toolbar">
+    <div class="toolbar-section">
+      {{> includes/header-appmenu-trigger}}
+    </div>
+    <div class="toolbar-section title">
+      <h1>Page Title</h1>
+    </div>
+
+    <div class="toolbar-section search">
+      <label for="header-searchfield" class="audible">Search</label>
+      <input id="header-searchfield" class="searchfield" name="header-searchfield" data-options="{'collapsible': true, 'clearable': true}" />
+    </div>
+
+    {{> includes/header-actionbutton}}
+
+  </div>
+</header>
+
+<script>
+  $('body').on('initialized', () => {
+    $('[data-theme-name="theme-classic"]').parent().addClass('is-disabled');
+  });
+</script>

--- a/app/views/includes/head.html
+++ b/app/views/includes/head.html
@@ -194,6 +194,16 @@
             },'html');
           }
         }
+
+        setTimeout(() => {
+          const wcTheme = $('#ids-stylesheet');
+          if (wcTheme && wcTheme.length) {
+            const attr = wcTheme.attr('href');
+            if (parts[1] === 'new') {
+              wcTheme.attr('href', attr.replace('-light', `-${parts[2]}`).replace('-dark', `-${parts[2]}`).replace('-contrast', `-${parts[2]}`))
+            }
+          }
+        }, 100);
       });
   </script>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,17 +12,15 @@
 
 - `[Button]` Fixed unneeded timeout in performAnimation. ([#8541](https://github.com/infor-design/enterprise/issues/8541))
 - `[Cards]` Fixed title and button regression and position. ([#8602](https://github.com/infor-design/enterprise/issues/8602))
-- `[Cards]` Fixed title and button regression and position. ([#8602](https://github.com/infor-design/enterprise/issues/8602))
 - `[Contextual Action Panel]` Fixed added padding on contextual action panel. ([#8553](https://github.com/infor-design/enterprise/issues/8553))
 - `[Dropdown/Lookup]` Add option to remove margin in dropdown and lookup wrapper.
 - `[Forms]` Fixed fileupload layout in compact form. ([#8537](https://github.com/infor-design/enterprise/issues/8537))
-- `[Cards]` Fixed title and button regression and position. ([#8602](https://github.com/infor-design/enterprise/issues/8602))
 - `[Contextual Action Panel]` Fixed added padding on contextual action panel. ([#8553](https://github.com/infor-design/enterprise/issues/8553))
-- `[Forms]` Fixed fileupload layout in compact form. ([#8537](https://github.com/infor-design/enterprise/issues/8537))
 - `[Datagrid]` Fixed search icon misalignment in dropwdown cells. ([#8515](https://github.com/infor-design/enterprise/issues/8515))
 - `[Datagrid]` Fixed search icon misalignment in dropdown cells. ([#8515](https://github.com/infor-design/enterprise/issues/8515))
 - `[Datagrid]` Fixed an error editing on non first page in server side paging datagrid. ([#8537](https://github.com/infor-design/enterprise-ng/issues/1672))
 - `[Forms]` Fixed fileupload layout in compact form. ([#8537](https://github.com/infor-design/enterprise/issues/8537))
+- `[Header]` Fixed default color, and changed to flex layout by default. This is to allow for ids-breadcrumb to work. ([#2178](https://github.com/infor-design/enterprise-wc/issues/2178))
 - `[Homepage]` Fixed bug that caused errors on resize when no widgets. ([#8611](https://github.com/infor-design/enterprise/issues/8611))
 - `[Month Picker]` Fixed cursor for down button. ([#7315](https://github.com/infor-design/enterprise/issues/7315))
 - `[Searchfield]` Fixed misalignment in clear icon on mobile. ([#8332](https://github.com/infor-design/enterprise/issues/8332))

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -8,10 +8,17 @@ $subheader-height: 60px;
 // Top Header
 .header {
   background-color: $header-bg-color;
-  display: block;
+  border-bottom: 1px solid $header-bottom-border-color;
+  display: inline-flex;
   height: $header-height;
-  overflow: hidden;
   width: 100%;
+
+  /* stylelint-disable-next-line selector-type-no-unknown */
+  ids-breadcrumb {
+    align-self: center;
+    margin: 0 8px;
+    width: calc(100% - 16px);
+  }
 
   &.scrollable {
     overflow: auto;
@@ -148,6 +155,7 @@ $subheader-height: 60px;
   .toolbar {
     height: $header-height;
     padding: 0 1rem;
+    width: 100%;
 
     &.searchfield-active {
       .toolbar-searchfield-wrapper.active {
@@ -347,6 +355,7 @@ $subheader-height: 60px;
     height: inherit;
     max-height: $header-height;
     padding: 0 1.3rem;
+    width: 100%;
 
     &.has-title-button + .breadcrumb {
       padding-left: 56px;

--- a/src/components/personalize/personalize.js
+++ b/src/components/personalize/personalize.js
@@ -278,7 +278,7 @@ Personalize.prototype = {
     colors.btnBgHoverColor = 'rgba(0, 0, 0, 0.3) !important';
     colors.focusBoxShadow = `0 0 0 2px transparent, 0 0 0 0 ${colors.subtext}, 0 0 2px 1px ${colors.subtext}`;
     colors.btnFocusBorderColor = colors.contrast;
-    colors.btnDisabledColor = 'rgba(255, 255, 255, 0.3) !important';
+    colors.btnDisabledColor = 'rgba(255, 255, 255, 0.5) !important';
     colors.btnOpacity = 0.8;
     colors.btnPrimaryColor = colors.base;
     colors.btnPrimaryColorHover = colors.darker;
@@ -406,7 +406,7 @@ Personalize.prototype = {
 
       colors.tabCloseInactiveColor = 'rgb(111, 111, 118)';
       colors.tabCloseHoverColor = colors.contrast;
-      
+
       if (!newTheme) {
         colors.btnTertiaryBgHoverColor = themeColors.palette.slate[30].value;
       }

--- a/src/components/personalize/personalize.styles.js
+++ b/src/components/personalize/personalize.styles.js
@@ -29,6 +29,31 @@ function personalizeStyles(colors) {
   color: ${colors.darkest} !important;
 }
 
+.header.is-personalizable {
+  --ids-color-background-default: ${colors.tabHeaderColor};
+  --ids-breadcrumb-color-text-default: ${colors.contrast};
+  --ids-breadcrumb-color-text-disabled: ${colors.btnDisabledColor};
+
+  --ids-button-tertiary-color-text-default: ${colors.btnTertiaryHoverColorHeader};
+  --ids-button-tertiary-color-text-hover: ${colors.btnTertiaryHoverColorHeader};
+  --ids-button-tertiary-color-background-hover: ${colors.btnTertiaryBgHoverColorHeader};
+  --ids-button-tertiary-color-border-hover: ${colors.btnTertiaryBgHoverColorHeader};
+  --ids-button-menu-background-color-active: ${colors.btnTertiaryBgHoverColorHeader};
+  --ids-button-menu-color-text-active: ${colors.btnTertiaryHoverColorHeader};
+  --ids-button-tertiary-color-border-hover: transparent;
+  --ids-button-tertiary-color-background-pressed: ${colors.btnTertiaryBgHoverColorHeader};
+  --ids-button-tertiary-color-border-pressed: transparent;
+  --ids-button-tertiary-color-text-pressed: ${colors.btnTertiaryHoverColorHeader};
+  --ids-button-tertiary-shadow-focus: ${colors.btnBoxShadow};
+  --ids-button-tertiary-color-border-focus: ${colors.contrast};
+  --ids-hyperlink-color-text-default: ${colors.btnTertiaryHoverColorHeader};
+  --ids-shadow-focus: ${colors.btnBoxShadow};
+}
+
+.header.is-personalizable ids-hyperlink {
+  color: ${colors.contrast};
+}
+
 html.theme-classic-dark .is-personalizable .btn-primary:not(.destructive):not(.is-select):not(.is-select-month-pane):not(.is-cancel):not(.is-cancel-month-pane):disabled {
   color: #888B94 !important;
 }

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -2,7 +2,8 @@
 //================================================== //
 
 // Form Background Color
-$header-bg-color: $ids-color-palette-azure-60;
+$header-bg-color: $ids-color-palette-white;
+$header-bottom-border-color: $ids-color-palette-slate-30;
 $subhead-bg-color: $ids-color-palette-azure-70;
 $transparent: transparent;
 

--- a/src/themes/theme-classic-contrast.scss
+++ b/src/themes/theme-classic-contrast.scss
@@ -20,6 +20,7 @@
 //================================================== //
 // Form Background Color
 $header-bg-color: $ids-color-palette-azure-60;
+$header-bottom-border-color: $ids-color-palette-azure-80;
 $subhead-bg-color: $ids-color-palette-azure-70;
 $header-border-color: $ids-color-palette-slate-100;
 $header-text-color: $ids-color-palette-slate-100;

--- a/src/themes/theme-classic-dark.scss
+++ b/src/themes/theme-classic-dark.scss
@@ -23,6 +23,7 @@ $header-default-bg-hover-color: $ids-color-palette-slate-80;
 
 // Form Background Color
 $header-bg-color: $ids-color-palette-slate-60;
+$header-bottom-border-color: $ids-color-palette-slate-40;
 $subhead-bg-color: $ids-color-palette-slate-50;
 $header-text-color: $ids-color-palette-white;
 $header-border-color: $ids-color-palette-slate-100;

--- a/src/themes/theme-new-contrast.scss
+++ b/src/themes/theme-new-contrast.scss
@@ -41,7 +41,8 @@ $header-toolbar-searchfield-icon-color: $header-button-icon-color;
 $header-toolbar-button-hover-color: $ids-color-palette-azure-10;
 
 // Form Background Color
-$header-bg-color: $ids-color-palette-azure-80;
+$header-bg-color: $ids-color-palette-white;
+$header-bottom-border-color: $ids-color-palette-slate-40;
 $header-default-bg-color: $ids-color-palette-white;
 $header-default-bg-border-color: $ids-color-palette-slate-30;
 $header-default-bg-hover-color: rgba(0, 0, 0, .3);

--- a/src/themes/theme-new-dark.scss
+++ b/src/themes/theme-new-dark.scss
@@ -925,6 +925,7 @@ $header-button-hover-color: rgba($ids-color-palette-white, 1);
 $header-button-focus-color: rgba($ids-color-palette-white, 1);
 $header-button-color: $ids-color-palette-white;
 $header-bg-color: $ids-color-palette-slate-90;
+$header-bottom-border-color: $ids-color-palette-slate-70;
 $header-primary-btn-background-color: $ids-color-palette-slate-70;
 $header-primary-btn-background-hover-color: $ids-color-palette-slate-80;
 $header-flex-toolbar-input-searchfield-color: $ids-color-palette-white;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Added a fix to support using new ids-breadcrumb inside of legacy header. Also found that if you take is-personalization class off 

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-wc/issues/2178

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/header/test-no-personalize.html -> should be alabaster
- go to http://localhost:4000/components/header/example-wc-breadcrumb.html
- a) dropdown should open when resized and show overflowed items
- b) should be centered in the header
- c) go to http://localhost:4000/components/header/example-wc-breadcrumb.html?colors=1C86EF and try states and personalization should work
- regression test http://localhost:4000/components/header with https://main-enterprise.demo.design.infor.com/components

**Included in this Pull Request**:
- [x] A note to the change log.
