### PR TITLE
8870 - Datagrid Inline Editor SelectOnEdit

### DIFF
--- a/app/views/components/datagrid/test-editable-with-inline-editor.html
+++ b/app/views/components/datagrid/test-editable-with-inline-editor.html
@@ -120,6 +120,7 @@
       paging: true,
       pagesize: 5,
       pagesizes: [2, 5, 6],
+      selectOnEdit: false,
       trimSpaces: true,
       columnReorder: true,
       showDirty: true

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - `[Calendar]` Fixed `selectDay` being called twice on clicking events. ([#8769](https://github.com/infor-design/enterprise/issues/8769))
 - `[Cards]` Fixed a bug selected and deselected event are not triggered on action. ([NG#1731](https://github.com/infor-design/enterprise-ng/issues/1731))
+- `[Datagrid]` Fixed selectin issue on inline editor by adding `selectOnEdit` setting. ([#8870](https://github.com/infor-design/enterprise/issues/8870))
 - `[Datagrid]` Fixed layout issue on switch in personalization dialog. ([#8913](https://github.com/infor-design/enterprise/issues/8913))
 - `[Datagrid]` Fixed asterisk being cut off when `textOverflow` is set to ellipsis. ([NG#1651](https://github.com/infor-design/enterprise-ng/issues/1651))
 - `[Datagrid]` Fixed an error expanding rows with frozen columns. ([#8889](https://github.com/infor-design/enterprise/issues/8889))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 - `[Calendar]` Fixed `selectDay` being called twice on clicking events. ([#8769](https://github.com/infor-design/enterprise/issues/8769))
 - `[Cards]` Fixed a bug selected and deselected event are not triggered on action. ([NG#1731](https://github.com/infor-design/enterprise-ng/issues/1731))
-- `[Datagrid]` Fixed selectin issue on inline editor by adding `selectOnEdit` setting. ([#8870](https://github.com/infor-design/enterprise/issues/8870))
+- `[Datagrid]` Fixed selecting issue on inline editor by adding `selectOnEdit` setting. ([#8870](https://github.com/infor-design/enterprise/issues/8870))
 - `[Datagrid]` Fixed layout issue on switch in personalization dialog. ([#8913](https://github.com/infor-design/enterprise/issues/8913))
 - `[Datagrid]` Fixed asterisk being cut off when `textOverflow` is set to ellipsis. ([NG#1651](https://github.com/infor-design/enterprise-ng/issues/1651))
 - `[Datagrid]` Fixed an error expanding rows with frozen columns. ([#8889](https://github.com/infor-design/enterprise/issues/8889))

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -7756,7 +7756,7 @@ Datagrid.prototype = {
         if (e.type === 'click' && e.target.nodeName.toLowerCase() === 'input') {
           const el = e.target;
           el.focus();
-          el.select();
+          if (self.settings.selectOnEdit) el.select();
           e.preventDefault();
           e.stopPropagation();
         }


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix selecting issue on inline editor by adding `selectOnEdit` setting.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/8870

**Steps necessary to review your pull request (required)**:
- Pull this git repository, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-editable-with-inline-editor.html
- Click the value inside the inline editor
- It should not be select on click

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

