### PR TITLE
8773 - Add fix to refresh tooltip

### DIFF
--- a/app/views/components/datagrid/test-filter-with-default-operator.html
+++ b/app/views/components/datagrid/test-filter-with-default-operator.html
@@ -42,8 +42,6 @@
         actionableMode: true,
         cellNavigation: true,
         columnSizing: 'data',
-        disableClientFilter: true,
-        disableClientSort: true,
         disableRowActivation: true,
         editable: true,
         emptyMessage: {title: 'No Data Available', icon: 'icon-empty-no-data-new', color: 'azure'},

--- a/app/views/components/datagrid/test-filter-with-default-operator.html
+++ b/app/views/components/datagrid/test-filter-with-default-operator.html
@@ -20,7 +20,7 @@
       data.push({ id: 6, productId: null, productName: 'Some Compressor', manufacturerName: 'Marvin Companies', inStock: true, activity:  'inspect and Repair', quantity: 41, price: 123.99, orderDate: new Date(2014, 6, 9), time: '1:31 PM', action: 'On Hold', status: 'Confirmed'});
       data.push({ id: 7, productId: null, productName: 'Some Other Compressor', manufacturerName: 'Andersen Corporation', activity:  'Assemble', quantity: null, price: null, orderDate: null, action: 'Blank Row', status: 'Confirmed'});
       data.push({ id: 8, productId: null, productName: 'New and Improved Compressor', manufacturerName: 'Medtronic', activity:  'Assemble', quantity: null, price: null, orderDate: null, action: 'Blank Row', status: 'Confirmed'});
-
+      //
       var activities = [{id: 'Assemble Paint', value:'Assemble Paint', label: 'Assemble Paint'},
                          {id: 'Assemble', value:'Assemble', label: 'Assemble'},
                          {id: 'Inspect and Repair', value:'Inspect and Repair', label: 'Inspect and Repair'}];

