### PR TITLE
8527. Fixed module nav refreshing selected in accordion when closing then opening

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@
 - `[Lookup]` Fixed a bug where tooltip was not showing after selecting an item in lookup. ([#1646](https://github.com/infor-design/enterprise-ng/issues/1646))
 - `[Listview]` Fixed positioning of list alert icons in RTL mode. ([#8724](https://github.com/infor-design/enterprise/issues/8724))
 - `[Module Nav]` Fixed module nav switcher text was not vertically aligned. ([#8736](https://github.com/infor-design/enterprise/issues/8736))
+- `[Module Nav]` Fixed module nav refreshing selected in accordion when closing then opening. ([#8527](https://github.com/infor-design/enterprise/issues/8527))
 - `[Monthview]` Fixed monthview not updating after changing activeDate. ([NG#1659](https://github.com/infor-design/enterprise-ng/issues/1659))
 - `[Popup Menu]` Fixed bug on popupmenu showing behind app menu on mobile. ([#8582](https://github.com/infor-design/enterprise/issues/8582))
 - `[Popup Menu]` Fixed bug on popupmenu not opening on second right click. ([#8637](https://github.com/infor-design/enterprise/issues/8637))

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -732,7 +732,7 @@ Accordion.prototype = {
     if (!element || !element.length) {
       return;
     }
-    this.hasAnchor = false;
+
     // Make sure we select the anchor
     let anchor = element;
     let header = anchor.parent();

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -47,6 +47,7 @@ const ACCORDION_DEFAULTS = {
   rerouteOnLinkClick: true,
   notificationBadge: false,
   source: null,
+  selected: null,
   tooltipStyle: 'light'
 };
 
@@ -264,7 +265,7 @@ Accordion.prototype = {
         });
       }
 
-      this.select(targetsToExpand.last());
+      this.select(this.settings.selected ? this.settings.selected : targetsToExpand.last());
       targetsToExpand.next('.accordion-pane').removeClass('no-transition');
     }
 
@@ -449,7 +450,6 @@ Accordion.prototype = {
     * @param {object} header - The header object
     */
     this.element.trigger('selected', header);
-
     return true;
   },
 
@@ -732,7 +732,7 @@ Accordion.prototype = {
     if (!element || !element.length) {
       return;
     }
-
+    this.hasAnchor = false;
     // Make sure we select the anchor
     let anchor = element;
     let header = anchor.parent();

--- a/src/components/module-nav/module-nav.js
+++ b/src/components/module-nav/module-nav.js
@@ -241,6 +241,7 @@ ModuleNav.prototype = {
       });
       $(this.accordionEl).on(`selected.${COMPONENT_NAME}`, (e, header) => {
         if ($(header).is('#module-nav-settings-btn')) return;
+        this.settings.accordionSettings.selected = header;
         this.handleAutoCollapseOnMobile();
       });
       $(this.accordionEl).on(`followlink.${COMPONENT_NAME}`, (e, header) => {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Save selected element in module nav then added check in accordion if it should select latest expanded header or not

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #8527 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/module-nav/example-no-dropdown-search.html
- Open module nav
- Expand two headers
- Select a label
- Close module nav
- Open module nav
- Label should still be selected

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
