### PR TITLE
8769 - Fixed selectDay being called twice on clicking events

### DIFF
--- a/app/views/components/calendar/example-only-calendar.html
+++ b/app/views/components/calendar/example-only-calendar.html
@@ -18,8 +18,8 @@
         events = res;
 
         $('.calendar').calendar({
-          month: 4,
-          year: 2019,
+          month: 7,
+          year: 2018,
           eventTypes: eventTypes,
           showViewChanger: false,
           events: events

--- a/app/views/components/calendar/example-only-calendar.html
+++ b/app/views/components/calendar/example-only-calendar.html
@@ -18,8 +18,8 @@
         events = res;
 
         $('.calendar').calendar({
-          month: 7,
-          year: 2018,
+          month: 4,
+          year: 2019,
           eventTypes: eventTypes,
           showViewChanger: false,
           events: events

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## v4.97.0 Fixes
 
 - `[Autocomplete]` Fixed losing focus on keydown. ([#8618](https://github.com/infor-design/enterprise/issues/8618))
+- `[Calendar]` Fixed `selectDay` being called twice on clicking events. ([#8769](https://github.com/infor-design/enterprise/issues/8769))
 - `[Charts]` Fixed a bug where the `charts.setSelected()` method was not working in multiple charts in a single page. ([#NG#1671](https://github.com/infor-design/enterprise-ng/issues/1671))
 - `[Datagrid]` Fixed incorrect updates in commitCellEditUtil. ([#8850](https://github.com/infor-design/enterprise/issues/8850))
 - `[Datagrid]` Fixed a bug where button gets focus always during editing of lookup field. ([#8758](https://github.com/infor-design/enterprise/issues/8758))

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -932,10 +932,12 @@ Calendar.prototype = {
         // Switch to day view on click
         $(container)
           .off(`click.${COMPONENT_NAME}`)
-          .on(`click.${COMPONENT_NAME}`, '.calendar-event-more span', () => {
+          .on(`click.${COMPONENT_NAME}`, '.calendar-event-more span', (e) => {
             const thisDate = this.monthView.dayMap[idx].key;
             this.monthView.selectDay(thisDate, false, true);
             this.changeView('day');
+            e.preventDefault();
+            e.stopPropagation();
           });
       } else {
         setMoreSpan(moreSpan, parseInt(moreSpan.getAttribute('data-count'), 10) + 1);
@@ -1286,11 +1288,11 @@ Calendar.prototype = {
             $(e.currentTarget).addClass('slide-select-end');
             while (!hasStartSelect) {
               targetTd.addClass('slide-select');
-  
+
               if (targetTd.prev().hasClass('slide-select-start')) {
                 hasStartSelect = true;
               }
-  
+
               targetTd = targetTd.prev();
             }
             targetTd.removeClass('slide-select-end');
@@ -1303,10 +1305,10 @@ Calendar.prototype = {
           $(e.currentTarget).addClass('slide-select-start');
           $(e.currentTarget).addClass('slide-select-end');
           self.monthView.selectDay(firstKey, false, true, 'cell');
-    
+
           self.element.on(`mouseenter.${COMPONENT_NAME}`, 'td', (ev) => {
-            if ($(ev.currentTarget).prev().hasClass('slide-select-start') || 
-              $(ev.currentTarget).prev().hasClass('slide-select') || 
+            if ($(ev.currentTarget).prev().hasClass('slide-select-start') ||
+              $(ev.currentTarget).prev().hasClass('slide-select') ||
               $(ev.currentTarget).is('.slide-select-start')) {
               const keySlide = ev.currentTarget.getAttribute('data-key');
               if (firstKey < keySlide && keySlide > lastKey) {
@@ -1319,7 +1321,7 @@ Calendar.prototype = {
           });
         }
       });
-  
+
       this.element.off(`mouseup.${COMPONENT_NAME}`).on(`mouseup.${COMPONENT_NAME}`, (e) => {
         if (self.modalVisible()) {
           self.removeModal();
@@ -1336,12 +1338,12 @@ Calendar.prototype = {
         if (startDay.getTime() === endDay.getTime()) {
           return;
         }
-  
+
         const eventData = utils.extend({ }, this.settings.newEventDefaults);
         eventData.startKey = firstKey;
         eventData.endKey = lastKey;
         e.stopPropagation();
-  
+
         calendarShared.cleanEventData(
           eventData,
           false,

--- a/src/components/monthview/monthview.js
+++ b/src/components/monthview/monthview.js
@@ -683,7 +683,7 @@ MonthView.prototype = {
         month = islamicDate[1];
         elementDate = islamicDate;
         this.currentDay = islamicDate[2];
-      } else {  
+      } else {
         elementDate = s.activeDateIslamic;
       }
     }
@@ -2383,16 +2383,16 @@ MonthView.prototype = {
           if (!$(e.target).hasClass('slide-select-start') && ($(e.target).prev().hasClass('slide-select') || $(e.target).prev().hasClass('slide-select-start'))) {
             $(e.target).removeClass('slide-select');
             $(e.target).removeClass('slide-select-end');
-            
+
             if (!$(e.target).prev().hasClass('slide-select-start')) {
               $(e.target).prev().addClass('slide-select');
             }
-            
+
             $(e.target).prev().addClass('slide-select-end');
           }
         } else if (key === 39 && e.shiftKey) {
-          if (($(e.target).hasClass('slide-select-start') || 
-            $(e.target).prev().hasClass('slide-select-end') || 
+          if (($(e.target).hasClass('slide-select-start') ||
+            $(e.target).prev().hasClass('slide-select-end') ||
             $(e.target).hasClass('slide-select-end')) && $(e.target).next().length > 0) {
             $(e.target).removeClass('slide-select-end');
             $(e.target).next().addClass('slide-select');
@@ -3083,7 +3083,7 @@ MonthView.prototype = {
 
     this.element.empty();
     this.init();
-    
+
     return this;
   },
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Fixed selectDay being called twice on clicking events

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #8769 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
I'm not sure how to make an example page for this. What I did was add a console log in selectDay itself to see how many times it was called, the ticket doesn't give a specific example (no stackblitz or similar) too.

I used this page to test it: http://localhost:4000/components/calendar/example-only-calendar.html
Change the month and year to August 2018 for events that overflow in a day and have the +2 More tag appear

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
