### PR TITLE
8566 - Fixed dropdown height when showTags is set to true

### DIFF
--- a/app/views/components/dropdown/test-field-tag.html
+++ b/app/views/components/dropdown/test-field-tag.html
@@ -1,0 +1,49 @@
+<div class="row">
+  <div class="six columns">
+
+    <h2>Dropdown Test: Field with Tag</h2>
+
+    <p>Check that the height is the same.
+    </p>
+
+  </div>
+</div>
+
+<div class="row">
+  <div class="twelve columns">
+    <div style="display: inline-flex;">
+      <div class="field" style="margin-right: 5px">
+        <label for="a">No Tag</label>
+        <select id="a" name="a" class="dropdown" data-init="false"></select>
+      </div>
+
+      <div class="field">
+        <label for="b">With Tag</label>
+        <select id="b" name="b" class="dropdown" data-init="false"></select>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<script>
+  $('body').on('initialized', function() {
+    const s = (response, term) => {
+        $.getJSON('{{basepath}}api/states', function(data, term) {
+          response(data.map(item => ['AK', 'AR', 'WY'].includes(item.value) ? {
+            ...item,
+            disabled: true
+          } : item));
+        });
+      };
+    $('#a').dropdown({
+      source: s
+    });
+
+    $('#b').dropdown({
+      source: s,
+      showTags: true
+    });
+
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[Autocomplete]` Fixed autocomplete not properly highlighted on key down. ([#8618](https://github.com/infor-design/enterprise/issues/8618))
 - `[Datagrid]` Fixed add row not triggering after cell commit. ([#8624](https://github.com/infor-design/enterprise/issues/8624))
 - `[Datepicker]` Fixed focus date not properly assigned when calendar is used as datepicker. ([#8585](https://github.com/infor-design/enterprise/issues/8585))
+- `[Dropdown]` Fixed dropdown height when `showTags` is set to true. ([#8566](https://github.com/infor-design/enterprise/issues/8566))
 - `[Lookup]` Fixed bug on lookup not using minWidth settings. ([#8626](https://github.com/infor-design/enterprise/issues/8626))
 
 ## v4.95.0

--- a/src/components/dropdown/_dropdown-new.scss
+++ b/src/components/dropdown/_dropdown-new.scss
@@ -45,7 +45,7 @@ div.multiselect {
   }
 
   .tag-list {
-    padding: 2px 30px 4px 10px;
+    padding: 3px 30px 4px 10px;
 
     &.empty {
       padding: 16px 0 15px;

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -812,6 +812,7 @@ input.dropdown.error:focus {
 
     &.has-tags {
       height: auto;
+      min-height: 3.8rem;
 
       &.empty {
         height: $input-size-regular-height;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fixed dropdown height when showTags is set to true

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #8566 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/dropdown/test-field-tag.html
- Height should be the same for both dropdowns

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
