### PR TITLE
8640 - Fix incorrect height of homepage

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `[General]` Removed dups in sass packages thus reducing css file size. ([#8653](https://github.com/infor-design/enterprise/issues/8653))
 - `[Header]` Fixed default color, and changed to flex layout by default. This is to allow for ids-breadcrumb to work. ([#2178](https://github.com/infor-design/enterprise-wc/issues/2178))
 - `[Homepage]` Fixed bug that caused errors on resize when no widgets. ([#8611](https://github.com/infor-design/enterprise/issues/8611))
+- `[Homepage]` Fixed a bug where the homepage height was incorrect. ([#8640](https://github.com/infor-design/enterprise/issues/8640))
 - `[Month Picker]` Fixed cursor for down button. ([#7315](https://github.com/infor-design/enterprise/issues/7315))\
 - `[Pager]` Fixed misaligned hover state in RTL. ([#8508](https://github.com/infor-design/enterprise/issues/8508))
 - `[Personalization]` Fixed bug with wrong colors in landmark form examples. ([#8625](https://github.com/infor-design/enterprise/issues/8625))

--- a/src/components/homepage/homepage.js
+++ b/src/components/homepage/homepage.js
@@ -99,6 +99,7 @@ Homepage.prototype = {
     setTimeout(() => { // Timeout to let rtl load first before the render of the resize
       this.resize(this, false);
     }, 100);
+    this.setHomepageHeight(100);
     this.element.parent().addClass('homepage-background');
   },
 
@@ -139,6 +140,18 @@ Homepage.prototype = {
         s.widgetHeight = small.widgetHeight;
       }
     }
+  },
+
+  /**
+   * Set height to the homepage container.
+   * @private
+   * @param {number} [timeout=0] Delay in milliseconds before setting height.
+   */
+  setHomepageHeight(timeout = 0) {
+    setTimeout(() => {
+      const homepageHeight = this.element.get(0).scrollHeight + 16; // 16px is based on the padding
+      this.element.css('height', `${homepageHeight}px`);
+    }, timeout);
   },
 
   /**
@@ -843,10 +856,12 @@ Homepage.prototype = {
   handleEvents() {
     $('body').on('resize.homepage', () => {
       this.resize(this, this.settings.animate);
+      this.setHomepageHeight(500);
     });
 
     $('.application-menu').on('applicationmenuopen.homepage applicationmenuclose.homepage', () => {
       this.resize(this, this.settings.animate);
+      this.setHomepageHeight(400);
     });
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes a bug where the homepage contents gets cutoff at the bottom of the page.

**Related github/jira issue (required)**:

Closes #8640

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/cards/example-workspace-widgets.html
- Scroll at the bottom of the page
- Cards/Widgets at the bottom should not cut off
- Test on resize as well

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
