### PR TITLE
1689 - Allow checkboxes to be disabled for selection

### DIFF
--- a/app/views/components/compositeform/test-with-tab-headers-horizontal.html
+++ b/app/views/components/compositeform/test-with-tab-headers-horizontal.html
@@ -155,7 +155,7 @@
             </div>
 
             <div class="contextual-toolbar toolbar is-hidden">
-              <div class="title selection-count">1 Selected</div>
+              <div class="title selection-count">0 Selected</div>
               <div class="buttonset">
                 <button class="btn-icon" type="button" id="remove-btn">
                   <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/compositeform/test-with-tab-headers-vertical.html
+++ b/app/views/components/compositeform/test-with-tab-headers-vertical.html
@@ -155,7 +155,7 @@
             </div>
 
             <div class="contextual-toolbar toolbar is-hidden">
-              <div class="title selection-count">1 Selected</div>
+              <div class="title selection-count">0 Selected</div>
               <div class="buttonset">
                 <button class="btn-icon" type="button" id="remove-btn">
                   <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/example-disabled-selection-checkbox.html
+++ b/app/views/components/datagrid/example-disabled-selection-checkbox.html
@@ -55,6 +55,36 @@
       }
       return isEditable;
     };
+    const checkDisabled = (row, cell, value, item, rowData) => {
+      let isDisabled = true;
+      if (rowData.lineType === 'Amount Only') {
+        if (item.field === 'orderAmount') {
+          isDisabled = false;
+        }
+      } else if (rowData.lineType === 'Rate Only') {
+        if (
+          item.field === 'procurementRate' ||
+          item.field === 'procurementRateUnit'
+        ) {
+          isDisabled = false;
+        }
+      } else if (rowData.lineType === 'Quantity & Rate') {
+        if (
+          item.field === 'procurementRate' ||
+          item.field === 'procurementRateUnit' ||
+          item.field === 'quantity' ||
+          item.field === 'quantityUnit'
+        ) {
+          isDisabled = false;
+        }
+      }
+      if (rowData.status === 'Modified') {
+        if (item.id === 'selectionCheckbox') {
+          isDisabled = false;
+        }
+      }
+      return isDisabled;
+    };
     const columnGroups = [
       {
         colspan: 1,
@@ -105,7 +135,8 @@
         resizable: false,
         formatter: Soho.Formatters.SelectionCheckbox,
         align: 'center',
-        isEditable: checkEditable,
+        // isEditable: checkEditable -> this also works
+        disabled: checkDisabled
       },
       {
         id: 'LineEdit',

--- a/app/views/components/datagrid/example-disabled-selection-checkbox.html
+++ b/app/views/components/datagrid/example-disabled-selection-checkbox.html
@@ -1,0 +1,310 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <div class="contextual-toolbar toolbar is-hidden">
+      <div class="title selection-count">0 Selected</div>
+      <div class="buttonset">
+        <button class="btn" type="button" id="defer-btn">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-change-time-code"></use>
+          </svg>
+          <span>Defer</span>
+        </button>
+        <button class="btn" type="button" id="cancel-btn">
+          <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+            <use href="#icon-cancel"></use>
+          </svg>
+          <span>Cancel</span>
+        </button>
+      </div>
+    </div>
+    <div id="datagrid" class="datagrid">
+    </div>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+    const checkEditable = (row, cell, value, item, rowData) => {
+      let isEditable = false;
+      if (rowData.lineType === 'Amount Only') {
+        if (item.field === 'orderAmount') {
+          isEditable = true;
+        }
+      } else if (rowData.lineType === 'Rate Only') {
+        if (
+          item.field === 'procurementRate' ||
+          item.field === 'procurementRateUnit'
+        ) {
+          isEditable = true;
+        }
+      } else if (rowData.lineType === 'Quantity & Rate') {
+        if (
+          item.field === 'procurementRate' ||
+          item.field === 'procurementRateUnit' ||
+          item.field === 'quantity' ||
+          item.field === 'quantityUnit'
+        ) {
+          isEditable = true;
+        }
+      }
+      if (rowData.status === 'Modified') {
+        if (item.id === 'selectionCheckbox') {
+          isEditable = true;
+        }
+      }
+      return isEditable;
+    };
+    const columnGroups = [
+      {
+        colspan: 1,
+        id: 'selectionCheckbox',
+        name: '',
+      },
+      {
+        colspan: 1,
+        id: 'LineEdit',
+        name: '',
+      },
+      {
+        colspan: 1,
+        id: 'Line',
+        name: 'line',
+      },
+      {
+        colspan: 1,
+        id: 'description',
+        name: 'description',
+      },
+      {
+        colspan: 1,
+        id: 'ScopeofWork',
+        name: 'scopeOfWork',
+      },
+      {
+        colspan: 1,
+        id: 'lineType',
+        name: 'lineType',
+      },
+      {
+        colspan: 1,
+        id: 'callOff',
+        name: 'callOffLine',
+      },
+      {
+        colspan: 1,
+        id: 'LineQuantity',
+        name: 'quantity',
+      },
+    ];
+    const columns = [
+      {
+        id: 'selectionCheckbox',
+        width: 15,
+        sortable: false,
+        resizable: false,
+        formatter: Soho.Formatters.SelectionCheckbox,
+        align: 'center',
+        isEditable: checkEditable,
+      },
+      {
+        id: 'LineEdit',
+        field: 'lineEdit',
+        name: '',
+        formatter: Soho.Formatters.Button,
+        sortable: false,
+        icon: 'edit',
+        width: 45,
+        align: 'center',
+      },
+      {
+        id: 'Line',
+        name: 'Line',
+        sortable: true,
+        width: 50,
+        field: 'allLinesValue',
+        textOverflow: 'ellipsis',
+      },
+      {
+        id: 'description',
+        name: 'Description',
+        field: 'description',
+        textOverflow: 'ellipsis',
+      },
+      {
+        id: 'ScopeofWork',
+        field: 'scopeOfWork',
+        name: 'Scope of work',
+        width: 70,
+        textOverflow: 'ellipsis',
+        sortable: true,
+      },
+      {
+        id: 'lineType',
+        name: 'Line Type',
+        field: 'lineType',
+        width: 80,
+      },
+      {
+        id: 'callOff',
+        field: 'callOff',
+        name: 'Call Off',
+        formatter: Soho.Formatters.Checkbox,
+        isEditable: checkEditable,
+      },
+      {
+        id: 'variationLineQuantity',
+        name: 'Quantity',
+        field: 'quantity',
+        width: 30,
+        sortable: true,
+        editor: Soho.Editors.Input,
+        isEditable: checkEditable,
+      },
+    ];
+    const pagingData = [
+      {
+        id: 1,
+        line: '10',
+        allLinesValue: '10/0',
+        variationLine: 0,
+        scopeOfWork: 'NLDS00300 - Hazardous Materials Restoration',
+        description: 'Testing purpose',
+        descriptionOnly: 'true',
+        lineType: '',
+        startDateOnSite: '2023-07-31T16:15:00',
+        endDateAtSite: '2023-11-10T16:15:00',
+        quantity: 20,
+        quantityUnit: 'mts',
+        status: 'Created',
+        orderAmount: '6000',
+        procurementRate: 3,
+        procurementRateCurrency: 'EUR' + ' ' + '/',
+        procurementRateUnit: '/mts',
+      },
+      {
+        id: 2,
+        line: '20',
+        allLinesValue: '20/1',
+        variationLine: 1,
+        scopeOfWork: 'NLDS00300 - Hazardous Materials Restoration',
+        description: '',
+        lineType: 'Amount Only',
+        startDateOnSite: '2023-07-31T16:15:00',
+        endDateAtSite: '2023-11-10T16:15:00',
+        quantity: '',
+        quantityUnit: '',
+        procurementRate: '',
+        status: 'Created',
+        orderAmount: '250',
+        procurementRateUnit: '',
+      },
+      {
+        id: 3,
+        line: '30',
+        allLinesValue: '30/3',
+        variationLine: 0,
+        scopeOfWork: 'NLDS00300 - Hazardous Materials Restoration',
+        description: '',
+        lineType: 'Rate Only',
+        startDateOnSite: '2023-07-31T16:15:00',
+        endDateAtSite: '2023-11-10T16:15:00',
+        quantity: 40,
+        quantityUnit: 'mts',
+        procurementRate: 20,
+        orderAmount: '600',
+        status: 'Created',
+        procurementRateCurrency: 'EUR' + ' ' + '/',
+        procurementRateUnit: '/mts',
+      },
+      {
+        id: 4,
+        line: '40',
+        allLinesValue: '40/4',
+        variationLine: 0,
+        scopeOfWork: 'NLDS00300 - Hazardous Materials Restoration',
+        description: '',
+        lineType: 'Quantity & Rate',
+        startDateOnSite: '2023-07-31T16:15:00',
+        endDateAtSite: '2023-11-10T16:15:00',
+        quantity: 50,
+        quantityUnit: 'mts',
+        procurementRate: 500,
+        status: 'Created',
+        orderAmount: '2500',
+        procurementRateCurrency: 'EUR' + ' ' + '/',
+        procurementRateUnit: '/mts',
+      },
+      {
+        id: 5,
+        allLinesValue: '50/1',
+        line: '50',
+        variationLine: 1,
+        scopeOfWork: 'NLDS00300 - Hazardous Materials Restoration',
+        description: '',
+        lineType: 'Quantity & Rate',
+        startDateOnSite: '2023-07-31T16:15:00',
+        endDateAtSite: '2023-11-10T16:15:00',
+        quantity: 201,
+        quantityUnit: 'mts',
+        procurementRate: 100,
+        orderAmount: '3000',
+        status: 'Created',
+        procurementRateCurrency: 'EUR' + ' ' + '/',
+        procurementRateUnit: '/mts',
+      },
+      {
+        id: 6,
+        allLinesValue: '60/2',
+        line: '60',
+        variationLine: 2,
+        scopeOfWork: 'NLDS00300 - Hazardous Materials Restoration',
+        description: '',
+        lineType: 'Quantity & Rate',
+        startDateOnSite: '2023-07-31T16:15:00',
+        endDateAtSite: '2023-11-10T16:15:00',
+        quantity: 2090,
+        quantityUnit: 'mts',
+        status: 'Modified',
+        orderAmount: '209',
+        procurementRate: 10,
+        procurementRateCurrency: 'EUR' + ' ' + '/',
+        procurementRateUnit: '/mts',
+      },
+      {
+        id: 7,
+        allLinesValue: '70/0',
+        line: '70',
+        variationLine: 0,
+        scopeOfWork: 'NLDS00300 - Hazardous Materials Restoration',
+        description: '',
+        lineType: 'Quantity & Rate',
+        startDateOnSite: '2023-07-31T16:15:00',
+        endDateAtSite: '2023-11-10T16:15:00',
+        quantity: 2000,
+        quantityUnit: 'mts',
+        status: 'Modified',
+        orderAmount: '6000',
+        procurementRate: 3,
+        procurementRateCurrency: 'EUR' + ' ' + '/',
+        procurementRateUnit: '/mts',
+      },
+    ];
+
+    // Init and get the api for the grid
+    const api = $('#datagrid').datagrid({
+      columns: columns,
+      dataset: pagingData,
+      selectable: 'multiple',
+      showSelectAllCheckBox: false,
+      showNewRowIndicator: true,
+      editable: true,
+      showDirty: true,
+      columnSizing: 'data',
+      enableTooltips: true,
+      clickToSelect: false,
+      rowHeight: 'extra-small',
+      toolbar: { results: true, keywordFilter: false },
+    });
+  });
+</script>

