### PR TITLE
Misc - Fix child selection and demo app example

### DIFF
--- a/app/views/components/datagrid/example-disabled-selection-checkbox.html
+++ b/app/views/components/datagrid/example-disabled-selection-checkbox.html
@@ -85,48 +85,6 @@
       }
       return isDisabled;
     };
-    const columnGroups = [
-      {
-        colspan: 1,
-        id: 'selectionCheckbox',
-        name: '',
-      },
-      {
-        colspan: 1,
-        id: 'LineEdit',
-        name: '',
-      },
-      {
-        colspan: 1,
-        id: 'Line',
-        name: 'line',
-      },
-      {
-        colspan: 1,
-        id: 'description',
-        name: 'description',
-      },
-      {
-        colspan: 1,
-        id: 'ScopeofWork',
-        name: 'scopeOfWork',
-      },
-      {
-        colspan: 1,
-        id: 'lineType',
-        name: 'lineType',
-      },
-      {
-        colspan: 1,
-        id: 'callOff',
-        name: 'callOffLine',
-      },
-      {
-        colspan: 1,
-        id: 'LineQuantity',
-        name: 'quantity',
-      },
-    ];
     const columns = [
       {
         id: 'selectionCheckbox',

--- a/app/views/components/datagrid/example-index.html
+++ b/app/views/components/datagrid/example-index.html
@@ -26,6 +26,7 @@
         $('#datagrid').datagrid({
           columns: columns,
           dataset: res,
+          columnReorder: true,
           saveColumns: false,
           attributes: [{ name: 'id', value: 'custom-id' }, { name: 'data-automation-id', value: 'custom-automation-id' } ],
           toolbar: {title: 'Compressors', results: true, actions: true, rowHeight: true, personalize: true}

--- a/app/views/components/datagrid/example-tree-disabled-selection-checkbox.html
+++ b/app/views/components/datagrid/example-tree-disabled-selection-checkbox.html
@@ -1,0 +1,45 @@
+<div class="full-height full-width">
+  <div id="datagrid">
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+
+    var grid,
+      columns = [];
+      const checkDisabled = (row, cell, value, item, rowData) => {
+        let isDisabled = false;
+        if (rowData.id === 2 || rowData.id === 1 || rowData.id === 5 || rowData.id === 8 || rowData.id === 11) {
+          isDisabled = true;
+        }
+        return isDisabled;
+      };
+
+      //Define Columns for the Grid.
+      columns.push({ id: 'selectionCheckbox', width: 15, sortable: false, resizable: false, formatter: Soho.Formatters.SelectionCheckbox, align: 'center', disabled: checkDisabled });
+      columns.push({ id: 'taskName', hideable: false, name: 'Task', field: 'taskName', expanded: 'expanded', formatter: Soho.Formatters.Tree });
+      columns.push({ id: 'id', name: 'Id', field: 'id' });
+      columns.push({ id: 'desc', name: 'Description', field: 'desc' });
+      columns.push({ id: 'comments', name: 'Comments', field: 'comments', formatter: Soho.Formatters.Hyperlink });
+      columns.push({ id: 'time', name: 'Time', field: 'time' });
+
+      //Get some data via ajax
+      var url = '{{basepath}}api/tree-tasks';
+
+      $.getJSON(url, function (data) {
+
+        $('#datagrid').datagrid({
+          columns: columns,
+          dataset: data,
+          treeGrid: true,
+          selectable: 'multiple',
+          toolbar: { title: 'Tasks (Hierarchical)', results: true, personalize: true, actions: true, rowHeight: true }
+        }).on('selected', function (e, args) {
+          console.log(args);
+        }).on('rowactivated', function (e, args) {
+          console.log(args);
+        });
+      });
+    });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,8 @@
 ## v4.98.0 Features
 
 - `[Busy Indicator]` Added circular loading type. ([#8662](https://github.com/infor-design/enterprise/issues/8662))
-- `[Datagrid]` Add the ability for isEditable on selection checkbox columns to disable row selection. ([#1689](https://github.com/infor-design/enterprise-ng/issues/1689))
+- `[Datagrid]` Add the ability for isEditable on selection checkbox columns to disable row selection. ([#8915](https://github.com/infor-design/enterprise-ng/issues/8915))
+- `[Datagrid]` Add the ability for isEditable on selection checkbox columns to disable row selection on tree grid with child selection. ([#1](https://github.com/infor-design/enterprise/issues/8915))
 - `[Pie Chart]` Fixed alignment bug in chart on RTL. ([NG#1736](https://github.com/infor-design/enterprise-ng/issues/1736))
 - `[Mask]` Added setting `allowTrailingDecimalZeros` to always display decimals in input mask. ([NG#1715](https://github.com/infor-design/enterprise-ng/issues/1715))
 - `[Tab]` Selecting tabs in overflow menu will move the tab to a visible space. ([#8016](https://github.com/infor-design/enterprise/issues/8016))
@@ -16,6 +17,7 @@
 - `[Calendar]` Fixed `selectDay` being called twice on clicking events. ([#8769](https://github.com/infor-design/enterprise/issues/8769))
 - `[Button]` Fixed primary buttons on header flex toolbar. ([#8669](https://github.com/infor-design/enterprise/issues/8669))
 - `[Cards]` Fixed a bug selected and deselected event are not triggered on action. ([NG#1731](https://github.com/infor-design/enterprise-ng/issues/1731))
+- `[Datagrid]` Fixed demo app problem on the example page, not able to drag. ([#8920](https://github.com/infor-design/enterprise/issues/8920))
 - `[Datagrid]` Fixed selecting issue on inline editor by adding `selectOnEdit` setting. ([#8870](https://github.com/infor-design/enterprise/issues/8870))
 - `[Datagrid]` Fixed a bug in search keyword not functioning properly when using special characters. ([#8864](https://github.com/infor-design/enterprise/issues/8864))
 - `[Datagrid]` Fixed layout issue on switch in personalization dialog. ([#8913](https://github.com/infor-design/enterprise/issues/8913))
@@ -24,7 +26,7 @@
 - `[Datagrid]` Refresh pager when `applyFilter` is called. ([#8744](https://github.com/infor-design/enterprise/issues/8744))
 - `[Datagrid]` Fixed issue on selecting rows in group. ([NG#1740](https://github.com/infor-design/enterprise-ng/issues/1740))
 - `[Modal]` Removed accordion fixed width when used in modal. ([NG#1719](https://github.com/infor-design/enterprise-ng/issues/1719))
-- `[Tab]` Selecting an item in the appmenu accordion will also select the corresponding assigned tab to it (via `tab-id`). ([NG#1665](https://github.com/infor-design/enterprise-ng/issues/1665))
+- `[Tab]` Selecting an item in the `appmenu` accordion will also select the corresponding assigned tab to it (via `tab-id`). ([NG#1665](https://github.com/infor-design/enterprise-ng/issues/1665))
 - `[Tab]` Selecting tabs in overflow menu will move the tab to a visible space. ([#8880](https://github.com/infor-design/enterprise/issues/8880))
 - `[Switch]` Fix issue of not being able to click the label. ([#8896](https://github.com/infor-design/enterprise/issues/8896))
 

--- a/src/components/datagrid/_datagrid-new.scss
+++ b/src/components/datagrid/_datagrid-new.scss
@@ -83,7 +83,7 @@
 }
 
 .datagrid-checkbox-wrapper {
-  margin-top: -15px;
+  margin-top: -13px;
 }
 
 // Adjust Filter Text

--- a/src/components/datagrid/datagrid.formatters.js
+++ b/src/components/datagrid/datagrid.formatters.js
@@ -390,7 +390,7 @@ const formatters = {
 
     ariaString = xssUtils.ensureAlphaNumericWithSpaces(ariaString);
     const disabledClass = isColumnDisabled(row, cell, value, col, item) ? ' disabled' : '';
-    return `<div class="datagrid-checkbox-wrapper"><span role="checkbox" aria-label="${(col.name ? col.name : Locale.translate('Select') + ariaString)}" class="datagrid-checkbox datagrid-selection-checkbox${(isChecked ? ' is-checked no-animate' : '')}${disabledClass}"></span></div>`;
+    return `<div class="datagrid-checkbox-wrapper"><span role="checkbox" aria-label="${(col.name ? col.name : Locale.translate('Select') + ariaString).trim()}" class="datagrid-checkbox datagrid-selection-checkbox${(isChecked ? ' is-checked no-animate' : '')}${disabledClass}"></span></div>`;
   },
 
   SelectionRadio(row, cell, value, col, item, api) {

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -8921,6 +8921,16 @@ Datagrid.prototype = {
     const self = this;
     const selectClasses = `is-selected${self.settings.selectable === 'mixed' ? ' hide-selected-color' : ''}`;
 
+    // Do not select if checkbox is disabled
+    const selectionCol = this.columnById('selectionCheckbox')[0];
+    const selectionIdx = this.columnIdxById('selectionCheckbox');
+    const disabledFunc = selectionCol?.disabled;
+
+    if (disabledFunc) {
+      const isDisabled = disabledFunc(index, selectionIdx, '', selectionCol, data);
+      if (isDisabled) return;
+    }
+
     // do not add if already exists in selected
     if ((!data || self.isRowSelected(data)) && !force) {
       return;

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -9025,7 +9025,16 @@ Datagrid.prototype = {
             // if selectChildren is false
             if (s.selectChildren || (!s.selectChildren && i === 0)) {
               const canAdd = (!elem.is(rowNode) && !elem.hasClass('is-selected'));
-              self.selectNode(elem, index, data);
+
+              // Check for the selection checkbox in case it has a disabled function
+              const selectionCol = self.columnById('selectionCheckbox')[0];
+              const selectionIdx = self.columnIdxById('selectionCheckbox');
+              const disabledFunc = selectionCol?.disabled;
+              let isDisabled = false;
+              if (disabledFunc) {
+                isDisabled = disabledFunc(actualIdx, selectionIdx, '', selectionCol, data);
+              }
+              if (!isDisabled) self.selectNode(elem, index, data);
               if (canAdd && !isExists(actualIdx, elem)) {
                 args = {
                   idx: actualIdx,

--- a/src/components/switch/_switch.scss
+++ b/src/components/switch/_switch.scss
@@ -179,25 +179,26 @@ $handle-compact-width: 16px;
 
   .switch {
     .label-text {
-      top: 1px;
+      position: relative;
+      top: 2px;
     }
 
     input ~ .label-text::before,
     input ~ label::before {
-      inset-inline-start: 246px;
-      top: 1px;
+      inset-inline-start: 235px;
+      top: -3px;
     }
 
     input:empty ~ .label-text::after,
     input:empty ~ label::after {
-      inset-inline-start: 249px;
-      top: 3px;
+      inset-inline-start: 253px;
+      top: -1px;
     }
 
     input:checked ~ .label-text::after,
     input:checked ~ label::after {
-      inset-inline-start: 264px;
-      top: 3px;
+      inset-inline-start: 254px;
+      top: -1px;
     }
   }
 


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

Adds to a previous issue so checkboxes can be disabled and have it work with tree view.
Fixes the example page to show dragging

**Related github/jira issue (required)**:
Fixes https://github.com/infor-design/enterprise/issues/8915
Fixes https://github.com/infor-design/enterprise/issues/8920
Fixes https://github.com/infor-design/enterprise/issues/8925

**Steps necessary to review your pull request (required)**:
- go to http://localhost:4000/components/datagrid/example-tree-disabled-selection-checkbox.html
- try to select the disabled rows (should not able to)
- try to click a parent row where children are disabled (child rows should not be selected)
- go to http://localhost:4000/components/datagrid/example-indedx.html
- should be able to drag columns and drag them in the personalization dialog
- in safari go to http://localhost:4000/components/button/example-menubutton.html - refresh the page -> button should not resize

**Included in this Pull Request**:
- [x] A test for the bug or feature.
- [x] A note to the change log.
