### PR TITLE
Remove modification in calculateTextWidth that had incorrect selectors

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # What's New with Enterprise
 
+## v4.99.0 Fixes
+
+- `[Datagrid]` Remove modification in calculateTextWidth that had incorrect selectors. ([#8938](https://github.com/infor-design/enterprise/issues/8938))
+
 ## v4.98.0
 
 ## v4.98.0 Features

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5365,23 +5365,6 @@ Datagrid.prototype = {
       }
       let rowStart = 0;
       let arrayToTestlen = arrayToTest.length;
-      if (this.settings.paging === false) { // calculate what is visible in the screen only
-        let rowHt;
-        switch (this.settings.rowHeight) {
-          case 'normal':
-          case 'large':
-            rowHt = 40;
-            break;
-          case 'medium':
-            rowHt = 30;
-            break;
-          default:
-            rowHt = 25;
-        }
-        rowStart = Math.floor(this.element.find('.datagrid-wrapper.scrollable-x.scrollable-y').scrollTop() / rowHt);
-        const rowCnt = rowStart + Math.floor(this.element.closest('.h5-datagrid-container').height() / rowHt);
-        arrayToTestlen = arrayToTest.length < rowCnt ? arrayToTest.length : rowCnt;
-      }
       for (let i = rowStart; i < arrayToTestlen; i++) {
         let val = this.fieldValue(arrayToTest[i], columnDef.field);
         const row = arrayToTest[i];

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -5363,8 +5363,8 @@ Datagrid.prototype = {
       if (this.settings.groupable) {
         arrayToTest = this.originalDataset;
       }
-      let rowStart = 0;
-      let arrayToTestlen = arrayToTest.length;
+      const rowStart = 0;
+      const arrayToTestlen = arrayToTest.length;
       for (let i = rowStart; i < arrayToTestlen; i++) {
         let val = this.fieldValue(arrayToTest[i], columnDef.field);
         const row = arrayToTest[i];


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
On calculateTextWidth, code was introduced that had selectors that were specific to M3 in PR: https://github.com/infor-design/enterprise/pull/8833. Leading to calculated text width to not run causing issues in other applications that do not have the selector in the container.


**Related github/jira issue (required)**: https://inforwiki.atlassian.net/browse/MUA-14629 / https://github.com/infor-design/enterprise/issues/8938
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
--> 

**Steps necessary to review your pull request (required)**:
1) Open http://localhost:4000/components/datagrid/example-full-width.html
2) Make sure to resize the code to a size similar below:
![image](https://github.com/user-attachments/assets/3c302ff4-1555-407f-b463-c98485aec244)

With Fix:
![image](https://github.com/user-attachments/assets/4fa7801a-77b0-455b-92de-aba87543cfee)

 
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->

**Included in this Pull Request**:
- [ ] A test for the bug or feature.
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
