### PR TITLE
9004 - Selected tab in overflow menu change

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@
 - `[Swaplist]` Improved the size of the swaplist's drop area when there is no existing items. ([#8956](https://github.com/infor-design/enterprise/issues/8956))
 - `[Toolbar]` Fixed uncaught error when destroying the toolbar. ([#8946](https://github.com/infor-design/enterprise/issues/8946))
 - `[Tabs]` Fixed a bug where focus state is undefined when using breadcrumbs startup. ([#8910](https://github.com/infor-design/enterprise/issues/8910))
+- `[Tabs]` Selected tab in overflow menu is scrolled and focused instead of moved into last visible space. ([#9004](https://github.com/infor-design/enterprise/issues/9004))
 - `[Validation]` Add guards for new setting in case it is undefined. ([#8981](https://github.com/infor-design/enterprise/issues/8981))
 - `[Datagrid]` Fixed the filterWhenTyping feature, so that any input change (including backspace or cut/paste which previously did nothing) will update the search results. ([#9007](https://github.com/infor-design/enterprise/issues/9007))
 

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -3721,11 +3721,6 @@ Tabs.prototype = {
       const id = href.substr(1, href.length);
       const tab = self.doGetTab(id) || $();
 
-      const visibleTabs = self.getVisibleTabs();
-      const lastVisibleTab = $(visibleTabs[visibleTabs.length - 1]);
-
-      tab.insertBefore(lastVisibleTab);
-
       let a = tab ? tab.children('a') : $();
       let originalTab = anchor.data('original-tab').parent();
 
@@ -3922,17 +3917,22 @@ Tabs.prototype = {
 
     const liTop = Math.round(liBounding.top);
     const liRight = Math.round(liBounding.right);
+    const liLeft = Math.round(liBounding.left);
 
     let tablistTop = Math.round(tablistBounding.top + 1);
     let tablistContainerRight = Math.round(tablistContainerBounding.right);
+    let tabListContainerLeft = Math.round(tablistContainerBounding.left);
 
     // +1 to compensate for top border on Module Tabs
     if (this.isModuleTabs()) {
-      tablistTop += 1;
-      tablistContainerRight += 1;
+      tablistTop++;
+      tablistContainerRight++;
+      tabListContainerLeft++;
     }
 
-    return liTop > tablistTop || (checkHorizontal && liRight > tablistContainerRight);
+    const horizontal = liRight > tablistContainerRight || liLeft < tabListContainerLeft;
+
+    return liTop > tablistTop || (checkHorizontal && horizontal);
   },
 
   /**

--- a/tests/toolbar/toolbar.spec.js
+++ b/tests/toolbar/toolbar.spec.js
@@ -44,6 +44,7 @@ test.describe('Toolbar tests', () => {
       test('should match the visual snapshot in percy', async ({ page, browserName }) => {
         if (browserName !== 'chromium') return;
         await page.waitForLoadState();
+        await page.waitForSelector('.do-resize');
         await percySnapshot(page, 'toolbar-light');
       });
     });


### PR DESCRIPTION
**Explain the _details_ for making this change. What existing problem does the pull request solve?**
<!--
Example: When "Adding a function to do X",
explain why it is necessary to have a way to do X.
-->
- Removed previous behavior where selected tab in the overflow menu will be moved to the next visible space
- Added additional check on the isTabOverflowed method as the check didn't include overflow tabs on the left (which should update the overflow menu to include left overflow tabs now)

**Related github/jira issue (required)**:
<!--
Provide a link to the related issue(s) to this Pull Request;
auto-closing github issues if necessary (example: "Closes #100")
-->
Closes #9004 

**Steps necessary to review your pull request (required)**:
<!--
Include:
- commands you ran and their output
- screenshots / videos
- test scenarios
-->
- Pull this branch, build and run the app
- Go to: http://localhost:4000/components/tabs-header/example-index.html
- Select a tab in the overflow menu
- Should scroll to that tab

**Included in this Pull Request**:
- [ ] A note to the change log.

<!-- After submitting your PR, please check back to make sure tests pass on the github actions. -->