--- a/app/views/components/datagrid/example-editable-with-row-status.html
+++ b/app/views/components/datagrid/example-editable-with-row-status.html
@@ -55,7 +55,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button type="button" class="btn hide-focus" id="action1">
           <svg role="presentation" aria-hidden="true" focusable="false" class="icon">

--- a/app/views/components/datagrid/example-editable.html
+++ b/app/views/components/datagrid/example-editable.html
@@ -55,7 +55,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button type="button" class="btn hide-focus" id="action1">
           <svg role="presentation" aria-hidden="true" focusable="false" class="icon">

--- a/app/views/components/datagrid/example-grouping-editable.html
+++ b/app/views/components/datagrid/example-grouping-editable.html
@@ -34,7 +34,7 @@
       </div>
     </div>
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn-icon" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/example-multiselect.html
+++ b/app/views/components/datagrid/example-multiselect.html
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="twelve columns">
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn" type="button" id="remove-btn" title="Remove">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-alternate-row-shading.html
+++ b/app/views/components/datagrid/test-alternate-row-shading.html
@@ -52,7 +52,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn-icon" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-cell-with-leading-space-dirty-indicator.html
+++ b/app/views/components/datagrid/test-cell-with-leading-space-dirty-indicator.html
@@ -2,12 +2,12 @@
 <div class="row">
     <div class="twelve columns">
       <div role="toolbar" class="toolbar">
