### PR TITLE
8644 - Fix focus state border bottom being cut off

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@
 - `[Listview]` Fixed positioning of list alert icons in RTL mode. ([#8724](https://github.com/infor-design/enterprise/issues/8724))
 - `[Monthview]` Fixed monthview not updating after changing activeDate. ([NG#1659](https://github.com/infor-design/enterprise-ng/issues/1659))
 - `[Popup Menu]` Fixed bug on popupmenu showing behind app menu on mobile. ([#8582](https://github.com/infor-design/enterprise/issues/8582))
+- `[Tabs]` Fixed the focus state border bottom being cut off in horizontal tabs. ([#8644](https://github.com/infor-design/enterprise/issues/8644))
 
 ## v4.95.0
 

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -4157,6 +4157,8 @@ Tabs.prototype = {
         if (!isClassic) {
           targetRectObj.height -= 2;
         }
+      } else if (!isSelected && !isClassic) {
+        targetRectObj.height -= 5;
       } else {
         targetRectObj.height -= 4;
       }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the focus state (border bottom) being cut off in horizontal tabs. Adjusted the height by 1px when the focus state is on a tab that is not selected.

**Related github/jira issue (required)**:

Closes #8644 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/personalize/example-form-landmark.html
- Select a tab
- Then press left or right key to focus on other tab
- The border bottom of focus state should be visible

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
