### PR TITLE
8950 - Adjust detail row padding in datagrid

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## v4.99.0 Fixes
 
+- `[Datagrid]` Adjusted the padding of expandable detail rows in datagrid. ([#8950](https://github.com/infor-design/enterprise/issues/8950))
 - `[Datagrid]` Optimize the initial loading of datagrids with filterable setting. ([#8935](https://github.com/infor-design/enterprise-ng/issues/8935))
 - `[Datagrid]` Remove modification in calculateTextWidth that had incorrect selectors. ([#8938](https://github.com/infor-design/enterprise/issues/8938))
 - `[Datagrid]` Updated styles so pager works on cards. ([NG#1756](https://github.com/infor-design/enterprise-ng/issues/1756))

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -4649,7 +4649,7 @@ td .btn-actions {
 }
 
 .normal-rowheight {
-  @include row-height-padding(0px);
+  @include row-height-padding(0);
 }
 
 .medium-rowheight {

--- a/src/components/datagrid/_datagrid.scss
+++ b/src/components/datagrid/_datagrid.scss
@@ -17,6 +17,16 @@
 // toolbar/toolbar
 // tooltip/tooltip
 
+$datagrid-expandable-padding: 30px;
+
+@mixin row-height-padding($adjustment) {
+  .datagrid-expandable-row {
+    .datagrid-row-detail-padding {
+      padding: $datagrid-expandable-padding - $adjustment
+    }
+  }
+}
+
 @mixin rowstatus($color) {
   td {
     border-bottom: 1px solid $color !important;
@@ -4636,6 +4646,22 @@ td .btn-actions {
       color: transparent;
     }
   }
+}
+
+.normal-rowheight {
+  @include row-height-padding(0px);
+}
+
+.medium-rowheight {
+  @include row-height-padding(5px);
+}
+
+.small-rowheight {
+  @include row-height-padding(10px);
+}
+
+.extra-small-rowheight {
+  @include row-height-padding(15px);
 }
 
 //Grid Expandable Area

--- a/tests/datagrid/datagrid.spec.js
+++ b/tests/datagrid/datagrid.spec.js
@@ -4,43 +4,77 @@ import { expect } from '@playwright/test';
 import { test } from '../base-fixture';
 
 test.describe('Datagrid tests', () => {
-  const url = '/components/datagrid/example-index.html';
+  test.describe('Index page tests', () => {
+    const url = '/components/datagrid/example-index.html';
 
-  test.beforeEach(async ({ page }) => {
-    await page.goto(url);
-  });
+    test.beforeEach(async ({ page }) => {
+      await page.goto(url);
+    });
 
-  test.describe('general page checks', () => {
-    test('should have a title', async ({ page }) => {
-      await expect(page).toHaveTitle('IDS Enterprise');
+    test.describe('general page checks', () => {
+      test('should have a title', async ({ page }) => {
+        await expect(page).toHaveTitle('IDS Enterprise');
+      });
+    });
+
+    test.describe('accessibility tests', () => {
+      test('should pass an Axe scan', async ({ page, browserName }) => {
+        if (browserName !== 'chromium') return;
+        const accessibilityScanResults = await new AxeBuilder({ page })
+          .disableRules(['meta-viewport'])
+          .exclude('[disabled]')
+          .analyze();
+        expect(accessibilityScanResults.violations).toEqual([]);
+      });
+    });
+
+    test.describe('snapshot tests', () => {
+      test('should match the visual snapshot in percy', async ({ page, browserName }) => {
+        if (browserName !== 'chromium') return;
+        await percySnapshot(page, 'datagrid-light');
+      });
+    });
+
+    test.describe('functionality tests', () => {
+      test('should be able to disable selection with readonly checkboxes', async ({ page }) => {
+        await page.goto('/components/datagrid/example-disabled-selection-checkbox.html');
+        await page.locator('.datagrid tr:first-child td:first-child').click();
+        expect(await page.locator('.selection-count')).toHaveText('0 Selected');
+        await page.locator('.datagrid tr:first-child td:nth-child(6)').click();
+        expect(await page.locator('.selection-count')).toHaveText('0 Selected');
+      });
     });
   });
 
-  test.describe('accessibility tests', () => {
-    test('should pass an Axe scan', async ({ page, browserName }) => {
-      if (browserName !== 'chromium') return;
-      const accessibilityScanResults = await new AxeBuilder({ page })
-        .disableRules(['meta-viewport'])
-        .exclude('[disabled]')
-        .analyze();
-      expect(accessibilityScanResults.violations).toEqual([]);
-    });
-  });
+  test.describe('Expandable row page tests', () => {
+    const url = '/components/datagrid/example-expandable-row.html';
 
-  test.describe('snapshot tests', () => {
-    test('should match the visual snapshot in percy', async ({ page, browserName }) => {
-      if (browserName !== 'chromium') return;
-      await percySnapshot(page, 'datagrid-light');
+    test.beforeEach(async ({ page }) => {
+      await page.goto(url);
     });
-  });
 
-  test.describe('functionality tests', () => {
-    test('should be able to disable selection with readonly checkboxes', async ({ page }) => {
-      await page.goto('/components/datagrid/example-disabled-selection-checkbox.html');
-      await page.locator('.datagrid tr:first-child td:first-child').click();
-      expect(await page.locator('.selection-count')).toHaveText('0 Selected');
-      await page.locator('.datagrid tr:first-child td:nth-child(6)').click();
-      expect(await page.locator('.selection-count')).toHaveText('0 Selected');
+    test.describe('snapshot tests', () => {
+      test('should match the visual snapshot in percy', async ({ page, browserName }) => {
+        if (browserName !== 'chromium') return;
+
+        // Function to handle the actions and snapshot for specific row option
+        const captureSnapshot = async (option, snapshotName) => {
+          await page.locator('#custom-id-actions').click();
+          await page.locator(`a[data-option="row-${option}"]`).click();
+
+          // Capture a Percy snapshot with the specified name
+          await percySnapshot(page, snapshotName);
+        };
+
+        // Capture snapshot for "extra-small" row height
+        await captureSnapshot('extra-small', 'datagrid-expandable-row-extra-small-padding');
+
+        // Capture snapshot for "small" row height
+        await captureSnapshot('small', 'datagrid-expandable-row-small-padding');
+
+        // Capture snapshot for "medium" row height
+        await captureSnapshot('medium', 'datagrid-expandable-row-medium-padding');
+      });
     });
   });
 });

--- a/tests/datagrid/datagrid.spec.js
+++ b/tests/datagrid/datagrid.spec.js
@@ -74,6 +74,9 @@ test.describe('Datagrid tests', () => {
 
         // Capture snapshot for "medium" row height
         await captureSnapshot('medium', 'datagrid-expandable-row-medium-padding');
+
+        // Capture snapshot for "large" / "Normal" row height
+        await captureSnapshot('large', 'datagrid-expandable-row-large-padding');
       });
     });
   });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**

This PR adjusts the padding of detail row on different row heights.

`Normal/Large: 30px`
`Medium: 25px`
`Small: 20px`
`Extra Small: 15px`

**Related github/jira issue (required)**:

Closes #8950

**Steps necessary to review your pull request (required)**:
- Pull this branch, build, and run the app
- Go to http://localhost:4000/components/datagrid/example-expandable-row.html
- Check the `datagrid-row-detail-padding` element
- Navigate to different row heights
- Normal/Large should have `30px`
- Medium should have `25px`
- Small should have `20px`
- Extra small should have: `15px`


**Included in this Pull Request**:
- [x] A test for the bug or feature.
- [x] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
