### PR TITLE
Chore: Fix incorrect updates in commitCellEditUtil - Additional changes

### DIFF
--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10925,21 +10925,18 @@ Datagrid.prototype = {
       newValue = xssUtils.escapeHTML(newValue);
     }
 
-    let rowIndex;
+    let rowIndex = this.actualRowIndex(cellNode.parent());
     let dataRowIndex;
     if (this.settings.source !== null && isUseActiveRow) {
-      if (cellNode && this.actualRowIndex(cellNode.parent()) !== this.activeCell.rowIndex) {
-        rowIndex = this.actualRowIndex(cellNode.parent());
+      if (!isNaN(rowIndex) && rowIndex !== this.activeCell.rowIndex) {
         dataRowIndex = this.dataRowIndex(cellNode.parent());
       } else {
         rowIndex = this.activeCell.rowIndex;
         dataRowIndex = this.activeCell.dataRow;
       }
     } else {
-      rowIndex = this.actualRowIndex(cellNode.parent());
       dataRowIndex = this.dataRowIndex(cellNode.parent());
     }
-
     const cell = cellNode.attr('aria-colindex') - 1;
     const col = this.columnSettings(cell);
     const rowData = this.settings.treeGrid ? this.settings.treeDepth[dataRowIndex].node :

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -10925,7 +10925,7 @@ Datagrid.prototype = {
       newValue = xssUtils.escapeHTML(newValue);
     }
 
-    let rowIndex = this.actualRowIndex(cellNode.parent());
+    let rowIndex = this.actualRowIndex(cellNode?.parent());
     let dataRowIndex;
     if (this.settings.source !== null && isUseActiveRow) {
       if (!isNaN(rowIndex) && rowIndex !== this.activeCell.rowIndex) {


### PR DESCRIPTION
Explain the details for making this change. What existing problem does the pull request solve?

On commitCellEditUtil function:
https://github.com/infor-design/enterprise/pull/8838 combined with https://github.com/infor-design/enterprise/pull/8833 has issues where we encountered errors in this.actualRowIndex(cellNode.parent()) being NaN. This is a proposed PR to mitigate having console log errors.

Related github/jira issue (required):
https://inforwiki.atlassian.net/browse/MUA-14253

Fixes https://github.com/infor-design/enterprise/issues/8850

Steps necessary to review your pull request (required):
test scenarios:
In M3 Angular application:

Original Issue:
Open MMS300 Application -> Go to Data with valid editable cell.
Edit First Editable cell on first row then edit second row as well on same column.
On Second Row, Editable cell, press enter twice very fast.
Actual: Value in second row is being placed in first row editable cell.
![DoubleEnterKeyIssue](https://github.com/user-attachments/assets/3262a1e8-671c-44fd-9587-821bd874a742)

Issue caused by combination:
![image](https://github.com/user-attachments/assets/af7da3c5-c2eb-43d4-965d-588b509d7947)


Things to note in M3 Angular Application:
this.settings.source always has a value with an placeholder function much like this
() => {
/* placeholder empty */
};.
when enter is done, a different focus is received from BE and setActiveCell or element.click is used by the application to focus on the editable cell.

Replication steps is still in: 
http://localhost:4000/components/datagrid/test-editable-inline-editor-quick-focus-change.html.

Currently using v40.9.5.