--- a/app/views/components/datagrid/test-filter-with-default-operator.html
+++ b/app/views/components/datagrid/test-filter-with-default-operator.html
@@ -7,73 +7,54 @@
 
 <script>
   $('body').one('initialized', function () {
-      var grid,
-        columns = [],
+      var columns = [],
         data = [];
 
       // Define Some Sample Data
-      data.push({ id: 1, productId: undefined, productName: 'Compressor', inStock: true, activity:  'Assemble', quantity: 1, price: 410.99, orderDate: new Date(2014, 12, 8), time: '1:30:45 AM', action: 'Action', status: 'Error'});
-      data.push({ id: 2, productId: 2241202, productName: '1 Different Compressor', inStock: true, activity:  'Inspect and Repair', quantity: 2, price: 310.99, orderDate: new Date(2015, 7, 3), time: '2:00 AM', action: 'On Hold', status: 'En file d\'attente'});
-      data.push({ id: 3, productId: 2342203, productName: 'Compressor', inStock: true, activity:  'Inspect and Repair', quantity: 1, price: 620.99, orderDate: new Date(2014, 6, 3), time: '1:40:00 AM', action: 'Action', status: 'Error'});
-      data.push({ id: 4, productId: 2445204, productName: undefined, inStock: false, activity:  'Assemble Paint', quantity: 3, price: 1210.99, orderDate: new Date(2015, 3, 3), time: '5:00:45 PM', action: 'Action', status: 'En file d\'attente'});
-      data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', inStock: true, activity:  'Inspect and Repair', quantity: 4, price: 810.99, orderDate: new Date(2015, 5, 5), time: '5:30 PM', action: 'On Hold', status: 'Confirmed'});
-      data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', inStock: false, activity:  'Inspect and Repair', quantity: 41, price: 1120.99, orderDate: new Date(2014, 6, 9), time: '11:59:59 PM', action: 'On Hold', status: 'Error'});
-      data.push({ id: 6, productId: null, productName: 'Some Compressor', inStock: true, activity:  'inspect and Repair', quantity: 41, price: 123.99, orderDate: new Date(2014, 6, 9), time: '1:31 PM', action: 'On Hold', status: 'Confirmed'});
-      data.push({ id: 7, productId: null, productName: null, activity:  '', quantity: null, price: null, orderDate: null, action: 'Blank Row', status: 'Confirmed'});
-      data.push({ id: 8, productId: null, productName: null, activity:  null, quantity: null, price: null, orderDate: null, action: 'Blank Row', status: 'Confirmed'});
-
-      var statuses = [{id: '', value: '', label:'&nbsp;'},
-                      {id:'Confirmed', value:'Confirmed', label:'Confirmed'},
-                      {id:'En file d\'attente', value:'En file d\'attente', label:'En file d\'attente'},
-                      {id:'Error', value:'Error', label:'Error'}];
+      data.push({ id: 1, productId: undefined, productName: 'Compressor', manufacturerName: '3M Company', inStock: true, activity:  'Assemble', quantity: 1, price: 410.99, orderDate: new Date(2014, 12, 8), time: '1:30:45 AM', action: 'Action', status: 'Error'});
+      data.push({ id: 2, productId: 2241202, productName: '1 Different Compressor', manufacturerName: 'IBM Corporation', inStock: true, activity:  'Inspect and Repair', quantity: 2, price: 310.99, orderDate: new Date(2015, 7, 3), time: '2:00 AM', action: 'On Hold', status: 'En file d\'attente'});
+      data.push({ id: 3, productId: 2342203, productName: 'Compressor', manufacturerName: 'Cargill', inStock: true, activity:  'Inspect and Repair', quantity: 1, price: 620.99, orderDate: new Date(2014, 6, 3), time: '1:40:00 AM', action: 'Action', status: 'Error'});
+      data.push({ id: 4, productId: 2445204, productName: 'New Compressor', manufacturerName: 'General Mills', inStock: false, activity:  'Assemble Paint', quantity: 3, price: 1210.99, orderDate: new Date(2015, 3, 3), time: '5:00:45 PM', action: 'Action', status: 'En file d\'attente'});
+      data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', manufacturerName: 'Winnebago Industries', inStock: true, activity:  'Inspect and Repair', quantity: 4, price: 810.99, orderDate: new Date(2015, 5, 5), time: '5:30 PM', action: 'On Hold', status: 'Confirmed'});
+      data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', manufacturerName: 'Boston Scientific Corporation', inStock: false, activity:  'Inspect and Repair', quantity: 41, price: 1120.99, orderDate: new Date(2014, 6, 9), time: '11:59:59 PM', action: 'On Hold', status: 'Error'});
+      data.push({ id: 6, productId: null, productName: 'Some Compressor', manufacturerName: 'Marvin Companies', inStock: true, activity:  'inspect and Repair', quantity: 41, price: 123.99, orderDate: new Date(2014, 6, 9), time: '1:31 PM', action: 'On Hold', status: 'Confirmed'});
+      data.push({ id: 7, productId: null, productName: 'Some Other Compressor', manufacturerName: 'Andersen Corporation', activity:  'Assemble', quantity: null, price: null, orderDate: null, action: 'Blank Row', status: 'Confirmed'});
+      data.push({ id: 8, productId: null, productName: 'New and Improved Compressor', manufacturerName: 'Medtronic', activity:  'Assemble', quantity: null, price: null, orderDate: null, action: 'Blank Row', status: 'Confirmed'});
 
       var activities = [{id: 'Assemble Paint', value:'Assemble Paint', label: 'Assemble Paint'},
+                         {id: 'Assemble', value:'Assemble', label: 'Assemble'},
                          {id: 'Inspect and Repair', value:'Inspect and Repair', label: 'Inspect and Repair'}];
-
-    var lookupOptions = {
-      field: function (row, field, grid) {
-        return row.productId;
-      },
-      match: function (value, row, field, grid) {
-        return (row.productId) === value;
-      },
-      beforeShow: function (api, response) {
-        var url = '{{basepath}}api/lookupInfo';
-
-        $.getJSON(url, function(data) {
-          api.settings.options.columns = data[0].columns;
-          api.settings.options.dataset = data[0].dataset;
-          response();
-        });
-      },
-      options: {
-        selectable: 'single',
-        toolbar: {title: 'Products', results: true, dateFilter: false ,keywordFilter: false, actions: true, views: true , rowHeight: true}
-      }
-    };
 
       // Define Columns for the Grid.
       columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Soho.Formatters.SelectionCheckbox, align: 'center'});
