### PR TITLE
8736 - Fix module nave text switcher alignment

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[Lookup]` Fixed bug on lookup not using minWidth settings. ([#8626](https://github.com/infor-design/enterprise/issues/8626))
 - `[Lookup]` Fixed a bug where tooltip was not showing after selecting an item in lookup. ([#1646](https://github.com/infor-design/enterprise-ng/issues/1646))
 - `[Listview]` Fixed positioning of list alert icons in RTL mode. ([#8724](https://github.com/infor-design/enterprise/issues/8724))
+- `[Module Nav]` Fixed module nav switcher text was not vertically aligned. ([#8736](https://github.com/infor-design/enterprise/issues/8736))
 - `[Monthview]` Fixed monthview not updating after changing activeDate. ([NG#1659](https://github.com/infor-design/enterprise-ng/issues/1659))
 - `[Popup Menu]` Fixed bug on popupmenu showing behind app menu on mobile. ([#8582](https://github.com/infor-design/enterprise/issues/8582))
 

--- a/src/components/module-nav/module-nav.dropdown.scss
+++ b/src/components/module-nav/module-nav.dropdown.scss
@@ -5,7 +5,7 @@ $module-nav-container-size: $module-nav-switcher-button-size + $module-nav-switc
 
 @mixin module-nav-div-dropdown-adjustment() {
   background-color: $module-nav-switcher-dropdown-background-color;
-  padding-block-start: 7px;
+  padding-block-start: 9px;
   padding-block-end: 7px;
   padding-inline-start: 8px;
   padding-inline-end: 40px;
@@ -26,6 +26,10 @@ $module-nav-container-size: $module-nav-switcher-button-size + $module-nav-switc
 
     height: $module-nav-switcher-dropdown-height;
     width: $module-nav-switcher-dropdown-width;
+
+    &.is-disabled {
+      padding-block-start: 7px;
+    }
 
     .icon {
       margin-block-end: $module-nav-common-border-radius;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR fixes the module nav switcher text alignment. This issue was introduced in [this PR](https://github.com/infor-design/enterprise/pull/8577), where the disabled text needed adjustment due to its size.

**Related github/jira issue (required)**:

Closes #8736 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/module-nav/example-icon.html
- Open/Click the module nav dropdown
- Text shouldn't move
- Go to http://localhost:4000/components/module-nav/example-index.html?colors=fff
- Click the hamburger menu to expand
- Toggle `Disable switcher` checkbox
- Disabled text should still be vertically aligned

**Included in this Pull Request**:
~~- [ ] An e2e or functional test for the bug or feature.~~
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
