### PR TITLE
8618 - Autocomplete Keydown

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # What's New with Enterprise
 
+## v4.96.0
+
+## v4.96.0 Features
+
+## v4.96.0 Fixes
+
+- `[Autocomplete]` Fixed autocomplete not properly highlighted on key down. ([#8618](https://github.com/infor-design/enterprise/issues/8618))
+- `[Datepicker]` Fixed focus date not properly assigned when calendar is used as datepicker. ([#8585](https://github.com/infor-design/enterprise/issues/8585))
+- `[Lookup]` Fixed bug on lookup not using minWidth settings. ([#8626](https://github.com/infor-design/enterprise/issues/8626))
+
 ## v4.95.0
 
 ## v4.95.0 Important Changes

--- a/src/components/popupmenu/popupmenu.js
+++ b/src/components/popupmenu/popupmenu.js
@@ -2234,6 +2234,11 @@ PopupMenu.prototype = {
     li.parent().children('li').removeClass('is-focused');
     li.addClass('is-focused');
 
+    if (this.element.is('.autocomplete')) {
+      li.parent().children('li').removeClass('is-selected');
+      li.addClass('is-selected');
+    }
+
     // Prevent chrome from scrolling - toolbar
     if (anchor) {
       anchor.focus();


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix autocomplete not properly highlighted on key down.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/8618

**Steps necessary to review your pull request (required)**:
- Pull this git repository, build, and run the app
- Go to http://localhost:4000/components/autocomplete/example-index.html
- In the input field, type "ne" and wait for the results to appear.
- Hit the down arrow to nav down the list (notice the highlighted record is BLUE and FOCUS remains in the input field, which is correct behavior)
- Start over (clear the field or refresh the page)
- In the input field, type "ne" and WAIT for the results to appear (don't nav down).
- Now type another character "w" (for "new") and wait for the results to update.
- Hit the down arrow to nav down the list (should be blue focus too)

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