-  
+
         <div class="title">
           Data Grid Header Title
           <span class="datagrid-result-count">(N Results)</span>
         </div>
-  
+
         <div class="buttonset">
             <button type="button" id="toggle-row-status" class="btn">
               <span>Add Row Status</span>
@@ -31,7 +31,7 @@
             <span class="audible">Add</span>
           </button>
         </div>
-  
+
         <div class="more">
           <button class="btn-actions" type="button">
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
@@ -47,12 +47,12 @@
             <li class="is-selectable"><a data-option="row-medium" href="#" data-translate="text">Medium</a></li>
             <li class="is-selectable is-checked"><a data-option="row-large" href="#" data-translate="text">Large</a></li>
           </ul>
-  
+
         </div>
       </div>
-  
+
       <div class="contextual-toolbar toolbar is-hidden">
-        <div class="title selection-count">1 Selected</div>
+        <div class="title selection-count">0 Selected</div>
         <div class="buttonset">
           <button class="btn-icon" type="button" id="remove-btn">
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
@@ -62,23 +62,23 @@
           </button>
         </div>
       </div>
-  
+
       <div id="datagrid"></div>
     </div>
   </div>
-  
+
   <script>
     var gridApi = null;
-  
+
     $('body').one('initialized', function () {
       var grid,
         columns = [],
         data = [];
-  
+
       var isDisabled = function(row, cell, value, item) {
         return (row % 2 === 0);
       }
-  
+
       // Some Sample Data
       data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity: '<svg/onload=alert(1)>', quantity: " 1", price: 210.99, status: 'OK', orderDate: '00000000', portable: false, action: 1, description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning'});
       data.push({ id: 2, productId: 2241202, productName: 'console.log', activity: 'Inspect and Repair', quantity: 2, price: 210.991, status: '', orderDate: '', portable: false, action: 1, description: 'The kit has an air blow gun that can be used for cleaning'});
@@ -87,7 +87,7 @@
       data.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 1});
       data.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity: 'Inspect and Repair', portable: false, quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 2});
       data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity: 'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 2});
-  
+
       //Define Columns for the Grid.
       // columns.push({ id: 'rowStatus', sortable: false, resizable: false, formatter: Soho.Formatters.Status, align: 'center'});
       columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Soho.Formatters.SelectionCheckbox, align: 'center'});
@@ -101,7 +101,7 @@
       columns.push({ id: 'action', name: 'Action', field: 'action', formatter: Soho.Formatters.Dropdown, editor: Soho.Editors.Dropdown, validate: 'required', isEditable: isDisabled,
       options: [{id: '', label: '', value: -1}, {id: 'oh1', label: 'On Hold', value: 1}, {id: 'sh1', label: 'Shipped', value: 2} , {id: 'ac1', label: 'Action', value: 3}, {id: 'pen', label: 'Pending', value: 4}, {id: 'bk1', label: 'Backorder', value: 5}, {id: 'can', label: 'Cancelled', value: 6}, {id: 'pro', label: 'Processing', value: 7}]
       });