-      columns.push({ id: 'id', name: 'Id', field: 'id', formatter: Soho.Formatters.Readonly, filterType: 'text'});
-      columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Soho.Formatters.Lookup, editorOptions: lookupOptions, filterType: 'lookup', mask: '#######', defaultFilterOperator: 'starts-with',
-        filterConditions: ['contains', 'does-not-contain', 'equals', 'does-not-equal', 'is-empty', 'is-not-empty', 'in-range', 'less-than', {value: 'less-equals', selected: true}, 'greater-than', 'greater-equals']});
-      columns.push({ id: 'productName', name: 'Product Name', field: 'productName',  formatter: Soho.Formatters.Text, filterType: 'text', defaultFilterOperator: 'starts-with',
-        filterConditions: ['contains', 'does-not-contain', 'equals', 'does-not-equal', 'is-empty', 'is-not-empty', 'end-with', 'does-not-end-with', {value: 'start-with', selected: true}, 'does-not-end-with']});
-      columns.push({ id: 'activity', name: 'Activity', field: 'activity', formatter: Soho.Formatters.Dropdown, filterType: 'multiselect', options: activities, editorOptions: {showSelectAll: true}});
-      columns.push({ id: 'quantity', name: 'Qty', field: 'quantity', align: 'right', filterType: 'integer', minWidth: 95});
-      columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', formatter: Soho.Formatters.Date, dateFormat: 'MM/dd/yyyy', filterType: 'date', editorOptions: {showMonthYearPicker: true}, defaultFilterOperator:'less-equals',
-        filterConditions: ['equals', 'does-not-equal', 'in-range', 'less-than', {value: 'less-equals', selected: true}, 'greater-than', 'greater-equals']});
-
+      columns.push({ id: 'productName', name: 'Product Name', field: 'productName',  formatter: Soho.Formatters.Text, filterType: 'text', textOverflow: 'ellipsis', align: 'left', sortable: false, defaultFilterOperator: 'start-with',
+        filterConditions: ['contains', 'does-not-contain', 'equals', 'does-not-equal', 'is-empty', 'is-not-empty', 'end-with', 'does-not-end-with', { value: 'start-with', selected: true }, 'does-not-start-with']});
+      columns.push({ id: 'activity', name: 'Activity', field: 'activity', formatter: Soho.Formatters.Dropdown, filterType: 'multiselect', textOverflow: 'ellipsis', options: activities, editorOptions: {showSelectAll: true}});
+      columns.push({ id: 'quantity', name: 'Qty', field: 'quantity', align: 'right', filterType: 'integer', textOverflow: 'ellipsis', minWidth: 95});
+      columns.push({ id: 'price', name: 'Price', field: 'price', align: 'right', headerAlign: 'left', formatter: Soho.Formatters.Decimal, validate: 'required', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, filterType: 'decimal'});
+      columns.push({ id: 'manufacturerName', name: 'Manufacturer Name', field: 'manufacturerName',  formatter: Soho.Formatters.Text, filterType: 'text', textOverflow: 'ellipsis', align: 'left', sortable: false, defaultFilterOperator: 'start-with',
+        filterConditions: ['contains', 'does-not-contain', 'equals', 'does-not-equal', 'is-empty', 'is-not-empty', 'end-with', 'does-not-end-with', { value: 'start-with', selected: true }, 'does-not-start-with']});
 
       // Init and get the api for the grid
