### PR TITLE
NG1740 - Fixes on select row in group

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[Datagrid]` Fixed asterisk being cut off when `textOverflow` is set to ellipsis. ([NG#1651](https://github.com/infor-design/enterprise-ng/issues/1651))
 - `[Datagrid]` Fixed an error expanding rows with frozen columns. ([#8889](https://github.com/infor-design/enterprise/issues/8889))
 - `[Datagrid]` Refresh pager when `applyFilter` is called. ([#8744](https://github.com/infor-design/enterprise/issues/8744))
+- `[Datagrid]` Fixed issue on selecting rows in group. ([NG#1740](https://github.com/infor-design/enterprise-ng/issues/1740))
 - `[Modal]` Removed accordion fixed width when used in modal. ([NG#1719](https://github.com/infor-design/enterprise-ng/issues/1719))
 - `[Tab]` Selecting an item in the appmenu accordion will also select the corresponding assigned tab to it (via `tab-id`). ([NG#1665](https://github.com/infor-design/enterprise-ng/issues/1665))
 - `[Tab]` Selecting tabs in overflow menu will move the tab to a visible space. ([#8880](https://github.com/infor-design/enterprise/issues/8880))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7316,6 +7316,7 @@ Datagrid.prototype = {
     const rowElem = target.closest('tr');
     const cellElem = target.closest('td');
     const cell = cellElem.index();
+
     let row = this.settings.treeGrid ? this.actualRowIndex(rowElem) : this.dataRowIndex(rowElem);
     let isTrigger = true;
 
@@ -7336,13 +7337,7 @@ Datagrid.prototype = {
         isTrigger = false; // No need to trigger if no data item
       } else {
         row = self.actualPagingRowIndex(self.actualRowIndex(rowElem));
-        if (self.groupArray[row]) {
-          item = self.settings.dataset[self.groupArray[row].group];
-
-          if (item && item.values) {
-            item = item.values[self.groupArray[row].node - 1];
-          }
-        }
+        item = self.originalDataset[row];
       }
     }
 
@@ -9101,8 +9096,9 @@ Datagrid.prototype = {
           if (isNaN(row)) {
             return;
           }
-          const gData = self.groupArray[row];
-          rowData = self.settings.dataset[gData.group].values[gData.node];
+          rowData = self.originalDataset[row];
+          // const gData = self.groupArray[row];
+          // rowData = self.settings.dataset[gData.group].values[gData.node];
           if (!isExists(rowData.idx, rowNode)) {
             args = {
               idx: rowData.idx,
@@ -9791,9 +9787,7 @@ Datagrid.prototype = {
           rowData = s.dataset[selIdx];
         }
         if (s.groupable) {
-          const row = self.actualPagingRowIndex(self.actualRowIndex(rowNode));
-          const gData = self.groupArray[row];
-          rowData = self.settings.dataset[gData.group].values[gData.node];
+          rowData = self.originalDataset[selIdx];
         }
         if (rowData !== undefined) {
           if (s.paging && s.source) {
@@ -13075,6 +13069,8 @@ Datagrid.prototype = {
     if (this.settings.selectable) {
       this.syncDatasetWithSelectedRows();
     }
+
+    this.refreshIndexes();
   },
 
   /**

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9791,7 +9791,9 @@ Datagrid.prototype = {
           rowData = s.dataset[selIdx];
         }
         if (s.groupable) {
-          rowData = self.originalDataset[selIdx];
+          const row = self.actualPagingRowIndex(self.actualRowIndex(rowNode));
+          const gData = self.groupArray[row];
+          rowData = self.settings.dataset[gData.group].values[gData.node];
         }
         if (rowData !== undefined) {
           if (s.paging && s.source) {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7336,11 +7336,11 @@ Datagrid.prototype = {
         isTrigger = false; // No need to trigger if no data item
       } else {
         row = self.actualPagingRowIndex(self.actualRowIndex(rowElem));
-
         if (self.groupArray[row]) {
           item = self.settings.dataset[self.groupArray[row].group];
+
           if (item && item.values) {
-            item = item.values[self.groupArray[row].node];
+            item = item.values[self.groupArray[row].node - 1];
           }
         }
       }

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9097,8 +9097,6 @@ Datagrid.prototype = {
             return;
           }
           rowData = self.originalDataset[row];
-          // const gData = self.groupArray[row];
-          // rowData = self.settings.dataset[gData.group].values[gData.node];
           if (!isExists(rowData.idx, rowNode)) {
             args = {
               idx: rowData.idx,
@@ -13069,8 +13067,6 @@ Datagrid.prototype = {
     if (this.settings.selectable) {
       this.syncDatasetWithSelectedRows();
     }
-
-    this.refreshIndexes();
   },
 
   /**


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
Updated index used to get row data on select event. Updated dataset used when unselecting rows to sync correctly (dataset used to check if a row is selected or not was different with the dataset updated when deselecting rows, which is why row couldn't be selected a second time)

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes https://github.com/infor-design/enterprise-ng/issues/1740

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/datagrid/example-grouping-multiselect.html
- For row with Customer ID 7:
   - Select row. Should have correct row data in console
   - Deselect
   - Select again. Checkbox should be checked

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
