### PR TITLE
8817 - Fixed zindex on module nav

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,7 +22,7 @@
 - `[ModuleNav]` Fix icon layout issue. ([#8788](https://github.com/infor-design/enterprise/issues/8788))
 - `[Masthead]` Fixed size of image avatar. ([#8788](https://github.com/infor-design/enterprise/issues/8788))
 - `[ModuleNav]` Fixed icon layout issue. ([#8788](https://github.com/infor-design/enterprise/issues/8788))
-- `[ModuleNav]` Fixed zindex issue on the overlay. ([#8817](https://github.com/infor-design/enterprise/issues/8817))
+- `[ModuleNav]` Fixed zindex issue on the overlay in mobile mode. ([#8817](https://github.com/infor-design/enterprise/issues/8817))
 - `[Multiselect]` Fixed bug in multiselect noted in RTL mode. ([#8811](https://github.com/infor-design/enterprise/issues/8811))
 - `[Tabs]` Fixed example page for disabling dismissible tags. ([NG#1697](https://github.com/infor-design/enterprise/issues/1697))
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Note: See commit diff https://github.com/infor-design/enterprise/commit/82b803a5e89e61d4b6df0e45470f029778827aae

**Related github/jira issue (required)**:
Fixes #8817
 
**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/module-nav/example-datagrid.html?colors=fff
- make page tablet size
- open menu to collapsed mode
- make sure the headers in the grid dont stick out
- NOTE: You can still click out on the overlay  to close it

**Included in this Pull Request**:
- [x] A note to the change log.