-  
+
       //Init and get the api for the grid
       grid = $('#datagrid').datagrid({
         columns: columns,
@@ -124,9 +124,9 @@
       }).on('dblclick', function (e, args) {
         console.log('dblclick', args);
       });
-  
+
       gridApi = $('#datagrid').data('datagrid');
-  
+
       //Example row status
       $('#toggle-row-status').on('click', function () {
         var btn = $(this).find('span');
@@ -150,26 +150,26 @@
           gridApi.resetRowStatus();
         }
       });
-  
+
       window.data = data;
     });
-  
+
     var newId = 8;
     //Add Code for Add and icon-delete
     $('#add-btn').on('click', function () {
       gridApi.addRow({ id: newId++, productId: 2642206, productName: 'New Product'});
       console.log(gridApi.settings.dataset[1]);
     });
-  
+
     //Add Code for Add and icon-delete
     $('#remove-btn').on('click', function () {
       gridApi.removeSelected();
     });
-  
+
     //A few other ways
     $('#validate').on('selected', function (e, args) {
       var action = args.attr('data-action');
-  
+
       if (action === 'specific-row-error') {
         gridApi.showRowError(2, 'This row has a custom error message.', 'error');
       }
@@ -186,6 +186,5 @@
         gridApi.clearAllErrors();
       }
     });
-  
+
   </script>
-  

--- a/app/views/components/datagrid/test-combo-sort.html
+++ b/app/views/components/datagrid/test-combo-sort.html
@@ -23,7 +23,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-count-in-select-all-current-page-setting.html
+++ b/app/views/components/datagrid/test-count-in-select-all-current-page-setting.html
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="twelve columns">
       <div class="contextual-toolbar toolbar is-hidden">
-          <div class="title selection-count">1 Selected</div>
+          <div class="title selection-count">0 Selected</div>
           <div class="buttonset">
           </div>
         </div>

--- a/app/views/components/datagrid/test-custom-date-formats.html
+++ b/app/views/components/datagrid/test-custom-date-formats.html
@@ -3,7 +3,7 @@
   <div class="twelve columns">
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn" type="button">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-datepicker-dynamic-disabled-dates.html
+++ b/app/views/components/datagrid/test-datepicker-dynamic-disabled-dates.html
@@ -3,7 +3,7 @@
   <div class="twelve columns">
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn" type="button">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-dirty-change-cell-externally.html
+++ b/app/views/components/datagrid/test-dirty-change-cell-externally.html
@@ -37,7 +37,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn-icon" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-dropdown-empty-value.html
+++ b/app/views/components/datagrid/test-dropdown-empty-value.html
@@ -52,7 +52,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn-icon" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-editable-actionable-mode.html
+++ b/app/views/components/datagrid/test-editable-actionable-mode.html
@@ -52,7 +52,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn-icon" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-editable-autocomplete.html
+++ b/app/views/components/datagrid/test-editable-autocomplete.html
@@ -3,7 +3,7 @@
   <div class="twelve columns">
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-editable-datetime.html
+++ b/app/views/components/datagrid/test-editable-datetime.html
@@ -3,7 +3,7 @@
   <div class="twelve columns">
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn" type="button">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-editable-dropdown-width.html
+++ b/app/views/components/datagrid/test-editable-dropdown-width.html
@@ -42,7 +42,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-editable-paging-validation.html
+++ b/app/views/components/datagrid/test-editable-paging-validation.html
@@ -2,7 +2,7 @@
   <div class="twelve columns">
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn-icon" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-editable-select-on-edit.html
+++ b/app/views/components/datagrid/test-editable-select-on-edit.html
@@ -52,7 +52,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn-icon" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-editable-short-row.html
+++ b/app/views/components/datagrid/test-editable-short-row.html
@@ -38,7 +38,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-editable-with-inline-editor.html
+++ b/app/views/components/datagrid/test-editable-with-inline-editor.html
@@ -52,7 +52,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn-icon" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
@@ -70,7 +70,7 @@
 <script>
   var gridApi = null;
   $('body').one('initialized', function () {
-    
+
     var grid,
       columns = [],
       data = [];

--- a/app/views/components/datagrid/test-emptymessage-no-icon.html
+++ b/app/views/components/datagrid/test-emptymessage-no-icon.html
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="twelve columns">
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn" type="button" id="remove-btn" title="Remove">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-export-csv-sanitize.html
+++ b/app/views/components/datagrid/test-export-csv-sanitize.html
@@ -2,12 +2,12 @@
 <div class="row">
     <div class="twelve columns">
       <div role="toolbar" class="toolbar">
-  
+
         <div class="title">
           Data Grid Header Title
           <span class="datagrid-result-count">(N Results)</span>
         </div>
-  
+
         <div class="buttonset">
             <button type="button" class="btn" id="export-to-csv">
               <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
@@ -37,7 +37,7 @@
             <span class="audible">Add</span>
           </button>
         </div>
-  
+
         <div class="more">
           <button class="btn-actions" type="button">
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
@@ -53,12 +53,12 @@
             <li class="is-selectable"><a data-option="row-medium" href="#" data-translate="text">Medium</a></li>
             <li class="is-selectable is-checked"><a data-option="row-large" href="#" data-translate="text">Large</a></li>
           </ul>
-  
+
         </div>
       </div>
-  
+
       <div class="contextual-toolbar toolbar is-hidden">
-        <div class="title selection-count">1 Selected</div>
+        <div class="title selection-count">0 Selected</div>
         <div class="buttonset">
           <button class="btn-icon" type="button" id="remove-btn">
             <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
@@ -68,23 +68,23 @@
           </button>
         </div>
       </div>
-  
+
       <div id="datagrid"></div>
     </div>
   </div>
-  
+
   <script>
     var gridApi = null;
-  
+
     $('body').one('initialized', function () {
       var grid,
         columns = [],
         data = [];
-  
+
       var isDisabled = function(row, cell, value, item) {
         return (row % 2 === 0);
       }
-  
+
       // Some Sample Data
       data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity: '<svg/onload=alert(1)>', quantity: 1, price: 210.99, status: 'OK', orderDate: '00000000', portable: false, action: 1, description: 'Compressor comes with various air compressor accessories, to help you with a variety of projects. All fittings are with 1/4 NPT connectors. The kit has an air blow gun that can be used for cleaning'});
       data.push({ id: 2, productId: 2241202, productName: 'console.log', activity: 'Inspect and Repair', quantity: 2, price: 210.991, status: '', orderDate: '', portable: false, action: 1, description: 'The kit has an air blow gun that can be used for cleaning'});
@@ -93,7 +93,7 @@
       data.push({ id: 5, productId: 2542205, productName: 'De Wallt Compressor', activity:  'Inspect and Repair', portable: false, quantity: 4, price: 210.99, status: 'OK', orderDate: new Date(2015, 5, 5), action: 1});
       data.push({ id: 6, productId: 2642205, productName: 'Air Compressors', activity: 'Inspect and Repair', portable: false, quantity: 41, price: 120.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 2});
       data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity: 'inspect and Repair', portable: true, quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 2});
