### PR TITLE
8773 - Add fix for new case on missing tooltip

### DIFF
--- a/app/views/components/datagrid/test-filter-with-default-operator.html
+++ b/app/views/components/datagrid/test-filter-with-default-operator.html
@@ -1,7 +1,21 @@
 <div class="row">
   <div class="twelve columns">
+
+    <div class="toolbar no-actions-button" role="toolbar">
+      <div class="title">
+        Data Grid Header Title
+        <span class="datagrid-result-count">(N Results)</span>
+      </div>
+      <div class="buttonset">
+        <button type="button" class="btn" id="set-filter-conditions">
+          <span>Set Filter Conditions</span>
+        </button>
+      </div>
+    </div>
+
     <div id="datagrid">
     </div>
+
   </div>
 </div>
 
@@ -64,6 +78,10 @@
       var gridApi = grid.data('datagrid');
 
       gridApi.hideColumn('quantity');
+
+    $('#set-filter-conditions').on('click', function () {
+      gridApi.setFilterConditions([{ columnId: 'productName', operator: 'contains', value: 'Air' }]);
+    });
  });
 
 </script>

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5865,7 +5865,7 @@ Datagrid.prototype = {
 
         const tooltip = $(elem).data('gridtooltip') || self.cacheTooltip(elem);
         if ($(elem).hasClass('btn-filter')) {
-          const contents = (elem?.querySelector('span')?.textContent || '').trim();
+          const contents = tooltip?.content || (elem?.querySelector('span')?.textContent || '').trim();
           tooltip.content = `<p>${contents}</p>`;
         }
         if (tooltip && (tooltip.forced || (tooltip.textwidth > (width - 35))) && !isPopup) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes an additional case on #8773 noted when changing the filter row button with the API

**Related github/jira issue (required)**:
Fixes #8773

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/test-filter-with-default-operator.html
- hover the filter buttons and make sure the tooltip is correct and matches
- click the "Set Filter Conditions" button to set it with an API
- see that the filter condition and tooltip are both updated
- try in a language http://localhost:4000/components/datagrid/test-filter-with-default-operator.html?locale=de-DE

**Included in this Pull Request**:
No change log as added for the original issue