-      $('#datagrid').datagrid({
+      var grid = $('#datagrid').datagrid({
         columns: columns,
         dataset: data,
-        filterable: true,
-        filterWhenTyping: false,
-        selectable: 'mixed',
+        actionableMode: true,
+        cellNavigation: true,
+        columnSizing: 'data',
+        disableClientFilter: true,
+        disableClientSort: true,
+        disableRowActivation: true,
         editable: true,
-        emptyMessage: {title: Soho.Locale.translate('NoData'), info: Soho.Locale.translate('NoDataFilter'), icon: 'icon-empty-no-data-new'},
+        emptyMessage: {title: 'No Data Available', icon: 'icon-empty-no-data-new', color: 'azure'},
+        enableTooltips: true,
+        filterWhenTyping: false,
+        filterable: true,
+        headerBackgroundColor: 'light',
+        redrawOnResize: false,
+        rowHeight: 'extra-small',
+        selectable: 'mixed',
+        showDirty: false,
         toolbar: {title: 'Filterable Datagrid', filterRow: true, results: true, dateFilter: false ,keywordFilter: false, actions: true, views: false, rowHeight: true, collapsibleFilter: false}
       }).on('filtered', function (e, args) {
         console.log('filter ran', args);
@@ -81,6 +62,10 @@
         console.log('event details', e);
         console.log('event arguments', args);
       });
+
+      var gridApi = grid.data('datagrid');
+
+      gridApi.hideColumn('quantity');
  });
 
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## v4.97.0 Fixes
 