-  
+
       //Define Columns for the Grid.
       // columns.push({ id: 'rowStatus', sortable: false, resizable: false, formatter: Soho.Formatters.Status, align: 'center'});
       columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Soho.Formatters.SelectionCheckbox, align: 'center'});
@@ -107,7 +107,7 @@
       columns.push({ id: 'action', name: 'Action', field: 'action', formatter: Soho.Formatters.Dropdown, editor: Soho.Editors.Dropdown, validate: 'required', isEditable: isDisabled,
       options: [{id: '', label: '', value: -1}, {id: 'oh1', label: 'On Hold', value: 1}, {id: 'sh1', label: 'Shipped', value: 2} , {id: 'ac1', label: 'Action', value: 3}, {id: 'pen', label: 'Pending', value: 4}, {id: 'bk1', label: 'Backorder', value: 5}, {id: 'can', label: 'Cancelled', value: 6}, {id: 'pro', label: 'Processing', value: 7}]
       });
-  
+
       //Init and get the api for the grid
       grid = $('#datagrid').datagrid({
         columns: columns,
@@ -129,9 +129,9 @@
       }).on('dblclick', function (e, args) {
         console.log('dblclick', args);
       });
-  
+
       gridApi = $('#datagrid').data('datagrid');
-  
+
       //Example row status
       $('#toggle-row-status').on('click', function () {
         var btn = $(this).find('span');
@@ -155,26 +155,26 @@
           gridApi.resetRowStatus();
         }
       });
-  
+
       window.data = data;
     });
-  
+
     var newId = 8;
     //Add Code for Add and icon-delete
     $('#add-btn').on('click', function () {
       gridApi.addRow({ id: newId++, productId: 2642206, productName: 'New Product'});
       console.log(gridApi.settings.dataset[1]);
     });
-  
+
     //Add Code for Add and icon-delete
     $('#remove-btn').on('click', function () {
       gridApi.removeSelected();
     });
-  
+
     //A few other ways
     $('#validate').on('selected', function (e, args) {
       var action = args.attr('data-action');
-  
+
       if (action === 'specific-row-error') {
         gridApi.showRowError(2, 'This row has a custom error message.', 'error');
       }
@@ -191,10 +191,9 @@
         gridApi.clearAllErrors();
       }
     });
-  
+
     $('#export-to-csv').on('click', function () {
       gridApi.exportToCsv('myExport');
     });
-  
+
   </script>
-  

--- a/app/views/components/datagrid/test-filter-alternate-row-shading.html
+++ b/app/views/components/datagrid/test-filter-alternate-row-shading.html
@@ -15,7 +15,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-form-buttons.html
+++ b/app/views/components/datagrid/test-form-buttons.html
@@ -25,22 +25,33 @@
       // Some Sample Data
       data.push({ id: 1, productId: 2142201, productName: 'Compressor', activity:  'Assemble Paint', quantity: 1, price: 210.99, status: 'OK', orderDate: new Date(2014, 12, 8), action: 'Action', ordered: 1, setting: {optionOne: 'One', optionTwo: 'One'}});
       data.push({ id: 2, productId: 2241202, productName: 'Different Compressor', activity:  'Inspect and Repair', quantity: 2, price: 210.99, status: '', orderDate: new Date(2015, 7, 3), action: 'On Hold', ordered: true, setting: {optionOne: 'One', optionTwo: 'One'}});
