### PR TITLE
NG1678 - ModuleNav Collapsed Tooltip

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[Datagrid]` Optimize the initial loading of datagrids with filterable setting. ([#8935](https://github.com/infor-design/enterprise-ng/issues/8935))
 - `[Datagrid]` Remove modification in calculateTextWidth that had incorrect selectors. ([#8938](https://github.com/infor-design/enterprise/issues/8938))
+- `[ModuleNav]` Fixed tooltip not showing on render if set collapsed by default. ([NG#1678](https://github.com/infor-design/enterprise-ng/issues/1678))
 
 ## v4.98.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - `[Datagrid]` Optimize the initial loading of datagrids with filterable setting. ([#8935](https://github.com/infor-design/enterprise-ng/issues/8935))
 - `[Datagrid]` Remove modification in calculateTextWidth that had incorrect selectors. ([#8938](https://github.com/infor-design/enterprise/issues/8938))
-- `[ModuleNav]` Fixed tooltip not showing on render if set collapsed by default. ([NG#1678](https://github.com/infor-design/enterprise-ng/issues/1678))
+- `[ModuleNav]` Fixed a bug where the tooltip was not showing when collapsed by default. ([NG#1678](https://github.com/infor-design/enterprise-ng/issues/1678))
 
 ## v4.98.0
 

--- a/src/components/module-nav/module-nav.js
+++ b/src/components/module-nav/module-nav.js
@@ -395,7 +395,7 @@ ModuleNav.prototype = {
     this.accordionAPI.updated(newSettings);
 
     // Build tooltips on top-level accordion headers in collapsed mode
-    const headers = this.accordionEl.querySelectorAll('.accordion-section > .accordion-header, .accordion-section > soho-module-nav-settings > .accordion-header');
+    const headers = this.accordionEl.querySelectorAll('.accordion-section > .module-nav-switcher, .accordion-section > .accordion-header, .accordion-section > soho-module-nav-settings > .accordion-header');
     if (headers.length) {
       [...headers].forEach((header) => {
         configureNavItemTooltip(header, this.settings.displayMode);


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix tooltip not showing on render if set collapsed by default.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise-ng/issues/1678

**Steps necessary to review your pull request (required)**:
- Pull this git repository, build, and run the app
- Go to http://localhost:4000/components/module-nav/example-index.html?colors=fff
- Hover `Em`
- Tooltip should show

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

