### PR TITLE
8639 - Add fix in adding text width

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -468,13 +468,13 @@ Modal.prototype = {
         // Get the width of the button
         const buttonWidth = button.offsetWidth;
         // Get the width of the button's text
-        const textWidth = button.querySelector('span').scrollWidth;
+        const textWidth = button.querySelector('span')?.scrollWidth;
 
         // Check if the button's width is less than the text's width
         if (buttonWidth < textWidth) {
           // Add a tooltip to the button
           $(button).tooltip({
-            content: button.querySelector('span').textContent,
+            content: button.querySelector('span')?.textContent,
             placement: 'top',
             trigger: 'hover'
           });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

While implementing this fix (https://github.com/infor-design/enterprise/issues/8639) in the NG wrapper, I encountered an issue. Some implementations of buttonset don't use `<span>` as the element for the buttonset text. This PR addresses that.

Just need to add optional chaining to escape non span buttonset.

**Related github/jira issue (required)**:

Closes #8639

**Steps necessary to review your pull request (required)**:
 - N/A

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
~~- [ ] A note to the change log.~~

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
