### PR TITLE
NG1644 - Fixed an error that occurred when clicking on a dropdown cell

### DIFF
--- a/app/views/components/datagrid/test-focusout-lookup.html
+++ b/app/views/components/datagrid/test-focusout-lookup.html
@@ -1,0 +1,120 @@
+<div class="row">
+  <div class="twelve columns">
+    <div role="toolbar" class="toolbar">
+
+      <div class="title">
+        Example illustrates selected row issue with Save and New.
+       </div>
+
+      <div class="buttonset">
+        <button type="button" id="add-row-button" class="btn">
+          <span>Add Row</span>
+        </button>
+      </div>
+    </div>
+
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+  let gridApi = null;
+
+  $('body').one('initialized', function () {
+      let grid,
+        data = [],
+        columns = [],
+
+        //lookup data
+        lookupOptions,
+        lookupData = [],
+        lookupColumns = [];
+
+        // Some Sample Data for Lookup
+        lookupData.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action'});
+        lookupData.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold'});
+        lookupData.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action'});
+        lookupData.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 3, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action'});
+        lookupData.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold'});
+        lookupData.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+        lookupData.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold'});
+
+        //Define Columns for the Lookup Grid.
+        lookupColumns.push({ id: 'productId', name: 'Product Id', field: 'productId', width: 140});
+        lookupColumns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', width: 250, formatter: Soho.Formatters.Hyperlink});
+        lookupColumns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity', width: 125});
+        lookupColumns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', width: 125});
+        lookupColumns.push({ id: 'price', name: 'Price', field: 'price', width: 125, formatter: Soho.Formatters.Decimal});
+        lookupColumns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Soho.Formatters.Date, dateFormat: 'M/d/yyyy'});
+
+        lookupOptions = {
+          // field: 'productId',
+          field: function (row, field, grid) {
+            return row.productId;
+          },
+          match: function (value, row, field, grid) {
+            return (row.productId) === value;
+          },
+          options: {
+            columns: lookupColumns,
+            dataset: lookupData,
+            selectable: 'single', //multiselect or single
+            toolbar: {title: 'Products', results: true, dateFilter: false ,keywordFilter: false, actions: true, views: true , rowHeight: true}
+          }
+        };
+
+      // Some Sample Data
+      data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  '<svg/onload=alert(1)>', quantity: 1, price: 210.99, status: 'OK', orderDate:  new Date(2016, 2, 15, 12, 30, 36), portable: false, action: 'pen', description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning'});
+      data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.991, status: '', orderDate: new Date(2016, 2, 15, 0, 30, 36), portable: false, action: 'oh', description: 'The kit has an air blow gun that can be used for cleaning'});
+      data.push({ id: 3, productId: 2342203, productName: 'Portable Compressor', activity:  'Inspect and Repair', portable: true, quantity: 1, price: 120.992, status: null, orderDate: new Date(2014, 6, 3), action: 'ac'});
+      data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', portable: true, quantity: 3, price: null, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'bo', description: 'Compressor comes with with air tool kit'});
+      data.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'can'});
+      data.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', portable: false, quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'oh'});
+      data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'pre'});
+
+      // Define Columns for the Grid.
+      columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Soho.Formatters.SelectionCheckbox, align: 'center'});
+      columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', formatter: Soho.Formatters.Ellipsis, editor: Soho.Editors.Input });
+      columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Soho.Formatters.Lookup, editor: Soho.Editors.Lookup, editorOptions: lookupOptions });
+      columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, align: 'right', formatter: Soho.Formatters.Decimal, numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Soho.Editors.Input });
+      columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Soho.Formatters.Date, editor: Soho.Editors.Date });
+      columns.push({ id: 'action', name: 'Action', field: 'action', formatter: Soho.Formatters.Dropdown, editor: Soho.Editors.Dropdown,
+        options: [{label: '', value: ''}, {label: 'On Hold', value: 'oh'}, {label: 'Shipped', value: 'sh'} , {label: 'Action', value: 'ac'}, {label: 'Pending', value: 'pen'}, {label: 'Backorder', value: 'bo'}, {label: 'Cancelled', value: 'can'}, {label: 'Processing', value: 'pre'}]
+      });
+
+      const gridOptions = {
+        columns: columns,
+        dataset: data,
+        editable: true,
+        toolbar: {keywordFilter: true, results: true},
+        showDirty: true,
+        clickToSelect: true,
+        actionableMode: true,
+        cellNavigation: true,
+        rowNavigation: true,
+        showNewRowIndicator: true,
+        showSelectAllCheckBox: true,
+        enableTooltips: true,
+        paging: true,
+        pagesize: 10,
+        selectable: 'mixed',
+        rowHeight: 'short'
+      };
+
+      grid = $('#datagrid').datagrid(gridOptions)
+        .on('cellchange', function (e, args) {
+          if (gridApi) {
+            gridApi.validateAll();
+            gridApi.updateCell(args.row, args.cell, args.value)
+            gridApi.updated(gridOptions, null, false);
+          }
+        });
+
+      gridApi = $('#datagrid').data('datagrid');
+
+      $('#add-row-button').on('click', function (e) {
+        gridApi.addRow({}, 0);
+      });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -184,8 +184,6 @@
 - `[Multiselect]` Fixed misaligned `x` buttons. ([8421](https://github.com/infor-design/enterprise/issues/8421))
 - `[Pie]` Fixed an error encountered when having many records inside the graph. ([#8422](https://github.com/infor-design/enterprise/issues/8422))
 - `[Popupmenu]` Fixed a bug where single select check items were getting deselected. ([8422](https://github.com/infor-design/enterprise/issues/8422))
-- `[Multiselect]` Fixed misaligned `x` buttons. ([#8421](https://github.com/infor-design/enterprise/issues/8421))
-- `[Popupmenu]` Fixed a bug where single select check items were getting deselected. ([#8422](https://github.com/infor-design/enterprise/issues/8422))
 - `[Searchfield]` Fixed alignment issues in go button.([#8334](https://github.com/infor-design/enterprise/issues/8334))
 - `[Searchfield]` Fixed alignment issues in clear button.([#8399](https://github.com/infor-design/enterprise/issues/8399))
 - `[Slider]` Fixed visibility of slider ticks inside of a modal.([#8397](https://github.com/infor-design/enterprise/issues/8397))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[Datagrid]` Fixed styling issue with one cell and frozen columns. ([#8728](https://github.com/infor-design/enterprise/issues/8728))
 - `[Datagrid]` Fixed add row not triggering after cell commit. ([#8624](https://github.com/infor-design/enterprise/issues/8624))
 - `[Datagrid]` Fixed an error that occurred in some situations. ([#8709](https://github.com/infor-design/enterprise/issues/8709))
+- `[Datagrid]` Fixed an error that occurred when clicking on a dropdown cell after calling `updated` method. ([NG#1644](https://github.com/infor-design/enterprise-ng/issues/1644))
 - `[Datepicker]` Fixed focus date not properly assigned when calendar is used as datepicker. ([#8585](https://github.com/infor-design/enterprise/issues/8585))
 - `[Dropdown]` Fixed dropdown height when `showTags` is set to true. ([#8566](https://github.com/infor-design/enterprise/issues/8566))
 - `[Dropdown]` Fixed RTL alignments and border colors for field filter. ([#8659](https://github.com/infor-design/enterprise/issues/8659))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -13751,9 +13751,10 @@ Datagrid.prototype = {
   * Update the datagrid and optionally apply new settings.
   * @param  {object} settings the settings to update to.
   * @param  {object} pagingInfo information about the pager state
+  * @param  {boolean} rerender Rerender datagrid or not
   * @returns {object} The plugin api for chaining.
   */
-  updated(settings, pagingInfo) {
+  updated(settings, pagingInfo, rerender = true) {
     const isInitialPaging = this.settings.paging !== settings?.paging && settings?.paging && !pagingInfo;
     this.settings = utils.mergeSettings(this.element, settings, this.settings);
 
@@ -13793,8 +13794,12 @@ Datagrid.prototype = {
     this.setRowHeightClass();
     this.handlePaging();
     this.attachPagingEvents();
-    this.render(null, pagingInfo, isInitialPaging);
-    this.renderHeader();
+
+    if (rerender) {
+      this.render(null, pagingInfo, isInitialPaging);
+      this.renderHeader();
+    }
+
     return this;
   }
 };


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
The error occurs when updated is called, specifically when render is called (it might be that the dropdown element is deleted and that's when the undefined exception happens). If rendering needs to be done, it might be better to do it after the cellchange event.

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise-ng/issues/1644

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datagrid/test-focusout-lookup.html
- Add new row
- Select a Product Id
- Go to Action dropdown after
- No error should appear in console

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
