### PR TITLE
8900 - Datagrid Compact Mode

### DIFF
--- a/app/views/components/datagrid/test-lookup-filter-compact-mode.html
+++ b/app/views/components/datagrid/test-lookup-filter-compact-mode.html
@@ -1,0 +1,151 @@
+
+<div class="row">
+  <div class="twelve columns">
+    <form class="form-layout-compact">
+      <div class="toolbar" role="toolbar">
+        <div class="title">
+          Compressors
+          <span class="datagrid-result-count">(N Results)</span>
+        </div>
+        <div class="buttonset">
+
+          <label class="audible" for="common-toolbar-searchfield">Keyword Search</label>
+          <input id="common-toolbar-searchfield" name="common-toolbar-searchfield" class="searchfield" />
+
+          <button class="btn btn-toggle no-ripple hide-focus is-pressed" type="button" aria-pressed="true" id="toggle-compact">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-change-row-line-height"></use>
+            </svg>
+            <span>Compact Mode</span>
+          </button>
+        </div>
+
+        <div class="more">
+          <button class="btn-actions" type="button">
+            <svg class="icon" focusable="false" aria-hidden="true" role="presentation">
+              <use href="#icon-more"></use>
+            </svg>
+            <span class="audible">More Actions</span>
+          </button>
+          <ul class="popupmenu">
+            <li><a data-option="personalize-columns" href="#" data-translate="text">PersonalizeColumns</a></li>
+            <li><a data-option="reset-layout" href="#" data-translate="text">ResetDefault</a></li>
+            <li class="separator"></li>
+            <li class="heading">Filter</li>
+            <li class="show-filter is-toggleable is-checked"><a data-option="show-filter-row" data-translate="text">ShowFilterRow</a></li>
+            <li class="is-indented"><a data-option="run-filter" data-translate="text">RunFilter</a></li>
+            <li class="is-indented"><a data-option="clear-filter" data-translate="text">ClearFilter</a></li>
+            <li class="separator single-selectable-section"></li>
+            <li class="heading">Row Height</li>
+            <li class="is-selectable is-checked"><a data-option="row-extra-small" href="#" data-translate="text">ExtraSmall</a></li>
+            <li class="is-selectable"><a data-option="row-small" href="#" data-translate="text">Small</a></li>
+            <li class="is-selectable"><a data-option="row-medium" href="#" data-translate="text">Medium</a></li>
+            <li class="is-selectable"><a data-option="row-large" href="#" data-translate="text">Large</a></li>
+          </ul>
+
+        </div>
+      </div>
+      <div id="datagrid">
+      </div>
+    </form>
+  </div>
+</div>
+
+<script>
+  $('body').one('initialized', function () {
+
+    var grid,
+      columns = [],
+      data = [];
+
+    //lookup data
+    var idLookupOptions;
+    var numericFilterConditions= [ 'equals', 'does-not-equal', 'is-empty', 'is-not-empty', 'less-than', 'less-equals', 'greater-than', 'greater-equals' ];
+
+    idLookupOptions = {
+      // field: 'productId',
+      field: function (row, field, grid) {
+        return row.productId;
+      },
+      match: function (value, row, field, grid) {
+        return (row.productId) === value;
+      },
+      click: function (event, lookup, clickArguments) {
+        console.log(event, lookup, clickArguments);
+        if ($.isEmptyObject(clickArguments)) {
+          alert('No click arguments returned');
+        } else {
+          if (!$.isEmptyObject(clickArguments.grid)) {
+            alert('Grid information found');
+          }
+        }
+      },
+
+      options: {
+        selectable: 'single', //multiselect or single
+        toolbar: {title: 'Products', results: true, dateFilter: false ,keywordFilter: false, actions: true, views: true , rowHeight: true}
+      }
+    };
+
+    //Define Columns for the Grid.
+    columns.push({ id: 'selectionCheckbox', sortable: false, resizable: false, formatter: Soho.Formatters.SelectionCheckbox, align: 'center' });
+    columns.push({ id: 'id', name: 'Id', field: 'id', formatter: Soho.Formatters.Readonly, filterType: 'text'});
+    columns.push({ id: 'productId', name: 'Product Id', field: 'productId', formatter: Soho.Formatters.Lookup, editor: Soho.Editors.Lookup, validate: 'required', editorOptions: idLookupOptions, width: 120, filterType: 'lookup', filterConditions: numericFilterConditions });
+    columns.push({ id: 'productName', name: 'Product Name', sortable: false, field: 'productName', filterType: 'text', formatter: Soho.Formatters.Hyperlink, editor: Soho.Editors.Input});
+    columns.push({ id: 'activity', hidden: true, name: 'Activity', field: 'activity',  filterType: 'integer', editor: Soho.Editors.Input});
+    columns.push({ id: 'quantity', name: 'Quantity', field: 'quantity', filterType: 'contents', options: [{id: '1', value: '1', label: '1'}, {id: '2', value: '2', label: '2'}]});
+    columns.push({ id: 'price', name: 'Price', field: 'price', width: 125, filterType: 'decimal', formatter: Soho.Formatters.Decimal});
+    columns.push({ id: 'orderDate', name: 'Order Date', field: 'orderDate', filterType: 'date', formatter: Soho.Formatters.Date, dateFormat: 'M/d/yyyy'});
+
+    //Init and get the api for the grid
+    grid = $('#datagrid').datagrid({
+      allowSelectAcrossPages: true,
+      columns: columns,
+      selectable: 'multiple',
+      paging: true,
+      editable: true,
+      filterable: true,
+      pagesize: 10,
+      rowHeight: 'extra-small',
+      resultsText: function (grid, count, filterCount) {
+        console.log('ResultsText:', grid, count, filterCount);
+        if (filterCount > 0) {
+          return '(' + filterCount + ' of '+ count + ')';
+        }
+        else {
+          return '(' + 'all '+ count + ')';
+        }
+      },
+      source: function(req, response) {
+        var url = '{{basepath}}api/compressors?pageNum='+ req.activePage +'&pageSize='+ req.pagesize;
+
+        if (req.sortField) {
+          url += '&sortField=' + req.sortField + '&sortAsc=' + req.sortAsc;
+        }
+
+        if (req.filterExpr && req.filterExpr[0]) {
+          url += '&filterValue=' + req.filterExpr[0].value;
+          url += '&filterOp=' + req.filterExpr[0].operator;
+          url += '&filterColumn=' + req.filterExpr[0].columnId;
+        }
+
+        //Get Page Based on info in Req, return results into response;
+        $.getJSON(url, function(res) {
+          // This is the total going into the grid so the pager works (filtered total or total)
+          req.total = res.total;
+          req.preserveSelected = true;
+          if ((req.filterExpr && req.filterExpr[0])) {
+            req.total = res.total;
+            req.grandTotal = res.grandTotal; // This is the total amount on the server
+          }
+          response(res.data, req);
+        });
+      },
+      toolbar: {title: 'Data Grid Header Title', filterRow: true, personalize: true, results: true, keywordFilter: false, actions: true, rowHeight: true, filterRow: true}
+    });
+
+    $('#toggle-compact').on('click', function () {
+      Soho.utils.toggleCompactMode(document.querySelector('form'));
+    });
+  });
+</script>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,10 +6,11 @@
 
 ## v4.99.0 Fixes
 
