### PR TITLE
Update Datagrid Search on Input Change

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `[Toolbar]` Fixed uncaught error when destroying the toolbar. ([#8946](https://github.com/infor-design/enterprise/issues/8946))
 - `[Tabs]` Fixed a bug where focus state is undefined when using breadcrumbs startup. ([#8910](https://github.com/infor-design/enterprise/issues/8910))
 - `[Validation]` Add guards for new setting in case it is undefined. ([#8981](https://github.com/infor-design/enterprise/issues/8981))
+- `[Datagrid]` Fixed the filterWhenTyping feature, so that any input change (including backspace or cut/paste which previously did nothing) will update the search results. ([#9007](https://github.com/infor-design/enterprise/issues/9007))
 
 ## v4.98.2
 

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -8441,7 +8441,7 @@ Datagrid.prototype = {
             const thisSearch1 = param[1];
             self1.keywordSearch(thisSearch1.val());
           }, 400, [self, thisSearch]);
-        })
+        });
       }
       clearButton.off('click.datagrid').on('click.datagrid', () => {
         self.keywordSearch(thisSearch.val());

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -8431,16 +8431,18 @@ Datagrid.prototype = {
           e.preventDefault();
           self.keywordSearch(thisSearch.val());
         }
-
-        if (self.settings.filterWhenTyping) {
+      });
+      
+      if (self.settings.filterWhenTyping) {
+        thisSearch.on('input.datagrid', () => {
           clearTimeout(typingTimer);
           typingTimer = setTimeout((param) => {
             const self1 = param[0];
             const thisSearch1 = param[1];
             self1.keywordSearch(thisSearch1.val());
           }, 400, [self, thisSearch]);
-        }
-      });
+        })
+      }
       clearButton.off('click.datagrid').on('click.datagrid', () => {
         self.keywordSearch(thisSearch.val());
       });
@@ -13916,7 +13918,7 @@ Datagrid.prototype = {
       const searchfield = toolbar.find('.searchfield');
       const searchfieldApi = searchfield.data('searchfield');
       const xIcon = searchfield.parent().find('.close.icon');
-      searchfield.off('keypress.datagrid');
+      searchfield.off('keydown.datagrid input.datagrid');
       xIcon.off('click.datagrid');
       if (searchfieldApi && typeof searchfieldApi.destroy === 'function') {
         searchfieldApi.destroy();

--- a/src/components/datagrid/datagrid.js
+++ b/src/components/datagrid/datagrid.js
@@ -13918,7 +13918,7 @@ Datagrid.prototype = {
       const searchfield = toolbar.find('.searchfield');
       const searchfieldApi = searchfield.data('searchfield');
       const xIcon = searchfield.parent().find('.close.icon');
-      searchfield.off('keydown.datagrid input.datagrid');
+      searchfield.off('keypress.datagrid input.datagrid');
       xIcon.off('click.datagrid');
       if (searchfieldApi && typeof searchfieldApi.destroy === 'function') {
         searchfieldApi.destroy();


### PR DESCRIPTION
This fixes the filterWhenTyping feature in the datagrid search, so that any input change (including backspace or cut and paste which previously did nothing) will update the search results

https://github.com/infor-design/enterprise/issues/9007
