### PR TITLE
8728 - Add fix for editing frozen columns and one column

### DIFF
--- a/app/views/components/datagrid/test-frozen-cell-shift.html
+++ b/app/views/components/datagrid/test-frozen-cell-shift.html
@@ -1,0 +1,34 @@
+<div class="full-height full-width">
+  <div id="datagrid" class="datagrid">
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    var grid,
+      columns = [],
+      data = [];
+
+    var url = '{{basepath}}api/compressors?pageNum=1&pageSize=100';
+    $.getJSON(url, function (res) {
+      data = res.data;
+
+      // Define Columns for the Grid.
+      columns.push({ id: 'productName', name: 'Product Name', field: 'productName', formatter: Soho.Formatters.Hyperlink, href: 'http://www.google.com', target: '_blank' });
+      columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', editor: Soho.Editors.Input });
+
+      // Init and get the api for the grid
+      $('#datagrid').datagrid({
+        columns: columns,
+        dataset: data,
+        paging: true,
+        pagesize: 50,
+        editable: true,
+        frozenColumns: {
+          left: ['productName']
+        },
+        toolbar: { title: 'Compressors', actions: true, rowHeight: true, results: true, personalize: true, exportToExcel: true }
+      });
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[Autocomplete]` Fixed autocomplete not properly highlighted on key down. ([#8618](https://github.com/infor-design/enterprise/issues/8618))
 - `[AppMenu]` Fixed hover state on menu button in app menu. ([#8723](https://github.com/infor-design/enterprise/issues/8723))
 - `[Bar-Stacked/Column-Stacked]` Fixed an error encountered when having many records inside the graph. ([NG#1675](https://github.com/infor-design/enterprise-ng/issues/1675))
+- `[Datagrid]` Fixed styling issue with one cell and frozen columns. ([#8728](https://github.com/infor-design/enterprise/issues/8728))
 - `[Datagrid]` Fixed add row not triggering after cell commit. ([#8624](https://github.com/infor-design/enterprise/issues/8624))
 - `[Datagrid]` Fixed an error that occurred in some situations. ([#8709](https://github.com/infor-design/enterprise/issues/8709))
 - `[Datepicker]` Fixed focus date not properly assigned when calendar is used as datepicker. ([#8585](https://github.com/infor-design/enterprise/issues/8585))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -3063,14 +3063,6 @@ $datagrid-small-row-height: 25px;
         min-height: $datagrid-row-height + 7;
       }
 
-      .datagrid-cell-wrapper {
-        left: 0;
-        position: absolute;
-        text-overflow: clip;
-        top: 0;
-        width: 100%;
-      }
-
       .lookup-wrapper {
         margin-bottom: 0;
         padding-left: 0;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Removes a 9 year old style fix that was probably there for IE 8/9/10. To solve an issue with the cell collapsing

**Related github/jira issue (required)**:
Fixes #8728 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-frozen-cell-shift
- click in the second cell and edit - should look normal
- test editing on http://localhost:4000/components/datagrid/example-editable.html on all 4 row heights and see it looks normal as well

**Included in this Pull Request**:
- [x] A note to the change log.
