### PR TITLE
8828 - Refix grid issue

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[Datagrid]` Fixed issue with textEllipsis in right aligned number columns. ([#8821](https://github.com/infor-design/enterprise/issues/8821))
 - `[DataGrid]` Fixed bug with non refreshed tooltip in filter row conditions. ([#8773](https://github.com/infor-design/enterprise/issues/8773))
 - `[Donut]` Fixed bug where chart is cut off on bottom legend placement mode. ([#8755](https://github.com/infor-design/enterprise/issues/8755))
+- `[Grid]` Fixed an issue where module nav would change grid styles. ([#8828](https://github.com/infor-design/enterprise/issues/8828))
 - `[ModuleNav]` Fix icon layout issue. ([#8788](https://github.com/infor-design/enterprise/issues/8788))
 - `[Masthead]` Fixed size of image avatar. ([#8788](https://github.com/infor-design/enterprise/issues/8788))
 - `[ModuleNav]` Fixed icon layout issue. ([#8788](https://github.com/infor-design/enterprise/issues/8788))

--- a/src/components/grid/_grid.scss
+++ b/src/components/grid/_grid.scss
@@ -421,23 +421,11 @@ $gutter-neg-size: -20px;
   }
 }
 
-// For when its in page container for module nav
+// Seperate fields in module nav
 .module-nav-container {
-  @media (max-width: $breakpoint-wide-tablet) {
-    .columns {
-      width: 100%;
-    }
-  }
-
   &.mode-expanded {
-    .columns {
-      width: 100%;
-    }
-
-    @media (min-width: $breakpoint-tablet-to-desktop) {
-      .six.columns {
-        width: calc(50% - 20px);
-      }
+    .columns .field {
+      margin-inline-end: 20px;
     }
   }
 }

--- a/src/components/grid/_grid.scss
+++ b/src/components/grid/_grid.scss
@@ -423,10 +423,8 @@ $gutter-neg-size: -20px;
 
 // Seperate fields in module nav
 .module-nav-container {
-  &.mode-expanded {
-    .columns .field {
-      margin-inline-end: 20px;
-    }
+  .columns .field {
+    margin-inline-end: 20px;
   }
 }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
Refixes the issue https://github.com/infor-design/enterprise/pull/8738 with a different fix that doesnt break the grid.

**Related github/jira issue (required)**:
Fixes #8828

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/module-nav/test-six-columns.html?colors=fff
- resize the page around the size of the attached screen shot and smaller/bigger and make sure the fields dont touch
- go to http://localhost:4000/components/module-nav/example-index.html?colors=fff
- and inspect the .columns element and make sure the module nav doesnt add styles to it

**Included in this Pull Request**:
- [x] A note to the change log.

**Screen Shots**

![Screenshot 2024-06-18 at 12 20 29 PM](https://github.com/infor-design/enterprise/assets/814283/006ea701-5961-427f-91c7-c043b82aa69e)
![Screenshot 2024-06-18 at 12 19 47 PM](https://github.com/infor-design/enterprise/assets/814283/39d7bb62-57ed-4466-9490-3b55349de05e)