+- `[DataGrid]` Fixed bug with non refreshed tooltip in filter row conditions. ([#8773](https://github.com/infor-design/enterprise/issues/8773))
 - `[ModuleNav]` Fix icon layout issue. ([#8788](https://github.com/infor-design/enterprise/issues/8788))
 - `[Masthead]` Fixed size of image avatar. ([#8788](https://github.com/infor-design/enterprise/issues/8788))
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5856,7 +5856,7 @@ Datagrid.prototype = {
 
         const tooltip = $(elem).data('gridtooltip') || self.cacheTooltip(elem);
         if ($(elem).hasClass('btn-filter')) {
-          const contents = elem?.querySelector('span')?.innerText;
+          const contents = (elem?.querySelector('span')?.textContent || '').trim();
           tooltip.content = `<p>${contents}</p>`;
         }
         if (tooltip && (tooltip.forced || (tooltip.textwidth > (width - 35))) && !isPopup) {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5830,6 +5830,29 @@ Datagrid.prototype = {
         const width = self.getOuterWidth(containerEl);
 
         const tooltip = $(elem).data('gridtooltip') || self.cacheTooltip(elem);
+        if ($(elem).hasClass('btn-filter')) {
+          const contents = $(elem).attr('data-default');
+          const tooltips = {
+            contains: 'Contains',
+            'does-not-contain': 'DoesNotContain',
+            equals: 'Equals',
+            'does-not-equal': 'DoesNotEqual',
+            'is-empty': 'IsEmpty',
+            'is-not-empty': 'IsNotEmpty',
+            'end-with': 'EndsWith',
+            'does-not-end-with': 'DoesNotEndWith',
+            'start-with': 'StartsWith',
+            'does-not-start-with': 'DoesNotStartWith',
+            'selected-notselected': 'All',
+            selected: 'Selected',
+            'not-selected': 'NotSelected',
+            'less-than': 'EarlyThan',
+            'less-equals': 'EarlyOrEquals',
+            'greater-than': 'LaterThan',
+            'greater-equals': 'LaterOrEquals'
+          };
+          tooltip.content = `<p>${Locale.translate(tooltips[contents])}</p>`;
+        }
         if (tooltip && (tooltip.forced || (tooltip.textwidth > (width - 35))) && !isPopup) {
           self.showTooltip(tooltip);
         }

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -2225,6 +2225,30 @@ Datagrid.prototype = {
   },
 
   /**
+  * Maps the Filter text to the tooltip/text
+  * @returns {Array} The mapping array
+  */
+  filterText: {
+    contains: 'Contains',
+    'does-not-contain': 'DoesNotContain',
+    equals: 'Equals',
+    'does-not-equal': 'DoesNotEqual',
+    'is-empty': 'IsEmpty',
+    'is-not-empty': 'IsNotEmpty',
+    'end-with': 'EndsWith',
+    'does-not-end-with': 'DoesNotEndWith',
+    'start-with': 'StartsWith',
+    'does-not-start-with': 'DoesNotStartWith',
+    'selected-notselected': 'All',
+    selected: 'Selected',
+    'not-selected': 'NotSelected',
+    'less-than': 'EarlyThan',
+    'less-equals': 'EarlyOrEquals',
+    'greater-than': 'LaterThan',
+    'greater-equals': 'LaterOrEquals'
+  },
+
+  /**
   * Render the Filter Button and Menu based on filterType - which determines the options
   * @private
   * @param {object} col The column object
@@ -2280,7 +2304,8 @@ Datagrid.prototype = {
 
     const renderButton = function (defaultValue, extraClass) {
       const isSingle = col.filterConditions !== undefined && col.filterConditions.length === 1;
-      return `<button type="button" ${attrs} class="btn-menu btn-filter${extraClass ? ` ${extraClass}` : ''}${isSingle ? ' single' : ''}" data-init="false" ${isDisabled || isSingle ? ' disabled' : ''}${defaultValue ? ` data-default="${defaultValue}"` : ''} tabindex="0" type="button"><span class="audible">Filter</span>` +
+      const text = Locale.translate(self.filterText[defaultValue]);
+      return `<button type="button" ${attrs} class="btn-menu btn-filter${extraClass ? ` ${extraClass}` : ''}${isSingle ? ' single' : ''}" data-init="false" ${isDisabled || isSingle ? ' disabled' : ''}${defaultValue ? ` data-default="${defaultValue}"` : ''} tabindex="0" type="button"><span class="audible">${text}</span>` +
       `<svg class="icon-dropdown icon" focusable="false" aria-hidden="true" role="presentation"><use href="#icon-filter-{{icon}}"></use></svg>${
         $.createIcon({ icon: 'dropdown', classes: 'icon-dropdown' })
       }</button><ul class="popupmenu has-icons is-translatable is-selectable">`;
@@ -5831,27 +5856,8 @@ Datagrid.prototype = {
 
         const tooltip = $(elem).data('gridtooltip') || self.cacheTooltip(elem);
         if ($(elem).hasClass('btn-filter')) {
-          const contents = $(elem).attr('data-default');
-          const tooltips = {
-            contains: 'Contains',
-            'does-not-contain': 'DoesNotContain',
-            equals: 'Equals',
-            'does-not-equal': 'DoesNotEqual',
-            'is-empty': 'IsEmpty',
-            'is-not-empty': 'IsNotEmpty',
-            'end-with': 'EndsWith',
-            'does-not-end-with': 'DoesNotEndWith',
-            'start-with': 'StartsWith',
-            'does-not-start-with': 'DoesNotStartWith',
-            'selected-notselected': 'All',
-            selected: 'Selected',
-            'not-selected': 'NotSelected',
-            'less-than': 'EarlyThan',
-            'less-equals': 'EarlyOrEquals',
-            'greater-than': 'LaterThan',
-            'greater-equals': 'LaterOrEquals'
-          };
-          tooltip.content = `<p>${Locale.translate(tooltips[contents])}</p>`;
+          const contents = elem?.querySelector('span')?.innerText;
+          tooltip.content = `<p>${contents}</p>`;
         }
         if (tooltip && (tooltip.forced || (tooltip.textwidth > (width - 35))) && !isPopup) {
           self.showTooltip(tooltip);

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -43,7 +43,7 @@ const TOOLTIP_TRIGGER_METHODS = ['hover', 'immediate', 'click', 'focus'];
 * @param {boolean} [settings.contentAlignment] Content text alignment.
  * @param {string} [settings.extraClass] Extra css class.
  * @param {object} [settings.placementOpt] Placement options.
- * 
+ *
  * @param {string} [settings.maxWidth] Toolip max width.
  * @param {boolean} [settings.initializeContent] Init the content in the tooltip.
  * @param {string} [settings.headerClass] If set this color will be used on the header (if a popover).


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adds a fix to refresh possibly cached tooltip in prod mode. (Hard to test) @claudenbach can you test on your end.

**Related github/jira issue (required)**:
Fixes #8773 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-filter-with-default-operator.html
- hover each button the filter row and see that the tooltip matches
- select different items and make sure it changes for the tooltip
- try another language http://localhost:4000/components/datagrid/test-filter-with-default-operator.html?locale=de-DE

**Included in this Pull Request**:
- [x] A note to the change log.
