### PR TITLE
8913 - Fix switch layout issue in Datagrid Personalization

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - `[Calendar]` Fixed `selectDay` being called twice on clicking events. ([#8769](https://github.com/infor-design/enterprise/issues/8769))
 - `[Cards]` Fixed a bug selected and deselected event are not triggered on action. ([NG#1731](https://github.com/infor-design/enterprise-ng/issues/1731))
+- `[Datagrid]` Fixed layout issue on switch in personalization dialog. ([#8913](https://github.com/infor-design/enterprise/issues/8913))
 - `[Datagrid]` Fixed asterisk being cut off when `textOverflow` is set to ellipsis. ([NG#1651](https://github.com/infor-design/enterprise-ng/issues/1651))
 - `[Datagrid]` Fixed an error expanding rows with frozen columns. ([#8889](https://github.com/infor-design/enterprise/issues/8889))
 - `[Datagrid]` Refresh pager when `applyFilter` is called. ([#8744](https://github.com/infor-design/enterprise/issues/8744))

--- a/src/components/switch/_switch.scss
+++ b/src/components/switch/_switch.scss
@@ -184,19 +184,19 @@ $handle-compact-width: 16px;
 
     input ~ .label-text::before,
     input ~ label::before {
-      inset-inline-start: 240px;
-      top: 10px;
+      inset-inline-start: 246px;
+      top: 1px;
     }
 
     input:empty ~ .label-text::after,
     input:empty ~ label::after {
-      inset-inline-start: 235px;
+      inset-inline-start: 249px;
       top: 3px;
     }
 
     input:checked ~ .label-text::after,
     input:checked ~ label::after {
-      inset-inline-start: 255px;
+      inset-inline-start: 264px;
       top: 3px;
     }
   }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Recent fixes broke the layout of the switch in the personalization dialog.

**Related github/jira issue (required)**:
Fixes #8913 

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-index.html
- click ...
- open personalization and review the switch styles 

**Included in this Pull Request**:
- [x] A note to the change log.
