### PR TITLE
8758 - Datagrid Focus With Button (Lookup)

### DIFF
--- a/app/views/components/datagrid/test-grid-input-lost-focus.html
+++ b/app/views/components/datagrid/test-grid-input-lost-focus.html
@@ -1,0 +1,36 @@
+
+<div class="row">
+  <div class="full-width">
+    <div id="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+
+      var columns = [], data = [];
+
+      // Some Sample Data
+      data.push({ id: 1, productId: 2142201, productName: 'Compressor', productFieldA: 'productFieldA', productFieldB: 'productFieldB', productFieldC: 'productFieldC'});
+
+      // Define Columns for the Grid.
+      columns.push({ id: 'productId', formatter: Soho.Formatters.Lookup, focusable: true, align: 'left', editor: Soho.Editors.Lookup, name: 'Product Id', field: 'productId'});
+      columns.push({ id: 'productName', formatter: Soho.Formatters.Lookup, focusable: true, align: 'left', editor: Soho.Editors.Lookup, name: 'Product Name', field: 'productName'});
+      columns.push({ id: 'productFieldA', formatter: Soho.Formatters.Lookup, focusable: true, align: 'left', editor: Soho.Editors.Lookup, name: 'Product Field A', field: 'productFieldA'});
+      columns.push({ id: 'productFieldB', formatter: Soho.Formatters.Lookup, focusable: true, align: 'left', editor: Soho.Editors.Lookup, name: 'Product Field B', field: 'productFieldB'});
+      columns.push({ id: 'productFieldC', formatter: Soho.Formatters.Lookup, focusable: true, align: 'left', editor: Soho.Editors.Lookup, name: 'Product Field C', field: 'productFieldC'});
+
+      // Init and get the api for the grid
+      $('#datagrid').datagrid({
+        columns: columns,
+        dataset: data,
+        editable: true,
+        selectable: 'single',
+        cellNavigation: false,
+        clickToSelect: true,
+        toolbar: {title: 'Data Grid Header Title', results: true, personalize: true, actions: true, rowHeight: true, keywordFilter: true,  collapsibleFilter: true}
+      }).data('datagrid');
+ });
+
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## v4.97.0 Fixes
 
 - `[Charts]` Fixed a bug where the `charts.setSelected()` method was not working in multiple charts in a single page. ([#NG#1671](https://github.com/infor-design/enterprise-ng/issues/1671))
+- `[Datagrid]` Fixed a bug where button gets focus always during editing of lookup field. ([#8758](https://github.com/infor-design/enterprise/issues/8758))
 - `[Datagrid]` Added `cellLayout` setting to remove datagrid cell layout from expandable rows. ([NG#1524](https://github.com/infor-design/enterprise-ng/issues/1524))
 - `[Dropdown]` Fixed no results text still displaying after removing filter text. ([#8768](https://github.com/infor-design/enterprise/issues/8768))
 - `[Masthead]` Fixed size of image avatar. ([#8788](https://github.com/infor-design/enterprise/issues/8788))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -12291,10 +12291,6 @@ Datagrid.prototype = {
       }
     }
 
-    if (self.activeCell.node.is('.is-focusable')) {
-      self.activeCell.node.find('button').focus();
-    }
-
     if (dataRowNum !== undefined) {
       self.activeCell.dataRow = dataRowNum;
     }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix a bug where button gets focus always during editing of lookup field.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/8758

**Steps necessary to review your pull request (required)**:
- Pull this git repository, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-grid-input-lost-focus.html
- Input `333` to the `Product Name` grid and then click the current input area again and again.
- Focus should still be in the input box not in the button

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

