### PR TITLE
NG1697 - Fixed example page for disabling dismissible tags

### DIFF
--- a/app/views/components/tabs/test-prevent-dismissible.html
+++ b/app/views/components/tabs/test-prevent-dismissible.html
@@ -36,17 +36,16 @@
 
 <script>
   $('body').on('initialized', function() {
-    var tabs = $('#dismissible-tabs');
+    const tabs = $('#dismissible-tabs');
 
-    function announceEvent(e, li) {
-      var type = e.type,
-        a = li.children('a'),
-        href = a.attr('href');
+    function announceEvent(e, a) {
+      const type = e.type;
+      const href = a.attr('href');
 
       $('body').toast({
-        title: '<span style="color: #bb6666; font-weight: bold;">' + e.type + '</span> triggered!',
-        message: 'A ' + e.type + ' event was triggered on the <span class="color: #66bbbb; font-weight: bold;">' + href + '</span> tab.'
-      });
+          title: '<span style="color: #bb6666; font-weight: bold;">' + e.type + '</span> triggered!',
+          message: 'A ' + e.type + ' event was triggered on the <span class="color: #66bbbb; font-weight: bold;">' + href + '</span> tab.'
+        });
 
       if (type === 'beforeclose' && href === '#tabs-prevented-dismissible') {
         return false;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[Masthead]` Fixed size of image avatar. ([#8788](https://github.com/infor-design/enterprise/issues/8788))
 - `[ModuleNav]` Fix icon layout issue. ([#8788](https://github.com/infor-design/enterprise/issues/8788))
 - `[Multiselect]` Fixed bug in multiselect noted in RTL mode. ([#8811](https://github.com/infor-design/enterprise/issues/8811))
+- `[Tabs]` Fixed example page for disabling dismissible tags. ([NG#1697](https://github.com/infor-design/enterprise/issues/1697))
 
 ## v4.96.0
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Updated example page. The issue was the check, it would have never returned false. The element passed on the beforeclose event is already the hyperlink and not the list item, so finding the child hyperlink leads to nothing (and therefore leads to undefined which leads to the if statement on the example page never being executed).

> Add ability to disable the x button
> Check the dismissible attribute is working (this one hides the x)

I'm also not sure if disabling /hidingthe close icon when a tag has the "dismissible" class is what it should be for because the "Dismissible" tag has the same class in the example
https://github.com/infor-design/enterprise/blob/main/app/views/components/tabs/test-prevent-dismissible.html#L16
The only tag that has no close icon is the one without the dismissible class. Could toggling the presence of the dismissible class and updating tags be a solution if the close icon existing is an issue?

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise-ng/issues/1697

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/tabs/test-prevent-dismissible.html
- Dismissible tag should close when closing
- Prevent Dismissible tag should not close

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
