### PR TITLE
8896 - Added fix for switch click event

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[Modal]` Removed accordion fixed width when used in modal. ([NG#1719](https://github.com/infor-design/enterprise-ng/issues/1719))
 - `[Tab]` Selecting an item in the appmenu accordion will also select the corresponding assigned tab to it (via `tab-id`). ([NG#1665](https://github.com/infor-design/enterprise-ng/issues/1665))
 - `[Tab]` Selecting tabs in overflow menu will move the tab to a visible space. ([#8880](https://github.com/infor-design/enterprise/issues/8880))
+- `[Switch]` Fix issue of not being able to click the label. ([#8896](https://github.com/infor-design/enterprise/issues/8896))
 
 ## v4.97.0
 

--- a/src/components/switch/_switch.scss
+++ b/src/components/switch/_switch.scss
@@ -72,11 +72,6 @@ $handle-compact-width: 16px;
     }
   }
 
-  label,
-  .label-text {
-    pointer-events: none;
-  }
-
   label::before,
   label::after,
   .label-text::before,
@@ -108,6 +103,7 @@ $handle-compact-width: 16px;
       border-radius: 99px;
       box-sizing: border-box;
       inset-inline-start: 0;
+      top: -2px;
     }
 
     ~ .label-text::before,
@@ -129,7 +125,7 @@ $handle-compact-width: 16px;
       background-color: $ids-color-palette-white;
       border-radius: 99px;
       inset-inline-start: 2px;
-      top: 2px;
+      top: 0;
     }
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Fixes the switch so you can click the label. Also updated the text to be more centered

**Related github/jira issue (required)**:
Fixes #8896

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/switch/example-index.html
- click both the label and the switch -> should now work in both cases

**Included in this Pull Request**:
- [x] A note to the change log.
