### PR TITLE
8767 - Add a callback function setting in notification

### DIFF
--- a/app/views/components/notification/example-widget.html
+++ b/app/views/components/notification/example-widget.html
@@ -45,11 +45,23 @@
 </script>
 
 <script>
+  function showToastMessage(type) {
+    $('body').toast({
+      title: 'Notification',
+      message: `This is ${type} type.`,
+    });
+  }
+</script>
+
+<script>
   $('.notification-container').notification({
     type: 'error',
     message: 'ION API Error, please contact admin',
     parent: '.notification-container',
-    linkText: ''
+    linkText: '',
+    callback: function () {
+      showToastMessage(this.type);
+    }
   });
 
 </script>
@@ -59,7 +71,10 @@
       type: 'alert',
       message: 'Session Timeout, Reconnecting in 2 seconds before it resumes',
       parent: '.notification-container',
-      linkText: ''
+      linkText: '',
+      callback: function () {
+        showToastMessage(this.type);
+      }
     });
 
   </script>
@@ -69,7 +84,10 @@
       type: 'success',
       message: 'Records successfully updated!',
       parent: '.notification-container',
-      linkText: ''
+      linkText: '',
+      callback: function () {
+        showToastMessage(this.type);
+      }
     });
 
   </script>
@@ -79,7 +97,10 @@
     type: 'info',
     message: 'You can drag/drop items ',
     parent: '.notification-cointainer',
-    linkText: ''
+    linkText: '',
+    callback: function () {
+      showToastMessage(this.type);
+    }
   });
 
 </script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # What's New with Enterprise
 
+## v4.99.0 Features
+
+- `[Notification]` Added a callback function setting to be called when the notification is closed. ([#8767](https://github.com/infor-design/enterprise/issues/8767))
+
 ## v4.99.0 Fixes
 
 - `[Datagrid]` Remove modification in calculateTextWidth that had incorrect selectors. ([#8938](https://github.com/infor-design/enterprise/issues/8938))

--- a/src/components/notification/notification.js
+++ b/src/components/notification/notification.js
@@ -26,6 +26,7 @@ const NOTIFICATION_DEFAULTS = {
  * @param {string} [settings.link] The url to use for the hyperlink
  * @param {string} [settings.linkText] The text to show in the hyperlink. Leave empty for no link.
  * @param {array|object} [settings.attributes=null] Add extra attributes like id's to the element. e.g. `attributes: { name: 'id', value: 'my-unique-id' }`
+ * @param {Function} [settings.callback = undefined] A callback function to call after the notification button is closed.
  */
 function Notification(element, settings) {
   this.settings = utils.mergeSettings(element, settings, NOTIFICATION_DEFAULTS);
@@ -73,6 +74,12 @@ Notification.prototype = {
         </svg>
         <span class="audible">${Locale.translate('Close')}</span>
       </button>`;
+
+    $(this.notificationEl).on('click', '.notification-close', () => {
+      if (typeof this.settings.callback === 'function') {
+        this.settings.callback();
+      }
+    });
 
     this.notificationEl.innerHTML = htmlIcon.concat(htmlText, htmlButton);
     const parentEl = document.querySelector(this.settings.parent);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR adds a callback function setting that executes an action before the notification is closed.

In the example, a toast message is shown when the notification is closed.

**Related github/jira issue (required)**:

Closes #8767 

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/notification/example-widget.html
- Close any notification
- It should show a toast message (this is due to a callback function as a setting)

**Included in this Pull Request**:
- [ ] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
