### PR TITLE
NG1710 - Fixed a bug where date would be cleared after updating cell on different locales

### DIFF
--- a/app/views/components/datagrid/test-addrow-with-is-editable.html
+++ b/app/views/components/datagrid/test-addrow-with-is-editable.html
@@ -86,7 +86,18 @@
       columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Soho.Formatters.Ellipsis, editor: Soho.Editors.Input, isEditable: customIsEditable  });
       columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Soho.Formatters.Lookup, editor: Soho.Editors.Lookup, editorOptions: lookupOptions, isEditable: customIsEditable  });
       columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, align: 'right', formatter: Soho.Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Soho.Editors.Input, isEditable: customIsEditable });
-      columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Soho.Formatters.Date, editor: Soho.Editors.Date5, isEditable: customIsEditable });
+      columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Soho.Formatters.Date, editor: Soho.Editors.Date, editorOptions: {
+        showTime: true,
+        timeFormat: Soho.Locale.calendar().timeFormat,
+        minuteInterval: 1,
+        secondInterval: 10,
+        roundToInterval: false,
+        dateFormat: Soho.Locale.calendar().dateFormat.short,
+        placeholder: 'placeholder',
+        showLegend: false,
+        showMonthYearPicker: true,
+        calendarName: 'gregorian'
+        } });
 
       // Init and get the api for the grid
       grid = $('#datagrid').datagrid({

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[Datagrid]` Fixed styling issue with one cell and frozen columns. ([#8728](https://github.com/infor-design/enterprise/issues/8728))
 - `[Datagrid]` Fixed add row not triggering after cell commit. ([#8624](https://github.com/infor-design/enterprise/issues/8624))
 - `[Datagrid]` Fixed an error that occurred in some situations. ([#8709](https://github.com/infor-design/enterprise/issues/8709))
+- `[Datagrid]` Fixed a bug where date would be cleared after updating cell on different locales. ([NG#1710](https://github.com/infor-design/enterprise-ng/issues/1710))
 - `[Datepicker]` Fixed focus date not properly assigned when calendar is used as datepicker. ([#8585](https://github.com/infor-design/enterprise/issues/8585))
 - `[Dropdown]` Fixed dropdown height when `showTags` is set to true. ([#8566](https://github.com/infor-design/enterprise/issues/8566))
 - `[Dropdown]` Fixed RTL alignments and border colors for field filter. ([#8659](https://github.com/infor-design/enterprise/issues/8659))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10840,7 +10840,7 @@ Datagrid.prototype = {
         const editorValue = this.editor.val();
         newValue = editorValue;
 
-        if (this.editor.name === 'date') {
+        if (this.editor.name === 'date' && !newValue) {
           const format = this.columnSettings(this.editor.cell)?.dateFormat;
 
           if (format === undefined) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Additional check on updating cell value so that value won't be cleared.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise-ng/issues/1710

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datagrid/test-addrow-with-is-editable.html?locale=fr-FR
- Click "Add Row"
- On new row, select a date for Order Date
- Unfocus cell by clicking out or pressing Enter
- Date should still be there

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
