### PR TITLE
NG1651 - Fixed asterisk being cut off when textOverflow is set to ellipsis

### DIFF
--- a/app/views/components/datagrid/example-editable.html
+++ b/app/views/components/datagrid/example-editable.html
@@ -138,7 +138,7 @@
     columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Soho.Formatters.SelectionCheckbox, align: 'center'});
     columns.push({ id: 'id', name: 'Row Id', field: 'id', minWidth: 75, formatter: Soho.Formatters.Readonly});
     columns.push({ id: 'productName', name: 'Product Name', minWidth: 150, sortable: false, field: 'productName', formatter: Soho.Formatters.Hyperlink, editor: Soho.Editors.Input});
-    columns.push({ id: 'activity', name: 'Activity', field: 'activity', minWidth: 75, required: true, editor: Soho.Editors.Input, validate: 'required'});  //maxLength: 2
+    columns.push({ id: 'activity', name: 'Activity', field: 'activity', minWidth: 75, required: true, textOverflow: 'ellipsis', editor: Soho.Editors.Input, validate: 'required'});  //maxLength: 2
     columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', minWidth: 90, align: 'right', editor: Soho.Editors.Input, mask: '###', isEditable: isDisabled});
     columns.push({ id: 'portable', name: 'Portable', field: 'portable', minWidth: 75, align: 'center', formatter: Soho.Formatters.Checkbox, editor: Soho.Editors.Checkbox});
     columns.push({ id: 'price', name: 'Price', field: 'price', minWidth: 75, align: 'right', formatter: Soho.Formatters.Decimal, validate: 'required', numberFormat: {minimumFractionDigits: 3, maximumFractionDigits: 3}, editor: Soho.Editors.Input});

--- a/app/views/components/datagrid/test-ellipsis.html
+++ b/app/views/components/datagrid/test-ellipsis.html
@@ -55,7 +55,7 @@
     // Define Columns for the Grid.
     columns.push({ id: 'id', name: 'Id', field: 'id', formatter: Soho.Formatters.Readonly, filterType: 'text' });
     columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Soho.Formatters.Lookup, editorOptions: lookupOptions, width: 120, filterType: 'lookup' });
-    columns.push({ id: 'productName', name: 'Formatter Ellipsis', field: 'productName',  formatter: Soho.Formatters.Ellipsis, filterType: 'text' });
+    columns.push({ id: 'productName', name: 'Formatter Ellipsis', field: 'productName', required: true, textOverflow: 'ellipsis',  formatter: Soho.Formatters.Ellipsis, filterType: 'text' });
     columns.push({ id: 'productName', name: 'Formatter Hyperlink', field: 'productName',  formatter: Soho.Formatters.Hyperlink, filterType: 'text', textOverflow: 'ellipsis' });
     columns.push({ id: 'activity', name: 'Activity', field: 'activity', formatter: Soho.Formatters.Dropdown, filterType: 'multiselect', options: activities, editorOptions: { showSelectAll: true }, textOverflow: 'ellipsis' });
     columns.push({ id: 'quantity', name: 'Qty', field: 'quantity', align: 'right', filterType: 'integer' });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[Datagrid]` Fixed incorrect updates in commitCellEditUtil. ([#8850](https://github.com/infor-design/enterprise/issues/8850))
 - `[Datagrid]` Fixed a bug where button gets focus always during editing of lookup field. ([#8758](https://github.com/infor-design/enterprise/issues/8758))
 - `[Datagrid]` Added `cellLayout` setting to remove datagrid cell layout from expandable rows. ([NG#1524](https://github.com/infor-design/enterprise-ng/issues/1524))
+- `[Datagrid]` Fixed asterisk being cut off when `textOverflow` is set to ellipsis. ([NG#1651](https://github.com/infor-design/enterprise-ng/issues/1651))
 - `[Dropdown]` Fixed no results text still displaying after removing filter text. ([#8768](https://github.com/infor-design/enterprise/issues/8768))
 - `[Masthead]` Fixed size of image avatar. ([#8788](https://github.com/infor-design/enterprise/issues/8788))
 - `[Datagrid]` Fixed cell value from argument passed on hyperlink click. ([#8762](https://github.com/infor-design/enterprise/issues/8762))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -3577,7 +3577,7 @@ $datagrid-small-row-height: 25px;
 
       &.required::after {
         @include required-indicator();
-
+        position: static;
         color: $datagrid-required-icon-color;
       }
     }

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -3577,6 +3577,7 @@ $datagrid-small-row-height: 25px;
 
       &.required::after {
         @include required-indicator();
+
         position: static;
         color: $datagrid-required-icon-color;
       }

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -5717,6 +5717,7 @@ html[dir='rtl'] {
     .required::after {
       @include required-indicator();
 
+      position: static;
       color: $datagrid-required-icon-color;
       left: -2px;
       top: 0;


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fixed asterisk being cut off when textOverflow is set to ellipsis

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise-ng/issues/1651

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to
  - http://localhost:4000/components/datagrid/example-editable.html
  - http://localhost:4000/components/datagrid/test-ellipsis.html
- Required columns should have asterisk (*) fully viewable
- Minimize columns
- Ellipsis should still appear

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