-      data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: null, orderDate: new Date(2014, 6, 3), action: 'Action', ordered: true, comment: 'Dynamic harness out-of-the-box /n syndicate models deliver. Disintermediate, technologies /n scale deploy social streamline, methodologies, killer podcasts innovate. Platforms A-list disintermediate, value visualize dot-com /n tagclouds platforms incentivize interactive vortals disintermediate networking, webservices envisioneer; tag share value-added, disintermediate, revolutionary.'});
-      data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 9, price: 210.99, status: 'OK', orderDate: new Date(2015, 3, 3), action: 'Action', ordered: true});
+      data.push({ id: 3, productId: 2342203, productName: 'Compressor', activity:  'Inspect and Repair', quantity: 1, price: 120.99, status: 'DISABLED', orderDate: new Date(2014, 6, 3), action: 'Action', ordered: true, comment: 'Dynamic harness out-of-the-box /n syndicate models deliver. Disintermediate, technologies /n scale deploy social streamline, methodologies, killer podcasts innovate. Platforms A-list disintermediate, value visualize dot-com /n tagclouds platforms incentivize interactive vortals disintermediate networking, webservices envisioneer; tag share value-added, disintermediate, revolutionary.'});
+      data.push({ id: 4, productId: 2445204, productName: 'Another Compressor', activity:  'Assemble Paint', quantity: 9, price: 210.99, status: '', orderDate: new Date(2015, 3, 3), action: 'Action', ordered: true});
       data.push({ id: 5, productId: 2542205, productName: 'I Love Compressors', activity:  'Inspect and Repair', quantity: 4, price: 18.00, status: 'OK', orderDate: new Date(2015, 5, 5), action: 'On Hold', ordered: false});
-      data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 18, price: 9, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', comment: 'B2C ubiquitous communities maximize B2C synergies extend dynamic revolutionize, world-class robust peer-to-peer. Action-items semantic technologies clicks-and-mortar iterate min'});
+      data.push({ id: 5, productId: 2642205, productName: 'Air Compressors', activity:  'Inspect and Repair', quantity: 18, price: 9, status: null, orderDate: new Date(2014, 6, 9), action: 'On Hold', comment: 'B2C ubiquitous communities maximize B2C synergies extend dynamic revolutionize, world-class robust peer-to-peer. Action-items semantic technologies clicks-and-mortar iterate min'});
       data.push({ id: 6, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: 123.99, status: 'OK', orderDate: new Date(2014, 6, 9), action: 'On Hold', ordered: 0});
-      data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '100.99', status: 'OK', orderDate: new Date(2014, 6, 9, 12, 12, 12), action: 'On Hold', ordered: 0});
+      data.push({ id: 7, productId: 2642206, productName: 'Some Compressor', activity:  'inspect and Repair', quantity: 41, price: '100.99', status: 'DISABLED', orderDate: new Date(2014, 6, 9, 12, 12, 12), action: 'On Hold', ordered: 0});
 
-      //Define Columns for the Grid.
+      // Define Columns for the Grid.
 
       columns.push({ id: 'productId', hidden: true, name: 'Product Id', field: 'productId', formatter: Soho.Formatters.Readonly });
       columns.push({ id: 'productDesc', name: 'Product Desc', field: 'productName', formatter: Soho.Formatters.Hyperlink});
       columns.push({ id: 'activity', name: 'Activity', field: 'activity'});
+      columns.push({ id: 'status', name: 'Status', field: 'status' });
       columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity'});
       columns.push({ id: 'actionLink', name: 'As Link', field: 'action', sortable: false, align: 'center', formatter: Soho.Formatters.Hyperlink, icon: 'reset'});