-- `[Datagrid]` Optimize the initial loading of datagrids with filterable setting. ([#8935](https://github.com/infor-design/enterprise-ng/issues/8935))
+- `[Datagrid]` Fixed a bug in compact mode where datagrid filters doesn't extend all throughout the parents width. ([#8900](https://github.com/infor-design/enterprise-/issues/8900))
+- `[Datagrid]` Optimize the initial loading of datagrids with filterable setting. ([#8935](https://github.com/infor-design/enterprise/issues/8935))
 - `[Datagrid]` Remove modification in calculateTextWidth that had incorrect selectors. ([#8938](https://github.com/infor-design/enterprise/issues/8938))
 - `[Datagrid]` Updated styles so pager works on cards. ([NG#1756](https://github.com/infor-design/enterprise-ng/issues/1756))
-- `[General]` Upgrade dependencies, this involved updating sass and test dependencies with a few css deprecations that were fixed. ([#8947](https://github.com/infor-design/enterprise-ng/issues/8947))
+- `[General]` Upgrade dependencies, this involved updating sass and test dependencies with a few css deprecations that were fixed. ([#8947](https://github.com/infor-design/enterprise/issues/8947))
 - `[Message]` Updated docs in settings. ([#8839](https://github.com/infor-design/enterprise/issues/8839))
 - `[ModuleNav]` Fixed a bug where the tooltip was not showing when collapsed by default. ([NG#1678](https://github.com/infor-design/enterprise-ng/issues/1678))
 

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -781,7 +781,6 @@ $datagrid-small-row-height: 25px;
 
           input {
             left: 0;
-            width: calc(100% - 41px);
           }
 
           .lookup-wrapper .trigger {
@@ -821,7 +820,6 @@ $datagrid-small-row-height: 25px;
         font-size: $input-size-compact-font-size;
         height: 22px;
         left: 3px !important;
-        width: calc(100% - 43px) !important;
       }
 
       .dropdown {


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This pull request will fix a bug in compact mode where datagrid filters doesn't extend all throughout the parents width.

**Related github/jira issue (required)**:
Closes https://github.com/infor-design/enterprise/issues/8910

**Steps necessary to review your pull request (required)**:
- Pull this git repository, build, and run the app
- Go to http://localhost:4000/components/datagrid/test-lookup-filter-compact-mode
- Click `Compact Mode`
- See the `Product ID` Filter should expand all the width

**Included in this Pull Request**:
- [ ] An e2e or functional test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->

