### PR TITLE
NG1646 - fix tooltip not showing after selecting item in lookup

### DIFF
--- a/app/views/components/lookup/test-beforeshow.html
+++ b/app/views/components/lookup/test-beforeshow.html
@@ -4,7 +4,7 @@
 
     <div class="field">
       <label for="product-lookup" class="label">Products</label>
-      <input id="product-lookup" data-init="false" class="lookup" name="product-lookup" type="text"/>
+      <input id="product-lookup" data-init="false" class="lookup" name="product-lookup" type="text" />
     </div>
 
   </div>
@@ -19,6 +19,8 @@
         beforeShow: function (api, response) {
           var url = '{{basepath}}api/lookupInfo';
 
+          console.log({api, response});
+
           $.getJSON(url, function(data) {
             api.settings.options.columns = data[0].columns;
             api.settings.options.dataset = data[0].dataset;
@@ -32,6 +34,12 @@
           selectable: 'single', //multiple or single
           toolbar: {title: 'Products', results: true, collapsibleFilter: false, dateFilter: false ,keywordFilter: true, actions: true, views: true , rowHeight: true}
         }
+    });
+
+    var lookupElem = $('#product-lookup');
+    lookupElem.tooltip({
+      content: 'testing tooltip',
+      trigger: 'hover',
     });
 
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[Datagrid]` Fixed add row not triggering after cell commit. ([#8624](https://github.com/infor-design/enterprise/issues/8624))
 - `[Datepicker]` Fixed focus date not properly assigned when calendar is used as datepicker. ([#8585](https://github.com/infor-design/enterprise/issues/8585))
 - `[Lookup]` Fixed bug on lookup not using minWidth settings. ([#8626](https://github.com/infor-design/enterprise/issues/8626))
+- `[Lookup]` Fixed a bug where tooltip was not showing after selecting an item in lookup. ([#1646](https://github.com/infor-design/enterprise-ng/issues/1646))
 
 ## v4.95.0
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

When you set up a tooltip in a lookup, it does not show after selecting an item or after closing the lookup modal. There is a method for setting up a tooltip that is only intended for multiple selections in a lookup. This also affects the `beforeShow` setting, causing it to be called when hovering over the input field. This PR fixes those issues.

**Related github/jira issue (required)**:

Closes https://github.com/infor-design/enterprise-ng/issues/1646

**Steps necessary to review your pull request (required)**:
1. Pull this branch, build, and run the app.
2. Go to [http://localhost:4000/components/lookup/test-beforeshow.html](http://localhost:4000/components/lookup/test-beforeshow.html).
3. Hover over the lookup input field.
   - It should show the tooltip: `testing tooltip`.
4. Inspect and check the console.
   - There should be no message output about `beforeShow` (API and response).
5. Open the lookup and select any item.
   - After closing the lookup modal, it should still show the tooltip: `testing tooltip`.
   - The console message should only appear after the lookup modal is closed.

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