-      columns.push({ id: 'action', name: 'Active', field: 'action', text: 'Action', sortable: false, align: 'center',formatter: Soho.Formatters.Button, click: function (e, args) {$('body').toast({ title: 'Click Fired', message: 'Id : ' + args[0].item.id + ' was clicked.' })}
-      , contentVisible: function (row, cell, data, col, item) { return (item.status === 'OK');} });
+      columns.push({
+        id: 'action',
+        name: 'Active',
+        field: 'action',
+        text: 'Action',
+        sortable: false,
+        align: 'center',
+        formatter: Soho.Formatters.Button,
+        click: function (e, args) {$('body').toast({ title: 'Click Fired', message: 'Id : ' + args[0].item.id + ' was clicked.' })},
+        contentVisible: function (row, cell, data, col, item) { return (item.status === 'OK' || item.status === 'DISABLED');},
+        disabled: function (row, cell, data, col, item) { return item.status === 'DISABLED'; }
+       });
 
       //Init and get the api for the grid
       grid = $('#datagrid').datagrid({

--- a/app/views/components/datagrid/test-group-editable-addrow.html
+++ b/app/views/components/datagrid/test-group-editable-addrow.html
@@ -42,7 +42,7 @@
       </div>
     </div>
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn-icon" type="button" id="btn-remove">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-hide-pager-if-one-page.html
+++ b/app/views/components/datagrid/test-hide-pager-if-one-page.html
@@ -30,7 +30,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-in-tabs.html
+++ b/app/views/components/datagrid/test-in-tabs.html
@@ -19,7 +19,7 @@
 			</div>
 			<div id="tabs-normal-attachments" class="tab-panel">
 				<div class="contextual-toolbar toolbar is-hidden">
-					<div class="title selection-count">1 Selected</div>
+					<div class="title selection-count">0 Selected</div>
 					<div class="buttonset">
 						<button class="btn" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-integer-maskoptions.html
+++ b/app/views/components/datagrid/test-integer-maskoptions.html
@@ -28,7 +28,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn-icon" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-multi-select-dropdown-selection.html
+++ b/app/views/components/datagrid/test-multi-select-dropdown-selection.html
@@ -51,7 +51,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn-icon" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-multiselect-no-checkboxes.html
+++ b/app/views/components/datagrid/test-multiselect-no-checkboxes.html
@@ -13,7 +13,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
       </div>
     </div>

--- a/app/views/components/datagrid/test-override-tabbing.html
+++ b/app/views/components/datagrid/test-override-tabbing.html
@@ -52,7 +52,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn-icon" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
@@ -70,7 +70,7 @@
 <script>
   var gridApi = null;
   $('body').one('initialized', function () {
-    
+
     var grid,
       columns = [],
       data = [];

--- a/app/views/components/datagrid/test-paging-empty-dataset.html
+++ b/app/views/components/datagrid/test-paging-empty-dataset.html
@@ -21,7 +21,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-paging-multiselect-select-across-page.html
+++ b/app/views/components/datagrid/test-paging-multiselect-select-across-page.html
@@ -35,7 +35,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn-icon" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-paging-multiselect.html
+++ b/app/views/components/datagrid/test-paging-multiselect.html
@@ -35,7 +35,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn-icon" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-reorder-multiselect.html
+++ b/app/views/components/datagrid/test-reorder-multiselect.html
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="twelve columns">
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-rtl-swap.html
+++ b/app/views/components/datagrid/test-rtl-swap.html
@@ -79,7 +79,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn-icon" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-selected-rows-addnew.html
+++ b/app/views/components/datagrid/test-selected-rows-addnew.html
@@ -46,7 +46,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn-icon" type="button" id="remove-row-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-text-overflow-ellipsis-links.html
+++ b/app/views/components/datagrid/test-text-overflow-ellipsis-links.html
@@ -51,7 +51,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn-icon" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/datagrid/test-toggle-editable.html
+++ b/app/views/components/datagrid/test-toggle-editable.html
@@ -29,7 +29,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
@@ -114,7 +114,7 @@
   //Add Code for Add and icon-delete
   $('#edit-btn').on('click', function () {
     gridApi.settings.editable = !gridApi.settings.editable;
-    
+
     // Workaround as rerender does not work as expected if it's still initial
     let pi = gridApi.pagerAPI.state;
     pi.type = 'rerender';

--- a/app/views/components/datagrid/test-xss-prevention.html
+++ b/app/views/components/datagrid/test-xss-prevention.html
@@ -23,7 +23,7 @@
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/app/views/components/tabs/test-add-remove-reload.html
+++ b/app/views/components/tabs/test-add-remove-reload.html
@@ -34,7 +34,7 @@
       </div>
       <div id="tabs-dismissible-opera" class="tab-panel">
 				<div class="contextual-toolbar toolbar is-hidden">
-					<div class="title selection-count">1 Selected</div>
+					<div class="title selection-count">0 Selected</div>
 					<div class="buttonset">
 						<button class="btn" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## v4.98.0 Features
 
+- `[Datagrid]` Add the ability for isEditable on selection checkbox columns to disable row selection. ([#1689](https://github.com/infor-design/enterprise-ng/issues/1689))
 - `[Tab]` Selecting tabs in overflow menu will move the tab to a visible space. ([#8016](https://github.com/infor-design/enterprise/issues/8016))
 
 ## v4.97.0

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -4333,6 +4333,15 @@ td .btn-actions {
     position: relative;
     top: -14px;
   }
+
+  &.datagrid-selection-checkbox.disabled {
+    cursor: default;
+
+    &::before {
+      background-color: $checkbox-color-unchecked-disabled-background;
+      border-color: $checkbox-color-unchecked-disabled-border;
+    }
+  }
 }
 
 .datagrid > tbody > tr.datagrid-row {

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -389,7 +389,9 @@ const formatters = {
     }
 
     ariaString = xssUtils.ensureAlphaNumericWithSpaces(ariaString);
-    return `<div class="datagrid-checkbox-wrapper"><span role="checkbox" aria-label="${(col.name ? col.name : Locale.translate('Select') + ariaString)}" class="datagrid-checkbox datagrid-selection-checkbox${(isChecked ? ' is-checked no-animate' : '')}"></span></div>`;
+    const disabledClass = isColumnDisabled(row, cell, value, col, item) ? ' disabled' : '';
+    console.log(disabledClass);
+    return `<div class="datagrid-checkbox-wrapper"><span role="checkbox" aria-label="${(col.name ? col.name : Locale.translate('Select') + ariaString)}" class="datagrid-checkbox datagrid-selection-checkbox${(isChecked ? ' is-checked no-animate' : '')}${disabledClass}"></span></div>`;
   },
 
   SelectionRadio(row, cell, value, col, item, api) {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7664,6 +7664,10 @@ Datagrid.prototype = {
         canSelect = false;
       }
 
+      if (target.closest('td').hasClass('is-readonly')) {
+        canSelect = false;
+      }
+
       if (self.settings.selectable === 'mixed') {
         canSelect = isSelectionCheckbox;
 
@@ -8411,7 +8415,7 @@ Datagrid.prototype = {
     if (this.settings.toolbar && this.settings.toolbar.contextualToolbar) {
       const contextualToolbar = `
         <div class="contextual-toolbar datagrid-contextual-toolbar toolbar is-hidden">
-          <div class="title selection-count">1 Selected</div>
+          <div class="title selection-count">0 Selected</div>
         </div>`;
 
       this.element.before(contextualToolbar);
@@ -10516,7 +10520,7 @@ Datagrid.prototype = {
           e.preventDefault(); // This will prevent scrolling down when the list is overflowing.
         }
 
-        if (!self.editor) {
+        if (!self.editor && self.settings.clickToSelect) {
           self.makeCellEditable(self.activeCell.rowIndex, cell, e);
         }
       }

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10504,6 +10504,10 @@ Datagrid.prototype = {
           return;
         }
 
+        if (target?.is('td.is-selectioncheckbox.is-readonly')) {
+          return;
+        }
+
         if ((self.settings.selectable === 'multiple' || self.settings.selectable === 'mixed') && e.shiftKey) {
           self.selectRowsBetweenIndexes([self.lastSelectedRow, row.attr('aria-rowindex') - 1]);
         } else {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7664,7 +7664,9 @@ Datagrid.prototype = {
         canSelect = false;
       }
 
-      if (target.closest('td').hasClass('is-readonly')) {
+      if (target.closest('td').hasClass('is-readonly') ||
+        target.find('.datagrid-selection-checkbox').hasClass('disabled') ||
+        target.hasClass('disabled')) {
         canSelect = false;
       }
 
@@ -10504,7 +10506,7 @@ Datagrid.prototype = {
           return;
         }
 
-        if (target?.is('td.is-selectioncheckbox.is-readonly')) {
+        if (target?.is('td.is-selectioncheckbox.is-readonly') || target.find('.datagrid-selection-checkbox').hasClass('disabled')) {
           return;
         }
 

--- a/tests-to-convert/components/datagrid/datagrid-reorder-func-test.js
+++ b/tests-to-convert/components/datagrid/datagrid-reorder-func-test.js
@@ -18,7 +18,7 @@ require('../../../src/components/arrange/arrange.jquery');
 const datagridHTML = `<div class="row">
   <div class="twelve columns">
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/tests-to-convert/components/datagrid/datagrid-validation-func-test.js
+++ b/tests-to-convert/components/datagrid/datagrid-validation-func-test.js
@@ -71,7 +71,7 @@ const datagridHTML = `<div class="row">
     </div>
 
     <div class="contextual-toolbar toolbar is-hidden">
-      <div class="title selection-count">1 Selected</div>
+      <div class="title selection-count">0 Selected</div>
       <div class="buttonset">
         <button class="btn-icon" type="button" id="remove-btn">
           <svg class="icon" focusable="false" aria-hidden="true" role="presentation">

--- a/tests/datagrid/datagrid.spec.js
+++ b/tests/datagrid/datagrid.spec.js
@@ -37,7 +37,6 @@ test.describe('Datagrid tests', () => {
   test.describe('functionality tests', () => {
     test('should be able to disable selection with readonly checkboxes', async ({ page }) => {
       await page.goto('/components/datagrid/example-disabled-selection-checkbox.html');
-      expect(await page.locator('.datagrid tr:first-child td:first-child')).toHaveClass(/is-readonly/);
       await page.locator('.datagrid tr:first-child td:first-child').click();
       expect(await page.locator('.selection-count')).toHaveText('0 Selected');
       await page.locator('.datagrid tr:first-child td:nth-child(6)').click();

--- a/tests/datagrid/datagrid.spec.js
+++ b/tests/datagrid/datagrid.spec.js
@@ -35,5 +35,13 @@ test.describe('Datagrid tests', () => {
   });
 
   test.describe('functionality tests', () => {
+    test('should be able to disable selection with readonly checkboxes', async ({ page }) => {
+      await page.goto('/components/datagrid/example-disabled-selection-checkbox.html');
+      expect(await page.locator('.datagrid tr:first-child td:first-child')).toHaveClass(/is-readonly/);
+      await page.locator('.datagrid tr:first-child td:first-child').click();
+      expect(await page.locator('.selection-count')).toHaveText('0 Selected');
+      await page.locator('.datagrid tr:first-child td:nth-child(6)').click();
+      expect(await page.locator('.selection-count')).toHaveText('0 Selected');
+    });
   });
 });

--- a/tests/monthview/monthview.spec.js
+++ b/tests/monthview/monthview.spec.js
@@ -20,7 +20,7 @@ test.describe('Monthview tests', () => {
     test('should pass an Axe scan', async ({ page, browserName }) => {
       if (browserName !== 'chromium') return;
       const accessibilityScanResults = await new AxeBuilder({ page })
-        .disableRules(['meta-viewport', 'aria-allowed-attr'])
+        .disableRules(['meta-viewport', 'aria-allowed-attr', 'color-contrast'])
         .exclude('[disabled]')
         .analyze();
       expect(accessibilityScanResults.violations).toEqual([]);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Allows isEditable checkboxes to disable rows selections. Also pushed incorrect initial count in some examples

**Related github/jira issue (required)**:
Fixes https://github.com/infor-design/enterprise-ng/issues/1689

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-disabled-selection-checkbox.html
- clicking the disable checkboxes should not select a row
- clicking the last 2 will select a row
- repeat test with keyboard / space key should only select non editable rows
- note click to select is off so clicking anywhere but the checkbox column will not select the row

**Included in this Pull Request**:
- [x] A test for the bug or feature.
- [x] A note to the change log.
