### PR TITLE
NG1715 - Allow Trailing Decimal Zeros

### DIFF
--- a/app/views/components/mask/test-allow-trailing-decimals.html
+++ b/app/views/components/mask/test-allow-trailing-decimals.html
@@ -1,0 +1,9 @@
+
+<div class="row">
+  <div class="one-half column">
+    <div class="field">
+      <label for="decimal-field">Trailing Decimals</label>
+      <input id="decimal-field" name="decimal-field" type="text" inputmode="numeric" placeholder="0.00" class="new-mask" data-options='{ "process": "number", "patternOptions": { "requireDecimal": true, "allowTrailingDecimalZeros": true, "allowDecimal": true, "integerLimit": 3, "decimalLimit": 2, "prefix" : "$", "symbols": { "decimal": "." } } }' />
+    </div>
+  </div>
+</div>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## v4.98.0 Features
 
 - `[Datagrid]` Add the ability for isEditable on selection checkbox columns to disable row selection. ([#1689](https://github.com/infor-design/enterprise-ng/issues/1689))
+- `[Mask]` Added setting `allowTrailingDecimalZeros` to always display decimals in input mask. ([NG#1715](https://github.com/infor-design/enterprise-ng/issues/1715))
 - `[Tab]` Selecting tabs in overflow menu will move the tab to a visible space. ([#8016](https://github.com/infor-design/enterprise/issues/8016))
 
 ## v4.98.0 Fixes

--- a/src/components/mask/mask-input.js
+++ b/src/components/mask/mask-input.js
@@ -392,9 +392,9 @@ MaskInput.prototype = {
 
     // Use the piped value, if applicable.
     let finalValue = processed.pipedValue ? processed.pipedValue : processed.conformedValue;
-    const decimal = "."
-    const zero = "0";
-    const blank = "";
+    const decimal = '.';
+    const zero = '0';
+    const blank = '';
     if (this.settings.patternOptions.allowTrailingDecimalZeros) {
       const hasDecimal = finalValue.lastIndexOf(decimal) !== -1;
 
@@ -402,7 +402,7 @@ MaskInput.prototype = {
         finalValue += decimal;
       }
 
-      let value = hasDecimal ? finalValue.split(decimal)[1].length : 0;
+      const value = hasDecimal ? finalValue.split(decimal)[1].length : 0;
       
       let trailingZeros = blank;
       for (let j = value; j < this.settings.patternOptions.decimalLimit; j++) {
@@ -639,7 +639,6 @@ MaskInput.prototype = {
         if (decimalParts[1]) {
           this.settings.patternOptions.allowDecimal = true;
           this.settings.patternOptions.decimalLimit = decimalParts[1].toString().replace(/[^#0]/g, '').length;
-          debugger;
           if (!this.settings.patternOptions.symbols.decimal) {
             this.settings.patternOptions.symbols.decimal = decimal;
           }

--- a/src/components/mask/mask-input.js
+++ b/src/components/mask/mask-input.js
@@ -41,6 +41,7 @@ const COMPONENT_NAME = 'mask';
  * @param {boolean} [settings.patternOptions.requireDecimal] [number masks only] forces the placement of a decimal point in a number mask with a decimal limit defined.
  * @param {number} [settings.patternOptions.decimalLimit] [number masks only] defines the number of characters allowed after the decimal point.
  * @param {number} [settings.patternOptions.integerLimit] [number masks only] defines the number of characters allowed before the decimal point.
+ * @param {number} [settings.patternOptions.allowTrailingDecimalZeros] [number masks only] defines where to show trailing decimal zeros.
  * @param {boolean} [settings.patternOptions.allowNegative] [number masks only] allows a number to be negative (adds/retains a "minus" symbol at the beginning of the value)
  * @param {boolean} [settings.patternOptions.allowLeadingZeros] [number masks only] allows a zero be placed before a decimal or other numbers.
  * @param {string} [settings.placeholderChar='_'] If using the `settings.guide`, will be used as the placeholder
@@ -391,6 +392,26 @@ MaskInput.prototype = {
 
     // Use the piped value, if applicable.
     let finalValue = processed.pipedValue ? processed.pipedValue : processed.conformedValue;
+    const decimal = "."
+    const zero = "0";
+    const blank = "";
+    if (this.settings.patternOptions.allowTrailingDecimalZeros) {
+      const hasDecimal = finalValue.lastIndexOf(decimal) !== -1;
+
+      if (!hasDecimal) {
+        finalValue += decimal;
+      }
+
+      let value = hasDecimal ? finalValue.split(decimal)[1].length : 0;
+      
+      let trailingZeros = blank;
+      for (let j = value; j < this.settings.patternOptions.decimalLimit; j++) {
+        trailingZeros += zero;
+      }
+
+      finalValue += trailingZeros;
+    }
+
     if (finalValue !== '' && patternOptions && patternOptions.suffix && finalValue.indexOf(patternOptions.suffix) < 0) {
       finalValue += this.settings.patternOptions.suffix;
     }
@@ -618,6 +639,7 @@ MaskInput.prototype = {
         if (decimalParts[1]) {
           this.settings.patternOptions.allowDecimal = true;
           this.settings.patternOptions.decimalLimit = decimalParts[1].toString().replace(/[^#0]/g, '').length;
+          debugger;
           if (!this.settings.patternOptions.symbols.decimal) {
             this.settings.patternOptions.symbols.decimal = decimal;
           }

--- a/src/components/mask/masks.js
+++ b/src/components/mask/masks.js
@@ -289,7 +289,7 @@ masks.numberMask = function sohoNumberMask(rawValue, options) {
 
       let trailingZeros = masks.EMPTY_STRING;
       for (let j = 0; j < options.decimalLimit; j++) {
-        trailingZeros += "0";
+        trailingZeros += '0';
       }
 
       mask.push(trailingZeros);

--- a/src/components/mask/masks.js
+++ b/src/components/mask/masks.js
@@ -80,6 +80,7 @@ const DEFAULT_NUMBER_MASK_OPTIONS = {
     thousands: ','
   },
   allowDecimal: true,
+  allowTrailingDecimalZeros: false,
   decimalLimit: 2,
   locale: '',
   requireDecimal: false,
@@ -277,6 +278,21 @@ masks.numberMask = function sohoNumberMask(rawValue, options) {
       if (options.requireDecimal === true && thisRawValue[indexOfLastDecimal - 1] === DECIMAL) {
         mask.push(masks.DIGITS_REGEX);
       }
+    }
+
+    if (!hasDecimal && options.allowDecimal && options.decimalLimit && options.allowTrailingDecimalZeros) {
+      mask.push(masks.CARET_TRAP);
+
+      if (!options.requireDecimal) {
+        mask.push(DECIMAL);
+      }
+
+      let trailingZeros = masks.EMPTY_STRING;
+      for (let j = 0; j < options.decimalLimit; j++) {
+        trailingZeros += "0";
+      }
+
+      mask.push(trailingZeros);
     }
 
     if (prefixLength > 0) {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will add setting `allowTrailingDecimalZeros` to always display decimals in input mask.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1715

**Steps necessary to review your pull request (required)**:
- Pull this git repository, build, and run the app
- Go to http://localhost:4000/components/mask/test-allow-trailing-decimals.html
- Try to put a number in it.

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

