### PR TITLE
8745 - Datagrid Dropdown Filter Keys

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[AppMenu]` Fixed hover state on menu button in app menu. ([#8723](https://github.com/infor-design/enterprise/issues/8723))
 - `[Autocomplete]` Fixed autocomplete not properly highlighted on key down. ([#8618](https://github.com/infor-design/enterprise/issues/8618))
 - `[Bar-Stacked/Column-Stacked]` Fixed an error encountered when having many records inside the graph. ([NG#1675](https://github.com/infor-design/enterprise-ng/issues/1675))
+- `[Datagrid]` Fixed dropdown keys not properly triggering when using keyboard. ([#8745](https://github.com/infor-design/enterprise/issues/8745))
 - `[Datagrid]` Fixed cell changed trigger event on number and string comparison. ([#8719](https://github.com/infor-design/enterprise/issues/8719))
 - `[Datagrid]` Fixed styling issue with one cell and frozen columns. ([#8728](https://github.com/infor-design/enterprise/issues/8728))
 - `[Datagrid]` Fixed add row not triggering after cell commit. ([#8624](https://github.com/infor-design/enterprise/issues/8624))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -3912,7 +3912,7 @@ $datagrid-small-row-height: 25px;
 
     .lookup-wrapper {
       background-color: transparent;
-      display: inline;
+      display: inline-block;
       left: 0;
       vertical-align: top;
       width: calc(100% - 44px);
@@ -3921,7 +3921,7 @@ $datagrid-small-row-height: 25px;
         background-color: transparent;
         left: 10px;
         padding-right: 20px;
-        width: calc(100% - 44px);
+        width: 100%;
 
         &:not(:disabled) + .trigger > .icon:hover,
         &:hover:not(:disabled) + .trigger > .icon {

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -2103,7 +2103,11 @@ Dropdown.prototype = {
     // It adjust the position of datagrid filter dropdown
     // if the element goes out of the datagrid's container
     if (this.list.hasClass('datagrid-filter-dropdown') && document.querySelector('.datagrid-container') !== null) {
-      const gridContainerPos = this.dropdownParent.closest('.datagrid-container').getBoundingClientRect();
+      let gridContainerPos = document.querySelector('.datagrid-container').getBoundingClientRect();
+      if (this.dropdownParent !== undefined) {
+        gridContainerPos = this.dropdownParent.closest('.datagrid-container').getBoundingClientRect();
+      }
+
       const gridFilterDropdownPos = document.querySelector('.datagrid-filter-dropdown').getBoundingClientRect();
       const pageContainerPos = document.querySelector(this.settings.appendTo).getBoundingClientRect().right;
       const adjustedPosition = pageContainerPos - gridContainerPos.right;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix dropdown keys not properly triggering when using keyboard.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/8745

**Steps necessary to review your pull request (required)**:
- Pull this git repository, build, and run the app
- Go to http://localhost:4000/components/datagrid/example-filter.html
- Place focus in Product Name cell on the filter row
- Hit the Tab key to tab into Activity cell on the filter row
- Hit the Enter or Space Bar key to open the dropdown
- Hit the Up/Down keys to navigate the options in the dropdown

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

